### PR TITLE
Fix broken callstacks in interpreter on MonoVM.

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -227,11 +227,6 @@ typedef struct {
 	guchar *stack_pointer;
 	/* Used for allocation of localloc regions */
 	FrameDataAllocator data_stack;
-	/* Used when a thread self-suspends at a safepoint in the interpreter, points to the
-	 * currently executing frame. (If a thread self-suspends somewhere else in the runtime, this
-	 * is NULL - the LMF will point to the InterpFrame before the thread exited the interpreter)
-	 */
-	InterpFrame *safepoint_frame;
 } ThreadContext;
 
 typedef struct {

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -248,7 +248,7 @@ static gboolean interp_init_done = FALSE;
 static void
 interp_exec_method (InterpFrame *frame, ThreadContext *context, FrameClauseArgs *clause_args);
 
-static MonoException* do_transform_method (InterpFrame *frame, ThreadContext *context);
+static MonoException* do_transform_method (InterpMethod *imethod, InterpFrame *method, ThreadContext *context);
 
 static InterpMethod* lookup_method_pointer (gpointer addr);
 
@@ -419,27 +419,12 @@ interp_free_context (gpointer ctx)
 		set_context (NULL);
 	}
 
-	context->safepoint_frame = NULL;
-
 	mono_vfree (context->stack_start, INTERP_STACK_SIZE, MONO_MEM_ACCOUNT_INTERP_STACK);
 	/* Prevent interp_mark_stack from trying to scan the data_stack, before freeing it */
 	context->stack_start = NULL;
 	mono_compiler_barrier ();
 	frame_data_allocator_free (&context->data_stack);
 	g_free (context);
-}
-
-static void
-context_set_safepoint_frame (ThreadContext *context, InterpFrame *frame)
-{
-	g_assert (!context->has_resume_state);
-	context->safepoint_frame = frame;
-}
-
-static void
-context_clear_safepoint_frame (ThreadContext *context)
-{
-	context->safepoint_frame = NULL;
 }
 
 void
@@ -1052,6 +1037,8 @@ interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, con
 	 */
 	frame->state.ip = ip + 1;
 
+	interp_push_lmf (&ext, frame);
+
 	if (mono_object_isinst_checked ((MonoObject *) ex, mono_defaults.exception_class, error)) {
 		MonoException *mono_ex = ex;
 		if (!rethrow) {
@@ -1071,7 +1058,6 @@ interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, con
 	 * Since ctx.ip is 0, this will start unwinding from the LMF frame
 	 * pushed above, which points to our frames.
 	 */
-	interp_push_lmf (&ext, frame);
 
 	mono_handle_exception (&ctx, (MonoObject*)ex);
 
@@ -1085,6 +1071,62 @@ interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, con
 
 	g_assert (context->has_resume_state);
 }
+
+static MONO_NEVER_INLINE MonoException *
+interp_error_convert_to_exception (InterpFrame *frame, MonoError *error, const guint16 *ip)
+{
+	MonoLMFExt ext;
+	MonoException *ex;
+
+	/*
+	 * When calling runtime functions we pass the ip of the instruction triggering the runtime call.
+	 * Offset the subtraction from interp_frame_get_ip, so we don't end up in prev instruction.
+	 */
+	frame->state.ip = ip + 1;
+
+	interp_push_lmf (&ext, frame);
+	ex = mono_error_convert_to_exception (error);
+	interp_pop_lmf (&ext);
+	return ex;
+}
+
+#define INTERP_BUILD_EXCEPTION_TYPE_FUNC_NAME(prefix_name, type_name) \
+prefix_name ## _ ## type_name
+
+#define INTERP_GET_EXCEPTION(exception_type) \
+static MONO_NEVER_INLINE MonoException * \
+INTERP_BUILD_EXCEPTION_TYPE_FUNC_NAME(interp_get_exception, exception_type) (InterpFrame *frame, const guint16 *ip)\
+{ \
+	MonoLMFExt ext; \
+	MonoException *ex; \
+	frame->state.ip = ip + 1; \
+	interp_push_lmf (&ext, frame); \
+	ex = mono_get_exception_ ## exception_type ## (); \
+	interp_pop_lmf (&ext); \
+	return ex; \
+}
+
+#define INTERP_GET_EXCEPTION_CHAR_ARG(exception_type) \
+static MONO_NEVER_INLINE MonoException * \
+INTERP_BUILD_EXCEPTION_TYPE_FUNC_NAME(interp_get_exception, exception_type) (const char *arg, InterpFrame *frame, const guint16 *ip)\
+{ \
+	MonoLMFExt ext; \
+	MonoException *ex; \
+	frame->state.ip = ip + 1; \
+	interp_push_lmf (&ext, frame); \
+	ex = mono_get_exception_ ## exception_type ## (arg); \
+	interp_pop_lmf (&ext); \
+	return ex; \
+}
+
+INTERP_GET_EXCEPTION(null_reference)
+INTERP_GET_EXCEPTION(divide_by_zero)
+INTERP_GET_EXCEPTION(overflow)
+INTERP_GET_EXCEPTION(invalid_cast)
+INTERP_GET_EXCEPTION(index_out_of_range)
+INTERP_GET_EXCEPTION(array_type_mismatch)
+INTERP_GET_EXCEPTION(arithmetic)
+INTERP_GET_EXCEPTION_CHAR_ARG(argument_out_of_range)
 
 // We conservatively pin exception object here to avoid tweaking the
 // numerous call sites of this macro, even though, in a few cases,
@@ -1102,7 +1144,7 @@ interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, con
 
 #define NULL_CHECK(o) do { \
 	if (G_UNLIKELY (!(o))) \
-		THROW_EX (mono_get_exception_null_reference (), ip); \
+		THROW_EX (interp_get_exception_null_reference (frame, ip), ip); \
 	} while (0)
 
 #define EXCEPTION_CHECKPOINT	\
