### PR TITLE
Fix a few Clang 13 warnings

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -390,6 +390,8 @@ if (CLR_CMAKE_HOST_UNIX)
     # to a struct or a class that has virtual members or a base class. In that case, clang
     # may not generate the same object layout as MSVC.
     add_compile_options(-Wno-incompatible-ms-struct)
+
+    add_compile_options(-Wno-reserved-identifier)
   else()
     add_compile_options(-Wno-unused-but-set-variable)
     add_compile_options(-Wno-uninitialized)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -815,6 +815,7 @@ static int32_t GetSearchIteratorUsingCollator(
     if (!U_SUCCESS(err))
     {
         int32_t r;
+        (void)r; // used only in assert
         r = RestoreSearchHandle(pSortHandle, *pSearchIterator, options);
         assert(r && "restoring search handle shouldn't fail.");
         return -1;
@@ -824,6 +825,7 @@ static int32_t GetSearchIteratorUsingCollator(
     if (!U_SUCCESS(err))
     {
         int32_t r;
+        (void)r; // used only in assert
         r = RestoreSearchHandle(pSortHandle, *pSearchIterator, options);
         assert(r && "restoring search handle shouldn't fail.");
         return -1;

--- a/src/libraries/Native/Unix/System.Native/pal_signal.c
+++ b/src/libraries/Native/Unix/System.Native/pal_signal.c
@@ -627,6 +627,7 @@ void SystemNative_DisablePosixSignalHandling(int signalCode)
 void InstallTTOUHandlerForConsole(ConsoleSigTtouHandler handler)
 {
     bool installed;
+    (void)installed; // used only for assert
 
     pthread_mutex_lock(&lock);
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1289,6 +1289,7 @@ static void HandleShutdown()
     // ensures that there are no callers already inside the string table
     // when the unload (possibly) executes.
     int result = pthread_mutex_lock(&g_err_mutex);
+    (void)result; // used only in assert
     assert(!result && "Acquiring the error string table mutex failed.");
 
     g_err_unloaded = 1;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.c
@@ -37,6 +37,7 @@ const char* CryptoNative_ErrReasonErrorString(uint64_t error)
 
 #if defined NEED_OPENSSL_1_1 || defined NEED_OPENSSL_3_0
     int result = pthread_mutex_lock(&g_err_mutex);
+    (void)result; // used only in assert
     assert(!result && "Acquiring the error string table mutex failed.");
 
     if (!g_err_unloaded)
@@ -57,6 +58,7 @@ void CryptoNative_ErrErrorStringN(uint64_t e, char* buf, int32_t len)
 {
 #if defined NEED_OPENSSL_1_1 || defined NEED_OPENSSL_3_0
     int result = pthread_mutex_lock(&g_err_mutex);
+    (void)result; // used only in assert
     assert(!result && "Acquiring the error string table mutex failed.");
 
     if (!g_err_unloaded)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -75,6 +75,7 @@ static void DetectCiphersuiteConfiguration()
     SSL_free(ssl);
 
     int rv = SSL_CTX_set_cipher_list(ctx, "ALL");
+    (void)rv; // used only in assert
     assert(rv);
 
     ssl = SSL_new(ctx);


### PR DESCRIPTION
Fix `-Wunused-but-set-variable` and `-Wcast-function-type` warnings

Contributes to #60326 