### PR TITLE
[tests] In test wrapper scripts if -debug is gdb or lldb, add separator before corerun and args

### DIFF
--- a/docs/workflow/testing/mono/testing.md
+++ b/docs/workflow/testing/mono/testing.md
@@ -39,20 +39,12 @@ make run-tests-coreclr-all
 To debug a single test with `lldb`:
 
 1. Run the test at least once normally (or manually run the `mono.proj` `PatchCoreClrCoreRoot` target)
-2. Edit the `.sh` file for the test and change the line
-```
-    LAUNCHER="$_DebuggerFullPath "$CORE_ROOT/corerun" -p "System.Reflection.Metadata.MetadataUpdater.IsSupported=false"  ${__DotEnvArg}"
-```
-to add `--` after the debugger full path
-```
-    LAUNCHER="$_DebuggerFullPath -- "$CORE_ROOT/corerun" -p "System.Reflection.Metadata.MetadataUpdater.IsSupported=false"  ${__DotEnvArg}"
-```
-3. Run the shell script for the test case manually:
+2. Run the shell script for the test case manually:
 ```
 bash ./artifacts/tests/coreclr/OSX.x64.Release/JIT/opt/InstructionCombining/DivToMul/DivToMul.sh -coreroot=`pwd`/artifacts/tests/coreclr/OSX.x64.Release/Tests/Core_Root -debug=/usr/bin/lldb
 ```
-4. In LLDB add the debug symbols for mono: `add-dsym <CORE_ROOT>/libcoreclr.dylib.dwarf`
-5. Run/debug the test
+3. In LLDB add the debug symbols for mono: `add-dsym <CORE_ROOT>/libcoreclr.dylib.dwarf`
+4. Run/debug the test
 
 ### WebAssembly:
 Build the runtime tests for WebAssembly

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -306,11 +306,17 @@ $__Command msbuild $CORE_ROOT/wasm-test-runner/WasmTestRunner.proj /p:NetCoreApp
     <![CDATA[
 $(BashLinkerTestLaunchCmds)
 
+_DebuggerArgsSeparator=
+if [[ "$_DebuggerFullPath" == *lldb* ]];
+then
+  _DebuggerArgsSeparator=--
+fi
+
 if [ ! -z "$CLRCustomTestLauncher" ];
 then
     LAUNCHER="$CLRCustomTestLauncher $PWD/"
 else
-    LAUNCHER="$_DebuggerFullPath $(CLRTestRunFile)"
+    LAUNCHER="$_DebuggerFullPath $_DebuggerArgsSeparator $(CLRTestRunFile)"
 fi
 
 $(BashIlrtTestLaunchCmds)

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -310,6 +310,9 @@ _DebuggerArgsSeparator=
 if [[ "$_DebuggerFullPath" == *lldb* ]];
 then
   _DebuggerArgsSeparator=--
+elif [[ "$_DebuggerFullPath" == *gdb* ]]
+then
+  _DebuggerArgsSeparator=--args
 fi
 
 if [ ! -z "$CLRCustomTestLauncher" ];


### PR DESCRIPTION
For runtime test shell scripts, if a debugger is specified with
`-debug=/usr/bin/lddb` or the like, add a separator so that `lldb` doesn't try
to interpret `-p` as a PID argument.

Also update mono workflow doc