### PR TITLE
Fix System.Numerics.Vectors tests on iOS and other FullAOT targets

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -42,6 +42,12 @@
     <AdditionalXHarnessArguments Condition="'$(XUnitClassName)' != ''">$(AdditionalXHarnessArguments) --arg=-c=$(XUnitClassName)</AdditionalXHarnessArguments>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetOS)' == 'MacCatalyst' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator'">
+    <!-- Pass the -m or -c flag along to the app bundle, note that due to the double hyphen this needs to be the last argument -->
+    <AdditionalXHarnessArguments Condition="'$(XUnitMethodName)' != ''">$(AdditionalXHarnessArguments) -- -m=$(XUnitMethodName)</AdditionalXHarnessArguments>
+    <AdditionalXHarnessArguments Condition="'$(XUnitClassName)' != ''">$(AdditionalXHarnessArguments) -- -c=$(XUnitClassName)</AdditionalXHarnessArguments>
+  </PropertyGroup>
+
   <UsingTask Condition="'$(RunAOTCompilation)' == 'true'" TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" />
   <Import Condition="'$(RunAOTCompilation)' == 'true'" Project="$(MonoAOTCompilerDir)MonoAOTCompiler.props" />
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -48,6 +48,8 @@ namespace System
         public static bool IsNotArm64Process => !IsArm64Process;
         public static bool IsArmOrArm64Process => IsArmProcess || IsArm64Process;
         public static bool IsNotArmNorArm64Process => !IsArmOrArm64Process;
