### PR TITLE
Fix PerformanceCounter tests

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
@@ -190,7 +190,7 @@ namespace System.Diagnostics
         }
 
         /// <summary>
-        ///     Registers one extensible performance category of type NumberOfItems32 with the system
+        /// Registers one extensible performance category with counter type NumberOfItems32 with the system
         /// </summary>
         [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp) instead.")]
         public static PerformanceCounterCategory Create(string categoryName, string categoryHelp, string counterName, string counterHelp)
@@ -199,6 +199,9 @@ namespace System.Diagnostics
             return Create(categoryName, categoryHelp, PerformanceCounterCategoryType.Unknown, new CounterCreationDataCollection(new CounterCreationData[] { customData }));
         }
 
+        /// <summary>
+        /// Registers one extensible performance category of the specified category type with counter type NumberOfItems32 with the system
+        /// </summary>
         public static PerformanceCounterCategory Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp)
         {
             CounterCreationData customData = new CounterCreationData(counterName, counterHelp, PerformanceCounterType.NumberOfItems32);
@@ -206,7 +209,7 @@ namespace System.Diagnostics
         }
 
         /// <summary>
-        ///     Registers the extensible performance category with the system on the local machine
+        /// Registers the extensible performance category with the system on the local machine
         /// </summary>
         [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData) instead.")]
         public static PerformanceCounterCategory Create(string categoryName, string categoryHelp, CounterCreationDataCollection counterData)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
@@ -13,9 +13,9 @@ namespace System.Diagnostics.Tests
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void CounterSampleCalculator_ElapsedTime()
         {
-            var name = nameof(CounterSampleCalculator_ElapsedTime) + "_Counter";
+            string categoryName = nameof(CounterSampleCalculator_ElapsedTime) + "_Category";
 
-            PerformanceCounter counterSample = CreateCounter(name, PerformanceCounterType.ElapsedTime);
+            PerformanceCounter counterSample = CreateCounter(categoryName, PerformanceCounterType.ElapsedTime);
 
             counterSample.RawValue = Stopwatch.GetTimestamp();
             DateTime Start = DateTime.Now;
@@ -25,27 +25,26 @@ namespace System.Diagnostics.Tests
 
             var counterVal = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
             var dateTimeVal = DateTime.Now.Subtract(Start).TotalSeconds;
-            Helpers.DeleteCategory(name);
+            Helpers.DeleteCategory(categoryName);
             Assert.True(Math.Abs(dateTimeVal - counterVal) < .3);
         }
 
-        public static PerformanceCounter CreateCounter(string name, PerformanceCounterType counterType)
+        public static PerformanceCounter CreateCounter(string categoryName, PerformanceCounterType counterType)
         {
-            var category = name + "_Category";
-            var instance = name + "_Instance";
+            string counterName = categoryName + "_Counter";
 
             CounterCreationDataCollection ccdc = new CounterCreationDataCollection();
             CounterCreationData ccd = new CounterCreationData();
             ccd.CounterType = counterType;
-            ccd.CounterName = name;
+            ccd.CounterName = counterName;
             ccdc.Add(ccd);
 
-            Helpers.DeleteCategory(name);
-            PerformanceCounterCategory.Create(category, "description", PerformanceCounterCategoryType.SingleInstance, ccdc);
+            Helpers.DeleteCategory(categoryName);
+            PerformanceCounterCategory.Create(categoryName, "description", PerformanceCounterCategoryType.SingleInstance, ccdc);
 
-            Assert.True(Helpers.PerformanceCounterCategoryCreated(category));
+            Helpers.VerifyPerformanceCounterCategoryCreated(categoryName);
 
-            return new PerformanceCounter(category, name, false);
+            return new PerformanceCounter(categoryName, counterName, readOnly:false);
         }
     }
 }

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
@@ -17,37 +17,53 @@ namespace System.Diagnostics.Tests
         public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer; }
         public static bool CanReadNetPerfCounters { get => File.Exists(Environment.SystemDirectory + Path.DirectorySeparatorChar + "netfxperf.dll"); }
 
-        public static string CreateCategory(string name, PerformanceCounterCategoryType categoryType)
+        public static void CreateCategory(string categoryName, PerformanceCounterCategoryType categoryType)
         {
-            var category = name + "_Category";
-
-            // If the categry already exists, delete it, then create it.
-            DeleteCategory(name);
-            PerformanceCounterCategory.Create(category, "description", categoryType, name, "counter description");
-
-            Assert.True(PerformanceCounterCategoryCreated(category));
-            return category;
+            string counterName = categoryName.Replace("_Category", "_Counter");
+            CreateCategory(categoryName, counterName, categoryType);
         }
 
