### PR TITLE
Constraint generic work

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1192,6 +1192,11 @@ namespace System.StubHelpers
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void ThrowInteropParamException(int resID, int paramIdx);
 
+        internal static void ThrowInvalidProgramException()
+        {
+            throw new System.Security.VerificationException("Attempt to call constrained method without correct instantiation");
+        }
+
         internal static IntPtr AddToCleanupList(ref CleanupWorkListElement? pCleanupWorkList, SafeHandle handle)
         {
             SafeHandleCleanupWorkListElement element = new SafeHandleCleanupWorkListElement(handle);

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1192,7 +1192,7 @@ namespace System.StubHelpers
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void ThrowInteropParamException(int resID, int paramIdx);
 
-        internal static void ThrowInvalidProgramException()
+        internal static void ThrowVerificationException()
         {
             throw new System.Security.VerificationException("Attempt to call constrained method without correct instantiation");
         }

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -789,7 +789,7 @@ enum CorInfoFlag
     CORINFO_FLG_SHAREDINST            = 0x00020000, // the code for this method is shared between different generic instantiations (also set on classes/types)
     CORINFO_FLG_DELEGATE_INVOKE       = 0x00040000, // "Delegate
     CORINFO_FLG_PINVOKE               = 0x00080000, // Is a P/Invoke call
-//  CORINFO_FLG_UNUSED                = 0x00100000,
+    CORINFO_FLG_CONSTRAINTFAIL        = 0x00100000, // Indicates the method doesn't satisfy its constraints
     CORINFO_FLG_NOGCCHECK             = 0x00200000, // This method is FCALL that has no GC check.  Don't put alone in loops
     CORINFO_FLG_INTRINSIC             = 0x00400000, // This method MAY have an intrinsic ID
     CORINFO_FLG_CONSTRUCTOR           = 0x00800000, // This method is an instance or type initializer
@@ -1519,6 +1519,9 @@ enum CorInfoTokenKind
 
     // token comes from an instruction that allows a ByRef but not void
     CORINFO_TOKENKIND_ClassNotVoid = 0x1000 | CORINFO_TOKENKIND_Class,
+
+    // token comes from a CALL instruction
+    CORINFO_TOKENKIND_Method_CallInstr = 0x2000 | CORINFO_TOKENKIND_Method,
 };
 
 struct CORINFO_RESOLVED_TOKEN

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4435,7 +4435,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 else
                 {
                     if ((info.compCompHnd->getClassAttribs(tFrom) & CORINFO_FLG_SHAREDINST) ||
-                        (info.compCompHnd->getClassAttribs(tFrom) & CORINFO_FLG_SHAREDINST))
+                        (info.compCompHnd->getClassAttribs(tTo) & CORINFO_FLG_SHAREDINST))
                     {
                         // Maybe CanCastTo. This isn't the most optimal version of this possible, but it isn't wrong
                         break;

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -52,6 +52,7 @@ enum NamedIntrinsic : unsigned short
     NI_System_Type_get_IsValueType,
     NI_System_Type_IsAssignableFrom,
     NI_System_Type_IsAssignableTo,
+    NI_System_Type_IsAssignableTo_Generic,
     NI_System_Type_op_Equality,
     NI_System_Type_op_Inequality,
     NI_System_Type_GetTypeFromHandle,

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -521,6 +521,11 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
         m_pInstMethodHashTable = InstMethodHashTable::Create(GetLoaderAllocator(), this, PARAMMETHODS_HASH_BUCKETS, pamTracker);
     }
 
+    if (m_pConstraintFailInstMethodHashTable == NULL)
+    {
+        m_pConstraintFailInstMethodHashTable = InstMethodHashTable::Create(GetLoaderAllocator(), this, PARAMMETHODS_HASH_BUCKETS, pamTracker);
+    }
+    
     if (m_pMemberRefToDescHashTable == NULL)
     {
         if (IsReflection())
@@ -7538,6 +7543,10 @@ void Module::EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
         if (m_pInstMethodHashTable.IsValid())
         {
             m_pInstMethodHashTable->EnumMemoryRegions(flags);
+        }
+        if (m_pConstraintFailInstMethodHashTable.IsValid())
+        {
+            m_pConstraintFailInstMethodHashTable->EnumMemoryRegions(flags);
         }
         if (m_pAvailableClassesCaseIns.IsValid())
         {

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -952,6 +952,9 @@ public:
     // Hashtable of instantiated methods and per-instantiation static methods
     PTR_InstMethodHashTable m_pInstMethodHashTable;
 
+    // Hashtable of instantiated methods which have failed constraint checks
+    PTR_InstMethodHashTable m_pConstraintFailInstMethodHashTable;
+
     // This is used by the Debugger. We need to store a dword
     // for a count of JMC functions. This is a count, not a pointer.
     // We'll pass the address of this field
@@ -1416,6 +1419,19 @@ protected:
         LIMITED_METHOD_CONTRACT;
 
         return m_pInstMethodHashTable;
+    }
+
+    InstMethodHashTable *GetConstraintFailInstMethodHashTable()
+    {
+        LIMITED_METHOD_CONTRACT;
+        {
+            // IsResource() may lock when accessing metadata, but this is only in debug,
+            // for the assert below
+            CONTRACT_VIOLATION(TakesLockViolation);
+
+            _ASSERTE(!IsResource());
+        }
+        return m_pConstraintFailInstMethodHashTable;
     }
 
     // Creates a new Method table for an array.  Used to make type handles

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1424,13 +1424,7 @@ protected:
     InstMethodHashTable *GetConstraintFailInstMethodHashTable()
     {
         LIMITED_METHOD_CONTRACT;
-        {
-            // IsResource() may lock when accessing metadata, but this is only in debug,
-            // for the assert below
-            CONTRACT_VIOLATION(TakesLockViolation);
 
-            _ASSERTE(!IsResource());
-        }
         return m_pConstraintFailInstMethodHashTable;
     }
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -1002,7 +1002,7 @@ DEFINE_METHOD(BUFFER,               MEMCPY,                 Memcpy,             
 DEFINE_CLASS(STUBHELPERS,           StubHelpers,            StubHelpers)
 DEFINE_METHOD(STUBHELPERS,          GET_NDIRECT_TARGET,     GetNDirectTarget,           SM_IntPtr_RetIntPtr)
 DEFINE_METHOD(STUBHELPERS,          GET_DELEGATE_TARGET,    GetDelegateTarget,          SM_Delegate_RefIntPtr_RetIntPtr)
-DEFINE_METHOD(STUBHELPERS,          THROW_INVALID_PROGRAM_EXCEPTION, ThrowInvalidProgramException, NoSig)
+DEFINE_METHOD(STUBHELPERS,          THROW_VERIFICATION_EXCEPTION, ThrowVerificationException, NoSig)
 #ifdef FEATURE_COMINTEROP
 DEFINE_METHOD(STUBHELPERS,          GET_COM_HR_EXCEPTION_OBJECT,              GetCOMHRExceptionObject,            SM_Int_IntPtr_Obj_RetException)
 DEFINE_METHOD(STUBHELPERS,          GET_COM_IP_FROM_RCW,                      GetCOMIPFromRCW,                    SM_Obj_IntPtr_RefIntPtr_RefBool_RetIntPtr)

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -1002,6 +1002,7 @@ DEFINE_METHOD(BUFFER,               MEMCPY,                 Memcpy,             
 DEFINE_CLASS(STUBHELPERS,           StubHelpers,            StubHelpers)
 DEFINE_METHOD(STUBHELPERS,          GET_NDIRECT_TARGET,     GetNDirectTarget,           SM_IntPtr_RetIntPtr)
 DEFINE_METHOD(STUBHELPERS,          GET_DELEGATE_TARGET,    GetDelegateTarget,          SM_Delegate_RefIntPtr_RetIntPtr)
+DEFINE_METHOD(STUBHELPERS,          THROW_INVALID_PROGRAM_EXCEPTION, ThrowInvalidProgramException, NoSig)
 #ifdef FEATURE_COMINTEROP
 DEFINE_METHOD(STUBHELPERS,          GET_COM_HR_EXCEPTION_OBJECT,              GetCOMHRExceptionObject,            SM_Int_IntPtr_Obj_RetException)
 DEFINE_METHOD(STUBHELPERS,          GET_COM_IP_FROM_RCW,                      GetCOMIPFromRCW,                    SM_Obj_IntPtr_RefIntPtr_RefBool_RetIntPtr)

--- a/src/coreclr/vm/genericdict.cpp
+++ b/src/coreclr/vm/genericdict.cpp
@@ -1127,7 +1127,7 @@ Dictionary::PopulateEntry(
             {
                 if (allowConstraintFailure && pMethod->AsInstantiatedMethodDesc()->FailedConstraintCheck())
                 {
-                    result = (CORINFO_GENERIC_HANDLE)CoreLibBinder::GetMethod(METHOD__STUBHELPERS__THROW_INVALID_PROGRAM_EXCEPTION)->GetMultiCallableAddrOfCode();
+                    result = (CORINFO_GENERIC_HANDLE)CoreLibBinder::GetMethod(METHOD__STUBHELPERS__THROW_VERIFICATION_EXCEPTION)->GetMultiCallableAddrOfCode();
                 }
                 else
                 {

--- a/src/coreclr/vm/genmeth.cpp
+++ b/src/coreclr/vm/genmeth.cpp
@@ -967,15 +967,6 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                methodInst,
                                                FALSE /* no inst param */);
 
-            if (allowConstraintFailure && pResultMD == NULL)
-            {
-                pResultMD = pConstraintFailTable->FindMethodDesc(TypeHandle(pExactMT),
-                                               methodDef,
-                                               TRUE, /* forceBoxedEntryPoint */
-                                               methodInst,
-                                               FALSE /* no inst param */);
-            }
-
             if (!pResultMD)
             {
                 // !allowCreate ==> GC_NOTRIGGER ==> no entering Crst
@@ -993,15 +984,6 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                    TRUE, /* forceBoxedEntryPoint */
                                                    methodInst,
                                                    FALSE /* no inst param */);
-
-                if (allowConstraintFailure && pResultMD == NULL)
-                {
-                    pResultMD = pConstraintFailTable->FindMethodDesc(TypeHandle(pExactMT),
-                                                methodDef,
-                                                TRUE, /* forceBoxedEntryPoint */
-                                                methodInst,
-                                                FALSE /* no inst param */);
-                }
 
                 if (pResultMD == NULL)
                 {
@@ -1182,7 +1164,8 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                 InstantiatedMethodDesc::FindLoadedInstantiatedMethodDesc(pExactMT,
                                                                          methodDef,
                                                                          methodInst,
-                                                                         FALSE);
+                                                                         FALSE,
+                                                                         allowConstraintFailure);
 
             // No - so create one.  Go fetch the shared one first
             if (pInstMD == NULL)
@@ -1201,7 +1184,8 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                                           /* allowInstParam */ TRUE,
                                                                           /* forceRemotableMethod */ FALSE,
                                                                           /* allowCreate */ TRUE,
-                                                                          /* level */ level);
+                                                                          /* level */ level,
+                                                                          allowConstraintFailure);
 
                 _ASSERTE(pWrappedMD->IsSharedByGenericInstantiations());
                 _ASSERTE(!methodInst.IsEmpty() || !pWrappedMD->IsSharedByGenericMethodInstantiations());
@@ -1210,7 +1194,8 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                                             pMDescInCanonMT,
                                                                             pWrappedMD,
                                                                             methodInst,
-                                                                            FALSE);
+                                                                            FALSE,
+                                                                            allowConstraintFailure);
             }
         }
         else
