### PR TITLE
[wasm][test] BrowserHttpHandler stream large responses with SetBrowserResponseStreamingEnabled

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -126,41 +126,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
-        public async Task BrowserHttpHandler_Streaming()
-        {
-            var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
-
-            var size = 1500 * 1024 * 1024;
-            var req = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.RemoteSecureHttp11Server.BaseUri + "large.ashx?size=" + size);
-
-            req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
-
-            using (HttpClient client = CreateHttpClientForRemoteServer(Configuration.Http.RemoteSecureHttp11Server))
-            // we need to switch off Response buffering of default ResponseContentRead option
-            using (HttpResponseMessage response = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
-            {
-                Assert.Equal(typeof(StreamContent), response.Content.GetType());
-
-                Assert.Equal("application/octet-stream", response.Content.Headers.ContentType.MediaType);
-                Assert.True(size == response.Content.Headers.ContentLength, "ContentLength");
-
-                var stream = await response.Content.ReadAsStreamAsync();
-                Assert.Equal("ReadOnlyStream", stream.GetType().Name);
-                var buffer = new byte[1024 * 1024];
-                int totalCount = 0;
-                int fetchedCount = 0;
-                do
-                {
-                    // with WebAssemblyEnableStreamingResponse option set, we will be using https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/read
-                    fetchedCount = await stream.ReadAsync(buffer, 0, buffer.Length);
-                    totalCount += fetchedCount;
-                } while (fetchedCount != 0);
-                Assert.Equal(size, totalCount);
-            }
-        }
-
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         public async Task GetAsync_UseResponseHeadersReadAndCallLoadIntoBuffer_Success(Configuration.Http.RemoteServer remoteServer)
@@ -262,7 +227,43 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
+
 #if NETCOREAPP
+        [OuterLoop]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
+        public async Task BrowserHttpHandler_Streaming()
+        {
+            var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
+
+            var size = 1500 * 1024 * 1024;
+            var req = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.RemoteSecureHttp11Server.BaseUri + "large.ashx?size=" + size);
+
+            req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
+
+            using (HttpClient client = CreateHttpClientForRemoteServer(Configuration.Http.RemoteSecureHttp11Server))
+            // we need to switch off Response buffering of default ResponseContentRead option
+            using (HttpResponseMessage response = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
+            {
+                Assert.Equal(typeof(StreamContent), response.Content.GetType());
+
+                Assert.Equal("application/octet-stream", response.Content.Headers.ContentType.MediaType);
+                Assert.True(size == response.Content.Headers.ContentLength, "ContentLength");
+
+                var stream = await response.Content.ReadAsStreamAsync();
+                Assert.Equal("ReadOnlyStream", stream.GetType().Name);
+                var buffer = new byte[1024 * 1024];
+                int totalCount = 0;
+                int fetchedCount = 0;
+                do
+                {
+                    // with WebAssemblyEnableStreamingResponse option set, we will be using https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/read
+                    fetchedCount = await stream.ReadAsync(buffer, 0, buffer.Length);
+                    totalCount += fetchedCount;
+                } while (fetchedCount != 0);
+                Assert.Equal(size, totalCount);
+            }
+        }
+
         [Theory]
         [InlineData(TransferType.ContentLength, TransferError.ContentLengthTooLarge)]
         [InlineData(TransferType.Chunked, TransferError.MissingChunkTerminator)]

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -127,18 +127,17 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop]
-        [MemberData(nameof(RemoteServersMemberData))]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
-        public async Task BrowserHttpHandler_Streaming(Configuration.Http.RemoteServer remoteServer)
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
+        public async Task BrowserHttpHandler_Streaming()
         {
             var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
 
             var size = 1500 * 1024 * 1024;
-            var req = new HttpRequestMessage(HttpMethod.Get, remoteServer.BaseUri + "large.ashx?size=" + size);
+            var req = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.RemoteSecureHttp11Server.BaseUri + "large.ashx?size=" + size);
 
             req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
 
-            using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
+            using (HttpClient client = CreateHttpClientForRemoteServer(Configuration.Http.RemoteSecureHttp11Server))
             // we need to switch off Response buffering of default ResponseContentRead option
             using (HttpResponseMessage response = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
             {

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/GenericHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/GenericHandler.cs
@@ -83,6 +83,11 @@ namespace NetCoreServer
                 await TestHandler.InvokeAsync(context);
                 return;
             }
+            if (path.Equals(new PathString("/large.ashx")))
+            {
+                await LargeResponseHandler.InvokeAsync(context);
+                return;
+            }
 
             // Default handling.
             await EchoHandler.InvokeAsync(context);

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/LargeResponse.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/LargeResponse.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace NetCoreServer
+{
+    public class LargeResponseHandler
+    {
+        public static async Task InvokeAsync(HttpContext context)
+        {
+            RequestHelper.AddResponseCookies(context);
+
+            if (!AuthenticationHelper.HandleAuthentication(context))
+            {
+                return;
+            }
+
+            // Add original request method verb as a custom response header.
+            context.Response.Headers.Add("X-HttpRequest-Method", context.Request.Method);
+
+            var size = 1024;
+            if (context.Request.Query.TryGetValue("size", out var value))
+            {
+                size = Int32.Parse(value);
+            }
+
+            var bytes =new byte[size];
+            Random.Shared.NextBytes(bytes);
+
+            context.Response.ContentType = "application/octet-stream";
+            context.Response.ContentLength = bytes.Length;
+            await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+        }
+    }
+}

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/LargeResponse.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/LargeResponse.cs
@@ -28,13 +28,18 @@ namespace NetCoreServer
             {
                 size = Int32.Parse(value);
             }
-
-            var bytes =new byte[size];
-            Random.Shared.NextBytes(bytes);
-
             context.Response.ContentType = "application/octet-stream";
-            context.Response.ContentLength = bytes.Length;
-            await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+            context.Response.ContentLength = size;
+            const int bufferSize = 1024 * 100;
+            var bytes = new byte[bufferSize];
+            Random.Shared.NextBytes(bytes);
+            var remaining = size;
+            while (remaining > 0)
+            {
+                var send = Math.Min(remaining, bufferSize);
+                await context.Response.Body.WriteAsync(bytes, 0, send);
+                remaining -= send;
+            }
         }
     }
 }

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
@@ -18,6 +18,7 @@
     <Compile Include="Handlers\EchoWebSocketHeadersHandler.cs" />
     <Compile Include="Handlers\EmptyContentHandler.cs" />
     <Compile Include="Handlers\GZipHandler.cs" />
+    <Compile Include="Handlers\LargeResponse.cs" />
     <Compile Include="Handlers\RedirectHandler.cs" />
     <Compile Include="Handlers\StatusCodeHandler.cs" />
     <Compile Include="Handlers\TestHandler.cs" />


### PR DESCRIPTION
In order to be able to use `WebAssemblyEnableStreamingResponse` option, the user should also set `HttpCompletionOption.ResponseHeadersRead` so that the content would not be cached in memory.

This is unit test covering the user scenario.
Fixes https://github.com/dotnet/runtime/issues/60287