### PR TITLE
[release/5.0] Make upgrade install new host first, then uninstall old

### DIFF
--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -15,6 +15,7 @@
       <WixProductMoniker>$(SharedHostBrandName)</WixProductMoniker>
       <RegKeyProductName>sharedhost</RegKeyProductName>
       <WixDependencyKeyName>Dotnet_CLI_SharedHost</WixDependencyKeyName>
+      <MajorUpgradeSchedule>afterInstallExecute</MajorUpgradeSchedule>
       <VSInsertionShortComponentName>SharedHost</VSInsertionShortComponentName>
 
       <PublishRootDir>$(IntermediateOutputPath)publishRoot/</PublishRootDir>


### PR DESCRIPTION
Backport of #60307 to release/5.0
Requires https://github.com/dotnet/arcade/pull/8029

## Customer Impact

Customers installing upgrades of .NET 5.0 observe the entry for dotnet will move to the end of the PATH variable, often resulting in x86 dotnet being first and winning.

## Testing

Manual build of host and upgrade testing.  I've tested upgrade scenarios where 5.0 x86 + x64 is installed.  Upgrade to 6.0 x64 without the fix will move x64 PATH to end.  Once fix is in place we don't move PATH entry.

## Risk

Low.  This doesn't change installer behavior like some of the other options we considered.  The change is scoped to only the host MSI