@@ -1221,7 +1206,8 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                 InstantiatedMethodDesc::FindLoadedInstantiatedMethodDesc(pExactMT,
                                                                          methodDef,
                                                                          methodInst,
-                                                                         FALSE);
+                                                                         FALSE,
+                                                                         allowConstraintFailure);
 
             // No - so create one.
             if (pInstMD == NULL)
@@ -1235,7 +1221,8 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                                                             pMDescInCanonMT,
                                                                             NULL,
                                                                             methodInst,
-                                                                            FALSE);
+                                                                            FALSE,
+                                                                            allowConstraintFailure);
             }
         }
         _ASSERTE(pInstMD);

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -5343,6 +5343,8 @@ void CEEInfo::getCallInfo(
                     IfFailThrow(sp.SkipExactlyOne());
                 }
 
+                if (pMD->)
+
                 pCalleeForSecurity = MethodDesc::FindOrCreateAssociatedMethodDesc(pMD, calleeTypeForSecurity.GetMethodTable(), FALSE, Instantiation(genericMethodArgs, nGenericMethodArgs), FALSE);
             }
             else

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1071,7 +1071,7 @@ void CEEInfo::resolveToken(/* IN, OUT */ CORINFO_RESOLVED_TOKEN * pResolvedToken
 
                 // We need the method desc to carry exact instantiation, thus allowInstParam == FALSE.
                 pMD = MemberLoader::GetMethodDescFromMethodSpec(pModule, metaTOK, &typeContext, (tokenType != CORINFO_TOKENKIND_Ldtoken), FALSE /* allowInstParam */,
-                    &th, TRUE, &pResolvedToken->pTypeSpec, (ULONG*)&pResolvedToken->cbTypeSpec, &pResolvedToken->pMethodSpec, (ULONG*)&pResolvedToken->cbMethodSpec);
+                    &th, TRUE, &pResolvedToken->pTypeSpec, (ULONG*)&pResolvedToken->cbTypeSpec, &pResolvedToken->pMethodSpec, (ULONG*)&pResolvedToken->cbMethodSpec, tokenType == CORINFO_TOKENKIND_Method_CallInstr);
             }
             break;
 
@@ -5101,6 +5101,10 @@ void CEEInfo::getCallInfo(
 
         bool allowInstParam = (flags & CORINFO_CALLINFO_ALLOWINSTPARAM);
 
+        BOOL callMayConvertToThrowHelper = (S_OK == pMD->GetModule()->GetCustomAttribute(pMD->GetMemberDef(), WellKnownAttribute::ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute, NULL, NULL));
+        if (callMayConvertToThrowHelper)
+            allowInstParam = FALSE;
+
         // If the target method is resolved via constrained static virtual dispatch
         // And it requires an instParam, we do not have the generic dictionary infrastructure
         // to load the correct generic context arg via EmbedGenericHandle.
@@ -5343,9 +5347,9 @@ void CEEInfo::getCallInfo(
                     IfFailThrow(sp.SkipExactlyOne());
                 }
 
-                if (pMD->)
-
-                pCalleeForSecurity = MethodDesc::FindOrCreateAssociatedMethodDesc(pMD, calleeTypeForSecurity.GetMethodTable(), FALSE, Instantiation(genericMethodArgs, nGenericMethodArgs), FALSE);
+                // If the ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute is present, we can allow the target method to be loaded even if it violates constraints
+                BOOL allowConstraintFailure = (S_OK == pMD->GetModule()->GetCustomAttribute(pMD->GetMemberDef(), WellKnownAttribute::ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute, NULL, NULL));
+                pCalleeForSecurity = MethodDesc::FindOrCreateAssociatedMethodDesc(pMD, calleeTypeForSecurity.GetMethodTable(), FALSE, Instantiation(genericMethodArgs, nGenericMethodArgs), FALSE, FALSE, TRUE, CLASS_LOADED, allowConstraintFailure);
             }
             else
             if (pResolvedToken->pTypeSpec != NULL)
