### PR TITLE
Fix CRC32 encoding

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -10292,7 +10292,7 @@ GOT_DSP:
                     noway_assert((int)dsp == dsp);
 
                     // This requires, specifying a SIB byte after ModRM byte.
-                    if (EncodedBySSE38orSSE3A(ins))
+                    if (EncodedBySSE38orSSE3A(ins) || (ins == INS_crc32))
                     {
                         dst += emitOutputByte(dst, code | 0x04);
                     }


### PR DESCRIPTION
On x64, when the crc32 instruction 2nd operand is a memory address
(such as for a static field), and that address is containable
(which normally doesn't happen, because the address will be above
the 4GB lower address space), then the instruction was being
improperly encoded.

Fixes #59714