### PR TITLE
Remove FlakyAppHostTests category in installer tests

### DIFF
--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -432,22 +432,6 @@ jobs:
       #     creator: dotnet-bot
       #     testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
-# Run disabled installer tests on Linux x64
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: Release
-    platforms:
-    - Linux_x64
-    jobParameters:
-      nameSuffix: Installer_Tests
-      isOfficialBuild: ${{ variables.isOfficialBuild }}
-      buildArgs: -s clr+libs+host+packs -restore -build -test -c $(_BuildConfig) -lc Debug /p:PortableBuild=true /p:RunOnStaging=true
-      useContinueOnErrorDuringBuild: true
-      enablePublisTestResults: true
-      testResultsFormat: xunit
-      timeoutInMinutes: 90
-
 #
 # Build Browser_wasm, on windows, run console and browser tests
 #

--- a/src/installer/tests/Directory.Build.props
+++ b/src/installer/tests/Directory.Build.props
@@ -11,8 +11,6 @@
     <TestArchitectures>$(TargetArchitecture)</TestArchitectures>
     <TestInfraTargetFramework>$(NetCoreAppToolCurrent)</TestInfraTargetFramework>
     <TestRunnerAdditionalArguments>-notrait category=failing</TestRunnerAdditionalArguments>
-    <TestRunnerAdditionalArguments Condition="'$(RunOnStaging)' != 'true'">$(TestRunnerAdditionalArguments) -notrait category=FlakyAppHostTests</TestRunnerAdditionalArguments>
-    <TestRunnerAdditionalArguments Condition="'$(RunOnStaging)' == 'true'">$(TestRunnerAdditionalArguments) -trait category=FlakyAppHostTests</TestRunnerAdditionalArguments>
     <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -15,7 +15,6 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    [Trait("category", "FlakyAppHostTests")]
     public class BundleExtractToSpecificPath : BundleTestBase, IClassFixture<BundleExtractToSpecificPath.SharedTestState>
     {
         private SharedTestState sharedTestState;

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileApiTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    [Trait("category", "FlakyAppHostTests")]
     public class SingleFileApiTests : BundleTestBase, IClassFixture<SingleFileSharedState>
     {
         private SingleFileSharedState sharedTestState;


### PR DESCRIPTION
The underlying issue was fixed: https://github.com/dotnet/runtime/issues/53587

I looked at AzDO test result analytics on runtime-staging where the FlakyAppHostTests ran and it had a 100% pass rate in the last 14 days. 