@@ -6513,6 +6517,11 @@ DWORD CEEInfo::getMethodAttribsInternal (CORINFO_METHOD_HANDLE ftn)
     if (!g_pConfig->TieredCompilation_QuickJitForLoops())
     {
         result |= CORINFO_FLG_DISABLE_TIER0_FOR_LOOPS;
+    }
+
+    if (pMD->HasMethodInstantiation() && pMD->AsInstantiatedMethodDesc()->FailedConstraintCheck())
+    {
+        result |= CORINFO_FLG_CONSTRAINTFAIL;
     }
 
     return result;

--- a/src/coreclr/vm/memberload.h
+++ b/src/coreclr/vm/memberload.h
@@ -136,7 +136,8 @@ public:
                                                     PCCOR_SIGNATURE * ppTypeSig = NULL, // Optionally, return generic signatures fetched from metadata during loading.
                                                     ULONG * pcbTypeSig = NULL,
                                                     PCCOR_SIGNATURE * ppMethodSig = NULL,
-                                                    ULONG * pcbMethodSig = NULL);
+                                                    ULONG * pcbMethodSig = NULL,
+                                                    BOOL allowConstraintFail = FALSE);
 
     //-------------------------------------------------------------------
     // METHOD AND FIELD LOOKUP BY NAME AND SIGNATURE

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -3433,18 +3433,20 @@ private:
 #ifdef FEATURE_COMINTEROP
         HasComPlusCallInfo                  = 0x10, // this IMD contains an optional ComPlusCallInfo
 #endif // FEATURE_COMINTEROP
-        FailedConstraintCheck               = 0x20,
+        FailedConstraintCheckFlag           = 0x20,
     };
 
     void SetFailedConstraintCheck()
     {
-        m_wFlags2 |= FailedConstraintCheck;
+        m_wFlags2 |= FailedConstraintCheckFlag;
     }
 
+public:
     bool FailedConstraintCheck()
     {
-        return m_wFlags2 & FailedConstraintCheck;
+        return m_wFlags2 & FailedConstraintCheckFlag;
     }
+private:
 
     friend class MethodDesc; // this fields are currently accessed by MethodDesc::Save/Restore etc.
     union {

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1561,7 +1561,8 @@ public:
                                                         BOOL allowInstParam,
                                                         BOOL forceRemotableMethod = FALSE,
                                                         BOOL allowCreate = TRUE,
-                                                        ClassLoadLevel level = CLASS_LOADED);
+                                                        ClassLoadLevel level = CLASS_LOADED,
+                                                        BOOL allowConstraintFailure = FALSE);
 
     // Normalize methoddesc for reflection
     static MethodDesc* FindOrCreateAssociatedMethodDescForReflection(MethodDesc *pMethod,
@@ -3432,7 +3433,18 @@ private:
 #ifdef FEATURE_COMINTEROP
         HasComPlusCallInfo                  = 0x10, // this IMD contains an optional ComPlusCallInfo
 #endif // FEATURE_COMINTEROP
+        FailedConstraintCheck               = 0x20,
     };
+
+    void SetFailedConstraintCheck()
+    {
+        m_wFlags2 |= FailedConstraintCheck;
+    }
+
+    bool FailedConstraintCheck()
+    {
+        return m_wFlags2 & FailedConstraintCheck;
+    }
 
     friend class MethodDesc; // this fields are currently accessed by MethodDesc::Save/Restore etc.
     union {
@@ -3464,7 +3476,8 @@ public:
     static InstantiatedMethodDesc* FindLoadedInstantiatedMethodDesc(MethodTable *pMT,
                                                                     mdMethodDef methodDef,
                                                                     Instantiation methodInst,
-                                                                    BOOL getSharedNotStub);
+                                                                    BOOL getSharedNotStub,
+                                                                    BOOL allowConstraintFailure = FALSE);
 
 private:
 
@@ -3472,7 +3485,8 @@ private:
                                                              MethodDesc* pGenericMDescInRepMT,
                                                              MethodDesc* pSharedMDescForStub,
                                                              Instantiation methodInst,
-                                                             BOOL getSharedNotStub);
+                                                             BOOL getSharedNotStub,
+                                                             BOOL allowConstraintFailure = FALSE);
 
 };
 

--- a/src/coreclr/vm/wellknownattributes.h
+++ b/src/coreclr/vm/wellknownattributes.h
@@ -39,6 +39,7 @@ enum class WellKnownAttribute : DWORD
     ObjectiveCTrackedTypeAttribute,
     GenericParameterSupportsAnyTypeAttribute,
     GenericParameterSupportsOnlyNonByRefLikeAttribute,
+    ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute,
 
     CountOfWellKnownAttributes
 };
@@ -113,6 +114,8 @@ inline const char *GetWellKnownAttributeName(WellKnownAttribute attribute)
             return "System.Runtime.CompilerServices.GenericParameterSupportsAnyTypeAttribute";
         case WellKnownAttribute::GenericParameterSupportsOnlyNonByRefLikeAttribute:
             return "System.Runtime.CompilerServices.GenericParameterSupportsOnlyNonByRefLikeAttribute";
+        case WellKnownAttribute::ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute:
+            return "System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute";
         case WellKnownAttribute::CountOfWellKnownAttributes:
         default:
             break; // Silence compiler warnings

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -699,6 +699,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ConfiguredCancelableAsyncEnumerable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ConfiguredValueTaskAwaitable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ContractHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CreateNewOnMetadataUpdateAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CustomConstantAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\DateTimeConstantAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute : Attribute
+    {
+        public ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute() { }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -113,6 +113,8 @@ namespace System
 
         [Intrinsic]
         public bool IsAssignableTo([NotNullWhen(true)] Type? targetType) => targetType?.IsAssignableFrom(this) ?? false;
+        [Intrinsic]
+        public static bool IsAssignableTo<TFrom, TTo>() => typeof(TTo).IsAssignableFrom(typeof(TFrom));
         protected virtual bool IsValueTypeImpl() => IsSubclassOf(typeof(ValueType));
 
         public virtual bool IsSignatureType => false;

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6878,6 +6878,7 @@ namespace System
         protected abstract bool IsArrayImpl();
         public virtual bool IsAssignableFrom([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] System.Type? c) { throw null; }
         public bool IsAssignableTo([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] System.Type? targetType) { throw null; }
+        public static bool IsAssignableTo<TFrom, TTo>() { throw null; }
         protected abstract bool IsByRefImpl();
         protected abstract bool IsCOMObjectImpl();
         protected virtual bool IsContextfulImpl() { throw null; }
@@ -12841,6 +12842,10 @@ namespace System.Runtime.CompilerServices
             public void OnCompleted(System.Action continuation) { }
             public void UnsafeOnCompleted(System.Action continuation) { }
         }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false)]
