### PR TITLE
Use SDK-selected runtime in IL SDK

### DIFF
--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/sdk/Sdk.props
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/sdk/Sdk.props
@@ -12,11 +12,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
   <PropertyGroup>
     <!-- By default the SDK produces ref assembly for 5.0 or later -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/sdk/Sdk.props
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/sdk/Sdk.props
@@ -12,6 +12,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <!-- By default the SDK produces ref assembly for 5.0 or later -->
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
 </Project>

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/targets/Microsoft.NET.Sdk.IL.targets
@@ -27,16 +27,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </ItemGroup>
 
   <PropertyGroup>
-    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('windows'))">win</_OSPlatform>
-    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('linux'))">linux</_OSPlatform>
-    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('osx'))">osx</_OSPlatform>
-    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('freebsd'))">freebsd</_OSPlatform>
-    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('netbsd'))">netbsd</_OSPlatform>
-    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('illumos'))">illumos</_OSPlatform>
-    <_OSPlatform Condition="$([MSBuild]::IsOSPlatform('solaris'))">solaris</_OSPlatform>
-    <_OSArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</_OSArchitecture>
-
-    <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(_OSPlatform)-$(_OSArchitecture.ToLower())</MicrosoftNetCoreIlasmPackageRuntimeId>
+    <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(NETCoreSdkPortableRuntimeIdentifier)</MicrosoftNetCoreIlasmPackageRuntimeId>
     <MicrosoftNETCoreILAsmVersion Condition="'$(MicrosoftNETCoreILAsmVersion)' == ''">6.0.0</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNetCoreIlasmPackageName>runtime.$(MicrosoftNetCoreIlasmPackageRuntimeId).microsoft.netcore.ilasm</MicrosoftNetCoreIlasmPackageName>
     <MicrosoftNetCoreIldasmPackageName>runtime.$(MicrosoftNetCoreIlasmPackageRuntimeId).microsoft.netcore.ildasm</MicrosoftNetCoreIldasmPackageName>


### PR DESCRIPTION
When IL SDK is publicly consumed, it is less usable on variety of platforms than the .NET SDK. The reason is a hardcoded list of runtime identifiers.

Repro:
```sh
# on alpine-x64
$ mkdir testilsdk
$ cd testilsdk
$ cat > testilsdk.ilproj <<EOF
<Project Sdk="Microsoft.NET.Sdk.IL">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net5.0</TargetFramework>
  </PropertyGroup>
</Project>
EOF

$ cat > global.json <<EOF
{
  "msbuild-sdks": {
    "Microsoft.NET.Sdk.IL": "5.0.0"
  }
}
EOF

$ cat > Program.il <<EOF
.assembly extern System.Runtime
{
  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A)
}
.assembly extern System.Console { }

.assembly ConsoleApp { }

.class public auto ansi abstract sealed beforefieldinit Program extends System.Object
{
    .method public hidebysig static void Main () cil managed
    {
        .entrypoint
        .maxstack 8

        ldstr "Hello World! 👋"
        call void [System.Console]System.Console::WriteLine(string)
        ret
    }
}
EOF

$ dotnet build
```

which throws the following error:
> /home/am11/.nuget/packages/microsoft.net.sdk.il/5.0.0/targets/Microsoft.NET.Sdk.IL.targets(139,5): error MSB3073: The command "/home/am11/.nuget/packages/runtime.linux-x64.microsoft.netcore.ilasm/5.0.0/runtimes/linux-x64/native/ilasm -QUIET -NOLOGO -EXE  -OUTPUT="obj/Debug/net5.0/testilsdk.dll"  Program.il" exited with code 127. [/home/am11/projects/testilsdk/testilsdk.ilproj]
>
> The build failed. Fix the build errors and run again.


It is trying to access linux-x64, rather than linux-musl-x64.
PR fixes the problem by delegating external usages default to the runtime picked by its parent; the .NET SDK.

Workaround:

It requires us leaking the internal usage details to public and we need to explicitly pass (a very weird looking long property with) the desired runtime:

```sh
$ dotnet build -p:MicrosoftNetCoreIlasmPackageRuntimeId=linux-musl-x64
# while for the rest of the ecosystem
#     --runtime <VAL>
#     or
#     --use-curren-runtime
# suffice
```
