### PR TITLE
[release/6.0] Move 2 Drawing APIs that are not implemented in netfx to net6.0 or later

### DIFF
--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -596,11 +596,11 @@ namespace System.Drawing
         public static System.Drawing.Graphics FromImage(System.Drawing.Image image) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [System.ObsoleteAttribute("Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations.", DiagnosticId = "SYSLIB0016", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public object GetContextInfo() { throw null; }
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void GetContextInfo(out PointF offset) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]

--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -596,12 +596,16 @@ namespace System.Drawing
         public static System.Drawing.Graphics FromImage(System.Drawing.Image image) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
+#if NET6_0_OR_GREATER
         [System.ObsoleteAttribute("Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations.", DiagnosticId = "SYSLIB0016", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
         public object GetContextInfo() { throw null; }
+#if NET6_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void GetContextInfo(out PointF offset) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void GetContextInfo(out PointF offset, out Region? clip) { throw null; }
+#endif
         public static System.IntPtr GetHalftonePalette() { throw null; }
         public System.IntPtr GetHdc() { throw null; }
         public System.Drawing.Color GetNearestColor(System.Drawing.Color color) { throw null; }

--- a/src/libraries/System.Drawing.Common/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Drawing.Common/src/CompatibilitySuppressions.xml
@@ -1,18 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Drawing.Graphics.GetContextInfo(System.Drawing.PointF@)</Target>
-    <Left>lib/netstandard2.0/System.Drawing.Common.dll</Left>
-    <Right>lib/net461/System.Drawing.Common.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Drawing.Graphics.GetContextInfo(System.Drawing.PointF@,System.Drawing.Region@)</Target>
-    <Left>lib/netstandard2.0/System.Drawing.Common.dll</Left>
-    <Right>lib/net461/System.Drawing.Common.dll</Right>
-  </Suppression>
-  <Suppression>
     <DiagnosticId>CP0001</DiagnosticId>
     <Target>T:System.Drawing.FontConverter</Target>
     <Left>lib/netstandard2.0/System.Drawing.Common.dll</Left>

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -583,6 +583,7 @@ namespace System.Drawing
             throw new NotImplementedException();
         }
 
+#if NET6_0_OR_GREATER
         [EditorBrowsable(EditorBrowsableState.Never)]
         [SupportedOSPlatform("windows")]
         public void GetContextInfo(out PointF offset)
@@ -596,6 +597,7 @@ namespace System.Drawing
         {
             throw new PlatformNotSupportedException();
         }
+#endif
 
         private void CheckErrorStatus(int status)
         {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -583,7 +583,7 @@ namespace System.Drawing
             throw new NotImplementedException();
         }
 
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [EditorBrowsable(EditorBrowsableState.Never)]
         [SupportedOSPlatform("windows")]
         public void GetContextInfo(out PointF offset)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -684,7 +684,7 @@ namespace System.Drawing
         /// WARNING: This method is for internal FX support only.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [Obsolete(Obsoletions.GetContextInfoMessage, DiagnosticId = Obsoletions.GetContextInfoDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         [SupportedOSPlatform("windows")]
@@ -765,7 +765,7 @@ namespace System.Drawing
             }
         }
 
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         /// <summary>
         ///  Gets the cumulative offset.
         /// </summary>

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -684,7 +684,9 @@ namespace System.Drawing
         /// WARNING: This method is for internal FX support only.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET6_0_OR_GREATER
         [Obsolete(Obsoletions.GetContextInfoMessage, DiagnosticId = Obsoletions.GetContextInfoDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         [SupportedOSPlatform("windows")]
         public object GetContextInfo()
         {
@@ -763,6 +765,7 @@ namespace System.Drawing
             }
         }
 
+#if NET6_0_OR_GREATER
         /// <summary>
         ///  Gets the cumulative offset.
         /// </summary>
@@ -789,6 +792,7 @@ namespace System.Drawing
             Vector2 translation = cumulativeTransform.Translation;
             offset = new PointF(translation.X, translation.Y);
         }
+#endif
 
         public RectangleF VisibleClipBounds
         {

--- a/src/libraries/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
+++ b/src/libraries/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
@@ -61,6 +61,7 @@ namespace System.Drawing.Internal
             {
                 Region? clip = null;
 
+#if NET6_0_OR_GREATER
                 if (properties.HasFlag(ApplyGraphicsProperties.Clipping))
                 {
                     g.GetContextInfo(out offset, out clip);
@@ -69,6 +70,21 @@ namespace System.Drawing.Internal
                 {
                     g.GetContextInfo(out offset);
                 }
+#else
+                Matrix? worldTransf = null;
+                if (g.GetContextInfo() is object[] data && data.Length == 2)
+                {
+                    if (properties.HasFlag(ApplyGraphicsProperties.Clipping))
+                    {
+                        clip = data[0] as Region;
+                    }
+                    worldTransf = data[1] as Matrix;
+                    if (worldTransf != null)
+                    {
+                        offset = worldTransf.Offset;
+                    }
+                }
+#endif
 
                 if (clip is not null)
                 {

--- a/src/libraries/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
+++ b/src/libraries/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
@@ -61,7 +61,7 @@ namespace System.Drawing.Internal
             {
                 Region? clip = null;
 
-#if NET6_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
                 if (properties.HasFlag(ApplyGraphicsProperties.Clipping))
                 {
                     g.GetContextInfo(out offset, out clip);


### PR DESCRIPTION
This was discovered with the new `Microsoft.DotNet.Compatibility` tool: https://github.com/dotnet/runtime/pull/60306#discussion_r727460226

## Customer Impact

In 6.0 we added two new graphics APIs for better performance, but these were added to the netstandard2.0 implementation which in NuGet packages that's the ref assembly as well. These APIs are not part of the netfx implementation and that could cause runtime problems if for example a library targeting netstandard2.0, used these APIs and then a net472 application consumed this library, it would fail with `MissingMethodException` at runtime. 

## Testing

Unit tests, `PackageValidation` and `API Compat`.

## Risk

Low, the I'm just bringing the old behavior before the APIs were added and conditioning these APIs to .NET Core 3.1 or greater.



