### PR TITLE
Fix build with clang 13

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -367,6 +367,8 @@ if (CLR_CMAKE_HOST_UNIX)
   #These seem to indicate real issues
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
 
+  add_compile_options(-Wno-unused-but-set-variable)
+
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wno-unknown-warning-option)
 
@@ -376,8 +378,6 @@ if (CLR_CMAKE_HOST_UNIX)
 
     # Disabled warnings
     add_compile_options(-Wno-unused-private-field)
-    # Explicit constructor calls are not supported by clang (this->ClassName::ClassName())
-    add_compile_options(-Wno-microsoft)
     # There are constants of type BOOL used in a condition. But BOOL is defined as int
     # and so the compiler thinks that there is a mistake.
     add_compile_options(-Wno-constant-logical-operand)
@@ -393,9 +393,7 @@ if (CLR_CMAKE_HOST_UNIX)
 
     add_compile_options(-Wno-reserved-identifier)
     add_compile_options(-Wno-cast-function-type)
-    add_compile_options(-Wno-unused-but-set-variable)
   else()
-    add_compile_options(-Wno-unused-but-set-variable)
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)
     add_compile_options(-Wno-array-bounds)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -390,6 +390,10 @@ if (CLR_CMAKE_HOST_UNIX)
     # to a struct or a class that has virtual members or a base class. In that case, clang
     # may not generate the same object layout as MSVC.
     add_compile_options(-Wno-incompatible-ms-struct)
+
+    add_compile_options(-Wno-reserved-identifier)
+    add_compile_options(-Wno-cast-function-type)
+    add_compile_options(-Wno-unused-but-set-variable)
   else()
     add_compile_options(-Wno-unused-but-set-variable)
     add_compile_options(-Wno-uninitialized)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -392,7 +392,6 @@ if (CLR_CMAKE_HOST_UNIX)
     add_compile_options(-Wno-incompatible-ms-struct)
 
     add_compile_options(-Wno-reserved-identifier)
-    add_compile_options(-Wno-cast-function-type)
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10912,7 +10912,7 @@ GenTree* Compiler::fgMorphCastedBitwiseOp(GenTreeOp* tree)
         //     tree             op1
         //     /   \             |
         //   op1   op2   ==>   tree
-        //    |     |          /   \
+        //    |     |          /   \.
         //    x     y         x     y
         //
         // (op2 becomes garbage)


### PR DESCRIPTION
Tested with:
```sh
$ clang --version | head -1
Ubuntu clang version 13.0.0-++20211006103153+fd1d8c2f04dd-1~exp1~20211006223759.3
```

Fixes #60326.