### PR TITLE
Don't include s390x in coreclr outerloop runs

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -211,7 +211,7 @@ jobs:
 
 # Linux s390x
 
-- ${{ if or(containsValue(parameters.platforms, 'Linux_s390x'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+- ${{ if containsValue(parameters.platforms, 'Linux_s390x') }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}


### PR DESCRIPTION
This was a copy-paste mistake, see https://github.com/dotnet/runtime/pull/60255#issuecomment-942539639