### PR TITLE
Fix null being passed to g_path_get_dirname when probing in wasm

### DIFF
--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -526,10 +526,8 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags)
 		module = netcore_probe_for_module_variations (pinvoke_search_directories[i], file_name, lflags);
 
 	// Check the assembly directory if the search flag is set and the image exists
-	if (
-		flags & DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY && image != NULL && 
-		module == NULL && (image->filename != NULL)
-	) {
+	if ((flags & DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY) != 0 && image != NULL && 
+		module == NULL && (image->filename != NULL)) {
 		char *mdirname = g_path_get_dirname (image->filename);
 		if (mdirname)
 			module = netcore_probe_for_module_variations (mdirname, file_name, lflags);

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -526,7 +526,10 @@ netcore_probe_for_module (MonoImage *image, const char *file_name, int flags)
 		module = netcore_probe_for_module_variations (pinvoke_search_directories[i], file_name, lflags);
 
 	// Check the assembly directory if the search flag is set and the image exists
-	if (flags & DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY && image != NULL && module == NULL) {
+	if (
+		flags & DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY && image != NULL && 
+		module == NULL && (image->filename != NULL)
+	) {
 		char *mdirname = g_path_get_dirname (image->filename);
 		if (mdirname)
 			module = netcore_probe_for_module_variations (mdirname, file_name, lflags);


### PR DESCRIPTION
Somewhat recently the module probing logic started passing null to g_path_get_dirname in some cases. While this wouldn't crash, it would print an error to the console.

cc @lambdageek 