-        public static bool PerformanceCounterCategoryCreated(string category)
+        public static void CreateCategory(string categoryName, string counterName, PerformanceCounterCategoryType categoryType)
         {
+            Assert.EndsWith("_Category", categoryName);
+            Assert.EndsWith("_Counter", counterName);
+
+            // If the category already exists, delete it, then create it.
+            DeleteCategory(categoryName);
+            PerformanceCounterCategory.Create(categoryName, "description", categoryType, counterName, "counter description");
+
+            VerifyPerformanceCounterCategoryCreated(categoryName);
+        }
+
+        public static void VerifyPerformanceCounterCategoryCreated(string categoryName)
+        {
+            Assert.EndsWith("_Category", categoryName);
             int tries = 0;
-            while (!PerformanceCounterCategory.Exists(category) && tries < 10)
+            while (!PerformanceCounterCategory.Exists(categoryName) && tries < 10)
             {
                 System.Threading.Thread.Sleep(100);
                 tries++;
             }
 
-            return PerformanceCounterCategory.Exists(category);
+            Assert.True(PerformanceCounterCategory.Exists(categoryName));
         }
 
-        public static void DeleteCategory(string name)
+        public static void DeleteCategory(string categoryName)
         {
-            var category = name + "_Category";
-            if (PerformanceCounterCategory.Exists(category))
+            Assert.EndsWith("_Category", categoryName);
+            if (PerformanceCounterCategory.Exists(categoryName))
             {
-                PerformanceCounterCategory.Delete(category);
+                PerformanceCounterCategory.Delete(categoryName);
             }
+
+            int tries = 0;
+            while (PerformanceCounterCategory.Exists(categoryName) && tries < 10)
+            {
+                System.Threading.Thread.Sleep(100);
+                tries++;
+            }
+
+            Assert.True(!PerformanceCounterCategory.Exists(categoryName));
         }
 
         public static T RetryOnAllPlatforms<T>(Func<T> func)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterCategoryTests.cs
@@ -80,60 +80,59 @@ namespace System.Diagnostics.Tests
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounterCategory_CategoryType_MultiInstance()
         {
-            var name = nameof(PerformanceCounterCategory_CategoryType_MultiInstance) + "_Counter";
+            string categoryName = nameof(PerformanceCounterCategory_CategoryType_MultiInstance) + "_Category";
 
-            var category = Helpers.CreateCategory(name, PerformanceCounterCategoryType.MultiInstance);
+            Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.MultiInstance);
 
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(category));
+            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(categoryName));
 
             Assert.Equal(PerformanceCounterCategoryType.MultiInstance, Helpers.RetryOnAllPlatforms(() => pcc.CategoryType));
-            PerformanceCounterCategory.Delete(category);
+            PerformanceCounterCategory.Delete(categoryName);
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounterCategory_CategoryType_SingleInstance()
         {
-            var name = nameof(PerformanceCounterCategory_CategoryType_SingleInstance) + "_Counter";
+            string categoryName = nameof(PerformanceCounterCategory_CategoryType_SingleInstance) + "_Category";
 
-            var category = Helpers.CreateCategory(name, PerformanceCounterCategoryType.SingleInstance);
+            Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.SingleInstance);
 
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(category));
+            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(categoryName));
 
             Assert.Equal(PerformanceCounterCategoryType.SingleInstance, Helpers.RetryOnAllPlatforms(() => pcc.CategoryType));