+        public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
+        public static bool IsNotX86Process => !IsX86Process;
         public static bool IsArgIteratorSupported => IsMonoRuntime || (IsWindows && IsNotArmProcess);
         public static bool IsArgIteratorNotSupported => !IsArgIteratorSupported;
         public static bool Is32BitProcess => IntPtr.Size == 4;

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -958,8 +958,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void AdditionInt64() { TestAddition<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void AdditionSingle() { TestAddition<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void AdditionDouble() { TestAddition<double>(); }
         private void TestAddition<T>() where T : struct
         {
@@ -1023,8 +1025,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void SubtractionInt64() { TestSubtraction<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void SubtractionSingle() { TestSubtraction<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void SubtractionDouble() { TestSubtraction<double>(); }
         private void TestSubtraction<T>() where T : struct
         {
@@ -1088,8 +1092,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void MultiplicationInt64() { TestMultiplication<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MultiplicationSingle() { TestMultiplication<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MultiplicationDouble() { TestMultiplication<double>(); }
         private void TestMultiplication<T>() where T : struct
         {
@@ -1122,8 +1128,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void MultiplicationWithScalarInt64() { TestMultiplicationWithScalar<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MultiplicationWithScalarSingle() { TestMultiplicationWithScalar<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MultiplicationWithScalarDouble() { TestMultiplicationWithScalar<double>(); }
         private void TestMultiplicationWithScalar<T>() where T : struct
         {
@@ -1164,8 +1172,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void DivisionInt64() { TestDivision<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void DivisionSingle() { TestDivision<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void DivisionDouble() { TestDivision<double>(); }
         private void TestDivision<T>() where T : struct
         {
@@ -1224,8 +1234,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void UnaryMinusInt64() { TestUnaryMinus<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void UnaryMinusSingle() { TestUnaryMinus<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void UnaryMinusDouble() { TestUnaryMinus<double>(); }
         private void TestUnaryMinus<T>() where T : struct
         {
@@ -1424,8 +1436,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void VectorGreaterThanInt64() { TestVectorGreaterThan<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void VectorGreaterThanSingle() { TestVectorGreaterThan<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void VectorGreaterThanDouble() { TestVectorGreaterThan<double>(); }
         private void TestVectorGreaterThan<T>() where T : struct
         {
@@ -1461,8 +1475,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void GreaterThanOrEqualInt64() { TestVectorGreaterThanOrEqual<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void GreaterThanOrEqualSingle() { TestVectorGreaterThanOrEqual<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void GreaterThanOrEqualDouble() { TestVectorGreaterThanOrEqual<double>(); }
         private void TestVectorGreaterThanOrEqual<T>() where T : struct
         {
@@ -1714,8 +1730,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void LessThanInt64() { TestVectorLessThan<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void LessThanSingle() { TestVectorLessThan<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void LessThanDouble() { TestVectorLessThan<double>(); }
         private void TestVectorLessThan<T>() where T : struct
         {
@@ -1751,8 +1769,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void LessThanOrEqualInt64() { TestVectorLessThanOrEqual<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void LessThanOrEqualSingle() { TestVectorLessThanOrEqual<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void LessThanOrEqualDouble() { TestVectorLessThanOrEqual<double>(); }
         private void TestVectorLessThanOrEqual<T>() where T : struct
         {
@@ -1788,8 +1808,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void LessThanAnyInt64() { TestVectorLessThanAny<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void LessThanAnySingle() { TestVectorLessThanAny<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void LessThanAnyDouble() { TestVectorLessThanAny<double>(); }
         private void TestVectorLessThanAny<T>() where T : struct
         {
@@ -2114,8 +2136,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void ConditionalSelectInt64() { TestConditionalSelect<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void ConditionalSelectSingle() { TestConditionalSelect<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void ConditionalSelectDouble() { TestConditionalSelect<double>(); }
         private void TestConditionalSelect<T>() where T : struct
         {
@@ -2166,8 +2190,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void DotProductInt64() { TestDotProduct<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void DotProductSingle() { TestDotProduct<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void DotProductDouble() { TestDotProduct<double>(); }
         private void TestDotProduct<T>() where T : struct
         {
@@ -2202,8 +2228,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void MaxInt64() { TestMax<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MaxSingle() { TestMax<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MaxDouble() { TestMax<double>(); }
         private void TestMax<T>() where T : struct
         {
@@ -2238,8 +2266,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void MinInt64() { TestMin<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MinSingle() { TestMin<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MinDouble() { TestMin<double>(); }
         private void TestMin<T>() where T : struct
         {
@@ -2274,8 +2304,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void SquareRootInt64() { TestSquareRoot<long>(-1); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void SquareRootSingle() { TestSquareRoot<float>(6); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void SquareRootDouble() { TestSquareRoot<double>(15); }
         private void TestSquareRoot<T>(int precision = -1) where T : struct, IEquatable<T>
         {
@@ -2368,8 +2400,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void AbsInt64() { TestAbs<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void AbsSingle() { TestAbs<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void AbsDouble() { TestAbs<double>(); }
         private void TestAbs<T>() where T : struct
         {
@@ -2406,8 +2440,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void MultiplicationReflectionInt64() { TestMultiplicationReflection<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MultiplicationReflectionSingle() { TestMultiplicationReflection<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void MultiplicationReflectionDouble() { TestMultiplicationReflection<double>(); }
         private void TestMultiplicationReflection<T>() where T : struct
         {
@@ -2443,8 +2479,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void AdditionReflectionInt64() { TestAdditionReflection<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void AdditionReflectionSingle() { TestAdditionReflection<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void AdditionReflectionDouble() { TestAdditionReflection<double>(); }
         private void TestAdditionReflection<T>() where T : struct
         {
@@ -2480,8 +2518,10 @@ namespace System.Numerics.Tests
         [Fact]
         public void DivisionReflectionInt64() { TestDivisionReflection<long>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void DivisionReflectionSingle() { TestDivisionReflection<float>(); }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60347", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsX86Process))]
         public void DivisionReflectionDouble() { TestDivisionReflection<double>(); }
         private void TestDivisionReflection<T>() where T : struct
         {

--- a/src/libraries/System.Numerics.Vectors/tests/Util.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Util.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
-
 namespace System.Numerics.Tests
 {
     public static class Util
@@ -93,57 +91,150 @@ namespace System.Numerics.Tests
 
         public static T Abs<T>(T value) where T : struct
         {
-            Type[] unsignedTypes = new[] { typeof(byte), typeof(ushort), typeof(uint), typeof(ulong) };
-            if (unsignedTypes.Contains(typeof(T)))
-            {
-                return value;
-            }
-
-            dynamic dyn = (dynamic)value;
-            var abs = Math.Abs(dyn);
-            T ret = (T)abs;
-            return ret;
+            // unsigned types
+            if      (value is byte)   return value;
+            else if (value is ushort) return value;
+            else if (value is uint)   return value;
+            else if (value is ulong)  return value;
+            // signed types
+            else if (value is short)  return (T)(ValueType)(short)  ( Math.Abs((short) (ValueType)value) );
+            else if (value is int)    return (T)(ValueType)(int)    ( Math.Abs((int)   (ValueType)value) );
+            else if (value is long)   return (T)(ValueType)(long)   ( Math.Abs((long)  (ValueType)value) );
+            else if (value is sbyte)  return (T)(ValueType)(sbyte)  ( Math.Abs((sbyte) (ValueType)value) );
+            else if (value is float)  return (T)(ValueType)(float)  ( Math.Abs((float) (ValueType)value) );
+            else if (value is double) return (T)(ValueType)(double) ( Math.Abs((double)(ValueType)value) );
+            else throw new NotImplementedException();
         }
 
         public static T Sqrt<T>(T value) where T : struct
         {
-            return unchecked((T)(dynamic)(Math.Sqrt((dynamic)value)));
+            unchecked
+            {
+                if      (value is short)  return (T)(ValueType)(short)  ( Math.Sqrt((short) (ValueType)value) );
+                else if (value is int)    return (T)(ValueType)(int)    ( Math.Sqrt((int)   (ValueType)value) );
+                else if (value is long)   return (T)(ValueType)(long)   ( Math.Sqrt((long)  (ValueType)value) );
+                else if (value is ushort) return (T)(ValueType)(ushort) ( Math.Sqrt((ushort)(ValueType)value) );
+                else if (value is uint)   return (T)(ValueType)(uint)   ( Math.Sqrt((uint)  (ValueType)value) );
+                else if (value is ulong)  return (T)(ValueType)(ulong)  ( Math.Sqrt((ulong) (ValueType)value) );
+                else if (value is byte)   return (T)(ValueType)(byte)   ( Math.Sqrt((byte)  (ValueType)value) );
+                else if (value is sbyte)  return (T)(ValueType)(sbyte)  ( Math.Sqrt((sbyte) (ValueType)value) );
+                else if (value is float)  return (T)(ValueType)(float)  ( Math.Sqrt((float) (ValueType)value) );
+                else if (value is double) return (T)(ValueType)(double) ( Math.Sqrt((double)(ValueType)value) );
+                else throw new NotImplementedException();
+            }
         }
 
         public static T Multiply<T>(T left, T right) where T : struct
         {
-            return unchecked((T)((dynamic)left * right));
+            unchecked
+            {
+                if      (left is short)  return (T)(ValueType)(short)  ( (short) (ValueType)left * (short) (ValueType)right );
+                else if (left is int)    return (T)(ValueType)(int)    ( (int)   (ValueType)left * (int)   (ValueType)right );
+                else if (left is long)   return (T)(ValueType)(long)   ( (long)  (ValueType)left * (long)  (ValueType)right );
+                else if (left is ushort) return (T)(ValueType)(ushort) ( (ushort)(ValueType)left * (ushort)(ValueType)right );
+                else if (left is uint)   return (T)(ValueType)(uint)   ( (uint)  (ValueType)left * (uint)  (ValueType)right );
+                else if (left is ulong)  return (T)(ValueType)(ulong)  ( (ulong) (ValueType)left * (ulong) (ValueType)right );
+                else if (left is byte)   return (T)(ValueType)(byte)   ( (byte)  (ValueType)left * (byte)  (ValueType)right );
+                else if (left is sbyte)  return (T)(ValueType)(sbyte)  ( (sbyte) (ValueType)left * (sbyte) (ValueType)right );
+                else if (left is float)  return (T)(ValueType)(float)  ( (float) (ValueType)left * (float) (ValueType)right );
+                else if (left is double) return (T)(ValueType)(double) ( (double)(ValueType)left * (double)(ValueType)right );
+                else throw new NotImplementedException();
+            }
         }
 
         public static T Divide<T>(T left, T right) where T : struct
         {
-            return (T)((dynamic)left / right);
+            if      (left is short)  return (T)(ValueType)(short)  ( (short) (ValueType)left / (short) (ValueType)right );
+            else if (left is int)    return (T)(ValueType)(int)    ( (int)   (ValueType)left / (int)   (ValueType)right );
+            else if (left is long)   return (T)(ValueType)(long)   ( (long)  (ValueType)left / (long)  (ValueType)right );
+            else if (left is ushort) return (T)(ValueType)(ushort) ( (ushort)(ValueType)left / (ushort)(ValueType)right );
+            else if (left is uint)   return (T)(ValueType)(uint)   ( (uint)  (ValueType)left / (uint)  (ValueType)right );
+            else if (left is ulong)  return (T)(ValueType)(ulong)  ( (ulong) (ValueType)left / (ulong) (ValueType)right );
+            else if (left is byte)   return (T)(ValueType)(byte)   ( (byte)  (ValueType)left / (byte)  (ValueType)right );
+            else if (left is sbyte)  return (T)(ValueType)(sbyte)  ( (sbyte) (ValueType)left / (sbyte) (ValueType)right );
+            else if (left is float)  return (T)(ValueType)(float)  ( (float) (ValueType)left / (float) (ValueType)right );
+            else if (left is double) return (T)(ValueType)(double) ( (double)(ValueType)left / (double)(ValueType)right );
+            else throw new NotImplementedException();
         }
 
         public static T Add<T>(T left, T right) where T : struct
         {
-            return unchecked((T)((dynamic)left + right));
+            unchecked
+            {
+                if      (left is short)  return (T)(ValueType)(short)  ( (short) (ValueType)left + (short) (ValueType)right );
+                else if (left is int)    return (T)(ValueType)(int)    ( (int)   (ValueType)left + (int)   (ValueType)right );
+                else if (left is long)   return (T)(ValueType)(long)   ( (long)  (ValueType)left + (long)  (ValueType)right );
+                else if (left is ushort) return (T)(ValueType)(ushort) ( (ushort)(ValueType)left + (ushort)(ValueType)right );
+                else if (left is uint)   return (T)(ValueType)(uint)   ( (uint)  (ValueType)left + (uint)  (ValueType)right );
+                else if (left is ulong)  return (T)(ValueType)(ulong)  ( (ulong) (ValueType)left + (ulong) (ValueType)right );
+                else if (left is byte)   return (T)(ValueType)(byte)   ( (byte)  (ValueType)left + (byte)  (ValueType)right );
+                else if (left is sbyte)  return (T)(ValueType)(sbyte)  ( (sbyte) (ValueType)left + (sbyte) (ValueType)right );
+                else if (left is float)  return (T)(ValueType)(float)  ( (float) (ValueType)left + (float) (ValueType)right );
+                else if (left is double) return (T)(ValueType)(double) ( (double)(ValueType)left + (double)(ValueType)right );
+                else throw new NotImplementedException();
+            }
         }
 
         public static T Subtract<T>(T left, T right) where T : struct
         {
-            return unchecked((T)((dynamic)left - right));
+            unchecked
+            {
+                if      (left is short)  return (T)(ValueType)(short)  ( (short) (ValueType)left - (short) (ValueType)right );
+                else if (left is int)    return (T)(ValueType)(int)    ( (int)   (ValueType)left - (int)   (ValueType)right );
+                else if (left is long)   return (T)(ValueType)(long)   ( (long)  (ValueType)left - (long)  (ValueType)right );
+                else if (left is ushort) return (T)(ValueType)(ushort) ( (ushort)(ValueType)left - (ushort)(ValueType)right );
+                else if (left is uint)   return (T)(ValueType)(uint)   ( (uint)  (ValueType)left - (uint)  (ValueType)right );
+                else if (left is ulong)  return (T)(ValueType)(ulong)  ( (ulong) (ValueType)left - (ulong) (ValueType)right );
+                else if (left is byte)   return (T)(ValueType)(byte)   ( (byte)  (ValueType)left - (byte)  (ValueType)right );
+                else if (left is sbyte)  return (T)(ValueType)(sbyte)  ( (sbyte) (ValueType)left - (sbyte) (ValueType)right );
+                else if (left is float)  return (T)(ValueType)(float)  ( (float) (ValueType)left - (float) (ValueType)right );
+                else if (left is double) return (T)(ValueType)(double) ( (double)(ValueType)left - (double)(ValueType)right );
+                else throw new NotImplementedException();
+            }
         }
 
         public static T Xor<T>(T left, T right) where T : struct
         {
-            return (T)((dynamic)left ^ right);
+            if      (left is short)  return (T)(ValueType)(short)  ( (short) (ValueType)left ^ (short) (ValueType)right );
+            else if (left is int)    return (T)(ValueType)(int)    ( (int)   (ValueType)left ^ (int)   (ValueType)right );
+            else if (left is long)   return (T)(ValueType)(long)   ( (long)  (ValueType)left ^ (long)  (ValueType)right );
+            else if (left is ushort) return (T)(ValueType)(ushort) ( (ushort)(ValueType)left ^ (ushort)(ValueType)right );
+            else if (left is uint)   return (T)(ValueType)(uint)   ( (uint)  (ValueType)left ^ (uint)  (ValueType)right );
+            else if (left is ulong)  return (T)(ValueType)(ulong)  ( (ulong) (ValueType)left ^ (ulong) (ValueType)right );
+            else if (left is byte)   return (T)(ValueType)(byte)   ( (byte)  (ValueType)left ^ (byte)  (ValueType)right );
+            else if (left is sbyte)  return (T)(ValueType)(sbyte)  ( (sbyte) (ValueType)left ^ (sbyte) (ValueType)right );
+            else throw new NotImplementedException();
         }
 
         public static T AndNot<T>(T left, T right) where T : struct
         {
-            return (T)((dynamic)left & ~(dynamic)right);
+            if      (left is short)  return (T)(ValueType)(short)  ( (short) (ValueType)left & ~(short) (ValueType)right );
+            else if (left is int)    return (T)(ValueType)(int)    ( (int)   (ValueType)left & ~(int)   (ValueType)right );
+            else if (left is long)   return (T)(ValueType)(long)   ( (long)  (ValueType)left & ~(long)  (ValueType)right );
+            else if (left is ushort) return (T)(ValueType)(ushort) ( (ushort)(ValueType)left & ~(ushort)(ValueType)right );
+            else if (left is uint)   return (T)(ValueType)(uint)   ( (uint)  (ValueType)left & ~(uint)  (ValueType)right );
+            else if (left is ulong)  return (T)(ValueType)(ulong)  ( (ulong) (ValueType)left & ~(ulong) (ValueType)right );
+            else if (left is byte)   return (T)(ValueType)(byte)   ( (byte)  (ValueType)left & ~(byte)  (ValueType)right );
+            else if (left is sbyte)  return (T)(ValueType)(sbyte)  ( (sbyte) (ValueType)left & ~(sbyte) (ValueType)right );
+            else throw new NotImplementedException();
         }
 
         public static T OnesComplement<T>(T left) where T : struct
         {
-            return unchecked((T)(~(dynamic)left));
+            unchecked
+            {
+                if      (left is short)  return (T)(ValueType)(short)  ( ~(short) (ValueType)left );
+                else if (left is int)    return (T)(ValueType)(int)    ( ~(int)   (ValueType)left );
+                else if (left is long)   return (T)(ValueType)(long)   ( ~(long)  (ValueType)left );
+                else if (left is ushort) return (T)(ValueType)(ushort) ( ~(ushort)(ValueType)left );
+                else if (left is uint)   return (T)(ValueType)(uint)   ( ~(uint)  (ValueType)left );
+                else if (left is ulong)  return (T)(ValueType)(ulong)  ( ~(ulong) (ValueType)left );
+                else if (left is byte)   return (T)(ValueType)(byte)   ( ~(byte)  (ValueType)left );
+                else if (left is sbyte)  return (T)(ValueType)(sbyte)  ( ~(sbyte) (ValueType)left );
+                else throw new NotImplementedException();
+            }
         }
+
         public static float Clamp(float value, float min, float max)
         {
             return value > max ? max : value < min ? min : value;
@@ -151,36 +242,92 @@ namespace System.Numerics.Tests
 
         public static T Zero<T>() where T : struct
         {
-            return (T)(dynamic)0;
+            if      (typeof(T) == typeof(short))  return  (T)(ValueType)(short)  0;
+            else if (typeof(T) == typeof(int))    return  (T)(ValueType)(int)    0;
+            else if (typeof(T) == typeof(long))   return  (T)(ValueType)(long)   0;
+            else if (typeof(T) == typeof(ushort)) return  (T)(ValueType)(ushort) 0;
+            else if (typeof(T) == typeof(uint))   return  (T)(ValueType)(uint)   0;
+            else if (typeof(T) == typeof(ulong))  return  (T)(ValueType)(ulong)  0;
+            else if (typeof(T) == typeof(byte))   return  (T)(ValueType)(byte)   0;
+            else if (typeof(T) == typeof(sbyte))  return  (T)(ValueType)(sbyte)  0;
+            else if (typeof(T) == typeof(float))  return  (T)(ValueType)(float)  0;
+            else if (typeof(T) == typeof(double)) return  (T)(ValueType)(double) 0;
+            else throw new NotImplementedException();
         }
 
         public static T One<T>() where T : struct
         {
-            return (T)(dynamic)1;
+            if      (typeof(T) == typeof(short))  return  (T)(ValueType)(short)  1;
+            else if (typeof(T) == typeof(int))    return  (T)(ValueType)(int)    1;
+            else if (typeof(T) == typeof(long))   return  (T)(ValueType)(long)   1;
+            else if (typeof(T) == typeof(ushort)) return  (T)(ValueType)(ushort) 1;
+            else if (typeof(T) == typeof(uint))   return  (T)(ValueType)(uint)   1;
+            else if (typeof(T) == typeof(ulong))  return  (T)(ValueType)(ulong)  1;
+            else if (typeof(T) == typeof(byte))   return  (T)(ValueType)(byte)   1;
+            else if (typeof(T) == typeof(sbyte))  return  (T)(ValueType)(sbyte)  1;
+            else if (typeof(T) == typeof(float))  return  (T)(ValueType)(float)  1;
+            else if (typeof(T) == typeof(double)) return  (T)(ValueType)(double) 1;
+            else throw new NotImplementedException();
         }
 
         public static bool GreaterThan<T>(T left, T right) where T : struct
         {
-            var result = (dynamic)left > right;
-            return (bool)result;
+            if      (left is short)  return  (short)(ValueType)  left > (short)(ValueType)  right;
+            else if (left is int)    return  (int)(ValueType)    left > (int)(ValueType)    right;
+            else if (left is long)   return  (long)(ValueType)   left > (long)(ValueType)   right;
+            else if (left is ushort) return  (ushort)(ValueType) left > (ushort)(ValueType) right;
+            else if (left is uint)   return  (uint)(ValueType)   left > (uint)(ValueType)   right;
+            else if (left is ulong)  return  (ulong)(ValueType)  left > (ulong)(ValueType)  right;
+            else if (left is byte)   return  (byte)(ValueType)   left > (byte)(ValueType)   right;
+            else if (left is sbyte)  return  (sbyte)(ValueType)  left > (sbyte)(ValueType)  right;
+            else if (left is float)  return  (float)(ValueType)  left > (float)(ValueType)  right;
+            else if (left is double) return  (double)(ValueType) left > (double)(ValueType) right;
+            else throw new NotImplementedException();
         }
 
         public static bool GreaterThanOrEqual<T>(T left, T right) where T : struct
         {
-            var result = (dynamic)left >= right;
-            return (bool)result;
+            if      (left is short)  return  (short)(ValueType)  left >= (short)(ValueType)  right;
+            else if (left is int)    return  (int)(ValueType)    left >= (int)(ValueType)    right;
+            else if (left is long)   return  (long)(ValueType)   left >= (long)(ValueType)   right;
+            else if (left is ushort) return  (ushort)(ValueType) left >= (ushort)(ValueType) right;
+            else if (left is uint)   return  (uint)(ValueType)   left >= (uint)(ValueType)   right;
+            else if (left is ulong)  return  (ulong)(ValueType)  left >= (ulong)(ValueType)  right;
+            else if (left is byte)   return  (byte)(ValueType)   left >= (byte)(ValueType)   right;
+            else if (left is sbyte)  return  (sbyte)(ValueType)  left >= (sbyte)(ValueType)  right;
+            else if (left is float)  return  (float)(ValueType)  left >= (float)(ValueType)  right;
+            else if (left is double) return  (double)(ValueType) left >= (double)(ValueType) right;
+            else throw new NotImplementedException();
         }
 
         public static bool LessThan<T>(T left, T right) where T : struct
         {
-            var result = (dynamic)left < right;
-            return (bool)result;
+            if      (left is short)  return  (short)(ValueType)  left < (short)(ValueType)  right;
+            else if (left is int)    return  (int)(ValueType)    left < (int)(ValueType)    right;
+            else if (left is long)   return  (long)(ValueType)   left < (long)(ValueType)   right;
+            else if (left is ushort) return  (ushort)(ValueType) left < (ushort)(ValueType) right;
+            else if (left is uint)   return  (uint)(ValueType)   left < (uint)(ValueType)   right;
+            else if (left is ulong)  return  (ulong)(ValueType)  left < (ulong)(ValueType)  right;
+            else if (left is byte)   return  (byte)(ValueType)   left < (byte)(ValueType)   right;
+            else if (left is sbyte)  return  (sbyte)(ValueType)  left < (sbyte)(ValueType)  right;
+            else if (left is float)  return  (float)(ValueType)  left < (float)(ValueType)  right;
+            else if (left is double) return  (double)(ValueType) left < (double)(ValueType) right;
+            else throw new NotImplementedException();
         }
 
         public static bool LessThanOrEqual<T>(T left, T right) where T : struct
         {
-            var result = (dynamic)left <= right;
-            return (bool)result;
+            if      (left is short)  return  (short)(ValueType)  left <= (short)(ValueType)  right;
+            else if (left is int)    return  (int)(ValueType)    left <= (int)(ValueType)    right;
+            else if (left is long)   return  (long)(ValueType)   left <= (long)(ValueType)   right;
+            else if (left is ushort) return  (ushort)(ValueType) left <= (ushort)(ValueType) right;
+            else if (left is uint)   return  (uint)(ValueType)   left <= (uint)(ValueType)   right;
+            else if (left is ulong)  return  (ulong)(ValueType)  left <= (ulong)(ValueType)  right;
+            else if (left is byte)   return  (byte)(ValueType)   left <= (byte)(ValueType)   right;
+            else if (left is sbyte)  return  (sbyte)(ValueType)  left <= (sbyte)(ValueType)  right;
+            else if (left is float)  return  (float)(ValueType)  left <= (float)(ValueType)  right;
+            else if (left is double) return  (double)(ValueType) left <= (double)(ValueType) right;
+            else throw new NotImplementedException();
         }
 
         public static bool AnyEqual<T>(T[] left, T[] right) where T : struct


### PR DESCRIPTION
Instead of using `dynamic` we can use explicit type checks which don't require runtime code generation.
Also fixed running just a subset of xunit tests on Apple targets in tests.mobile.targets.