### PR TITLE
Fix HTTP/3 loopback server WaitForCancellationAsync and aborting on finalization

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1305,7 +1305,8 @@ namespace System.Net.Http
                 else
                 {
                     // We shouldn't be using a managed instance here, but don't have much choice -- we
-                    // need to remove the stream from the connection's GOAWAY collection.
+                    // need to remove the stream from the connection's GOAWAY collection and properly abort.
+                    stream.AbortStream();
                     stream._connection.RemoveStream(stream._stream);
                     stream._connection = null!;
                 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Quic;
 using System.Net.Test.Common;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -27,9 +28,8 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
         public async Task IncompleteResponseStream_ResponseDropped_CancelsRequestToServer()
         {
-            if (UseVersion == HttpVersion30)
+            if (UseQuicImplementationProvider == QuicImplementationProviders.Mock)
             {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58234")]
                 return;
             }
 


### PR DESCRIPTION
Fixed WaitForCancellationAsync to take into account both read and write cancellations. ~(Partially?)~ fixed not aborting on finalization.

~I have additional questions on disposing being part of Http3ReadStream and not Http3WriteStream, and also the fact that _connection.RemoveStream is called only in Http3RequestStream.Dispose and in Http3ReadStream -- if Http3ReadStream was never created and Http3RequestStream was left for finalization it seems that Http3RequestStream instance will live until it's connection is disposed/finalized? I decided it will be better to investigate as a separate PR.~
UPD: answered below

Fixes #58234
~Contributes to~ Fixes #60141