+    public sealed partial class ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute : Attribute
+    {
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter, Inherited=false)]
     public abstract partial class CustomConstantAttribute : System.Attribute

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.cs
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.CompilerServices
+{
+    class ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute : Attribute { }
+}
+namespace UnconstrainedCallToConstrainedMethod
+{
+    interface IConstraint<T> { }
+    interface IConstraintCurious<T> where T : IConstraintCurious<T> { }
+
+    class ClassThatImplementsConstraintCurious : IConstraintCurious<ClassThatImplementsConstraintCurious> { }
+
+    class ClassThatImplementsConstraint : IConstraint<object> { }
+
+    struct StructThatImplementsConstraint : IConstraint<int>, IConstraint<object> { }
+
+    struct StructThatImplementsConstraintCurious : IConstraintCurious<StructThatImplementsConstraintCurious> { }
+
+
+
+    class TestClass
+    {
+        static int s_failures = 0;
+
+        static void TestHelperMethodRequiresConstraint_TEMPORARY<T, U>(bool expectSuccess) 
+        {
+            s_failures++;
+            Console.WriteLine($"FAILED Called TestHelperMethodRequiresConstraint_TEMPORARY<{typeof(T).FullName}, {typeof(U).FullName}>");
+        }
+        static void TestHelperMethodRequiresConstraintCurious_TEMPORARY<T>(bool expectSuccess)
+        {
+            s_failures++;
+            Console.WriteLine($"FAILED Called TestHelperMethodRequiresConstraintCurious_TEMPORARY<{typeof(T).FullName}>");
+        }
+
+        [ConvertUnconstrainedCallsToThrowInvalidProgramException]
+        static void TestHelperMethodRequiresConstraint<T, U>(bool expectSuccess) where T : IConstraint<U>
+        {
+            if (expectSuccess)
+                Console.WriteLine($"SUCCESS Called TesHelpertMethodRequiresConstraint<{typeof(T).FullName}, {typeof(U).FullName}>");
+            else
+            {
+                s_failures++;
+                Console.WriteLine($"FAILED Called TestHelperMethodRequiresConstraint<{typeof(T).FullName}, {typeof(U).FullName}>");
+            }
+        }
+        [ConvertUnconstrainedCallsToThrowInvalidProgramException]
+        static void TestHelperMethodRequiresConstraintCurious<T>(bool expectSuccess) where T : IConstraintCurious<T>
+        {
+            if (expectSuccess)
+                Console.WriteLine($"SUCCESS Called TestHelperMethodRequiresConstraintCurious<{typeof(T).FullName}>");
+            else
+            {
+                s_failures++;
+                Console.WriteLine($"FAILED Called TestHelperMethodRequiresConstraintCurious<{typeof(T).FullName}>");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConstraintTest<T, U>(bool expectSuccess)
+        {
+            try
+            {
+                TestHelperMethodRequiresConstraint<T, U>(expectSuccess);
+            }
+            catch (InvalidProgramException)
+            {
+                if (expectSuccess)
+                {
+                    s_failures++;
+                    Console.WriteLine($"FAILED Threw Exception ConstraintTest<{typeof(T).FullName}, {typeof(U).FullName}>");
+                }
+                else
+                {
+                    Console.WriteLine($"SUCCESS Threw Exception ConstraintTest<{typeof(T).FullName}, {typeof(U).FullName}>");
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ConstraintCuriousTest<T>(bool expectSuccess)
+        {
+            try
+            {
+                TestHelperMethodRequiresConstraintCurious<T>(expectSuccess);
+            }
+            catch (InvalidProgramException)
+            {
+                if (expectSuccess)
+                {
+                    s_failures++;
+                    Console.WriteLine($"FAILED Threw Exception ConstraintCuriousTest<{typeof(T).FullName}>");
+                }
+                else
+                {
+                    Console.WriteLine($"SUCCESS Threw Exception ConstraintCuriousTest<{typeof(T).FullName}>");
+                }
+            }
+        }
+
+        static int Main()
+        {
+            ConstraintTest<ClassThatImplementsConstraint, object>(expectSuccess: true);
+            ConstraintTest<ClassThatImplementsConstraint, int>(expectSuccess: false);
+            ConstraintTest<StructThatImplementsConstraint, int>(expectSuccess: true);
+            ConstraintTest<StructThatImplementsConstraint, object>(expectSuccess: true);
+            ConstraintTest<StructThatImplementsConstraint, short>(expectSuccess: false);
+
+            ConstraintCuriousTest<ClassThatImplementsConstraint>(expectSuccess: false);
+            ConstraintCuriousTest<ClassThatImplementsConstraintCurious>(expectSuccess: true);
+
+            ConstraintCuriousTest<StructThatImplementsConstraint>(expectSuccess: false);
+            ConstraintCuriousTest<StructThatImplementsConstraintCurious>(expectSuccess: true);
+
+            if (s_failures != 0)
+            {
+                Console.WriteLine($"{s_failures} Failures");
+                return 1;
+            }
+            return 100;
+        }
+    }
+}

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.cs
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.cs
@@ -35,7 +35,7 @@ namespace UnconstrainedCallToConstrainedMethod
             Console.WriteLine($"FAILED Called TestHelperMethodRequiresConstraintCurious_TEMPORARY<{typeof(T).FullName}>");
         }
 
-        [ConvertUnconstrainedCallsToThrowInvalidProgramException]
+        [ConvertUnconstrainedCallsToThrowVerificationException]
         static void TestHelperMethodRequiresConstraint<T, U>(bool expectSuccess) where T : IConstraint<U>
         {
             if (expectSuccess)
@@ -46,7 +46,7 @@ namespace UnconstrainedCallToConstrainedMethod
                 Console.WriteLine($"FAILED Called TestHelperMethodRequiresConstraint<{typeof(T).FullName}, {typeof(U).FullName}>");
             }
         }
-        [ConvertUnconstrainedCallsToThrowInvalidProgramException]
+        [ConvertUnconstrainedCallsToThrowVerificationException]
         static void TestHelperMethodRequiresConstraintCurious<T>(bool expectSuccess) where T : IConstraintCurious<T>
         {
             if (expectSuccess)

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.cs
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.cs
@@ -5,10 +5,6 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace System.Runtime.CompilerServices
-{
-    class ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute : Attribute { }
-}
 namespace UnconstrainedCallToConstrainedMethod
 {
     interface IConstraint<T> { }

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.il
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.il
@@ -280,7 +280,7 @@
   .method private hidebysig static void  TestHelperMethodRequiresConstraint<(class UnconstrainedCallToConstrainedMethod.IConstraint`1<!!U>) T,U>(bool expectSuccess) cil managed
   {
     .custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 00 00 00 ) 
-    .custom instance void System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute::.ctor() = ( 01 00 00 00 ) 
     .param type U 
     .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 02 00 00 ) 
     // Code size       177 (0xb1)
@@ -364,7 +364,7 @@
   .method private hidebysig static void  TestHelperMethodRequiresConstraintCurious<(class UnconstrainedCallToConstrainedMethod.IConstraintCurious`1<!!T>) T>(bool expectSuccess) cil managed
   {
     .custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 00 00 00 ) 
-    .custom instance void System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       95 (0x5f)
     .maxstack  3
     .locals init (bool V_0)
@@ -423,7 +423,7 @@
       IL_000a:  leave      IL_00c5
 
     }  // end .try
-    catch [System.Runtime]System.InvalidProgramException 
+    catch [System.Runtime]System.Security.VerificationException
     {
       IL_000f:  pop
       IL_0010:  nop
@@ -523,7 +523,7 @@
       IL_000a:  leave.s    IL_0070
 
     }  // end .try
-    catch [System.Runtime]System.InvalidProgramException 
+    catch [System.Runtime]System.Security.VerificationException
     {
       IL_000c:  pop
       IL_000d:  nop
@@ -644,22 +644,6 @@
   } // end of method TestClass::.ctor
 
 } // end of class UnconstrainedCallToConstrainedMethod.TestClass
-
-.class private auto ansi beforefieldinit System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute
-       extends [System.Runtime]System.Attribute
-{
-  .method public hidebysig specialname rtspecialname 
-          instance void  .ctor() cil managed
-  {
-    // Code size       8 (0x8)
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  call       instance void [System.Runtime]System.Attribute::.ctor()
-    IL_0006:  nop
-    IL_0007:  ret
-  } // end of method ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute::.ctor
-
-} // end of class System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute
 
 // *********** DISASSEMBLY COMPLETE ***********************
 // WARNING: Created Win32 resource file UnconstrainedCallToConstrainedMethod.res

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.il
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.il
@@ -1,0 +1,665 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
+// Metadata version: v4.0.30319
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 6:0:0:0
+}
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 6:0:0:0
+}
+.assembly UnconstrainedCallToConstrainedMethod
+{
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                                   63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom instance void [System.Runtime]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 07 01 00 00 00 00 ) 
+
+  .custom instance void [System.Runtime]System.Runtime.Versioning.TargetFrameworkAttribute::.ctor(string) = ( 01 00 18 2E 4E 45 54 43 6F 72 65 41 70 70 2C 56   // ....NETCoreApp,V
+                                                                                                              65 72 73 69 6F 6E 3D 76 36 2E 30 01 00 54 0E 14   // ersion=v6.0..T..
+                                                                                                              46 72 61 6D 65 77 6F 72 6B 44 69 73 70 6C 61 79   // FrameworkDisplay
+                                                                                                              4E 61 6D 65 00 )                                  // Name.
+  .custom instance void [System.Runtime]System.Reflection.AssemblyCompanyAttribute::.ctor(string) = ( 01 00 24 55 6E 63 6F 6E 73 74 72 61 69 6E 65 64   // ..$Unconstrained
+                                                                                                      43 61 6C 6C 54 6F 43 6F 6E 73 74 72 61 69 6E 65   // CallToConstraine
+                                                                                                      64 4D 65 74 68 6F 64 00 00 )                      // dMethod..
+  .custom instance void [System.Runtime]System.Reflection.AssemblyConfigurationAttribute::.ctor(string) = ( 01 00 05 44 65 62 75 67 00 00 )                   // ...Debug..
+  .custom instance void [System.Runtime]System.Reflection.AssemblyFileVersionAttribute::.ctor(string) = ( 01 00 07 31 2E 30 2E 30 2E 30 00 00 )             // ...1.0.0.0..
+  .custom instance void [System.Runtime]System.Reflection.AssemblyInformationalVersionAttribute::.ctor(string) = ( 01 00 05 31 2E 30 2E 30 00 00 )                   // ...1.0.0..
+  .custom instance void [System.Runtime]System.Reflection.AssemblyProductAttribute::.ctor(string) = ( 01 00 24 55 6E 63 6F 6E 73 74 72 61 69 6E 65 64   // ..$Unconstrained
+                                                                                                      43 61 6C 6C 54 6F 43 6F 6E 73 74 72 61 69 6E 65   // CallToConstraine
+                                                                                                      64 4D 65 74 68 6F 64 00 00 )                      // dMethod..
+  .custom instance void [System.Runtime]System.Reflection.AssemblyTitleAttribute::.ctor(string) = ( 01 00 24 55 6E 63 6F 6E 73 74 72 61 69 6E 65 64   // ..$Unconstrained
+                                                                                                    43 61 6C 6C 54 6F 43 6F 6E 73 74 72 61 69 6E 65   // CallToConstraine
+                                                                                                    64 4D 65 74 68 6F 64 00 00 )                      // dMethod..
+  .hash algorithm 0x00008004
+  .ver 1:0:0:0
+}
+.module UnconstrainedCallToConstrainedMethod.dll
+// MVID: {A27E6A78-61EA-45D7-BFDB-750E8567BFCC}
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x07220000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class private auto ansi sealed beforefieldinit Microsoft.CodeAnalysis.EmbeddedAttribute
+       extends [System.Runtime]System.Attribute
+{
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Attribute::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method EmbeddedAttribute::.ctor
+
+} // end of class Microsoft.CodeAnalysis.EmbeddedAttribute
+
+.class private auto ansi sealed beforefieldinit System.Runtime.CompilerServices.NullableAttribute
+       extends [System.Runtime]System.Attribute
+{
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [System.Runtime]System.AttributeUsageAttribute::.ctor(valuetype [System.Runtime]System.AttributeTargets) = ( 01 00 84 6B 00 00 02 00 54 02 0D 41 6C 6C 6F 77   // ...k....T..Allow
+                                                                                                                                     4D 75 6C 74 69 70 6C 65 00 54 02 09 49 6E 68 65   // Multiple.T..Inhe
+                                                                                                                                     72 69 74 65 64 00 )                               // rited.
+  .field public initonly uint8[] NullableFlags
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(uint8 A_1) cil managed
+  {
+    // Code size       24 (0x18)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Attribute::.ctor()
+    IL_0006:  nop
+    IL_0007:  ldarg.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  newarr     [System.Runtime]System.Byte
+    IL_000e:  dup
+    IL_000f:  ldc.i4.0
+    IL_0010:  ldarg.1
+    IL_0011:  stelem.i1
+    IL_0012:  stfld      uint8[] System.Runtime.CompilerServices.NullableAttribute::NullableFlags
+    IL_0017:  ret
+  } // end of method NullableAttribute::.ctor
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(uint8[] A_1) cil managed
+  {
+    // Code size       15 (0xf)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Attribute::.ctor()
+    IL_0006:  nop
+    IL_0007:  ldarg.0
+    IL_0008:  ldarg.1
+    IL_0009:  stfld      uint8[] System.Runtime.CompilerServices.NullableAttribute::NullableFlags
+    IL_000e:  ret
+  } // end of method NullableAttribute::.ctor
+
+} // end of class System.Runtime.CompilerServices.NullableAttribute
+
+.class private auto ansi sealed beforefieldinit System.Runtime.CompilerServices.NullableContextAttribute
+       extends [System.Runtime]System.Attribute
+{
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [System.Runtime]System.AttributeUsageAttribute::.ctor(valuetype [System.Runtime]System.AttributeTargets) = ( 01 00 4C 14 00 00 02 00 54 02 0D 41 6C 6C 6F 77   // ..L.....T..Allow
+                                                                                                                                     4D 75 6C 74 69 70 6C 65 00 54 02 09 49 6E 68 65   // Multiple.T..Inhe
+                                                                                                                                     72 69 74 65 64 00 )                               // rited.
+  .field public initonly uint8 Flag
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor(uint8 A_1) cil managed
+  {
+    // Code size       15 (0xf)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Attribute::.ctor()
+    IL_0006:  nop
+    IL_0007:  ldarg.0
+    IL_0008:  ldarg.1
+    IL_0009:  stfld      uint8 System.Runtime.CompilerServices.NullableContextAttribute::Flag
+    IL_000e:  ret
+  } // end of method NullableContextAttribute::.ctor
+
+} // end of class System.Runtime.CompilerServices.NullableContextAttribute
+
+.class interface private abstract auto ansi UnconstrainedCallToConstrainedMethod.IConstraint`1<T>
+{
+  .custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 02 00 00 ) 
+} // end of class UnconstrainedCallToConstrainedMethod.IConstraint`1
+
+.class interface private abstract auto ansi UnconstrainedCallToConstrainedMethod.IConstraintCurious`1<(class UnconstrainedCallToConstrainedMethod.IConstraintCurious`1<!T>) T>
+{
+} // end of class UnconstrainedCallToConstrainedMethod.IConstraintCurious`1
+
+.class private auto ansi beforefieldinit UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraintCurious
+       extends [System.Runtime]System.Object
+       implements class UnconstrainedCallToConstrainedMethod.IConstraintCurious`1<class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraintCurious>
+{
+  .interfaceimpl type class UnconstrainedCallToConstrainedMethod.IConstraintCurious`1<class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraintCurious>
+  .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8[]) = ( 01 00 02 00 00 00 00 01 00 00 ) 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method ClassThatImplementsConstraintCurious::.ctor
+
+} // end of class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraintCurious
+
+.class private auto ansi beforefieldinit UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraint
+       extends [System.Runtime]System.Object
+       implements class UnconstrainedCallToConstrainedMethod.IConstraint`1<object>
+{
+  .interfaceimpl type class UnconstrainedCallToConstrainedMethod.IConstraint`1<object>
+  .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8[]) = ( 01 00 02 00 00 00 00 01 00 00 ) 
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method ClassThatImplementsConstraint::.ctor
+
+} // end of class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraint
+
+.class private sequential ansi sealed beforefieldinit UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraint
+       extends [System.Runtime]System.ValueType
+       implements class UnconstrainedCallToConstrainedMethod.IConstraint`1<int32>,
+                  class UnconstrainedCallToConstrainedMethod.IConstraint`1<object>
+{
+  .pack 0
+  .size 1
+  .interfaceimpl type class UnconstrainedCallToConstrainedMethod.IConstraint`1<object>
+  .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8[]) = ( 01 00 02 00 00 00 00 01 00 00 ) 
+} // end of class UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraint
+
+.class private sequential ansi sealed beforefieldinit UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraintCurious
+       extends [System.Runtime]System.ValueType
+       implements class UnconstrainedCallToConstrainedMethod.IConstraintCurious`1<valuetype UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraintCurious>
+{
+  .pack 0
+  .size 1
+} // end of class UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraintCurious
+
+.class private auto ansi beforefieldinit UnconstrainedCallToConstrainedMethod.TestClass
+       extends [System.Runtime]System.Object
+{
+  .custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 02 00 00 ) 
+  .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 00 00 00 ) 
+  .field private static int32 s_failures
+  .method private hidebysig static void  TestHelperMethodRequiresConstraint_TEMPORARY<T,U>(bool expectSuccess) cil managed
+  {
+    // Code size       91 (0x5b)
+    .maxstack  4
+    IL_0000:  nop
+    IL_0001:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_0006:  ldc.i4.1
+    IL_0007:  add
+    IL_0008:  stsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_000d:  ldc.i4.5
+    IL_000e:  newarr     [System.Runtime]System.String
+    IL_0013:  dup
+    IL_0014:  ldc.i4.0
+    IL_0015:  ldstr      "FAILED Called TestHelperMethodRequiresConstraint_T"
+    + "EMPORARY<"
+    IL_001a:  stelem.ref
+    IL_001b:  dup
+    IL_001c:  ldc.i4.1
+    IL_001d:  ldtoken    !!T
+    IL_0022:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0027:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_002c:  stelem.ref
+    IL_002d:  dup
+    IL_002e:  ldc.i4.2
+    IL_002f:  ldstr      ", "
+    IL_0034:  stelem.ref
+    IL_0035:  dup
+    IL_0036:  ldc.i4.3
+    IL_0037:  ldtoken    !!U
+    IL_003c:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0041:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_0046:  stelem.ref
+    IL_0047:  dup
+    IL_0048:  ldc.i4.4
+    IL_0049:  ldstr      ">"
+    IL_004e:  stelem.ref
+    IL_004f:  call       string [System.Runtime]System.String::Concat(string[])
+    IL_0054:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0059:  nop
+    IL_005a:  ret
+  } // end of method TestClass::TestHelperMethodRequiresConstraint_TEMPORARY
+
+  .method private hidebysig static void  TestHelperMethodRequiresConstraintCurious_TEMPORARY<T>(bool expectSuccess) cil managed
+  {
+    // Code size       50 (0x32)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_0006:  ldc.i4.1
+    IL_0007:  add
+    IL_0008:  stsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_000d:  ldstr      "FAILED Called TestHelperMethodRequiresConstraintCu"
+    + "rious_TEMPORARY<"
+    IL_0012:  ldtoken    !!T
+    IL_0017:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_001c:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_0021:  ldstr      ">"
+    IL_0026:  call       string [System.Runtime]System.String::Concat(string,
+                                                                      string,
+                                                                      string)
+    IL_002b:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0030:  nop
+    IL_0031:  ret
+  } // end of method TestClass::TestHelperMethodRequiresConstraintCurious_TEMPORARY
+
+  .method private hidebysig static void  TestHelperMethodRequiresConstraint<(class UnconstrainedCallToConstrainedMethod.IConstraint`1<!!U>) T,U>(bool expectSuccess) cil managed
+  {
+    .custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 00 00 00 ) 
+    .custom instance void System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute::.ctor() = ( 01 00 00 00 ) 
+    .param type U 
+    .custom instance void System.Runtime.CompilerServices.NullableAttribute::.ctor(uint8) = ( 01 00 02 00 00 ) 
+    // Code size       177 (0xb1)
+    .maxstack  4
+    .locals init (bool V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  stloc.0
+    IL_0003:  ldloc.0
+    IL_0004:  brfalse.s  IL_0055
+
+    IL_0006:  ldc.i4.5
+    IL_0007:  newarr     [System.Runtime]System.String
+    IL_000c:  dup
+    IL_000d:  ldc.i4.0
+    IL_000e:  ldstr      "SUCCESS Called TesHelpertMethodRequiresConstraint<"
+    IL_0013:  stelem.ref
+    IL_0014:  dup
+    IL_0015:  ldc.i4.1
+    IL_0016:  ldtoken    !!T
+    IL_001b:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0020:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_0025:  stelem.ref
+    IL_0026:  dup
+    IL_0027:  ldc.i4.2
+    IL_0028:  ldstr      ", "
+    IL_002d:  stelem.ref
+    IL_002e:  dup
+    IL_002f:  ldc.i4.3
+    IL_0030:  ldtoken    !!U
+    IL_0035:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_003a:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_003f:  stelem.ref
+    IL_0040:  dup
+    IL_0041:  ldc.i4.4
+    IL_0042:  ldstr      ">"
+    IL_0047:  stelem.ref
+    IL_0048:  call       string [System.Runtime]System.String::Concat(string[])
+    IL_004d:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0052:  nop
+    IL_0053:  br.s       IL_00b0
+
+    IL_0055:  nop
+    IL_0056:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_005b:  ldc.i4.1
+    IL_005c:  add
+    IL_005d:  stsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_0062:  ldc.i4.5
+    IL_0063:  newarr     [System.Runtime]System.String
+    IL_0068:  dup
+    IL_0069:  ldc.i4.0
+    IL_006a:  ldstr      "FAILED Called TestHelperMethodRequiresConstraint<"
+    IL_006f:  stelem.ref
+    IL_0070:  dup
+    IL_0071:  ldc.i4.1
+    IL_0072:  ldtoken    !!T
+    IL_0077:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_007c:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_0081:  stelem.ref
+    IL_0082:  dup
+    IL_0083:  ldc.i4.2
+    IL_0084:  ldstr      ", "
+    IL_0089:  stelem.ref
+    IL_008a:  dup
+    IL_008b:  ldc.i4.3
+    IL_008c:  ldtoken    !!U
+    IL_0091:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0096:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_009b:  stelem.ref
+    IL_009c:  dup
+    IL_009d:  ldc.i4.4
+    IL_009e:  ldstr      ">"
+    IL_00a3:  stelem.ref
+    IL_00a4:  call       string [System.Runtime]System.String::Concat(string[])
+    IL_00a9:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_00ae:  nop
+    IL_00af:  nop
+    IL_00b0:  ret
+  } // end of method TestClass::TestHelperMethodRequiresConstraint
+
+  .method private hidebysig static void  TestHelperMethodRequiresConstraintCurious<(class UnconstrainedCallToConstrainedMethod.IConstraintCurious`1<!!T>) T>(bool expectSuccess) cil managed
+  {
+    .custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = ( 01 00 00 00 00 ) 
+    .custom instance void System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       95 (0x5f)
+    .maxstack  3
+    .locals init (bool V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  stloc.0
+    IL_0003:  ldloc.0
+    IL_0004:  brfalse.s  IL_002c
+
+    IL_0006:  ldstr      "SUCCESS Called TestHelperMethodRequiresConstraintC"
+    + "urious<"
+    IL_000b:  ldtoken    !!T
+    IL_0010:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0015:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_001a:  ldstr      ">"
+    IL_001f:  call       string [System.Runtime]System.String::Concat(string,
+                                                                      string,
+                                                                      string)
+    IL_0024:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0029:  nop
+    IL_002a:  br.s       IL_005e
+
+    IL_002c:  nop
+    IL_002d:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_0032:  ldc.i4.1
+    IL_0033:  add
+    IL_0034:  stsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_0039:  ldstr      "FAILED Called TestHelperMethodRequiresConstraintCu"
+    + "rious<"
+    IL_003e:  ldtoken    !!T
+    IL_0043:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0048:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+    IL_004d:  ldstr      ">"
+    IL_0052:  call       string [System.Runtime]System.String::Concat(string,
+                                                                      string,
+                                                                      string)
+    IL_0057:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_005c:  nop
+    IL_005d:  nop
+    IL_005e:  ret
+  } // end of method TestClass::TestHelperMethodRequiresConstraintCurious
+
+  .method private hidebysig static void  ConstraintTest<T,U>(bool expectSuccess) cil managed noinlining
+  {
+    // Code size       198 (0xc6)
+    .maxstack  4
+    .locals init (bool V_0)
+    IL_0000:  nop
+    .try
+    {
+      IL_0001:  nop
+      IL_0002:  ldarg.0
+      IL_0003:  call       void UnconstrainedCallToConstrainedMethod.TestClass::TestHelperMethodRequiresConstraint<!!0,!!1>(bool)
+      IL_0008:  nop
+      IL_0009:  nop
+      IL_000a:  leave      IL_00c5
+
+    }  // end .try
+    catch [System.Runtime]System.InvalidProgramException 
+    {
+      IL_000f:  pop
+      IL_0010:  nop
+      IL_0011:  ldarg.0
+      IL_0012:  stloc.0
+      IL_0013:  ldloc.0
+      IL_0014:  brfalse.s  IL_0073
+
+      IL_0016:  nop
+      IL_0017:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+      IL_001c:  ldc.i4.1
+      IL_001d:  add
+      IL_001e:  stsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+      IL_0023:  ldc.i4.5
+      IL_0024:  newarr     [System.Runtime]System.String
+      IL_0029:  dup
+      IL_002a:  ldc.i4.0
+      IL_002b:  ldstr      "FAILED Threw Exception ConstraintTest<"
+      IL_0030:  stelem.ref
+      IL_0031:  dup
+      IL_0032:  ldc.i4.1
+      IL_0033:  ldtoken    !!T
+      IL_0038:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+      IL_003d:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+      IL_0042:  stelem.ref
+      IL_0043:  dup
+      IL_0044:  ldc.i4.2
+      IL_0045:  ldstr      ", "
+      IL_004a:  stelem.ref
+      IL_004b:  dup
+      IL_004c:  ldc.i4.3
+      IL_004d:  ldtoken    !!U
+      IL_0052:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+      IL_0057:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+      IL_005c:  stelem.ref
+      IL_005d:  dup
+      IL_005e:  ldc.i4.4
+      IL_005f:  ldstr      ">"
+      IL_0064:  stelem.ref
+      IL_0065:  call       string [System.Runtime]System.String::Concat(string[])
+      IL_006a:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_006f:  nop
+      IL_0070:  nop
+      IL_0071:  br.s       IL_00c2
+
+      IL_0073:  nop
+      IL_0074:  ldc.i4.5
+      IL_0075:  newarr     [System.Runtime]System.String
+      IL_007a:  dup
+      IL_007b:  ldc.i4.0
+      IL_007c:  ldstr      "SUCCESS Threw Exception ConstraintTest<"
+      IL_0081:  stelem.ref
+      IL_0082:  dup
+      IL_0083:  ldc.i4.1
+      IL_0084:  ldtoken    !!T
+      IL_0089:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+      IL_008e:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+      IL_0093:  stelem.ref
+      IL_0094:  dup
+      IL_0095:  ldc.i4.2
+      IL_0096:  ldstr      ", "
+      IL_009b:  stelem.ref
+      IL_009c:  dup
+      IL_009d:  ldc.i4.3
+      IL_009e:  ldtoken    !!U
+      IL_00a3:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+      IL_00a8:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+      IL_00ad:  stelem.ref
+      IL_00ae:  dup
+      IL_00af:  ldc.i4.4
+      IL_00b0:  ldstr      ">"
+      IL_00b5:  stelem.ref
+      IL_00b6:  call       string [System.Runtime]System.String::Concat(string[])
+      IL_00bb:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_00c0:  nop
+      IL_00c1:  nop
+      IL_00c2:  nop
+      IL_00c3:  leave.s    IL_00c5
+
+    }  // end handler
+    IL_00c5:  ret
+  } // end of method TestClass::ConstraintTest
+
+  .method private hidebysig static void  ConstraintCuriousTest<T>(bool expectSuccess) cil managed noinlining
+  {
+    // Code size       113 (0x71)
+    .maxstack  3
+    .locals init (bool V_0)
+    IL_0000:  nop
+    .try
+    {
+      IL_0001:  nop
+      IL_0002:  ldarg.0
+      IL_0003:  call       void UnconstrainedCallToConstrainedMethod.TestClass::TestHelperMethodRequiresConstraintCurious<!!0>(bool)
+      IL_0008:  nop
+      IL_0009:  nop
+      IL_000a:  leave.s    IL_0070
+
+    }  // end .try
+    catch [System.Runtime]System.InvalidProgramException 
+    {
+      IL_000c:  pop
+      IL_000d:  nop
+      IL_000e:  ldarg.0
+      IL_000f:  stloc.0
+      IL_0010:  ldloc.0
+      IL_0011:  brfalse.s  IL_0047
+
+      IL_0013:  nop
+      IL_0014:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+      IL_0019:  ldc.i4.1
+      IL_001a:  add
+      IL_001b:  stsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+      IL_0020:  ldstr      "FAILED Threw Exception ConstraintCuriousTest<"
+      IL_0025:  ldtoken    !!T
+      IL_002a:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+      IL_002f:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+      IL_0034:  ldstr      ">"
+      IL_0039:  call       string [System.Runtime]System.String::Concat(string,
+                                                                        string,
+                                                                        string)
+      IL_003e:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_0043:  nop
+      IL_0044:  nop
+      IL_0045:  br.s       IL_006d
+
+      IL_0047:  nop
+      IL_0048:  ldstr      "SUCCESS Threw Exception ConstraintCuriousTest<"
+      IL_004d:  ldtoken    !!T
+      IL_0052:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+      IL_0057:  callvirt   instance string [System.Runtime]System.Type::get_FullName()
+      IL_005c:  ldstr      ">"
+      IL_0061:  call       string [System.Runtime]System.String::Concat(string,
+                                                                        string,
+                                                                        string)
+      IL_0066:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_006b:  nop
+      IL_006c:  nop
+      IL_006d:  nop
+      IL_006e:  leave.s    IL_0070
+
+    }  // end handler
+    IL_0070:  ret
+  } // end of method TestClass::ConstraintCuriousTest
+
+  .method private hidebysig static int32 
+          Main() cil managed
+  {
+    .entrypoint
+    // Code size       114 (0x72)
+    .maxstack  2
+    .locals init (bool V_0,
+             int32 V_1)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.1
+    IL_0002:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintTest<class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraint,object>(bool)
+    IL_0007:  nop
+    IL_0008:  ldc.i4.0
+    IL_0009:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintTest<class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraint,int32>(bool)
+    IL_000e:  nop
+    IL_000f:  ldc.i4.1
+    IL_0010:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintTest<valuetype UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraint,int32>(bool)
+    IL_0015:  nop
+    IL_0016:  ldc.i4.1
+    IL_0017:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintTest<valuetype UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraint,object>(bool)
+    IL_001c:  nop
+    IL_001d:  ldc.i4.0
+    IL_001e:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintTest<valuetype UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraint,int16>(bool)
+    IL_0023:  nop
+    IL_0024:  ldc.i4.0
+    IL_0025:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintCuriousTest<class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraint>(bool)
+    IL_002a:  nop
+    IL_002b:  ldc.i4.1
+    IL_002c:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintCuriousTest<class UnconstrainedCallToConstrainedMethod.ClassThatImplementsConstraintCurious>(bool)
+    IL_0031:  nop
+    IL_0032:  ldc.i4.0
+    IL_0033:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintCuriousTest<valuetype UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraint>(bool)
+    IL_0038:  nop
+    IL_0039:  ldc.i4.1
+    IL_003a:  call       void UnconstrainedCallToConstrainedMethod.TestClass::ConstraintCuriousTest<valuetype UnconstrainedCallToConstrainedMethod.StructThatImplementsConstraintCurious>(bool)
+    IL_003f:  nop
+    IL_0040:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_0045:  ldc.i4.0
+    IL_0046:  cgt.un
+    IL_0048:  stloc.0
+    IL_0049:  ldloc.0
+    IL_004a:  brfalse.s  IL_006b
+
+    IL_004c:  nop
+    IL_004d:  ldstr      "{0} Failures"
+    IL_0052:  ldsfld     int32 UnconstrainedCallToConstrainedMethod.TestClass::s_failures
+    IL_0057:  box        [System.Runtime]System.Int32
+    IL_005c:  call       string [System.Runtime]System.String::Format(string,
+                                                                      object)
+    IL_0061:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0066:  nop
+    IL_0067:  ldc.i4.1
+    IL_0068:  stloc.1
+    IL_0069:  br.s       IL_0070
+
+    IL_006b:  ldc.i4.s   100
+    IL_006d:  stloc.1
+    IL_006e:  br.s       IL_0070
+
+    IL_0070:  ldloc.1
+    IL_0071:  ret
+  } // end of method TestClass::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method TestClass::.ctor
+
+} // end of class UnconstrainedCallToConstrainedMethod.TestClass
+
+.class private auto ansi beforefieldinit System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute
+       extends [System.Runtime]System.Attribute
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Attribute::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute::.ctor
+
+} // end of class System.Runtime.CompilerServices.ConvertUnconstrainedCallsToThrowInvalidProgramExceptionAttribute
+
+// *********** DISASSEMBLY COMPLETE ***********************
+// WARNING: Created Win32 resource file UnconstrainedCallToConstrainedMethod.res

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.ilproj
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethod.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethodCSharp.cs
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethodCSharp.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using System.Security;
 using System.Runtime.CompilerServices;
 
 namespace UnconstrainedCallToConstrainedMethod