-            PerformanceCounterCategory.Delete(category);
+            PerformanceCounterCategory.Delete(categoryName);
         }
 
 #pragma warning disable 0618 // obsolete warning
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
         public static void PerformanceCounterCategory_Create_Obsolete()
         {
-            var name = nameof(PerformanceCounterCategory_Create_Obsolete) + "_Counter";
-            var category = name + "_Category";
+            string categoryName = nameof(PerformanceCounterCategory_Create_Obsolete) + "_Category";
+            string counterName = nameof(PerformanceCounterCategory_Create_Obsolete) + "_Counter";
 
-            Helpers.DeleteCategory(category);
+            Helpers.DeleteCategory(categoryName);
 
-            PerformanceCounterCategory.Create(category, "category help", name, "counter help");
+            PerformanceCounterCategory.Create(categoryName, "category help", counterName, "counter help");
 
-            Assert.True(PerformanceCounterCategory.Exists(category));
-            PerformanceCounterCategory.Delete(category);
+            Assert.True(PerformanceCounterCategory.Exists(categoryName));
+            PerformanceCounterCategory.Delete(categoryName);
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
         public static void PerformanceCounterCategory_Create_Obsolete_CCD()
         {
-            var name = nameof(PerformanceCounterCategory_Create_Obsolete_CCD) + "_Counter";
-            var category = name + "_Category";
+            string categoryName = nameof(PerformanceCounterCategory_Create_Obsolete) + "_Category";
 
-            CounterCreationData ccd = new CounterCreationData(name, "counter help", PerformanceCounterType.NumberOfItems32);
+            CounterCreationData ccd = new CounterCreationData(categoryName, "counter help", PerformanceCounterType.NumberOfItems32);
             CounterCreationDataCollection ccdc = new CounterCreationDataCollection();
             ccdc.Add(ccd);
 
-            Helpers.DeleteCategory(category);
+            Helpers.DeleteCategory(categoryName);
 
-            PerformanceCounterCategory.Create(category, "category help", ccdc);
+            PerformanceCounterCategory.Create(categoryName, "category help", ccdc);
 
-            Assert.True(PerformanceCounterCategory.Exists(category));
-            PerformanceCounterCategory.Delete(category);
+            Assert.True(PerformanceCounterCategory.Exists(categoryName));
+            PerformanceCounterCategory.Delete(categoryName);
         }
 #pragma warning restore 0618
 
@@ -207,12 +206,12 @@ namespace System.Diagnostics.Tests
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteToPerfCounters))]
         public static void PerformanceCounterCategory_DeleteCategory()
         {
-            var name = nameof(PerformanceCounterCategory_DeleteCategory) + "_Counter";
-            var category = Helpers.CreateCategory(name, PerformanceCounterCategoryType.SingleInstance);
+            string categoryName = nameof(PerformanceCounterCategory_DeleteCategory) + "_Category";
+            Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.SingleInstance);
 
-            PerformanceCounterCategory.Delete(category);
+            PerformanceCounterCategory.Delete(categoryName);
 
-            Assert.False(PerformanceCounterCategory.Exists(category));
+            Assert.False(PerformanceCounterCategory.Exists(categoryName));
         }
 
         [Fact]
@@ -226,14 +225,14 @@ namespace System.Diagnostics.Tests
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters))]
         public static void PerformanceCounterCategory_GetCounters()
         {
-            var name = nameof(PerformanceCounterCategory_GetCounters) + "_Counter";
-            var category = Helpers.CreateCategory(name, PerformanceCounterCategoryType.SingleInstance);
+            string categoryName = nameof(PerformanceCounterCategory_GetCounters) + "_Category";
+            Helpers.CreateCategory(categoryName, PerformanceCounterCategoryType.SingleInstance);
 
-            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(category));
+            PerformanceCounterCategory pcc = Helpers.RetryOnAllPlatforms(() => new PerformanceCounterCategory(categoryName));
             PerformanceCounter[] counters = pcc.GetCounters();
 
             Assert.True(counters.Length > 0);
-            PerformanceCounterCategory.Delete(category);
+            PerformanceCounterCategory.Delete(categoryName);
         }
 
         [Fact]

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceDataTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceDataTests.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics.Tests
         }
 
         // We run the test only if the stress mode is enabled and the process is elvated.
-        private static bool IsRunnableEnvironnement => Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters && TestEnvironment.IsStressModeEnabled && RemoteExecutor.IsSupported;
+        private static bool IsRunnableEnvironment => Helpers.IsElevatedAndCanWriteAndReadNetPerfCounters && TestEnvironment.IsStressModeEnabled && RemoteExecutor.IsSupported;
 
         /// <summary>
         /// This test was taken from System.Diagnostics.PerformanceData documentation https://msdn.microsoft.com/en-us/library/system.diagnostics.performancedata(v=vs.110).aspx
@@ -26,7 +26,7 @@ namespace System.Diagnostics.Tests
         /// ctrpp.exe -legacy provider.man
         /// rc.exe /r /i "c:\Program Files\Microsoft SDKs\Windows\v6.0\Include" provider.rc
         /// </summary>
-        [ConditionalFact(nameof(PerformanceDataTests.IsRunnableEnvironnement))]
+        [ConditionalFact(nameof(PerformanceDataTests.IsRunnableEnvironment))]
         public void PerformanceCounter_PerformanceData()
         {
             // We run test in isolated process to avoid interferences on internal performance counter shared state with other tests.


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/45182
Fix https://github.com/dotnet/runtime/issues/54943

This has failed sporadically since these tests were written 4 years ago. On investigating I found that counter names and category names were intermingled, sometimes with the opposite names. 
Changed to use consistent variable names and actual names. Added asserts. Moved deleting categories to after disposing the counter. Add retries on deleting category. Fix a few comments.

Fix https://github.com/dotnet/runtime/issues/29753

Change to use a counter less likely to be zero, and retry it.