@@ -1115,19 +1157,27 @@ interp_throw (ThreadContext *context, MonoException *ex, InterpFrame *frame, con
 	} while (0)
 
 // Reduce duplicate code in interp_exec_method
-static void
-do_safepoint (InterpFrame *frame, ThreadContext *context)
+static MONO_NEVER_INLINE void
+do_safepoint (InterpFrame *frame, ThreadContext *context, const guint16 *ip)
 {
-	context_set_safepoint_frame (context, frame);
+	MonoLMFExt ext;
+
+	/*
+	 * When calling runtime functions we pass the ip of the instruction triggering the runtime call.
+	 * Offset the subtraction from interp_frame_get_ip, so we don't end up in prev instruction.
+	 */
+	frame->state.ip = ip + 1;
+
+	interp_push_lmf (&ext, frame);
 	/* Poll safepoint */
 	mono_threads_safepoint ();
-	context_clear_safepoint_frame (context);
+	interp_pop_lmf (&ext);
 }
 
 #define SAFEPOINT \
 	do {						\
 		if (G_UNLIKELY (mono_polling_required)) \
-			do_safepoint (frame, context);	\
+			do_safepoint (frame, context, ip);	\
 	} while (0)
 
 static MonoObject*
@@ -2163,8 +2213,6 @@ interp_entry (InterpEntryData *data)
 
 	context->stack_pointer = (guchar*)sp;
 
-	g_assert (!context->safepoint_frame);
-
 	if (rmethod->needs_thread_attach)
 		mono_threads_detach_coop (orig_domain, &attach_cookie);
 
@@ -2634,29 +2682,34 @@ do_debugger_tramp (void (*tramp) (void), InterpFrame *frame)
 }
 
 static MONO_NEVER_INLINE MonoException*
-do_transform_method (InterpFrame *frame, ThreadContext *context)
+do_transform_method (InterpMethod *imethod, InterpFrame *frame, ThreadContext *context)
 {
 	MonoLMFExt ext;
 	/* Don't push lmf if we have no interp data */
 	gboolean push_lmf = frame->parent != NULL;
+	MonoException *ex = NULL;
 	ERROR_DECL (error);
-
-#if DEBUG_INTERP
-	char *mn = mono_method_full_name (frame->imethod->method, TRUE);
-	g_print ("(%p) Transforming %s\n", mono_thread_internal_current (), mn);
-	g_free (mn);
-#endif
 
 	/* Use the parent frame as the current frame is not complete yet */
 	if (push_lmf)
 		interp_push_lmf (&ext, frame->parent);
 
-	mono_interp_transform_method (frame->imethod, context, error);
+#if DEBUG_INTERP
+	if (imethod->method) {
+		char* mn = mono_method_full_name (imethod->method, TRUE);
+		g_print ("(%p) Transforming %s\n", mono_thread_internal_current (), mn);
+		g_free (mn);
+	}
+#endif
+
+	mono_interp_transform_method (imethod, context, error);
+	if (!is_ok (error))
+		ex = mono_error_convert_to_exception (error);
 
 	if (push_lmf)
 		interp_pop_lmf (&ext);
 
-	return mono_error_convert_to_exception (error);
+	return ex;
 }
 
 static void
@@ -3249,11 +3302,31 @@ static long opcode_counts[MINT_LASTOP];
 #define DUMP_INSTR()
 #endif
 
+static MONO_NEVER_INLINE MonoException*
+do_init_vtable (MonoVTable *vtable, MonoError *error, InterpFrame *frame, const guint16 *ip)
+{
+	MonoLMFExt ext;
+	MonoException *ex = NULL;
+
+	/*
+	 * When calling runtime functions we pass the ip of the instruction triggering the runtime call.
+	 * Offset the subtraction from interp_frame_get_ip, so we don't end up in prev instruction.
+	 */
+	frame->state.ip = ip + 1;
+
+	interp_push_lmf (&ext, frame);
+	mono_runtime_class_init_full (vtable, error);
+	if (!is_ok (error))
+		ex = mono_error_convert_to_exception (error);
+	interp_pop_lmf (&ext);
+	return ex;
+}
+
 #define INIT_VTABLE(vtable) do { \
 		if (G_UNLIKELY (!(vtable)->initialized)) { \
-			mono_runtime_class_init_full ((vtable), error); \
-			if (!is_ok (error)) \
-				THROW_EX (mono_error_convert_to_exception (error), ip); \
+			MonoException *__init_vtable_ex = do_init_vtable ((vtable), error, frame, ip); \
+			if (G_UNLIKELY (__init_vtable_ex)) \
+				THROW_EX (__init_vtable_ex, ip); \
 		} \
 	} while (0);
 
