### PR TITLE
fix TestOnStartWithArgsThenStop

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -20,6 +20,7 @@ namespace System.ServiceProcess.Tests
         private static readonly Lazy<bool> s_isElevated = new Lazy<bool>(() => AdminHelpers.IsProcessElevated());
         protected static bool IsProcessElevated => s_isElevated.Value;
         protected static bool IsElevatedAndSupportsEventLogs => IsProcessElevated && PlatformDetection.IsNotWindowsNanoServer;
+        protected static bool IsElevatedAndWindows10OrLater => IsProcessElevated && PlatformDetection.IsWindows10OrLater;
 
         private bool _disposed;
 
@@ -81,7 +82,7 @@ namespace System.ServiceProcess.Tests
             controller.WaitForStatus(ServiceControllerStatus.Stopped);
         }
 
-        [ConditionalFact(nameof(IsProcessElevated))]
+        [ConditionalFact(nameof(IsElevatedAndWindows10OrLater))] // flaky on Windows 8.1
         public void TestOnStartWithArgsThenStop()
         {
             ServiceController controller = ConnectToServer();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/49681

This test has failed every 10 days for some time, and only ever on Windows 8.1. It's the only test that attempts to write to the pipe back to the test during OnStart() and apparently that's taking too long or hanging. It's not obvious to me why, and rather than investigate, since it is likely a combination of test and OS issue (eg., the test is flawed, and the OS is less tolerant). So disabling the test on Windows 7/8.