### PR TITLE
prevent manifest sending for special cased event sources

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2895,9 +2895,10 @@ namespace System.Diagnostics.Tracing
 
         // Send out the ETW manifest XML out to ETW
         // Today, we only send the manifest to ETW, custom listeners don't get it.
+        // Don't send if we are specific "EventSource"s that are pass-throughs to native events
         private unsafe void SendManifest(byte[]? rawManifest)
         {
-            if (rawManifest == null)
+            if (rawManifest == null || m_guid.Equals(NativeRuntimeEventSourceGuid))
                 return;
 
             Debug.Assert(!SelfDescribingEvents);
@@ -3961,6 +3962,9 @@ namespace System.Diagnostics.Tracing
         // used for generating GUID from eventsource name
         private static byte[]? namespaceBytes;
 #endif
+
+        // GUIDs for special-cased EventSources, e.g., NativeRuntimeEventSource, that shouldn't send a manifest to ETW
+        private static readonly Guid NativeRuntimeEventSourceGuid = new Guid("E13C0D23-CCBC-4E12-931B-D9CC2EEE27E4"); // NativeRuntimeEventSource
 #endregion
     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3964,7 +3964,7 @@ namespace System.Diagnostics.Tracing
 #endif
 
         // GUIDs for special-cased EventSources, e.g., NativeRuntimeEventSource, that shouldn't send a manifest to ETW
-        private static readonly Guid NativeRuntimeEventSourceGuid = new Guid("E13C0D23-CCBC-4E12-931B-D9CC2EEE27E4"); // NativeRuntimeEventSource
+        private static readonly Guid NativeRuntimeEventSourceGuid = new Guid(unchecked((int)0xe13c0d23), unchecked((short)0xccbc), unchecked((short)0x4e12), 0x93, 0x1b, 0xd9, 0xcc, 0x2e, 0xee, 0x27, 0xe4); // NativeRuntimeEventSource
 #endregion
     }
 


### PR DESCRIPTION
As a workaround for making `NativeRuntimeEventSource` and specifically Portable Threadpool events show up under the `Microsoft-DotNETRuntime-Private` provider in .net6, [the GUID for the `EventSource` was set to be the same as the manually defined provider](https://github.com/dotnet/runtime/pull/47829).

This had an unfortunate side-effect of tripping up some ETW based listeners that request the manifest if a provider is an `EventSource`. ~It appears there may be some issues in the generated code that would cause the manifest returned by the `EventSource` to not match the hand-written one most tools use. Typically, consumers of `Microsoft-DotNETRuntime-Private` will use a local copy of `ClrEtwAll.man` to parse the events. If a consumer uses both that and the manifest collected from the `EventSource` it can mess up parsing.~

~This patch doesn't attempt to sort out the issues in the generating code, but corrects the behavior to not send a manifest for the `EventSource` which is more correct for how this code is set up. It also keeps the change small which will be better for backporting/getting into 6.~

The manifest generated from `ClrEtwAll.man` is _too_ correct and marks parameters as unsigned integer values. The `ClrTraceEventParser` in TraceEvent treats them as signed integer values at the other end. When we send this manifest it causes TraceEvent to treat the provider as an `EventSource` which results in different parsing logic depending on how you register callbacks. If customer/tool code is expecting events from events with this provider name and event name to have signed values, but get unsigned, it will cause exceptions in their code.

```csharp
using System;
using Microsoft.Diagnostics.Tracing;
using Microsoft.Diagnostics.Tracing.Parsers;
using Microsoft.Diagnostics.Tracing.Parsers.Clr;
using Microsoft.Diagnostics.Tracing.Session;

using (TraceEventSession session = new TraceEventSession("MySession"))
{
    DynamicTraceEventParser dynamicParser = new DynamicTraceEventParser(session.Source);
    dynamicParser.AddCallbackForProviderEvent(ClrTraceEventParser.ProviderName, "MethodJittingStarted_V1", (data) =>
    {
        // signed & named MethodJittingStarted_V1
    });
    dynamicParser.All += delegate (TraceEvent data)
    {
        if (data.EventName.StartsWith("MethodJitting"))
        {
            // signed & named MethodJittingStarted_V1
        }
    };

    session.Source.Clr.MethodJittingStarted += delegate (MethodJittingStartedTraceData data)
    {
        // unsigned & named Method/JittingStarted
    };
    session.EnableProvider(ClrTraceEventParser.ProviderGuid.ToString(), TraceEventLevel.Verbose, (ulong)ClrTraceEventParser.Keywords.Jit);
    session.Source.Process();
}

```

If customer or tool event handling code special cases the unboxing of the payload values based on the static manifest values, then they will hit cast failure exceptions in the `Dynamic*` cases above.

Reverting to draft - Looking for further validation from the issue reporter. This patch fixed their issue (hence the PR), but further investigation has made me doubt this is the _correct_ fix to check in to the runtime.

CC @benmwatson @brianrob 