@@ -3363,7 +3436,7 @@ method_entry (ThreadContext *context, InterpFrame *frame,
 	*out_ex = NULL;
 	if (!G_UNLIKELY (frame->imethod->transformed)) {
 		slow = TRUE;
-		MonoException *ex = do_transform_method (frame, context);
+		MonoException *ex = do_transform_method (frame->imethod, frame, context);
 		if (ex) {
 			*out_ex = ex;
 			/*
@@ -3620,10 +3693,7 @@ main_loop:
 				MONO_PROFILER_RAISE (method_tail_call, (frame->imethod->method, new_method->method));
 
 			if (!new_method->transformed) {
-				error_init_reuse (error);
-
-				mono_interp_transform_method (new_method, context, error);
-				MonoException *ex = mono_error_convert_to_exception (error);
+				MonoException *ex = do_transform_method (new_method, frame, context);
 				if (ex)
 					THROW_EX (ex, ip);
 				EXCEPTION_CHECKPOINT;
@@ -3648,6 +3718,7 @@ main_loop:
 			InterpMethod *del_imethod = (InterpMethod*)del->interp_invoke_impl;
 
 			if (!del_imethod) {
+				// FIXME push/pop LMF
 				if (is_multicast) {
 					error_init_reuse (error);
 					MonoMethod *invoke = mono_get_delegate_invoke_internal (del->object.vtable->klass);
@@ -3712,6 +3783,7 @@ main_loop:
 			cmethod = ftnptr_to_imethod (LOCAL_VAR (ip [2], gpointer), &need_unbox);
 
 			if (cmethod->method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) {
+				// FIXME push/pop LMF
 				cmethod = mono_interp_get_imethod (mono_marshal_get_native_wrapper (cmethod->method, FALSE, FALSE), error);
 				mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			}
@@ -3751,6 +3823,7 @@ main_loop:
 			guchar* code = LOCAL_VAR (ip [2], guchar*);
 			call_args_offset = ip [3];
 
+			// FIXME push/pop LMF
 			cmethod = mono_interp_get_native_func_wrapper (frame->imethod, csignature, code);
 
 			ip += 5;
@@ -3786,6 +3859,7 @@ main_loop:
 
 			slot = (gint16)ip [4];
 			ip += 5;
+			// FIXME push/pop LMF
 			cmethod = get_virtual_method_fast (cmethod, this_arg->vtable, slot);
 			if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (cmethod->method->klass)) {
 				/* unbox */
@@ -3800,6 +3874,7 @@ main_loop:
 			          code_type == IMETHOD_CODE_COMPILED);
 
 			if (G_UNLIKELY (code_type == IMETHOD_CODE_UNKNOWN)) {
+				// FIXME push/pop LMF
 				MonoMethodSignature *sig = mono_method_signature_internal (cmethod->method);
 				if (mono_interp_jit_call_supported (cmethod->method, sig))
 					code_type = IMETHOD_CODE_COMPILED;
@@ -3817,7 +3892,7 @@ main_loop:
 				error_init_reuse (error);
 				do_jit_call (context, (stackval*)(locals + return_offset), (stackval*)(locals + call_args_offset), frame, cmethod, error);
 				if (!is_ok (error)) {
-					MonoException *ex = mono_error_convert_to_exception (error);
+					MonoException *ex = interp_error_convert_to_exception (frame, error, ip);
 					THROW_EX (ex, ip);
 				}
 
@@ -3844,6 +3919,7 @@ main_loop:
 
 			MonoObject *this_arg = LOCAL_VAR (call_args_offset, MonoObject*);
 
+			// FIXME push/pop LMF
 			cmethod = get_virtual_method (cmethod, this_arg->vtable);
 			if (m_class_is_valuetype (this_arg->vtable->klass) && m_class_is_valuetype (cmethod->method->klass)) {
 				/* unbox */
@@ -3912,7 +3988,7 @@ call:
 			frame->state.ip = ip + 4;
 			do_jit_call (context, (stackval*)(locals + ip [1]), (stackval*)(locals + ip [2]), frame, rmethod, error);
 			if (!is_ok (error)) {
-				MonoException *ex = mono_error_convert_to_exception (error);
+				MonoException *ex = interp_error_convert_to_exception (frame, error, ip);
 				THROW_EX (ex, ip);
 			}
 
@@ -3930,7 +4006,7 @@ call:
 			frame->state.ip = ip + 6;
 			do_jit_call (context, (stackval*)(locals + ip [1]), frame, rmethod, error);
 			if (!is_ok (error)) {
-				MonoException *ex = mono_error_convert_to_exception (error);
+				MonoException *ex = interp_error_convert_to_exception (frame, error);
 				THROW_EX (ex, ip);
 			}
 
@@ -4828,9 +4904,9 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint32 i1 = LOCAL_VAR (ip [2], gint32);
 			gint32 i2 = LOCAL_VAR (ip [3], gint32);
 			if (i2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			if (i2 == (-1) && i1 == G_MININT32)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = i1 / i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -4839,9 +4915,9 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint64 l1 = LOCAL_VAR (ip [2], gint64);
 			gint64 l2 = LOCAL_VAR (ip [3], gint64);
 			if (l2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			if (l2 == (-1) && l1 == G_MININT64)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint64) = l1 / l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -4855,7 +4931,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_DIV_UN_I4) {
 			guint32 i2 = LOCAL_VAR (ip [3], guint32);
 			if (i2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint32) = LOCAL_VAR (ip [2], guint32) / i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -4863,7 +4939,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_DIV_UN_I8) {
 			guint64 l2 = LOCAL_VAR (ip [3], guint64);
 			if (l2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint64) = LOCAL_VAR (ip [2], guint64) / l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -4872,9 +4948,9 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint32 i1 = LOCAL_VAR (ip [2], gint32);
 			gint32 i2 = LOCAL_VAR (ip [3], gint32);
 			if (i2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			if (i2 == (-1) && i1 == G_MININT32)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = i1 % i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -4883,9 +4959,9 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint64 l1 = LOCAL_VAR (ip [2], gint64);
 			gint64 l2 = LOCAL_VAR (ip [3], gint64);
 			if (l2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			if (l2 == (-1) && l1 == G_MININT64)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint64) = l1 % l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -4901,7 +4977,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_REM_UN_I4) {
 			guint32 i2 = LOCAL_VAR (ip [3], guint32);
 			if (i2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint32) = LOCAL_VAR (ip [2], guint32) % i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -4909,7 +4985,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_REM_UN_I8) {
 			guint64 l2 = LOCAL_VAR (ip [3], guint64);
 			if (l2 == 0)
-				THROW_EX (mono_get_exception_divide_by_zero (), ip);
+				THROW_EX (interp_get_exception_divide_by_zero (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint64) = LOCAL_VAR (ip [2], guint64) % l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -5188,6 +5264,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD) {
 				s = (MonoString*)mono_method_get_wrapper_data (method, strtoken);
 			} else if (method->wrapper_type != MONO_WRAPPER_NONE) {
+				// FIXME push/pop LMF
 				s = mono_string_new_wrapper_internal ((const char*)mono_method_get_wrapper_data (method, strtoken));
 			} else {
 				g_assert_not_reached ();
@@ -5203,9 +5280,10 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 			newobj_class = (MonoClass*) frame->imethod->data_items [token];
 
+			// FIXME push/pop LMF
 			LOCAL_VAR (ip [1], MonoObject*) = ves_array_create (newobj_class, param_count, (stackval*)(locals + ip [2]), error);
 			if (!is_ok (error))
-				THROW_EX (mono_error_convert_to_exception (error), ip);
+				THROW_EX (interp_error_convert_to_exception (frame, error, ip), ip);
 			ip += 5;
 			MINT_IN_BREAK;
 		}
@@ -5227,10 +5305,11 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			return_offset = ip [1];
 			call_args_offset = ip [2];
 
+			// FIXME push/pop LMF
 			MonoObject *o = mono_gc_alloc_obj (vtable, m_class_get_instance_size (vtable->klass));
 			if (G_UNLIKELY (!o)) {
 				mono_error_set_out_of_memory (error, "Could not allocate %i bytes", m_class_get_instance_size (vtable->klass));
-				THROW_EX (mono_error_convert_to_exception (error), ip);
+				THROW_EX (interp_error_convert_to_exception (frame, error, ip), ip);
 			}
 
 			// This is return value
@@ -5247,10 +5326,11 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoVTable *vtable = (MonoVTable*) frame->imethod->data_items [ip [2]];
 			INIT_VTABLE (vtable);
 
+			// FIXME push/pop LMF
 			MonoObject *o = mono_gc_alloc_obj (vtable, m_class_get_instance_size (vtable->klass));
 			if (G_UNLIKELY (!o)) {
 				mono_error_set_out_of_memory (error, "Could not allocate %i bytes", m_class_get_instance_size (vtable->klass));
-				THROW_EX (mono_error_convert_to_exception (error), ip);
+				THROW_EX (interp_error_convert_to_exception (frame, error, ip), ip);
 			}
 
 			// This is return value
@@ -5301,9 +5381,10 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 			g_assert (!m_class_is_valuetype (newobj_class));
 
+			// FIXME push/pop LMF
 			MonoVTable *vtable = mono_class_vtable_checked (newobj_class, error);
 			if (!is_ok (error) || !mono_runtime_class_init_full (vtable, error)) {
-				MonoException *exc = mono_error_convert_to_exception (error);
+				MonoException *exc = interp_error_convert_to_exception (frame, error, ip);
 				g_assert (exc);
 				THROW_EX (exc, ip);
 			}
@@ -5321,7 +5402,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gpointer ptr = LOCAL_VAR (ip [2], gpointer);
 			int len = LOCAL_VAR (ip [3], gint32);
 			if (len < 0)
-				THROW_EX (mono_get_exception_argument_out_of_range ("length"), ip);
+				THROW_EX (interp_get_exception_argument_out_of_range ("length", frame, ip), ip);
 			gpointer span = locals + ip [1];
 			*(gpointer*)span = ptr;
 			*(gint32*)((gpointer*)span + 1) = len;
@@ -5395,6 +5476,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 					isinst = TRUE;
 				} else if (m_class_is_array_special_interface (c)) {
 					/* slow path */
+					// FIXME push/pop LMF
 					isinst = mono_interp_isinst (o, c); // FIXME: do not swallow the error
 				} else {
 					isinst = FALSE;
@@ -5405,7 +5487,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 					if (isinst_instr)
 						LOCAL_VAR (ip [1], MonoObject*) = NULL;
 					else
-						THROW_EX (mono_get_exception_invalid_cast (), ip);
+						THROW_EX (interp_get_exception_invalid_cast (frame, ip), ip);
 				} else {
 					LOCAL_VAR (ip [1], MonoObject*) = o;
 				}
@@ -5427,7 +5509,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 					if (isinst_instr)
 						LOCAL_VAR (ip [1], MonoObject*) = NULL;
 					else
-						THROW_EX (mono_get_exception_invalid_cast (), ip);
+						THROW_EX (interp_get_exception_invalid_cast (frame, ip), ip);
 				} else {
 					LOCAL_VAR (ip [1], MonoObject*) = o;
 				}
@@ -5442,12 +5524,13 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoObject *o = LOCAL_VAR (ip [2], MonoObject*);
 			if (o) {
 				MonoClass* const c = (MonoClass*)frame->imethod->data_items [ip [3]];
+				// FIXME push/pop LMF
 				if (!mono_interp_isinst (o, c)) { // FIXME: do not swallow the error
 					gboolean const isinst_instr = *ip == MINT_ISINST;
 					if (isinst_instr)
 						LOCAL_VAR (ip [1], MonoObject*) = NULL;
 					else
-						THROW_EX (mono_get_exception_invalid_cast (), ip);
+						THROW_EX (interp_get_exception_invalid_cast (frame, ip), ip);
 				} else {
 					LOCAL_VAR (ip [1], MonoObject*) = o;
 				}
@@ -5471,7 +5554,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoClass *c = (MonoClass*)frame->imethod->data_items [ip [3]];
 
 			if (!(m_class_get_rank (o->vtable->klass) == 0 && m_class_get_element_class (o->vtable->klass) == m_class_get_element_class (c)))
-				THROW_EX (mono_get_exception_invalid_cast (), ip);
+				THROW_EX (interp_get_exception_invalid_cast (frame, ip), ip);
 
 			LOCAL_VAR (ip [1], gpointer) = mono_object_unbox_internal (o);
 			ip += 4;
@@ -5480,7 +5563,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_THROW) {
 			MonoException *ex = LOCAL_VAR (ip [1], MonoException*);
 			if (!ex)
-				ex = mono_get_exception_null_reference ();
+				ex = interp_get_exception_null_reference (frame, ip);
 
 			THROW_EX (ex, ip);
 			MINT_IN_BREAK;
@@ -5689,7 +5772,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_U8_I4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < 0)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint64) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -5697,7 +5780,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_U8_I8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < 0)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint64) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -5705,7 +5788,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I8_U8) {
 			guint64 val = LOCAL_VAR (ip [2], guint64);
 			if (val > G_MAXINT64)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint64) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -5713,34 +5796,35 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_U8_R4) {
 			float val = LOCAL_VAR (ip [2], float);
 			if (!mono_try_trunc_u64 (val, (guint64*)(locals + ip [1])))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_U8_R8) {
 			double val = LOCAL_VAR (ip [2], double);
 			if (!mono_try_trunc_u64 (val, (guint64*)(locals + ip [1])))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_I8_R4) {
 			float val = LOCAL_VAR (ip [2], float);
 			if (!mono_try_trunc_i64 (val, (gint64*)(locals + ip [1])))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_I8_R8) {
 			double val = LOCAL_VAR (ip [2], double);
 			if (!mono_try_trunc_i64 (val, (gint64*)(locals + ip [1])))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_BOX) {
 			MonoVTable *vtable = (MonoVTable*)frame->imethod->data_items [ip [3]];
 
+			// FIXME push/pop LMF
 			MonoObject *o = mono_gc_alloc_obj (vtable, m_class_get_instance_size (vtable->klass));
 			MONO_HANDLE_ASSIGN_RAW (tmp_handle, o);
 			stackval_to_data (m_class_get_byval_arg (vtable->klass), (stackval*)(locals + ip [2]), mono_object_get_data (o), FALSE);
@@ -5754,6 +5838,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoVTable *vtable = (MonoVTable*)frame->imethod->data_items [ip [3]];
 			MonoClass *c = vtable->klass;
 
+			// FIXME push/pop LMF
 			MonoObject* o = mono_gc_alloc_obj (vtable, m_class_get_instance_size (c));
 			MONO_HANDLE_ASSIGN_RAW (tmp_handle, o);
 			mono_value_copy_internal (mono_object_get_data (o), locals + ip [2], c);
@@ -5767,6 +5852,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoVTable *vtable = (MonoVTable*)frame->imethod->data_items [ip [3]];
 			MonoClass *c = vtable->klass;
 
+			// FIXME push/pop LMF
 			MonoObject* o = mono_gc_alloc_obj (vtable, m_class_get_instance_size (c));
 			MONO_HANDLE_ASSIGN_RAW (tmp_handle, o);
 			mono_value_copy_internal (mono_object_get_data (o), LOCAL_VAR (ip [2], gpointer), c);
@@ -5779,16 +5865,18 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_BOX_NULLABLE_PTR) {
 			MonoClass *c = (MonoClass*)frame->imethod->data_items [ip [3]];
 
+			// FIXME push/pop LMF
 			LOCAL_VAR (ip [1], MonoObject*) = mono_nullable_box (LOCAL_VAR (ip [2], gpointer), c, error);
 			mono_interp_error_cleanup (error); /* FIXME: don't swallow the error */
 			ip += 4;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_NEWARR) {
+			// FIXME push/pop LMF
 			MonoVTable *vtable = (MonoVTable*)frame->imethod->data_items [ip [3]];
 			LOCAL_VAR (ip [1], MonoObject*) = (MonoObject*) mono_array_new_specific_checked (vtable, LOCAL_VAR (ip [2], gint32), error);
 			if (!is_ok (error)) {
-				THROW_EX (mono_error_convert_to_exception (error), ip);
+				THROW_EX (interp_error_convert_to_exception (frame, error, ip), ip);
 			}
 			ip += 4;
 			/*if (profiling_classes) {
@@ -5820,7 +5908,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			NULL_CHECK (s);
 			int i32 = LOCAL_VAR (ip [3], int);
 			if (i32 < 0 || i32 >= mono_string_length_internal (s))
-				THROW_EX (mono_get_exception_index_out_of_range (), ip);
+				THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = mono_string_chars_internal (s)[i32];
 			ip += 4;
 			MINT_IN_BREAK;
@@ -5834,7 +5922,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 			const gint32 length = *(gint32 *) (span + offset_length);
 			if (index < 0 || index >= length)
-				THROW_EX (mono_get_exception_index_out_of_range (), ip);
+				THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip);
 
 			gsize element_size = (gsize)(gint16)ip [4];
 			gsize offset_pointer = (gsize)(gint16)ip [6];
@@ -5860,6 +5948,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_ARRAY_ELEMENT_SIZE) {
+			// FIXME push/pop LMF
 			MonoObject *o = LOCAL_VAR (ip [2], MonoObject*);
 			NULL_CHECK (o);
 			LOCAL_VAR (ip [1], gint32) = mono_array_element_size (mono_object_class (o));
@@ -5879,7 +5968,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			NULL_CHECK (ao);
 			gint32 index = LOCAL_VAR (ip [3], gint32);
 			if (index >= ao->max_length)
-				THROW_EX (mono_get_exception_index_out_of_range (), ip);
+				THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip);
 			guint16 size = ip [4];
 			LOCAL_VAR (ip [1], gpointer) = mono_array_addr_with_size_fast (ao, size, index);
 			ip += 5;
@@ -5900,7 +5989,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 				gint32 lower = ao->bounds [i].lower_bound;
 				guint32 len = ao->bounds [i].length;
 				if (idx < lower || (guint32)(idx - lower) >= len)
-					THROW_EX (mono_get_exception_index_out_of_range (), ip);
+					THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip);
 				pos = (pos * len) + (guint32)(idx - lower);
 			}
 
@@ -5909,6 +5998,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_LDELEMA_TC) {
+			// FIXME push/pop LMF
 			stackval *sp = (stackval*)(locals + ip [2]);
 
 			MonoObject *o = (MonoObject*) sp [0].data.o;
@@ -5927,7 +6017,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 	NULL_CHECK (o); \
 	gint32 aindex = LOCAL_VAR (ip [3], gint32); \
 	if (aindex >= mono_array_length_internal (o)) \
-		THROW_EX (mono_get_exception_index_out_of_range (), ip); \
+		THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip); \
 	LOCAL_VAR (ip [1], datatype) = mono_array_get_fast (o, elemtype, aindex); \
 	ip += 4; \
 } while (0)
@@ -5947,7 +6037,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			NULL_CHECK (o);
 			mono_u aindex = LOCAL_VAR (ip [3], gint32);
 			if (aindex >= mono_array_length_internal (o))
-				THROW_EX (mono_get_exception_index_out_of_range (), ip);
+				THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip);
 
 			guint16 size = ip [4];
 			char *src_addr = mono_array_addr_with_size_fast ((MonoArray *) o, size, aindex);
@@ -5961,7 +6051,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 	NULL_CHECK (o); \
 	aindex = LOCAL_VAR (ip [2], gint32); \
 	if (aindex >= mono_array_length_internal (o)) \
-		THROW_EX (mono_get_exception_index_out_of_range (), ip); \
+		THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip); \
 } while (0)
 
 #define STELEM(datatype, elemtype) do { \
@@ -5987,9 +6077,10 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoObject *ref = LOCAL_VAR (ip [3], MonoObject*);
 
 			if (ref) {
+				// FIXME push/pop LMF
 				gboolean isinst = mono_interp_isinst (ref, m_class_get_element_class (mono_object_class (o)));
 				if (!isinst)
-					THROW_EX (mono_get_exception_array_type_mismatch (), ip);
+					THROW_EX (interp_get_exception_array_type_mismatch (frame, ip), ip);
 			}
 			mono_array_setref_fast ((MonoArray *) o, aindex, ref);
 			ip += 4;
@@ -6001,7 +6092,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			NULL_CHECK (o);
 			gint32 aindex = LOCAL_VAR (ip [2], gint32);
 			if (aindex >= mono_array_length_internal (o))
-				THROW_EX (mono_get_exception_index_out_of_range (), ip);
+				THROW_EX (interp_get_exception_index_out_of_range (frame, ip), ip);
 
 			guint16 size = ip [5];
 			char *dst_addr = mono_array_addr_with_size_fast ((MonoArray *) o, size, aindex);
@@ -6013,7 +6104,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I4_U4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < 0)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6021,7 +6112,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I4_I8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < G_MININT32 || val > G_MAXINT32)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint32) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6029,7 +6120,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I4_U8) {
 			guint64 val = LOCAL_VAR (ip [2], guint64);
 			if (val > G_MAXINT32)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint32) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6040,7 +6131,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val_r8 > ((double)G_MININT32 - 1) && val_r8 < ((double)G_MAXINT32 + 1))
 				LOCAL_VAR (ip [1], gint32) = (gint32) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
@@ -6049,14 +6140,14 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > ((double)G_MININT32 - 1) && val < ((double)G_MAXINT32 + 1))
 				LOCAL_VAR (ip [1], gint32) = (gint32) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_U4_I4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < 0)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6064,7 +6155,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_U4_I8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < 0 || val > G_MAXUINT32)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (guint32) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6075,7 +6166,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val_r8 > -1.0 && val_r8 < ((double)G_MAXUINT32 + 1))
 				LOCAL_VAR (ip [1], gint32) = (guint32)val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
@@ -6084,14 +6175,14 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > -1.0 && val < ((double)G_MAXUINT32 + 1))
 				LOCAL_VAR (ip [1], gint32) = (guint32)val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_I2_I4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < G_MININT16 || val > G_MAXINT16)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint16)val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6099,7 +6190,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I2_U4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < 0 || val > G_MAXINT16)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint16)val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6107,7 +6198,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I2_I8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < G_MININT16 || val > G_MAXINT16)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint16) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6115,7 +6206,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I2_U8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < 0 || val > G_MAXINT16)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint16) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6125,7 +6216,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > (G_MININT16 - 1) && val < (G_MAXINT16 + 1))
 				LOCAL_VAR (ip [1], gint32) = (gint16) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
@@ -6134,14 +6225,14 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > (G_MININT16 - 1) && val < (G_MAXINT16 + 1))
 				LOCAL_VAR (ip [1], gint32) = (gint16) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_U2_I4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < 0 || val > G_MAXUINT16)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6149,7 +6240,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_U2_I8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < 0 || val > G_MAXUINT16)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (guint16) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6159,7 +6250,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > -1.0f && val < (G_MAXUINT16 + 1))
 				LOCAL_VAR (ip [1], gint32) = (guint16) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
@@ -6168,14 +6259,14 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > -1.0 && val < (G_MAXUINT16 + 1))
 				LOCAL_VAR (ip [1], gint32) = (guint16) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_I1_I4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < G_MININT8 || val > G_MAXINT8)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6183,7 +6274,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I1_U4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < 0 || val > G_MAXINT8)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6191,7 +6282,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I1_I8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < G_MININT8 || val > G_MAXINT8)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint8) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6199,7 +6290,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_I1_U8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < 0 || val > G_MAXINT8)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (gint8) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6209,7 +6300,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > (G_MININT8 - 1) && val < (G_MAXINT8 + 1))
 				LOCAL_VAR (ip [1], gint32) = (gint8) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
@@ -6218,14 +6309,14 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > (G_MININT8 - 1) && val < (G_MAXINT8 + 1))
 				LOCAL_VAR (ip [1], gint32) = (gint8) val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CONV_OVF_U1_I4) {
 			gint32 val = LOCAL_VAR (ip [2], gint32);
 			if (val < 0 || val > G_MAXUINT8)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6233,7 +6324,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_CONV_OVF_U1_I8) {
 			gint64 val = LOCAL_VAR (ip [2], gint64);
 			if (val < 0 || val > G_MAXUINT8)
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = (guint8) val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6243,7 +6334,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > -1.0f && val < (G_MAXUINT8 + 1))
 				LOCAL_VAR (ip [1], gint32) = (guint8)val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
@@ -6252,14 +6343,14 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			if (val > -1.0 && val < (G_MAXUINT8 + 1))
 				LOCAL_VAR (ip [1], gint32) = (guint8)val;
 			else
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			ip += 3;
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_CKFINITE) {
 			double val = LOCAL_VAR (ip [2], double);
 			if (!mono_isfinite (val))
-				THROW_EX (mono_get_exception_arithmetic (), ip);
+				THROW_EX (interp_get_exception_arithmetic (frame, ip), ip);
 			LOCAL_VAR (ip [1], double) = val;
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6289,7 +6380,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 			MonoClass *c = (MonoClass*)frame->imethod->data_items [ip [3]];
 			if (c != tref->klass)
-				THROW_EX (mono_get_exception_invalid_cast (), ip);
+				THROW_EX (interp_get_exception_invalid_cast (frame, ip), ip);
 
 			LOCAL_VAR (ip [1], gpointer) = tref->value;
 			ip += 4;
@@ -6304,7 +6395,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint32 i1 = LOCAL_VAR (ip [2], gint32);
 			gint32 i2 = LOCAL_VAR (ip [3], gint32);
 			if (CHECK_ADD_OVERFLOW (i1, i2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = i1 + i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6313,7 +6404,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint64 l1 = LOCAL_VAR (ip [2], gint64);
 			gint64 l2 = LOCAL_VAR (ip [3], gint64);
 			if (CHECK_ADD_OVERFLOW64 (l1, l2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint64) = l1 + l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6322,7 +6413,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			guint32 i1 = LOCAL_VAR (ip [2], guint32);
 			guint32 i2 = LOCAL_VAR (ip [3], guint32);
 			if (CHECK_ADD_OVERFLOW_UN (i1, i2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint32) = i1 + i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6331,7 +6422,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			guint64 l1 = LOCAL_VAR (ip [2], guint64);
 			guint64 l2 = LOCAL_VAR (ip [3], guint64);
 			if (CHECK_ADD_OVERFLOW64_UN (l1, l2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint64) = l1 + l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6340,7 +6431,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint32 i1 = LOCAL_VAR (ip [2], gint32);
 			gint32 i2 = LOCAL_VAR (ip [3], gint32);
 			if (CHECK_MUL_OVERFLOW (i1, i2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = i1 * i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6349,7 +6440,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint64 l1 = LOCAL_VAR (ip [2], gint64);
 			gint64 l2 = LOCAL_VAR (ip [3], gint64);
 			if (CHECK_MUL_OVERFLOW64 (l1, l2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint64) = l1 * l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6358,7 +6449,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			guint32 i1 = LOCAL_VAR (ip [2], guint32);
 			guint32 i2 = LOCAL_VAR (ip [3], guint32);
 			if (CHECK_MUL_OVERFLOW_UN (i1, i2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint32) = i1 * i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6367,7 +6458,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			guint64 l1 = LOCAL_VAR (ip [2], guint64);
 			guint64 l2 = LOCAL_VAR (ip [3], guint64);
 			if (CHECK_MUL_OVERFLOW64_UN (l1, l2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint64) = l1 * l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6376,7 +6467,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint32 i1 = LOCAL_VAR (ip [2], gint32);
 			gint32 i2 = LOCAL_VAR (ip [3], gint32);
 			if (CHECK_SUB_OVERFLOW (i1, i2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint32) = i1 - i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6385,7 +6476,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gint64 l1 = LOCAL_VAR (ip [2], gint64);
 			gint64 l2 = LOCAL_VAR (ip [3], gint64);
 			if (CHECK_SUB_OVERFLOW64 (l1, l2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint64) = l1 - l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6394,7 +6485,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			guint32 i1 = LOCAL_VAR (ip [2], guint32);
 			guint32 i2 = LOCAL_VAR (ip [3], guint32);
 			if (CHECK_SUB_OVERFLOW_UN (i1, i2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], guint32) = i1 - i2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6403,7 +6494,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			guint64 l1 = LOCAL_VAR (ip [2], guint64);
 			guint64 l2 = LOCAL_VAR (ip [3], guint64);
 			if (CHECK_SUB_OVERFLOW64_UN (l1, l2))
-				THROW_EX (mono_get_exception_overflow (), ip);
+				THROW_EX (interp_get_exception_overflow (frame, ip), ip);
 			LOCAL_VAR (ip [1], gint64) = l1 - l2;
 			ip += 4;
 			MINT_IN_BREAK;
@@ -6481,10 +6572,12 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			ip += 3;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_MONO_NEWOBJ)
+			// FIXME push/pop LMF
 			LOCAL_VAR (ip [1], MonoObject*) = mono_interp_new ((MonoClass*)frame->imethod->data_items [ip [2]]); // FIXME: do not swallow the error
 			ip += 3;
 			MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_MONO_RETOBJ)
+			// FIXME push/pop LMF
 			stackval_from_data (mono_method_signature_internal (frame->imethod->method)->ret, frame->stack, LOCAL_VAR (ip [1], gpointer),
 			     mono_method_signature_internal (frame->imethod->method)->pinvoke);
 			frame_data_allocator_pop (&context->data_stack, frame);
@@ -6532,6 +6625,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 				static T ss_tramp;
 
 				if (!ss_tramp) {
+					// FIXME push/pop LMF
 					void *tramp = mini_get_single_step_trampoline ();
 					mono_memory_barrier ();
 					ss_tramp = (T)tramp;
@@ -6563,6 +6657,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			typedef void (*T) (void);
 			static T bp_tramp;
 			if (!bp_tramp) {
+				// FIXME push/pop LMF
 				void *tramp = mini_get_breakpoint_trampoline ();
 				mono_memory_barrier ();
 				bp_tramp = (T)tramp;
@@ -6724,6 +6819,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_LDFTN) {
 			InterpMethod *m = (InterpMethod*)frame->imethod->data_items [ip [2]];
 
+			// FIXME push/pop LMF
 			LOCAL_VAR (ip [1], gpointer) = imethod_to_ftnptr (m, FALSE);
 			ip += 3;
 			MINT_IN_BREAK;
@@ -6733,6 +6829,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoObject *o = LOCAL_VAR (ip [2], MonoObject*);
 			NULL_CHECK (o);
 
+			// FIXME push/pop LMF
 			InterpMethod *res_method = get_virtual_method (virtual_method, o->vtable);
 			gboolean need_unbox = m_class_is_valuetype (res_method->method->klass) && !m_class_is_valuetype (virtual_method->method->klass);
 			LOCAL_VAR (ip [1], gpointer) = imethod_to_ftnptr (res_method, need_unbox);
@@ -6744,6 +6841,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 			MonoMethod *cmethod = LOCAL_VAR (ip [2], MonoMethod*);
 
+			// FIXME push/pop LMF
 			if (G_UNLIKELY (mono_method_has_unmanaged_callers_only_attribute (cmethod))) {
 				cmethod = mono_marshal_get_managed_wrapper  (cmethod, NULL, (MonoGCHandle)0, error);
 				mono_error_assert_ok (error);
@@ -6766,6 +6864,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 				MonoProfilerCallContext *prof_ctx = g_new0 (MonoProfilerCallContext, 1);
 				prof_ctx->interp_frame = frame;
 				prof_ctx->method = frame->imethod->method;
+				// FIXME push/pop LMF
 				if (flag & TRACING_FLAG)
 					mono_trace_enter_method (frame->imethod->method, frame->imethod->jinfo, prof_ctx);
 				if (flag & PROFILING_FLAG)
@@ -6797,6 +6896,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 				prof_ctx->method = frame->imethod->method;
 				if (!is_void)
 					prof_ctx->return_value = frame->retval;
+				// FIXME push/pop LMF
 				if (flag & TRACING_FLAG)
 					mono_trace_leave_method (frame->imethod->method, frame->imethod->jinfo, prof_ctx);
 				if (flag & PROFILING_FLAG)
@@ -6891,7 +6991,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			gpointer src = LOCAL_VAR (ip [2], gpointer);
 			guint32 size = LOCAL_VAR (ip [3], guint32);
 			if (size && (!dest || !src))
-				THROW_EX (mono_get_exception_null_reference(), ip);
+				THROW_EX (interp_get_exception_null_reference(frame, ip), ip);
 			else
 				memcpy (dest, src, size);
 			ip += 4;
@@ -6922,12 +7022,13 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 
 			MonoException *exc = LOCAL_VAR (ip [1], MonoException*);
 			if (!exc)
-				exc = mono_get_exception_null_reference ();
+				exc = interp_get_exception_null_reference (frame, ip);
 
 			THROW_EX_GENERAL (exc, ip, TRUE);
 			MINT_IN_BREAK;
 		}
 		MINT_IN_CASE(MINT_LD_DELEGATE_METHOD_PTR) {
+			// FIXME push/pop LMF
 			MonoDelegate *del = LOCAL_VAR (ip [2], MonoDelegate*);
 			if (!del->interp_method) {
 				/* Not created from interpreted code */
@@ -7711,16 +7812,6 @@ metadata_update_prepare_to_invalidate (void)
 	FOREACH_THREAD_EXCLUDE (info, MONO_THREAD_INFO_FLAGS_NO_GC) {
 		if (!info || !info->jit_data)
 			continue;
-
-		ThreadContext *context = (ThreadContext*)info->jit_data->interp_context;
-
-		/* If the thread was in the interpreter and hit a safepoint
-		 * opcode and suspended, backup the frames since the last lmf.
-		 */
-		if (context && context->safepoint_frame) {
-			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "threadinfo=%p, has safepoint frame %p", info, context->safepoint_frame);
-			metadata_update_backup_frames (info, context->safepoint_frame);
-		}
 
 		MonoLMF *lmf = info->jit_data->lmf;
 		while (lmf) {

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1101,7 +1101,7 @@ INTERP_BUILD_EXCEPTION_TYPE_FUNC_NAME(interp_get_exception, exception_type) (Int
 	MonoException *ex; \
 	frame->state.ip = ip + 1; \
 	interp_push_lmf (&ext, frame); \
-	ex = mono_get_exception_ ## exception_type ## (); \
+	ex = INTERP_BUILD_EXCEPTION_TYPE_FUNC_NAME(mono_get_exception,exception_type) (); \
 	interp_pop_lmf (&ext); \
 	return ex; \
 }
@@ -1114,7 +1114,7 @@ INTERP_BUILD_EXCEPTION_TYPE_FUNC_NAME(interp_get_exception, exception_type) (con
 	MonoException *ex; \
 	frame->state.ip = ip + 1; \
 	interp_push_lmf (&ext, frame); \
-	ex = mono_get_exception_ ## exception_type ## (arg); \
+	ex = INTERP_BUILD_EXCEPTION_TYPE_FUNC_NAME(mono_get_exception,exception_type) (arg); \
 	interp_pop_lmf (&ext); \
 	return ex; \
 }


### PR DESCRIPTION
Running sample profiler on MonoVM interpreter sometimes hits broken callstacks, getting unknown frames in sampled callstacks, or callstacks missing chunks of methods, leading to incorrect display of callstacks in tools like SpeedScope, PerfView and Visual Studio. This is not a problem running under JIT or AOT, only interpreter.

Analysed and tracked down the missing chunks of methods in callstacks to interpreter not pushing LMF for several scenarios where we call into runtime code, meaning that the unwinder will jump pass interpreter methods until previous pushed LMF when sampled by sample profiler. Fixing this is a little tedious since we would need to audit interpreter code and make sure we push LMF when calling a MonoVM runtime method that might hit a safe point, blocking on coop locks, switching to GC safe etc. This PR fixes a couple of paths where I have seen broken callstacks, and also a couple of additional paths currently not in hot paths (mainly error cases or guarded by branches unlikely to happen). I have also marked several other paths that would need to be fixed at some point, but since they are currently in hot paths, or have not showed up in traces so far, I have just comment the code for potential future fix.

Tracked down the unknown frames to happen since we don't always add the ip to the frame when we push the LMF record (`frame->state.ip`). This issue became more visible when more code paths push LMF records as part of this PR.

With changes in this PR, running a couple of samples previously triggered both broken callstacks as well as callstacks with unknown frames, are now correctly displayed in tooling.