@@ -65,7 +66,7 @@ namespace UnconstrainedCallToConstrainedMethod
             {
                 TestHelperMethodRequiresConstraint<T, U>(expectSuccess);
             }
-            catch (InvalidProgramException)
+            catch (VerificationException)
             {
                 if (expectSuccess)
                 {
@@ -86,7 +87,7 @@ namespace UnconstrainedCallToConstrainedMethod
             {
                 TestHelperMethodRequiresConstraintCurious<T>(expectSuccess);
             }
-            catch (InvalidProgramException)
+            catch (VerificationException)
             {
                 if (expectSuccess)
                 {

--- a/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethodCSharp.csproj
+++ b/src/tests/JIT/Generics/Constraints/UnconstrainedCallToConstrainedMethodCSharp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics.IsAssignableToGeneric.cs
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics.IsAssignableToGeneric.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+public partial class Program
+{
+    public static void TestIsAssignableToGeneric()
+    {
+        // Primitive types
+        IsTrue (Type.IsAssignableTo<byte, byte>());
+        IsTrue (Type.IsAssignableTo<int, int>());
+        IsTrue (Type.IsAssignableTo<float, float>());
+        IsFalse (Type.IsAssignableTo<float, double>());
+        IsTrue (Type.IsAssignableTo<double, double>());
+
+        // Covariance/Contravariance 
+        IsTrue (Type.IsAssignableTo<List<string>, IEnumerable<object>>());
+
+        // System.__Canon
+        IsTrue (IsAssignableToGeneric<KeyValuePair<IDisposable, IDisposable>, KeyValuePair<IDisposable, IDisposable>>());
+        IsTrue (IsAssignableToGeneric<KeyValuePair<IDisposable, object>, KeyValuePair<IDisposable, object>>());
+        IsTrue (IsAssignableToGeneric<IDictionary<IDisposable, IDisposable>, IDictionary<IDisposable, IDisposable>>());
+        IsTrue (IsAssignableToGeneric<IDictionary<IDisposable, object>, IDictionary<IDisposable, object>>());
+        IsTrue (IsAssignableToGeneric<Dictionary<IDisposable, IDisposable>, Dictionary<IDisposable, IDisposable>>());
+        IsTrue (IsAssignableToGeneric<Dictionary<IDisposable, object>, Dictionary<IDisposable, object>>());
+        IsTrue (IsAssignableToGeneric<KeyValuePair<int, int>, KeyValuePair<int, int>>());
+        IsTrue (IsAssignableToGeneric<KeyValuePair<IEnumerable<int>, IEnumerable<int>>, KeyValuePair<IEnumerable<int>, IEnumerable<int>>>());
+        IsFalse(IsAssignableToGeneric<KeyValuePair<IDisposable, object>, KeyValuePair<IDisposable, IDisposable>>());
+        IsFalse(IsAssignableToGeneric<KeyValuePair<IDisposable, object>, KeyValuePair<IDisposable, int>>());
+        IsFalse(IsAssignableToGeneric<IDictionary<IDisposable, object>, IDictionary<IDisposable, IDisposable>>());
+        IsFalse(IsAssignableToGeneric<IDictionary<IDisposable, object>, IDictionary<IDisposable, int>>());
+        IsFalse(IsAssignableToGeneric<Dictionary<IDisposable, object>, Dictionary<IDisposable, IDisposable>>());
+        IsFalse(IsAssignableToGeneric<Dictionary<IDisposable, object>, Dictionary<IDisposable, int>>());
+        IsFalse(IsAssignableToGeneric<KeyValuePair<int, object>, KeyValuePair<int, int>>());
+        IsFalse(IsAssignableToGeneric<KeyValuePair<IEnumerable<int>, IEnumerable<uint>>, KeyValuePair<IEnumerable<int>, IEnumerable<int>>>());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool IsAssignableToGeneric<TFrom, TTo>() => Type.IsAssignableTo<TFrom, TTo>();
+}

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics.cs
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics.cs
@@ -98,6 +98,8 @@ public partial class Program
         ThrowsNRE(() => { IsValueTypeRef(ref _varStringNull); });
 
         TestIsAssignableFrom();
+        TestIsAssignableTo();
+        TestIsAssignableToGeneric();
 
         return 100 + _errors;
     }

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics_r.csproj
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics_r.csproj
@@ -8,5 +8,6 @@
     <Compile Include="TypeIntrinsics.cs" />
     <Compile Include="TypeIntrinsics.IsAssignableFrom.cs" />
     <Compile Include="TypeIntrinsics.IsAssignableTo.cs" />
+    <Compile Include="TypeIntrinsics.IsAssignableToGeneric.cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics_ro.csproj
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics_ro.csproj
@@ -8,5 +8,6 @@
     <Compile Include="TypeIntrinsics.cs" />
     <Compile Include="TypeIntrinsics.IsAssignableFrom.cs" />
     <Compile Include="TypeIntrinsics.IsAssignableTo.cs" />
+    <Compile Include="TypeIntrinsics.IsAssignableToGeneric.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add a new Type.IsAssignableTo<Tfrom, TTo> intrinsic and implement a ConvertUnconstrainedCallsToThrowVerificationExceptionAttribute which allows a method call to a static generic method to either succeed (if the method type parameters succeed the constraint check) or fail (with a VerificationException) if the constraints are not satisfied. This is the runtime portion of an MVP for implementing the constraint specialization work that I proposed