### PR TITLE
[HTTP] Add logging of request and response

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1900,7 +1900,7 @@ namespace System.Net.Http
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(async);
-            if (NetEventSource.Log.IsEnabled()) Trace($"{request}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Sending request: {request}");
 
             try
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -140,7 +140,7 @@ namespace System.Net.Http
             {
                 StreamId = streamId;
                 _availableCredit = initialWindowSize;
-                if (NetEventSource.Log.IsEnabled()) Trace($"{_request}, {nameof(initialWindowSize)}={initialWindowSize}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(initialWindowSize)}={initialWindowSize}");
             }
 
             public int StreamId { get; private set; }
@@ -1029,6 +1029,7 @@ namespace System.Net.Http
                 {
                     responseContent.SetStream(new Http2ReadStream(this));
                 }
+                if (NetEventSource.Log.IsEnabled()) Trace($"Received response: {_response}");
 
                 // Process Set-Cookie headers.
                 if (_connection._pool.Settings._useCookies)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -203,6 +203,8 @@ namespace System.Net.Http
                     throw new HttpRequestException(SR.net_http_request_aborted, null, RequestRetryType.RetryOnConnectionFailure);
                 }
 
+                if (NetEventSource.Log.IsEnabled()) Trace($"Sending request: {request}");
+
                 Task<HttpResponseMessage> responseTask = requestStream.SendAsync(cancellationToken);
 
                 // null out requestStream to avoid disposing in finally block. It is now in charge of disposing itself.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -235,6 +235,7 @@ namespace System.Net.Http
                     // A read stream is required to finish up the request.
                     responseContent.SetStream(new Http3ReadStream(this));
                 }
+                if (NetEventSource.Log.IsEnabled()) Trace($"Received response: {_response}");
 
                 // Process any Set-Cookie headers.
                 if (_connection.Pool.Settings._useCookies)


### PR DESCRIPTION
With #38874 we lost logging of HTTP request and response.
We do have telemetry, but it's missing method, headers, content type and with response everything (status and headers).

These information are very helpful when debugging scenarios like HTTP stress.

Originally, the logging was in `HttpMessageInvoker` but it lacks awaiting the `SendAsync`, so I added the logging in `HttpClient` where we have access to `HttpResponseMessage`.

Opening this PR to mainly kick of discussion since I expect some push back on this change.

cc: @MihaZupan @stephentoub @wfurt 