### PR TITLE
[reflection] Initialize default ALC gchandle in GetLoadContext

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
@@ -80,6 +80,7 @@ namespace System.Runtime.Loader
             // We only support looking up load context for runtime assemblies.
             if (rtAsm != null)
             {
+                var _ = Default;  // ensure the default ALC is initialized.
                 RuntimeAssembly runtimeAssembly = rtAsm;
                 IntPtr ptrAssemblyLoadContext = GetLoadContextForAssembly(runtimeAssembly);
                 loadContextForAssembly = GetAssemblyLoadContext(ptrAssemblyLoadContext);


### PR DESCRIPTION
If we try to get the ALC of an assembly from the default context before the
managed default ALC object has been created, the native gchandle has a null
target.
Ensure it is not null by explicitly referencing the Default ALC.

Fixes https://github.com/dotnet/runtime/issues/60348