### PR TITLE
Add test for struct with ref field

### DIFF
--- a/src/tests/Loader/classloader/RefFields/StructRefField.il
+++ b/src/tests/Loader/classloader/RefFields/StructRefField.il
@@ -1,0 +1,99 @@
+.assembly _
+{
+    .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = (
+        01 00 08 00 00 00 00 00
+    )
+    .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = (
+        01 00 01 00 54 02 16 57 72 61 70 4e 6f 6e 45 78
+        63 65 70 74 69 6f 6e 54 68 72 6f 77 73 01
+    )
+    .custom instance void [System.Private.CoreLib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Private.CoreLib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = (
+        01 00 07 01 00 00 00 00
+    )
+    .permissionset reqmin = (
+        2e 01 80 92 53 79 73 74 65 6d 2e 53 65 63 75 72
+        69 74 79 2e 50 65 72 6d 69 73 73 69 6f 6e 73 2e
+        53 65 63 75 72 69 74 79 50 65 72 6d 69 73 73 69
+        6f 6e 41 74 74 72 69 62 75 74 65 2c 20 53 79 73
+        74 65 6d 2e 50 72 69 76 61 74 65 2e 43 6f 72 65
+        4c 69 62 2c 20 56 65 72 73 69 6f 6e 3d 35 2e 30
+        2e 30 2e 30 2c 20 43 75 6c 74 75 72 65 3d 6e 65
+        75 74 72 61 6c 2c 20 50 75 62 6c 69 63 4b 65 79
+        54 6f 6b 65 6e 3d 37 63 65 63 38 35 64 37 62 65
+        61 37 37 39 38 65 15 01 54 02 10 53 6b 69 70 56
+        65 72 69 66 69 63 61 74 69 6f 6e 01
+    )
+    .hash algorithm 0x00008004 // SHA1
+    .ver 0:0:0:0
+}
+
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi sealed beforefieldinit S
+    extends [System.Private.CoreLib]System.ValueType
+{
+    .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .custom instance void [System.Private.CoreLib]System.ObsoleteAttribute::.ctor(string, bool) = (
+        01 00 52 54 79 70 65 73 20 77 69 74 68 20 65 6d
+        62 65 64 64 65 64 20 72 65 66 65 72 65 6e 63 65
+        73 20 61 72 65 20 6e 6f 74 20 73 75 70 70 6f 72
+        74 65 64 20 69 6e 20 74 68 69 73 20 76 65 72 73
+        69 6f 6e 20 6f 66 20 79 6f 75 72 20 63 6f 6d 70
+        69 6c 65 72 2e 01 00 00
+    )
+    // Fields
+    .field public string& f
+
+    // Methods
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor (
+            string& x
+        ) cil managed 
+    {
+        // Method begins at RVA 0x2050
+        // Code size 10 (0xa)
+        .maxstack 8
+
+        IL_0000: nop
+        IL_0001: ldarg.0
+        IL_0002: ldarg.1
+        IL_0004: stfld string& S::f
+        IL_0009: ret
+    } // end of method S::.ctor
+
+} // end of class S
+
+.class public auto ansi abstract sealed beforefieldinit R
+    extends [System.Private.CoreLib]System.Object
+{
+    // Methods
+    .method public hidebysig static 
+        void Main () cil managed 
+    {
+        // Method begins at RVA 0x205c
+        // Code size 19 (0x13)
+        .entrypoint
+        .maxstack 1
+        .locals init (
+            [0] string hi,
+            [1] string& w,
+            [2] valuetype S s
+        )
+
+        IL_0000: nop
+        IL_0001: ldstr "hello"
+        IL_0006: stloc.0
+        IL_0007: ldloca.s 0
+        IL_0009: stloc.1
+        IL_000a: ldloca.s 0
+        IL_000c: newobj instance void S::.ctor(string&)
+        IL_0011: stloc.2
+        IL_0012: ret
+    } // end of method R::Main
+
+} // end of class R
+

--- a/src/tests/Loader/classloader/RefFields/StructRefField.ilproj
+++ b/src/tests/Loader/classloader/RefFields/StructRefField.ilproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This test is currently failing with
```
Unhandled exception. System.Runtime.InteropServices.COMException (0x801312E4): Field of ByRef type. (0x801312E4)
```
when running with CoreCLR.