### PR TITLE
Exclude ref .cs files from .editorconfig formatting

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -25,12 +25,6 @@
       "commands": [
         "slngen"
       ]
-    },
-    "dotnet-format": {
-      "version": "6.0.240501",
-      "commands": [
-        "dotnet-format"
-      ]
     }
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ trim_trailing_whitespace = true
 indent_size = 2
 
 # Generated code
-[*{_AssemblyInfo.cs,.notsupported.cs}]
+[*{_AssemblyInfo.cs,.notsupported.cs,src/libraries/**/ref/*.cs}]
 generated_code = true
 
 # C# files

--- a/docs/coding-guidelines/code-formatting-tools.md
+++ b/docs/coding-guidelines/code-formatting-tools.md
@@ -8,7 +8,7 @@ To help enable an easy workflow and reduce the number of formatting changes requ
 
 ### C#/VB
 
-C# and VB code in the repository use the built-in Roslyn support for EditorConfig to enable auto-formatting in many IDEs. As a result, no additional tools are required to enable keeping your code formatted. If you want to use `dotnet format` to do formatting or are using the git pre-commit hook mentioned later in this document, you can run `./dotnet.cmd tool restore` or `./dotnet.sh tool restore` from the root of the repository to enable the `dotnet format` command.
+C# and VB code in the repository use the built-in Roslyn support for EditorConfig to enable auto-formatting in many IDEs. As a result, no additional tools are required to enable keeping your code formatted. You can also use the `dotnet format` command from the dotnet SDK to do formatting or use the git pre-commit hook mentioned later in this document.
 
 ### C/C++
 


### PR DESCRIPTION
The *.cs files in the libraries ref/ folder are auto-generated so we shouldn't try to format them.

Also removed the dotnet-format tool from dotnet-tools.json since it now ships as part of the .NET 6 SDK (https://github.com/dotnet/format/issues/1268).
We were already using the SDK-integrated tool in format.sh so update the docs to be in sync.