### PR TITLE
[release/6.0] Apply custom Message and Url to all [RequiresPreviewFeatures] attributes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,7 +51,7 @@
     <!-- Code analysis dependencies -->
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>3.10.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisCSharpVersion>3.10.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-rc1.21413.4</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0-rtm.21514.4</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <!-- SDK dependencies -->
     <MicrosoftDotNetCompatibilityVersion>1.0.0-rc.2.21419.17</MicrosoftDotNetCompatibilityVersion>
     <!-- Arcade dependencies -->

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -285,11 +285,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IAdditionOperators<byte, byte, byte>.operator +(byte left, byte right)
             => (byte)(left + right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IAdditionOperators<byte, byte, byte>.operator +(byte left, byte right)
         //     => checked((byte)(left + right));
 
@@ -297,30 +297,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IAdditiveIdentity<byte, byte>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBinaryInteger<byte>.LeadingZeroCount(byte value)
             => (byte)(BitOperations.LeadingZeroCount(value) - 24);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBinaryInteger<byte>.PopCount(byte value)
             => (byte)BitOperations.PopCount(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBinaryInteger<byte>.RotateLeft(byte value, int rotateAmount)
             => (byte)((value << (rotateAmount & 7)) | (value >> ((8 - rotateAmount) & 7)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBinaryInteger<byte>.RotateRight(byte value, int rotateAmount)
             => (byte)((value >> (rotateAmount & 7)) | (value << ((8 - rotateAmount) & 7)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBinaryInteger<byte>.TrailingZeroCount(byte value)
             => (byte)(BitOperations.TrailingZeroCount(value << 24) - 24);
 
@@ -328,11 +328,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<byte>.IsPow2(byte value)
             => BitOperations.IsPow2((uint)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBinaryNumber<byte>.Log2(byte value)
             => (byte)BitOperations.Log2(value);
 
@@ -340,19 +340,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBitwiseOperators<byte, byte, byte>.operator &(byte left, byte right)
             => (byte)(left & right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBitwiseOperators<byte, byte, byte>.operator |(byte left, byte right)
             => (byte)(left | right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBitwiseOperators<byte, byte, byte>.operator ^(byte left, byte right)
             => (byte)(left ^ right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IBitwiseOperators<byte, byte, byte>.operator ~(byte value)
             => (byte)(~value);
 
@@ -360,19 +360,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<byte, byte>.operator <(byte left, byte right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<byte, byte>.operator <=(byte left, byte right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<byte, byte>.operator >(byte left, byte right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<byte, byte>.operator >=(byte left, byte right)
             => left >= right;
 
@@ -380,11 +380,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IDecrementOperators<byte>.operator --(byte value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IDecrementOperators<byte>.operator --(byte value)
         //     => checked(--value);
 
@@ -392,11 +392,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right)
             => (byte)(left / right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right)
         //     => checked((byte)(left / right));
 
@@ -404,11 +404,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<byte, byte>.operator ==(byte left, byte right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<byte, byte>.operator !=(byte left, byte right)
             => left != right;
 
@@ -416,11 +416,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IIncrementOperators<byte>.operator ++(byte value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IIncrementOperators<byte>.operator ++(byte value)
         //     => checked(++value);
 
@@ -428,21 +428,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IMinMaxValue<byte>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IMinMaxValue<byte>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IModulusOperators<byte, byte, byte>.operator %(byte left, byte right)
             => (byte)(left % right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IModulusOperators<byte, byte, byte>.operator %(byte left, byte right)
         //     => checked((byte)(left % right));
 
@@ -450,18 +450,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IMultiplicativeIdentity<byte, byte>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right)
             => (byte)(left * right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right)
         //     => checked((byte)(left * right));
 
@@ -469,21 +469,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Abs(byte value)
             => value;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Clamp(byte value, byte min, byte max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static byte INumber<byte>.Create<TOther>(TOther value)
         {
@@ -550,7 +550,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static byte INumber<byte>.CreateSaturating<TOther>(TOther value)
         {
@@ -637,7 +637,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static byte INumber<byte>.CreateTruncating<TOther>(TOther value)
         {
@@ -704,31 +704,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (byte Quotient, byte Remainder) INumber<byte>.DivRem(byte left, byte right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Max(byte x, byte y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Min(byte x, byte y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte INumber<byte>.Sign(byte value)
             => (byte)((value == 0) ? 0 : 1);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<byte>.TryCreate<TOther>(TOther value, out byte result)
         {
@@ -914,11 +914,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<byte>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out byte result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<byte>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out byte result)
             => TryParse(s, style, provider, out result);
 
@@ -926,11 +926,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IParseable<byte>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<byte>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out byte result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -938,15 +938,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IShiftOperators<byte, byte>.operator <<(byte value, int shiftAmount)
             => (byte)(value << shiftAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IShiftOperators<byte, byte>.operator >>(byte value, int shiftAmount)
             => (byte)(value >> shiftAmount);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static byte IShiftOperators<byte, byte, byte>.operator >>>(byte value, int shiftAmount)
         //     => (byte)(value >> shiftAmount);
 
@@ -954,11 +954,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte ISpanParseable<byte>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<byte>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out byte result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -966,11 +966,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte ISubtractionOperators<byte, byte, byte>.operator -(byte left, byte right)
             => (byte)(left - right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte ISubtractionOperators<byte, byte, byte>.operator -(byte left, byte right)
         //     => checked((byte)(left - right));
 
@@ -978,11 +978,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IUnaryNegationOperators<byte, byte>.operator -(byte value)
             => (byte)(-value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IUnaryNegationOperators<byte, byte>.operator -(byte value)
         //     => checked((byte)(-value));
 
@@ -990,11 +990,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static byte IUnaryPlusOperators<byte, byte>.operator +(byte value)
             => (byte)(+value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked byte IUnaryPlusOperators<byte, byte>.operator +(byte value)
         //     => checked((byte)(+value));
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -1065,11 +1065,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IAdditionOperators<char, char, char>.operator +(char left, char right)
             => (char)(left + right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IAdditionOperators<char, char, char>.operator +(char left, char right)
         //     => checked((char)(left + right));
 
@@ -1077,30 +1077,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IAdditiveIdentity<char, char>.AdditiveIdentity => (char)0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBinaryInteger<char>.LeadingZeroCount(char value)
             => (char)(BitOperations.LeadingZeroCount(value) - 16);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBinaryInteger<char>.PopCount(char value)
             => (char)BitOperations.PopCount(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBinaryInteger<char>.RotateLeft(char value, int rotateAmount)
             => (char)((value << (rotateAmount & 15)) | (value >> ((16 - rotateAmount) & 15)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBinaryInteger<char>.RotateRight(char value, int rotateAmount)
             => (char)((value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBinaryInteger<char>.TrailingZeroCount(char value)
             => (char)(BitOperations.TrailingZeroCount(value << 16) - 16);
 
@@ -1108,11 +1108,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<char>.IsPow2(char value)
             => BitOperations.IsPow2((uint)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBinaryNumber<char>.Log2(char value)
             => (char)BitOperations.Log2(value);
 
@@ -1120,19 +1120,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBitwiseOperators<char, char, char>.operator &(char left, char right)
             => (char)(left & right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBitwiseOperators<char, char, char>.operator |(char left, char right)
             => (char)(left | right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBitwiseOperators<char, char, char>.operator ^(char left, char right)
             => (char)(left ^ right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IBitwiseOperators<char, char, char>.operator ~(char value)
             => (char)(~value);
 
@@ -1140,19 +1140,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<char, char>.operator <(char left, char right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<char, char>.operator <=(char left, char right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<char, char>.operator >(char left, char right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<char, char>.operator >=(char left, char right)
             => left >= right;
 
@@ -1160,11 +1160,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IDecrementOperators<char>.operator --(char value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IDecrementOperators<char>.operator --(char value)
         //     => checked(--value);
 
@@ -1172,11 +1172,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IDivisionOperators<char, char, char>.operator /(char left, char right)
             => (char)(left / right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IDivisionOperators<char, char, char>.operator /(char left, char right)
         //     => checked((char)(left / right));
 
@@ -1184,11 +1184,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<char, char>.operator ==(char left, char right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<char, char>.operator !=(char left, char right)
             => left != right;
 
@@ -1196,11 +1196,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IIncrementOperators<char>.operator ++(char value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IIncrementOperators<char>.operator ++(char value)
         //     => checked(++value);
 
@@ -1208,21 +1208,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IMinMaxValue<char>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IMinMaxValue<char>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IModulusOperators<char, char, char>.operator %(char left, char right)
             => (char)(left % right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IModulusOperators<char, char, char>.operator %(char left, char right)
         //     => checked((char)(left % right));
 
@@ -1230,18 +1230,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IMultiplicativeIdentity<char, char>.MultiplicativeIdentity => (char)1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IMultiplyOperators<char, char, char>.operator *(char left, char right)
             => (char)(left * right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IMultiplyOperators<char, char, char>.operator *(char left, char right)
         //     => checked((char)(left * right));
 
@@ -1249,21 +1249,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.One => (char)1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Zero => (char)0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Abs(char value)
             => value;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Clamp(char value, char min, char max)
             => (char)Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static char INumber<char>.Create<TOther>(TOther value)
         {
@@ -1330,7 +1330,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static char INumber<char>.CreateSaturating<TOther>(TOther value)
         {
@@ -1414,7 +1414,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static char INumber<char>.CreateTruncating<TOther>(TOther value)
         {
@@ -1481,23 +1481,23 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (char Quotient, char Remainder) INumber<char>.DivRem(char left, char right)
             => ((char, char))Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Max(char x, char y)
             => (char)Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Min(char x, char y)
             => (char)Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
         {
             if (s.Length != 1)
@@ -1507,11 +1507,11 @@ namespace System
             return s[0];
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char INumber<char>.Sign(char value)
             => (char)((value == 0) ? 0 : 1);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<char>.TryCreate<TOther>(TOther value, out char result)
         {
@@ -1689,11 +1689,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<char>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out char result)
             => TryParse(s, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<char>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out char result)
         {
             if (s.Length != 1)
@@ -1709,11 +1709,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IParseable<char>.Parse(string s, IFormatProvider? provider)
             => Parse(s);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<char>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out char result)
             => TryParse(s, out result);
 
@@ -1721,15 +1721,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IShiftOperators<char, char>.operator <<(char value, int shiftAmount)
             => (char)(value << shiftAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IShiftOperators<char, char>.operator >>(char value, int shiftAmount)
             => (char)(value >> shiftAmount);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static char IShiftOperators<char, char, char>.operator >>>(char value, int shiftAmount)
         //     => (char)(value >> shiftAmount);
 
@@ -1737,7 +1737,7 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char ISpanParseable<char>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
         {
             if (s.Length != 1)
@@ -1747,7 +1747,7 @@ namespace System
             return s[0];
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<char>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out char result)
         {
             if (s.Length != 1)
@@ -1763,11 +1763,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char ISubtractionOperators<char, char, char>.operator -(char left, char right)
             => (char)(left - right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char ISubtractionOperators<char, char, char>.operator -(char left, char right)
         //     => checked((char)(left - right));
 
@@ -1775,11 +1775,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IUnaryNegationOperators<char, char>.operator -(char value)
             => (char)(-value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IUnaryNegationOperators<char, char>.operator -(char value)
         //     => checked((char)(-value));
 
@@ -1787,11 +1787,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static char IUnaryPlusOperators<char, char>.operator +(char value)
             => (char)(+value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked char IUnaryPlusOperators<char, char>.operator +(char value)
         //     => checked((char)(+value));
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
@@ -836,19 +836,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateOnly, DateOnly>.operator <(DateOnly left, DateOnly right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateOnly, DateOnly>.operator <=(DateOnly left, DateOnly right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateOnly, DateOnly>.operator >(DateOnly left, DateOnly right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateOnly, DateOnly>.operator >=(DateOnly left, DateOnly right)
             => left >= right;
 
@@ -856,11 +856,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<DateOnly, DateOnly>.operator ==(DateOnly left, DateOnly right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<DateOnly, DateOnly>.operator !=(DateOnly left, DateOnly right)
             => left != right;
 
@@ -868,21 +868,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateOnly IMinMaxValue<DateOnly>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateOnly IMinMaxValue<DateOnly>.MaxValue => MaxValue;
 
         //
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateOnly IParseable<DateOnly>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider, DateTimeStyles.None);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<DateOnly>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateOnly result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 
@@ -890,11 +890,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateOnly ISpanParseable<DateOnly>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, provider, DateTimeStyles.None);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<DateOnly>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateOnly result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1521,11 +1521,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTime IAdditionOperators<DateTime, TimeSpan, DateTime>.operator +(DateTime left, TimeSpan right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked DateTime IAdditionOperators<DateTime, TimeSpan, DateTime>.operator +(DateTime left, TimeSpan right)
         //     => checked(left + right);
 
@@ -1533,7 +1533,7 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IAdditiveIdentity<DateTime, TimeSpan>.AdditiveIdentity
             => default;
 
@@ -1541,19 +1541,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTime, DateTime>.operator <(DateTime left, DateTime right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTime, DateTime>.operator <=(DateTime left, DateTime right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTime, DateTime>.operator >(DateTime left, DateTime right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTime, DateTime>.operator >=(DateTime left, DateTime right)
             => left >= right;
 
@@ -1561,11 +1561,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<DateTime, DateTime>.operator ==(DateTime left, DateTime right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<DateTime, DateTime>.operator !=(DateTime left, DateTime right)
             => left != right;
 
@@ -1573,21 +1573,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTime IMinMaxValue<DateTime>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTime IMinMaxValue<DateTime>.MaxValue => MaxValue;
 
         //
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTime IParseable<DateTime>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<DateTime>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateTime result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 
@@ -1595,11 +1595,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTime ISpanParseable<DateTime>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, provider, DateTimeStyles.None);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<DateTime>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateTime result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 
@@ -1607,19 +1607,19 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTime ISubtractionOperators<DateTime, TimeSpan, DateTime>.operator -(DateTime left, TimeSpan right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked DateTime ISubtractionOperators<DateTime, TimeSpan, DateTime>.operator -(DateTime left, TimeSpan right)
         //     => checked(left - right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan ISubtractionOperators<DateTime, DateTime, TimeSpan>.operator -(DateTime left, DateTime right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan ISubtractionOperators<DateTime, DateTime, TimeSpan>.operator -(DateTime left, DateTime right)
         //     => checked(left - right);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -870,11 +870,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTimeOffset IAdditionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator +(DateTimeOffset left, TimeSpan right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked DateTimeOffset IAdditionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator +(DateTimeOffset left, TimeSpan right)
         //     => checked(left + right);
 
@@ -882,26 +882,26 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IAdditiveIdentity<DateTimeOffset, TimeSpan>.AdditiveIdentity => default;
 
         //
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator <(DateTimeOffset left, DateTimeOffset right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator <=(DateTimeOffset left, DateTimeOffset right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator >(DateTimeOffset left, DateTimeOffset right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<DateTimeOffset, DateTimeOffset>.operator >=(DateTimeOffset left, DateTimeOffset right)
             => left >= right;
 
@@ -909,11 +909,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<DateTimeOffset, DateTimeOffset>.operator ==(DateTimeOffset left, DateTimeOffset right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<DateTimeOffset, DateTimeOffset>.operator !=(DateTimeOffset left, DateTimeOffset right)
             => left != right;
 
@@ -921,21 +921,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTimeOffset IMinMaxValue<DateTimeOffset>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTimeOffset IMinMaxValue<DateTimeOffset>.MaxValue => MaxValue;
 
         //
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTimeOffset IParseable<DateTimeOffset>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<DateTimeOffset>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out DateTimeOffset result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 
@@ -943,11 +943,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTimeOffset ISpanParseable<DateTimeOffset>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, provider, DateTimeStyles.None);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<DateTimeOffset>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out DateTimeOffset result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 
@@ -955,19 +955,19 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static DateTimeOffset ISubtractionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator -(DateTimeOffset left, TimeSpan right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked DateTimeOffset ISubtractionOperators<DateTimeOffset, TimeSpan, DateTimeOffset>.operator -(DateTimeOffset left, TimeSpan right)
         //     => checked(left - right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan ISubtractionOperators<DateTimeOffset, DateTimeOffset, TimeSpan>.operator -(DateTimeOffset left, DateTimeOffset right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan ISubtractionOperators<DateTimeOffset, DateTimeOffset, TimeSpan>.operator -(DateTimeOffset left, DateTimeOffset right)
         //     => checked(left - right);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -1085,11 +1085,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IAdditionOperators<decimal, decimal, decimal>.operator +(decimal left, decimal right)
             => checked(left + right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IAdditionOperators<decimal, decimal, decimal>.operator +(decimal left, decimal right)
         //     => checked(left + right);
 
@@ -1097,26 +1097,26 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IAdditiveIdentity<decimal, decimal>.AdditiveIdentity => 0.0m;
 
         //
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<decimal, decimal>.operator <(decimal left, decimal right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<decimal, decimal>.operator <=(decimal left, decimal right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<decimal, decimal>.operator >(decimal left, decimal right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<decimal, decimal>.operator >=(decimal left, decimal right)
             => left >= right;
 
@@ -1124,11 +1124,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IDecrementOperators<decimal>.operator --(decimal value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IDecrementOperators<decimal>.operator --(decimal value)
         //     => checked(--value);
 
@@ -1136,11 +1136,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IDivisionOperators<decimal, decimal, decimal>.operator /(decimal left, decimal right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IDivisionOperators<decimal, decimal, decimal>.operator /(decimal left, decimal right)
         //     => checked(left / right);
 
@@ -1148,11 +1148,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<decimal, decimal>.operator ==(decimal left, decimal right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<decimal, decimal>.operator !=(decimal left, decimal right)
             => left != right;
 
@@ -1160,11 +1160,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IIncrementOperators<decimal>.operator ++(decimal value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IIncrementOperators<decimal>.operator ++(decimal value)
         //     => checked(++value);
 
@@ -1172,21 +1172,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IMinMaxValue<decimal>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IMinMaxValue<decimal>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IModulusOperators<decimal, decimal, decimal>.operator %(decimal left, decimal right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IModulusOperators<decimal, decimal, decimal>.operator %(decimal left, decimal right)
         //     => checked(left % right);
 
@@ -1194,18 +1194,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IMultiplicativeIdentity<decimal, decimal>.MultiplicativeIdentity => 1.0m;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IMultiplyOperators<decimal, decimal, decimal>.operator *(decimal left, decimal right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IMultiplyOperators<decimal, decimal, decimal>.operator *(decimal left, decimal right)
         //     => checked(left * right);
 
@@ -1213,17 +1213,17 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.One => 1.0m;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Zero => 0.0m;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Abs(decimal value)
             => Math.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static decimal INumber<decimal>.Create<TOther>(TOther value)
         {
@@ -1290,7 +1290,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static decimal INumber<decimal>.CreateSaturating<TOther>(TOther value)
         {
@@ -1357,7 +1357,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static decimal INumber<decimal>.CreateTruncating<TOther>(TOther value)
         {
@@ -1424,35 +1424,35 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Clamp(decimal value, decimal min, decimal max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (decimal Quotient, decimal Remainder) INumber<decimal>.DivRem(decimal left, decimal right)
             => (left / right, left % right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Max(decimal x, decimal y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Min(decimal x, decimal y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal INumber<decimal>.Sign(decimal value)
             => Math.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<decimal>.TryCreate<TOther>(TOther value, out decimal result)
         {
@@ -1534,11 +1534,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<decimal>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out decimal result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<decimal>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out decimal result)
             => TryParse(s, style, provider, out result);
 
@@ -1546,11 +1546,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IParseable<decimal>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<decimal>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out decimal result)
             => TryParse(s, NumberStyles.Number, provider, out result);
 
@@ -1558,18 +1558,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal ISignedNumber<decimal>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal ISpanParseable<decimal>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Number, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<decimal>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out decimal result)
             => TryParse(s, NumberStyles.Number, provider, out result);
 
@@ -1577,11 +1577,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal ISubtractionOperators<decimal, decimal, decimal>.operator -(decimal left, decimal right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal ISubtractionOperators<decimal, decimal, decimal>.operator -(decimal left, decimal right)
         //     => checked(left - right);
 
@@ -1589,11 +1589,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IUnaryNegationOperators<decimal, decimal>.operator -(decimal value)
             => -value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IUnaryNegationOperators<decimal, decimal>.operator -(decimal value)
         //     => checked(-value);
 
@@ -1601,11 +1601,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static decimal IUnaryPlusOperators<decimal, decimal>.operator +(decimal value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked decimal IUnaryPlusOperators<decimal, decimal>.operator +(decimal value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -455,11 +455,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IAdditionOperators<double, double, double>.operator +(double left, double right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IAdditionOperators<double, double, double>.operator +(double left, double right)
         //     => checked(left + right);
 
@@ -467,14 +467,14 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IAdditiveIdentity<double, double>.AdditiveIdentity => 0.0;
 
         //
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<double>.IsPow2(double value)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(value);
@@ -487,7 +487,7 @@ namespace System
                 && (significand == MinSignificand);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IBinaryNumber<double>.Log2(double value)
             => Math.Log2(value);
 
@@ -495,28 +495,28 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IBitwiseOperators<double, double, double>.operator &(double left, double right)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(left) & BitConverter.DoubleToUInt64Bits(right);
             return BitConverter.UInt64BitsToDouble(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IBitwiseOperators<double, double, double>.operator |(double left, double right)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(left) | BitConverter.DoubleToUInt64Bits(right);
             return BitConverter.UInt64BitsToDouble(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IBitwiseOperators<double, double, double>.operator ^(double left, double right)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(left) ^ BitConverter.DoubleToUInt64Bits(right);
             return BitConverter.UInt64BitsToDouble(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IBitwiseOperators<double, double, double>.operator ~(double value)
         {
             ulong bits = ~BitConverter.DoubleToUInt64Bits(value);
@@ -527,19 +527,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<double, double>.operator <(double left, double right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<double, double>.operator <=(double left, double right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<double, double>.operator >(double left, double right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<double, double>.operator >=(double left, double right)
             => left >= right;
 
@@ -547,11 +547,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IDecrementOperators<double>.operator --(double value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IDecrementOperators<double>.operator --(double value)
         //     => checked(--value);
 
@@ -559,11 +559,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IDivisionOperators<double, double, double>.operator /(double left, double right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IDivisionOperators<double, double, double>.operator /(double left, double right)
         //     => checked(left / right);
 
@@ -571,11 +571,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<double, double>.operator ==(double left, double right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<double, double>.operator !=(double left, double right)
             => left != right;
 
@@ -583,200 +583,200 @@ namespace System
         // IFloatingPoint
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.E => Math.E;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Epsilon => Epsilon;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.NaN => NaN;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.NegativeInfinity => NegativeInfinity;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.NegativeZero => -0.0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Pi => Math.PI;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.PositiveInfinity => PositiveInfinity;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Tau => Math.Tau;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Acos(double x)
             => Math.Acos(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Acosh(double x)
             => Math.Acosh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Asin(double x)
             => Math.Asin(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Asinh(double x)
             => Math.Asinh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Atan(double x)
             => Math.Atan(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Atan2(double y, double x)
             => Math.Atan2(y, x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Atanh(double x)
             => Math.Atanh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.BitIncrement(double x)
             => Math.BitIncrement(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.BitDecrement(double x)
             => Math.BitDecrement(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Cbrt(double x)
             => Math.Cbrt(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Ceiling(double x)
             => Math.Ceiling(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.CopySign(double x, double y)
             => Math.CopySign(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Cos(double x)
             => Math.Cos(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Cosh(double x)
             => Math.Cosh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Exp(double x)
             => Math.Exp(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Floor(double x)
             => Math.Floor(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.FusedMultiplyAdd(double left, double right, double addend)
             => Math.FusedMultiplyAdd(left, right, addend);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.IEEERemainder(double left, double right)
             => Math.IEEERemainder(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TInteger IFloatingPoint<double>.ILogB<TInteger>(double x)
             => TInteger.Create(Math.ILogB(x));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Log(double x)
             => Math.Log(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Log(double x, double newBase)
             => Math.Log(x, newBase);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Log2(double x)
             => Math.Log2(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Log10(double x)
             => Math.Log10(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.MaxMagnitude(double x, double y)
             => Math.MaxMagnitude(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.MinMagnitude(double x, double y)
             => Math.MinMagnitude(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Pow(double x, double y)
             => Math.Pow(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Round(double x)
             => Math.Round(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits)
             => Math.Round(x, int.Create(digits));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Round(double x, MidpointRounding mode)
             => Math.Round(x, mode);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits, MidpointRounding mode)
             => Math.Round(x, int.Create(digits), mode);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.ScaleB<TInteger>(double x, TInteger n)
             => Math.ScaleB(x, int.Create(n));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Sin(double x)
             => Math.Sin(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Sinh(double x)
             => Math.Sinh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Sqrt(double x)
             => Math.Sqrt(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Tan(double x)
             => Math.Tan(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Tanh(double x)
             => Math.Tanh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IFloatingPoint<double>.Truncate(double x)
             => Math.Truncate(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsFinite(double d) => IsFinite(d);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsInfinity(double d) => IsInfinity(d);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsNaN(double d) => IsNaN(d);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsNegative(double d) => IsNegative(d);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsNegativeInfinity(double d) => IsNegativeInfinity(d);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsNormal(double d) => IsNormal(d);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsPositiveInfinity(double d) => IsPositiveInfinity(d);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<double>.IsSubnormal(double d) => IsSubnormal(d);
 
         // static double IFloatingPoint<double>.AcosPi(double x)
@@ -849,11 +849,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IIncrementOperators<double>.operator ++(double value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IIncrementOperators<double>.operator ++(double value)
         //     => checked(++value);
 
@@ -861,21 +861,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IMinMaxValue<double>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IMinMaxValue<double>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IModulusOperators<double, double, double>.operator %(double left, double right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IModulusOperators<double, double, double>.operator %(double left, double right)
         //     => checked(left % right);
 
@@ -883,18 +883,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IMultiplicativeIdentity<double, double>.MultiplicativeIdentity => 1.0;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IMultiplyOperators<double, double, double>.operator *(double left, double right)
             => (double)(left * right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IMultiplyOperators<double, double, double>.operator *(double left, double right)
         //     => checked((double)(left * right));
 
@@ -902,21 +902,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.One => 1.0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Zero => 0.0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Abs(double value)
             => Math.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Clamp(double value, double min, double max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static double INumber<double>.Create<TOther>(TOther value)
         {
@@ -983,7 +983,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static double INumber<double>.CreateSaturating<TOther>(TOther value)
         {
@@ -1050,7 +1050,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static double INumber<double>.CreateTruncating<TOther>(TOther value)
         {
@@ -1117,31 +1117,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (double Quotient, double Remainder) INumber<double>.DivRem(double left, double right)
             => (left / right, left % right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Max(double x, double y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Min(double x, double y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double INumber<double>.Sign(double value)
             => Math.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<double>.TryCreate<TOther>(TOther value, out double result)
         {
@@ -1223,11 +1223,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<double>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out double result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<double>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out double result)
             => TryParse(s, style, provider, out result);
 
@@ -1235,11 +1235,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IParseable<double>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<double>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out double result)
             => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
@@ -1247,18 +1247,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double ISignedNumber<double>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double ISpanParseable<double>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<double>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out double result)
             => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
@@ -1266,11 +1266,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double ISubtractionOperators<double, double, double>.operator -(double left, double right)
             => (double)(left - right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double ISubtractionOperators<double, double, double>.operator -(double left, double right)
         //     => checked((double)(left - right));
 
@@ -1278,11 +1278,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IUnaryNegationOperators<double, double>.operator -(double value)
             => (double)(-value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IUnaryNegationOperators<double, double>.operator -(double value)
         //     => checked((double)(-value));
 
@@ -1290,11 +1290,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IUnaryPlusOperators<double, double>.operator +(double value)
             => (double)(+value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IUnaryPlusOperators<double, double>.operator +(double value)
         //     => checked((double)(+value));
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1234,7 +1234,7 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Guid, Guid>.operator <(Guid left, Guid right)
         {
             if (left._a != right._a)
@@ -1295,7 +1295,7 @@ namespace System
             return false;
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Guid, Guid>.operator <=(Guid left, Guid right)
         {
             if (left._a != right._a)
@@ -1356,7 +1356,7 @@ namespace System
             return true;
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Guid, Guid>.operator >(Guid left, Guid right)
         {
             if (left._a != right._a)
@@ -1417,7 +1417,7 @@ namespace System
             return false;
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Guid, Guid>.operator >=(Guid left, Guid right)
         {
             if (left._a != right._a)
@@ -1482,11 +1482,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<Guid, Guid>.operator ==(Guid left, Guid right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<Guid, Guid>.operator !=(Guid left, Guid right)
             => left != right;
 
@@ -1494,11 +1494,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Guid IParseable<Guid>.Parse(string s, IFormatProvider? provider)
             => Parse(s);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<Guid>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Guid result)
             => TryParse(s, out result);
 
@@ -1506,11 +1506,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Guid ISpanParseable<Guid>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<Guid>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Guid result)
             => TryParse(s, out result);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -707,11 +707,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IAdditionOperators<Half, Half, Half>.operator +(Half left, Half right)
             => (Half)((float)left + (float)right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IAdditionOperators<Half, Half, Half>.operator +(Half left, Half right)
         //     => checked((Half)((float)left + (float)right));
 
@@ -719,14 +719,14 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IAdditiveIdentity<Half, Half>.AdditiveIdentity => PositiveZero;
 
         //
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<Half>.IsPow2(Half value)
         {
             uint bits = BitConverter.HalfToUInt16Bits(value);
@@ -739,7 +739,7 @@ namespace System
                 && (significand == MinSignificand);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IBinaryNumber<Half>.Log2(Half value)
             => (Half)MathF.Log2((float)value);
 
@@ -747,28 +747,28 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IBitwiseOperators<Half, Half, Half>.operator &(Half left, Half right)
         {
             ushort bits = (ushort)(BitConverter.HalfToUInt16Bits(left) & BitConverter.HalfToUInt16Bits(right));
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IBitwiseOperators<Half, Half, Half>.operator |(Half left, Half right)
         {
             ushort bits = (ushort)(BitConverter.HalfToUInt16Bits(left) | BitConverter.HalfToUInt16Bits(right));
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IBitwiseOperators<Half, Half, Half>.operator ^(Half left, Half right)
         {
             ushort bits = (ushort)(BitConverter.HalfToUInt16Bits(left) ^ BitConverter.HalfToUInt16Bits(right));
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IBitwiseOperators<Half, Half, Half>.operator ~(Half value)
         {
             ushort bits = (ushort)(~BitConverter.HalfToUInt16Bits(value));
@@ -779,19 +779,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Half, Half>.operator <(Half left, Half right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Half, Half>.operator <=(Half left, Half right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Half, Half>.operator >(Half left, Half right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<Half, Half>.operator >=(Half left, Half right)
             => left >= right;
 
@@ -799,7 +799,7 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IDecrementOperators<Half>.operator --(Half value)
         {
             var tmp = (float)value;
@@ -807,7 +807,7 @@ namespace System
             return (Half)tmp;
         }
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IDecrementOperators<Half>.operator --(Half value)
         // {
         //     var tmp = (float)value;
@@ -819,11 +819,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<Half, Half>.operator ==(Half left, Half right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<Half, Half>.operator !=(Half left, Half right)
             => left != right;
 
@@ -831,11 +831,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IDivisionOperators<Half, Half, Half>.operator /(Half left, Half right)
             => (Half)((float)left / (float)right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IDivisionOperators<Half, Half, Half>.operator /(Half left, Half right)
         //     => checked((Half)((float)left / (float)right));
 
@@ -843,59 +843,59 @@ namespace System
         // IFloatingPoint
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.E => (Half)MathF.E;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Epsilon => Epsilon;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.NaN => NaN;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.NegativeInfinity => NegativeInfinity;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.NegativeZero => NegativeZero;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Pi => (Half)MathF.PI;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.PositiveInfinity => PositiveInfinity;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Tau => (Half)MathF.Tau;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Acos(Half x)
             => (Half)MathF.Acos((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Acosh(Half x)
             => (Half)MathF.Acosh((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Asin(Half x)
             => (Half)MathF.Asin((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Asinh(Half x)
             => (Half)MathF.Asinh((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Atan(Half x)
             => (Half)MathF.Atan((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Atan2(Half y, Half x)
             => (Half)MathF.Atan2((float)y, (float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Atanh(Half x)
             => (Half)MathF.Atanh((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.BitIncrement(Half x)
         {
             ushort bits = BitConverter.HalfToUInt16Bits(x);
@@ -921,7 +921,7 @@ namespace System
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.BitDecrement(Half x)
         {
             ushort bits = BitConverter.HalfToUInt16Bits(x);
@@ -947,140 +947,140 @@ namespace System
             return BitConverter.UInt16BitsToHalf(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Cbrt(Half x)
             => (Half)MathF.Cbrt((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Ceiling(Half x)
             => (Half)MathF.Ceiling((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.CopySign(Half x, Half y)
             => (Half)MathF.CopySign((float)x, (float)y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Cos(Half x)
             => (Half)MathF.Cos((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Cosh(Half x)
             => (Half)MathF.Cosh((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Exp(Half x)
             => (Half)MathF.Exp((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Floor(Half x)
             => (Half)MathF.Floor((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.FusedMultiplyAdd(Half left, Half right, Half addend)
             => (Half)MathF.FusedMultiplyAdd((float)left, (float)right, (float)addend);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.IEEERemainder(Half left, Half right)
             => (Half)MathF.IEEERemainder((float)left, (float)right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TInteger IFloatingPoint<Half>.ILogB<TInteger>(Half x)
             => TInteger.Create(MathF.ILogB((float)x));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Log(Half x)
             => (Half)MathF.Log((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Log(Half x, Half newBase)
             => (Half)MathF.Log((float)x, (float)newBase);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Log2(Half x)
             => (Half)MathF.Log2((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Log10(Half x)
             => (Half)MathF.Log10((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.MaxMagnitude(Half x, Half y)
             => (Half)MathF.MaxMagnitude((float)x, (float)y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.MinMagnitude(Half x, Half y)
             => (Half)MathF.MinMagnitude((float)x, (float)y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Pow(Half x, Half y)
             => (Half)MathF.Pow((float)x, (float)y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Round(Half x)
             => (Half)MathF.Round((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Round<TInteger>(Half x, TInteger digits)
             => (Half)MathF.Round((float)x, int.Create(digits));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Round(Half x, MidpointRounding mode)
             => (Half)MathF.Round((float)x, mode);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Round<TInteger>(Half x, TInteger digits, MidpointRounding mode)
             => (Half)MathF.Round((float)x, int.Create(digits), mode);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.ScaleB<TInteger>(Half x, TInteger n)
             => (Half)MathF.ScaleB((float)x, int.Create(n));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Sin(Half x)
             => (Half)MathF.Sin((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Sinh(Half x)
             => (Half)MathF.Sinh((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Sqrt(Half x)
             => (Half)MathF.Sqrt((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Tan(Half x)
             => (Half)MathF.Tan((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Tanh(Half x)
             => (Half)MathF.Tanh((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IFloatingPoint<Half>.Truncate(Half x)
             => (Half)MathF.Truncate((float)x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsFinite(Half x) => IsFinite(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsInfinity(Half x) => IsInfinity(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsNaN(Half x) => IsNaN(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsNegative(Half x) => IsNegative(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsNegativeInfinity(Half x) => IsNegativeInfinity(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsNormal(Half x) => IsNormal(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsPositiveInfinity(Half x) => IsPositiveInfinity(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<Half>.IsSubnormal(Half x) => IsSubnormal(x);
 
 
@@ -1154,7 +1154,7 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IIncrementOperators<Half>.operator ++(Half value)
         {
             var tmp = (float)value;
@@ -1162,7 +1162,7 @@ namespace System
             return (Half)tmp;
         }
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IIncrementOperators<Half>.operator ++(Half value)
         // {
         //     var tmp = (float)value;
@@ -1174,21 +1174,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IMinMaxValue<Half>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IMinMaxValue<Half>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IModulusOperators<Half, Half, Half>.operator %(Half left, Half right)
             => (Half)((float)left % (float)right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IModulusOperators<Half, Half, Half>.operator %(Half left, Half right)
         //     => checked((Half)((float)left % (float)right));
 
@@ -1196,18 +1196,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IMultiplicativeIdentity<Half, Half>.MultiplicativeIdentity => (Half)1.0f;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IMultiplyOperators<Half, Half, Half>.operator *(Half left, Half right)
             => (Half)((float)left * (float)right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IMultiplyOperators<Half, Half, Half>.operator *(Half left, Half right)
         //     => checked((Half)((float)left * (float)right));
 
@@ -1215,21 +1215,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.One => (Half)1.0f;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Zero => PositiveZero;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Abs(Half value)
             => (Half)MathF.Abs((float)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Clamp(Half value, Half min, Half max)
             => (Half)Math.Clamp((float)value, (float)min, (float)max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static Half INumber<Half>.Create<TOther>(TOther value)
         {
@@ -1296,7 +1296,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static Half INumber<Half>.CreateSaturating<TOther>(TOther value)
         {
@@ -1363,7 +1363,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static Half INumber<Half>.CreateTruncating<TOther>(TOther value)
         {
@@ -1430,31 +1430,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (Half Quotient, Half Remainder) INumber<Half>.DivRem(Half left, Half right)
             => ((Half, Half))((float)left / (float)right, (float)left % (float)right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Max(Half x, Half y)
             => (Half)MathF.Max((float)x, (float)y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Min(Half x, Half y)
             => (Half)MathF.Min((float)x, (float)y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half INumber<Half>.Sign(Half value)
             => (Half)MathF.Sign((float)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<Half>.TryCreate<TOther>(TOther value, out Half result)
         {
@@ -1536,11 +1536,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<Half>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out Half result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<Half>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out Half result)
             => TryParse(s, style, provider, out result);
 
@@ -1548,11 +1548,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IParseable<Half>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<Half>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out Half result)
             => TryParse(s, DefaultParseStyle, provider, out result);
 
@@ -1560,18 +1560,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half ISignedNumber<Half>.NegativeOne => (Half)(-1.0f);
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half ISpanParseable<Half>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, DefaultParseStyle, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<Half>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Half result)
             => TryParse(s, DefaultParseStyle, provider, out result);
 
@@ -1579,11 +1579,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half ISubtractionOperators<Half, Half, Half>.operator -(Half left, Half right)
             => (Half)((float)left - (float)right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half ISubtractionOperators<Half, Half, Half>.operator -(Half left, Half right)
         //     => checked((Half)((float)left - (float)right));
 
@@ -1591,11 +1591,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IUnaryNegationOperators<Half, Half>.operator -(Half value)
             => (Half)(-(float)value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IUnaryNegationOperators<Half, Half>.operator -(Half value)
         //     => checked((Half)(-(float)value));
 
@@ -1603,11 +1603,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static Half IUnaryPlusOperators<Half, Half>.operator +(Half value)
             => value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked Half IUnaryPlusOperators<Half, Half>.operator +(Half value)
         //     => checked(value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/IAdditionOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IAdditionOperators.cs
@@ -13,7 +13,7 @@ namespace System
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TOther">The type that will be added to <typeparamref name="TSelf" />.</typeparam>
     /// <typeparam name="TResult">The type that contains the sum of <typeparamref name="TSelf" /> and <typeparamref name="TOther" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IAdditionOperators<TSelf, TOther, TResult>
         where TSelf : IAdditionOperators<TSelf, TOther, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IAdditiveIdentity.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IAdditiveIdentity.cs
@@ -12,7 +12,7 @@ namespace System
     /// <summary>Defines a mechanism for getting the additive identity of a given type.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TResult">The type that contains the additive identify of <typeparamref name="TSelf" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IAdditiveIdentity<TSelf, TResult>
         where TSelf : IAdditiveIdentity<TSelf, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IBitwiseOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IBitwiseOperators.cs
@@ -13,7 +13,7 @@ namespace System
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TOther">The type that will is used in the operation with <typeparamref name="TSelf" />.</typeparam>
     /// <typeparam name="TResult">The type that contains the result of <typeparamref name="TSelf" /> op <typeparamref name="TOther" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IBitwiseOperators<TSelf, TOther, TResult>
         where TSelf : IBitwiseOperators<TSelf, TOther, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IComparisonOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IComparisonOperators.cs
@@ -12,7 +12,7 @@ namespace System
     /// <summary>Defines a mechanism for comparing two values to determine relative order.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TOther">The type that will be compared with <typeparamref name="TSelf" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IComparisonOperators<TSelf, TOther>
         : IComparable,
           IComparable<TOther>,

--- a/src/libraries/System.Private.CoreLib/src/System/IDecrementOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IDecrementOperators.cs
@@ -11,7 +11,7 @@ namespace System
 {
     /// <summary>Defines a mechanism for decrementing a given value.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IDecrementOperators<TSelf>
         where TSelf : IDecrementOperators<TSelf>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IDivisionOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IDivisionOperators.cs
@@ -13,7 +13,7 @@ namespace System
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TOther">The type that will divide <typeparamref name="TSelf" />.</typeparam>
     /// <typeparam name="TResult">The type that contains the quotient of <typeparamref name="TSelf" /> and <typeparamref name="TOther" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IDivisionOperators<TSelf, TOther, TResult>
         where TSelf : IDivisionOperators<TSelf, TOther, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IEqualityOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IEqualityOperators.cs
@@ -12,7 +12,7 @@ namespace System
     /// <summary>Defines a mechanism for comparing two values to determine equality.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TOther">The type that will be compared with <typeparamref name="TSelf" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IEqualityOperators<TSelf, TOther> : IEquatable<TOther>
         where TSelf : IEqualityOperators<TSelf, TOther>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IFloatingPoint.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IFloatingPoint.cs
@@ -11,7 +11,7 @@ namespace System
 {
     /// <summary>Defines a floating-point type.</summary>
     /// <typeparam name="TSelf">The type that implements the interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IFloatingPoint<TSelf>
         : ISignedNumber<TSelf>
         where TSelf : IFloatingPoint<TSelf>
@@ -332,7 +332,7 @@ namespace System
 
     /// <summary>Defines a floating-point type that is represented in a base-2 format.</summary>
     /// <typeparam name="TSelf">The type that implements the interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IBinaryFloatingPoint<TSelf>
         : IBinaryNumber<TSelf>,
           IFloatingPoint<TSelf>

--- a/src/libraries/System.Private.CoreLib/src/System/IIncrementOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IIncrementOperators.cs
@@ -11,7 +11,7 @@ namespace System
 {
     /// <summary>Defines a mechanism for incrementing a given value.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IIncrementOperators<TSelf>
         where TSelf : IIncrementOperators<TSelf>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IInteger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IInteger.cs
@@ -11,7 +11,7 @@ namespace System
 {
     /// <summary>Defines an integer type that is represented in a base-2 format.</summary>
     /// <typeparam name="TSelf">The type that implements the interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IBinaryInteger<TSelf>
         : IBinaryNumber<TSelf>,
           IShiftOperators<TSelf, TSelf>

--- a/src/libraries/System.Private.CoreLib/src/System/IMinMaxValue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IMinMaxValue.cs
@@ -11,7 +11,7 @@ namespace System
 {
     /// <summary>Defines a mechanism for getting the minimum and maximum value of a type.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IMinMaxValue<TSelf>
         where TSelf : IMinMaxValue<TSelf>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IModulusOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IModulusOperators.cs
@@ -14,7 +14,7 @@ namespace System
     /// <typeparam name="TOther">The type that will divide <typeparamref name="TSelf" />.</typeparam>
     /// <typeparam name="TResult">The type that contains the modulus or remainder of <typeparamref name="TSelf" /> and <typeparamref name="TOther" />.</typeparam>
     /// <remarks>This type represents the <c>%</c> in C# which is often used to compute the remainder and may differ from an actual modulo operation depending on the type that implements the interface.</remarks>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IModulusOperators<TSelf, TOther, TResult>
         where TSelf : IModulusOperators<TSelf, TOther, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IMultiplicativeIdentity.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IMultiplicativeIdentity.cs
@@ -12,7 +12,7 @@ namespace System
     /// <summary>Defines a mechanism for getting the multiplicative identity of a given type.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TResult">The type that contains the multiplicative identify of <typeparamref name="TSelf" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IMultiplicativeIdentity<TSelf, TResult>
         where TSelf : IMultiplicativeIdentity<TSelf, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IMultiplyOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IMultiplyOperators.cs
@@ -13,7 +13,7 @@ namespace System
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TOther">The type that will multiply <typeparamref name="TSelf" />.</typeparam>
     /// <typeparam name="TResult">The type that contains the product of <typeparamref name="TSelf" /> and <typeparamref name="TOther" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IMultiplyOperators<TSelf, TOther, TResult>
         where TSelf : IMultiplyOperators<TSelf, TOther, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/INumber.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/INumber.cs
@@ -13,7 +13,7 @@ namespace System
 {
     /// <summary>Defines a number type.</summary>
     /// <typeparam name="TSelf">The type that implements the interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface INumber<TSelf>
         : IAdditionOperators<TSelf, TSelf, TSelf>,
           IAdditiveIdentity<TSelf, TSelf>,
@@ -153,7 +153,7 @@ namespace System
 
     /// <summary>Defines a number that is represented in a base-2 format.</summary>
     /// <typeparam name="TSelf">The type that implements the interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IBinaryNumber<TSelf>
         : IBitwiseOperators<TSelf, TSelf, TSelf>,
           INumber<TSelf>
@@ -172,7 +172,7 @@ namespace System
 
     /// <summary>Defines a number type which can represent both positive and negative values.</summary>
     /// <typeparam name="TSelf">The type that implements the interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface ISignedNumber<TSelf>
         : INumber<TSelf>
         where TSelf : ISignedNumber<TSelf>
@@ -183,7 +183,7 @@ namespace System
 
     /// <summary>Defines a number type which can only represent positive values, that is it cannot represent negative values.</summary>
     /// <typeparam name="TSelf">The type that implements the interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IUnsignedNumber<TSelf>
         : INumber<TSelf>
         where TSelf : IUnsignedNumber<TSelf>

--- a/src/libraries/System.Private.CoreLib/src/System/IParseable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IParseable.cs
@@ -12,7 +12,7 @@ namespace System
 {
     /// <summary>Defines a mechanism for parsing a string to a value.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IParseable<TSelf>
         where TSelf : IParseable<TSelf>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IShiftOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IShiftOperators.cs
@@ -12,7 +12,7 @@ namespace System
     /// <summary>Defines a mechanism for shifting a value by another value.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TResult">The type that contains the result of shifting <typeparamref name="TSelf" /> by <typeparamref name="TResult" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IShiftOperators<TSelf, TResult>
         where TSelf : IShiftOperators<TSelf, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/ISpanParseable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ISpanParseable.cs
@@ -11,7 +11,7 @@ namespace System
 {
     /// <summary>Defines a mechanism for parsing a span of characters to a value.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface ISpanParseable<TSelf> : IParseable<TSelf>
         where TSelf : ISpanParseable<TSelf>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/ISubtractionOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ISubtractionOperators.cs
@@ -13,7 +13,7 @@ namespace System
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TOther">The type that will be subtracted from <typeparamref name="TSelf" />.</typeparam>
     /// <typeparam name="TResult">The type that contains the difference of <typeparamref name="TOther" /> subtracted from <typeparamref name="TSelf" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface ISubtractionOperators<TSelf, TOther, TResult>
         where TSelf : ISubtractionOperators<TSelf, TOther, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IUnaryNegationOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IUnaryNegationOperators.cs
@@ -12,7 +12,7 @@ namespace System
     /// <summary>Defines a mechanism for computing the unary negation of a value.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TResult">The type that contains the result of negating <typeparamref name="TSelf" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IUnaryNegationOperators<TSelf, TResult>
         where TSelf : IUnaryNegationOperators<TSelf, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/IUnaryPlusOperators.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IUnaryPlusOperators.cs
@@ -12,7 +12,7 @@ namespace System
     /// <summary>Defines a mechanism for computing the unary plus of a value.</summary>
     /// <typeparam name="TSelf">The type that implements this interface.</typeparam>
     /// <typeparam name="TResult">The type that contains the result of negating <typeparamref name="TSelf" />.</typeparam>
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public interface IUnaryPlusOperators<TSelf, TResult>
         where TSelf : IUnaryPlusOperators<TSelf, TResult>
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -288,11 +288,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IAdditionOperators<short, short, short>.operator +(short left, short right)
             => (short)(left + right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IAdditionOperators<short, short, short>.operator +(short left, short right)
         //     => checked((short)(left + right));
 
@@ -300,30 +300,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IAdditiveIdentity<short, short>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBinaryInteger<short>.LeadingZeroCount(short value)
             => (short)(BitOperations.LeadingZeroCount((ushort)value) - 16);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBinaryInteger<short>.PopCount(short value)
             => (short)BitOperations.PopCount((ushort)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBinaryInteger<short>.RotateLeft(short value, int rotateAmount)
             => (short)((value << (rotateAmount & 15)) | ((ushort)value >> ((16 - rotateAmount) & 15)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBinaryInteger<short>.RotateRight(short value, int rotateAmount)
             => (short)(((ushort)value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBinaryInteger<short>.TrailingZeroCount(short value)
             => (byte)(BitOperations.TrailingZeroCount(value << 16) - 16);
 
@@ -331,11 +331,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<short>.IsPow2(short value)
             => BitOperations.IsPow2(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBinaryNumber<short>.Log2(short value)
         {
             if (value < 0)
@@ -349,19 +349,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBitwiseOperators<short, short, short>.operator &(short left, short right)
             => (short)(left & right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBitwiseOperators<short, short, short>.operator |(short left, short right)
             => (short)(left | right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBitwiseOperators<short, short, short>.operator ^(short left, short right)
             => (short)(left ^ right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IBitwiseOperators<short, short, short>.operator ~(short value)
             => (short)(~value);
 
@@ -369,19 +369,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<short, short>.operator <(short left, short right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<short, short>.operator <=(short left, short right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<short, short>.operator >(short left, short right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<short, short>.operator >=(short left, short right)
             => left >= right;
 
@@ -389,11 +389,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IDecrementOperators<short>.operator --(short value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IDecrementOperators<short>.operator --(short value)
         //     => checked(--value);
 
@@ -401,11 +401,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IDivisionOperators<short, short, short>.operator /(short left, short right)
             => (short)(left / right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IDivisionOperators<short, short, short>.operator /(short left, short right)
         //     => checked((short)(left / right));
 
@@ -413,11 +413,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<short, short>.operator ==(short left, short right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<short, short>.operator !=(short left, short right)
             => left != right;
 
@@ -425,11 +425,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IIncrementOperators<short>.operator ++(short value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IIncrementOperators<short>.operator ++(short value)
         //     => checked(++value);
 
@@ -437,21 +437,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IMinMaxValue<short>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IMinMaxValue<short>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IModulusOperators<short, short, short>.operator %(short left, short right)
             => (short)(left % right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IModulusOperators<short, short, short>.operator %(short left, short right)
         //     => checked((short)(left % right));
 
@@ -459,18 +459,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IMultiplicativeIdentity<short, short>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IMultiplyOperators<short, short, short>.operator *(short left, short right)
             => (short)(left * right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IMultiplyOperators<short, short, short>.operator *(short left, short right)
         //     => checked((short)(left * right));
 
@@ -478,21 +478,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Abs(short value)
             => Math.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Clamp(short value, short min, short max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short INumber<short>.Create<TOther>(TOther value)
         {
@@ -559,7 +559,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short INumber<short>.CreateSaturating<TOther>(TOther value)
         {
@@ -643,7 +643,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short INumber<short>.CreateTruncating<TOther>(TOther value)
         {
@@ -710,31 +710,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (short Quotient, short Remainder) INumber<short>.DivRem(short left, short right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Max(short x, short y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Min(short x, short y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short INumber<short>.Sign(short value)
             => (short)Math.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<short>.TryCreate<TOther>(TOther value, out short result)
         {
@@ -904,11 +904,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<short>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out short result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<short>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out short result)
             => TryParse(s, style, provider, out result);
 
@@ -916,11 +916,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IParseable<short>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<short>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out short result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -928,15 +928,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IShiftOperators<short, short>.operator <<(short value, int shiftAmount)
             => (short)(value << shiftAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IShiftOperators<short, short>.operator >>(short value, int shiftAmount)
             => (short)(value >> shiftAmount);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static short IShiftOperators<short, short>.operator >>>(short value, int shiftAmount)
         //     => (short)((ushort)value >> shiftAmount);
 
@@ -944,18 +944,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short ISignedNumber<short>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short ISpanParseable<short>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<short>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out short result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -963,11 +963,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short ISubtractionOperators<short, short, short>.operator -(short left, short right)
             => (short)(left - right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short ISubtractionOperators<short, short, short>.operator -(short left, short right)
         //     => checked((short)(left - right));
 
@@ -975,11 +975,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IUnaryNegationOperators<short, short>.operator -(short value)
             => (short)(-value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IUnaryNegationOperators<short, short>.operator -(short value)
         //     => checked((short)(-value));
 
@@ -987,11 +987,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static short IUnaryPlusOperators<short, short>.operator +(short value)
             => (short)(+value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked short IUnaryPlusOperators<short, short>.operator +(short value)
         //     => checked((short)(+value));
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -280,11 +280,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IAdditionOperators<int, int, int>.operator +(int left, int right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IAdditionOperators<int, int, int>.operator +(int left, int right)
         //     => checked(left + right);
 
@@ -292,30 +292,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IAdditiveIdentity<int, int>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBinaryInteger<int>.LeadingZeroCount(int value)
             => BitOperations.LeadingZeroCount((uint)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBinaryInteger<int>.PopCount(int value)
             => BitOperations.PopCount((uint)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBinaryInteger<int>.RotateLeft(int value, int rotateAmount)
             => (int)BitOperations.RotateLeft((uint)value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBinaryInteger<int>.RotateRight(int value, int rotateAmount)
             => (int)BitOperations.RotateRight((uint)value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBinaryInteger<int>.TrailingZeroCount(int value)
             => BitOperations.TrailingZeroCount(value);
 
@@ -323,11 +323,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<int>.IsPow2(int value)
             => BitOperations.IsPow2(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBinaryNumber<int>.Log2(int value)
         {
             if (value < 0)
@@ -341,19 +341,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBitwiseOperators<int, int, int>.operator &(int left, int right)
             => left & right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBitwiseOperators<int, int, int>.operator |(int left, int right)
             => left | right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBitwiseOperators<int, int, int>.operator ^(int left, int right)
             => left ^ right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IBitwiseOperators<int, int, int>.operator ~(int value)
             => ~value;
 
@@ -361,19 +361,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<int, int>.operator <(int left, int right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<int, int>.operator <=(int left, int right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<int, int>.operator >(int left, int right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<int, int>.operator >=(int left, int right)
             => left >= right;
 
@@ -381,11 +381,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IDecrementOperators<int>.operator --(int value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IDecrementOperators<int>.operator --(int value)
         //     => checked(--value);
 
@@ -393,11 +393,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IDivisionOperators<int, int, int>.operator /(int left, int right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IDivisionOperators<int, int, int>.operator /(int left, int right)
         //     => checked(left / right);
 
@@ -405,11 +405,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<int, int>.operator ==(int left, int right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<int, int>.operator !=(int left, int right)
             => left != right;
 
@@ -417,11 +417,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IIncrementOperators<int>.operator ++(int value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IIncrementOperators<int>.operator ++(int value)
         //     => checked(++value);
 
@@ -429,21 +429,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IMinMaxValue<int>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IMinMaxValue<int>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IModulusOperators<int, int, int>.operator %(int left, int right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IModulusOperators<int, int, int>.operator %(int left, int right)
         //     => checked(left % right);
 
@@ -451,18 +451,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IMultiplicativeIdentity<int, int>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IMultiplyOperators<int, int, int>.operator *(int left, int right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IMultiplyOperators<int, int, int>.operator *(int left, int right)
         //     => checked(left * right);
 
@@ -470,21 +470,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Abs(int value)
             => Math.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Clamp(int value, int min, int max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         internal static int Create<TOther>(TOther value)
             where TOther : INumber<TOther>
         {
@@ -551,12 +551,12 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static int INumber<int>.Create<TOther>(TOther value)
             => Create(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static int INumber<int>.CreateSaturating<TOther>(TOther value)
         {
@@ -636,7 +636,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static int INumber<int>.CreateTruncating<TOther>(TOther value)
         {
@@ -703,31 +703,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (int Quotient, int Remainder) INumber<int>.DivRem(int left, int right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Max(int x, int y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Min(int x, int y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int INumber<int>.Sign(int value)
             => Math.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<int>.TryCreate<TOther>(TOther value, out int result)
         {
@@ -873,11 +873,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<int>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out int result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<int>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out int result)
             => TryParse(s, style, provider, out result);
 
@@ -885,11 +885,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IParseable<int>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<int>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out int result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -897,15 +897,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IShiftOperators<int, int>.operator <<(int value, int shiftAmount)
             => value << shiftAmount;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IShiftOperators<int, int>.operator >>(int value, int shiftAmount)
             => value >> shiftAmount;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static int IShiftOperators<int, int>.operator >>>(int value, int shiftAmount)
         //     => (int)((uint)value >> shiftAmount);
 
@@ -913,18 +913,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int ISignedNumber<int>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int ISpanParseable<int>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<int>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out int result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -932,11 +932,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int ISubtractionOperators<int, int, int>.operator -(int left, int right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int ISubtractionOperators<int, int, int>.operator -(int left, int right)
         //     => checked(left - right);
 
@@ -944,11 +944,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IUnaryNegationOperators<int, int>.operator -(int value)
             => -value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IUnaryNegationOperators<int, int>.operator -(int value)
         //     => checked(-value);
 
@@ -956,11 +956,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static int IUnaryPlusOperators<int, int>.operator +(int value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked int IUnaryPlusOperators<int, int>.operator +(int value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -267,11 +267,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IAdditionOperators<long, long, long>.operator +(long left, long right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IAdditionOperators<long, long, long>.operator +(long left, long right)
         //     => checked(left + right);
 
@@ -279,30 +279,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IAdditiveIdentity<long, long>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBinaryInteger<long>.LeadingZeroCount(long value)
             => BitOperations.LeadingZeroCount((ulong)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBinaryInteger<long>.PopCount(long value)
             => BitOperations.PopCount((ulong)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBinaryInteger<long>.RotateLeft(long value, int rotateAmount)
             => (long)BitOperations.RotateLeft((ulong)value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBinaryInteger<long>.RotateRight(long value, int rotateAmount)
             => (long)BitOperations.RotateRight((ulong)value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBinaryInteger<long>.TrailingZeroCount(long value)
             => BitOperations.TrailingZeroCount(value);
 
@@ -310,11 +310,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<long>.IsPow2(long value)
             => BitOperations.IsPow2(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBinaryNumber<long>.Log2(long value)
         {
             if (value < 0)
@@ -328,19 +328,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBitwiseOperators<long, long, long>.operator &(long left, long right)
             => left & right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBitwiseOperators<long, long, long>.operator |(long left, long right)
             => left | right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBitwiseOperators<long, long, long>.operator ^(long left, long right)
             => left ^ right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IBitwiseOperators<long, long, long>.operator ~(long value)
             => ~value;
 
@@ -348,19 +348,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<long, long>.operator <(long left, long right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<long, long>.operator <=(long left, long right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<long, long>.operator >(long left, long right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<long, long>.operator >=(long left, long right)
             => left >= right;
 
@@ -368,11 +368,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IDecrementOperators<long>.operator --(long value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IDecrementOperators<long>.operator --(long value)
         //     => checked(--value);
 
@@ -380,11 +380,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IDivisionOperators<long, long, long>.operator /(long left, long right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IDivisionOperators<long, long, long>.operator /(long left, long right)
         //     => checked(left / right);
 
@@ -392,11 +392,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<long, long>.operator ==(long left, long right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<long, long>.operator !=(long left, long right)
             => left != right;
 
@@ -404,11 +404,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IIncrementOperators<long>.operator ++(long value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IIncrementOperators<long>.operator ++(long value)
         //     => checked(++value);
 
@@ -416,21 +416,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IMinMaxValue<long>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IMinMaxValue<long>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IModulusOperators<long, long, long>.operator %(long left, long right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IModulusOperators<long, long, long>.operator %(long left, long right)
         //     => checked(left % right);
 
@@ -438,18 +438,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IMultiplicativeIdentity<long, long>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IMultiplyOperators<long, long, long>.operator *(long left, long right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IMultiplyOperators<long, long, long>.operator *(long left, long right)
         //     => checked(left * right);
 
@@ -457,21 +457,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Abs(long value)
             => Math.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Clamp(long value, long min, long max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static long INumber<long>.Create<TOther>(TOther value)
         {
@@ -538,7 +538,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static long INumber<long>.CreateSaturating<TOther>(TOther value)
         {
@@ -613,7 +613,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static long INumber<long>.CreateTruncating<TOther>(TOther value)
         {
@@ -680,31 +680,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (long Quotient, long Remainder) INumber<long>.DivRem(long left, long right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Max(long x, long y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Min(long x, long y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long INumber<long>.Sign(long value)
             => Math.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<long>.TryCreate<TOther>(TOther value, out long result)
         {
@@ -826,11 +826,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<long>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out long result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<long>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out long result)
             => TryParse(s, style, provider, out result);
 
@@ -838,11 +838,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IParseable<long>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<long>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out long result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -850,15 +850,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IShiftOperators<long, long>.operator <<(long value, int shiftAmount)
             => value << (int)shiftAmount;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IShiftOperators<long, long>.operator >>(long value, int shiftAmount)
             => value >> (int)shiftAmount;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static long IShiftOperators<long, long>.operator >>>(long value, int shiftAmount)
         //     => (long)((ulong)value >> (int)shiftAmount);
 
@@ -866,18 +866,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long ISignedNumber<long>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long ISpanParseable<long>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<long>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out long result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -885,11 +885,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long ISubtractionOperators<long, long, long>.operator -(long left, long right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long ISubtractionOperators<long, long, long>.operator -(long left, long right)
         //     => checked(left - right);
 
@@ -897,11 +897,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IUnaryNegationOperators<long, long>.operator -(long value)
             => -value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IUnaryNegationOperators<long, long>.operator -(long value)
         //     => checked(-value);
 
@@ -909,11 +909,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static long IUnaryPlusOperators<long, long>.operator +(long value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked long IUnaryPlusOperators<long, long>.operator +(long value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -254,11 +254,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right)
         //     => checked(left + right);
 
@@ -266,14 +266,14 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IAdditiveIdentity<nint, nint>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBinaryInteger<nint>.LeadingZeroCount(nint value)
         {
             if (Environment.Is64BitProcess)
@@ -286,7 +286,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBinaryInteger<nint>.PopCount(nint value)
         {
             if (Environment.Is64BitProcess)
@@ -299,7 +299,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBinaryInteger<nint>.RotateLeft(nint value, int rotateAmount)
         {
             if (Environment.Is64BitProcess)
@@ -312,7 +312,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBinaryInteger<nint>.RotateRight(nint value, int rotateAmount)
 
         {
@@ -326,7 +326,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBinaryInteger<nint>.TrailingZeroCount(nint value)
         {
             if (Environment.Is64BitProcess)
@@ -343,11 +343,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<nint>.IsPow2(nint value)
             => BitOperations.IsPow2(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBinaryNumber<nint>.Log2(nint value)
         {
             if (value < 0)
@@ -369,19 +369,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBitwiseOperators<nint, nint, nint>.operator &(nint left, nint right)
             => left & right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBitwiseOperators<nint, nint, nint>.operator |(nint left, nint right)
             => left | right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBitwiseOperators<nint, nint, nint>.operator ^(nint left, nint right)
             => left ^ right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IBitwiseOperators<nint, nint, nint>.operator ~(nint value)
             => ~value;
 
@@ -389,19 +389,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nint, nint>.operator <(nint left, nint right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nint, nint>.operator <=(nint left, nint right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nint, nint>.operator >(nint left, nint right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nint, nint>.operator >=(nint left, nint right)
             => left >= right;
 
@@ -409,11 +409,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IDecrementOperators<nint>.operator --(nint value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IDecrementOperators<nint>.operator --(nint value)
         //     => checked(--value);
 
@@ -421,11 +421,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right)
         //     => checked(left / right);
 
@@ -433,11 +433,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<nint, nint>.operator ==(nint left, nint right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<nint, nint>.operator !=(nint left, nint right)
             => left != right;
 
@@ -445,11 +445,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IIncrementOperators<nint>.operator ++(nint value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IIncrementOperators<nint>.operator ++(nint value)
         //     => checked(++value);
 
@@ -457,21 +457,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IMinMaxValue<nint>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IMinMaxValue<nint>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IModulusOperators<nint, nint, nint>.operator %(nint left, nint right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IModulusOperators<nint, nint, nint>.operator %(nint left, nint right)
         //     => checked(left % right);
 
@@ -479,18 +479,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IMultiplicativeIdentity<nint, nint>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right)
         //     => checked(left * right);
 
@@ -498,21 +498,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Abs(nint value)
             => Math.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Clamp(nint value, nint min, nint max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nint INumber<nint>.Create<TOther>(TOther value)
         {
@@ -579,7 +579,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nint INumber<nint>.CreateSaturating<TOther>(TOther value)
         {
@@ -657,7 +657,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nint INumber<nint>.CreateTruncating<TOther>(TOther value)
         {
@@ -724,31 +724,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (nint Quotient, nint Remainder) INumber<nint>.DivRem(nint left, nint right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Max(nint x, nint y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Min(nint x, nint y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint INumber<nint>.Sign(nint value)
             => Math.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<nint>.TryCreate<TOther>(TOther value, out nint result)
         {
@@ -886,11 +886,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<nint>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out nint result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<nint>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out nint result)
             => TryParse(s, style, provider, out result);
 
@@ -898,11 +898,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IParseable<nint>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<nint>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out nint result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -910,15 +910,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IShiftOperators<nint, nint>.operator <<(nint value, int shiftAmount)
             => value << (int)shiftAmount;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IShiftOperators<nint, nint>.operator >>(nint value, int shiftAmount)
             => value >> (int)shiftAmount;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static nint IShiftOperators<nint, nint>.operator >>>(nint value, int shiftAmount)
         //     => (nint)((nuint)value >> (int)shiftAmount);
 
@@ -926,18 +926,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint ISignedNumber<nint>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint ISpanParseable<nint>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<nint>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out nint result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -945,11 +945,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint ISubtractionOperators<nint, nint, nint>.operator -(nint left, nint right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint ISubtractionOperators<nint, nint, nint>.operator -(nint left, nint right)
         //     => checked(left - right);
 
@@ -957,11 +957,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IUnaryNegationOperators<nint, nint>.operator -(nint value)
             => -value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IUnaryNegationOperators<nint, nint>.operator -(nint value)
         //     => checked(-value);
 
@@ -969,11 +969,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nint IUnaryPlusOperators<nint, nint>.operator +(nint value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nint IUnaryPlusOperators<nint, nint>.operator +(nint value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -242,6 +242,8 @@ namespace System
     internal static partial class Number
     {
         internal const int DecimalPrecision = 29; // Decimal.DecCalc also uses this value
+        internal const string PreviewFeatureMessage = "Generic Math is in preview.";
+        internal const string PreviewFeatureUrl = "https://aka.ms/dotnet-warnings/generic-math-preview";
 
         // SinglePrecision and DoublePrecision represent the maximum number of digits required
         // to guarantee that any given Single or Double can roundtrip. Some numbers may require

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Indicates that this version of runtime supports virtual static members of interfaces.
         /// </summary>
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         public const string VirtualStaticsInInterfaces = nameof(VirtualStaticsInInterfaces);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.PlatformNotSupported.cs
@@ -7,7 +7,7 @@ using System.Runtime.Versioning;
 namespace System.Runtime.Intrinsics.X86
 {
     [CLSCompliant(false)]
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public abstract class AvxVnni : Avx2
     {
         internal AvxVnni() { }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.PlatformNotSupported.cs
@@ -7,7 +7,7 @@ using System.Runtime.Versioning;
 namespace System.Runtime.Intrinsics.X86
 {
     [CLSCompliant(false)]
-    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
+    [RequiresPreviewFeatures("AvxVnni is in preview.")]
     public abstract class AvxVnni : Avx2
     {
         internal AvxVnni() { }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.Intrinsics.X86
 {
     [Intrinsic]
     [CLSCompliant(false)]
-    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
+    [RequiresPreviewFeatures("AvxVnni is in preview.")]
     public abstract class AvxVnni : Avx2
     {
         internal AvxVnni() { }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/AvxVnni.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.Intrinsics.X86
 {
     [Intrinsic]
     [CLSCompliant(false)]
-    [RequiresPreviewFeatures]
+    [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
     public abstract class AvxVnni : Avx2
     {
         internal AvxVnni() { }

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -297,11 +297,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator +(sbyte left, sbyte right)
             => (sbyte)(left + right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator +(sbyte left, sbyte right)
         //     => checked((sbyte)(left + right));
 
@@ -309,30 +309,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IAdditiveIdentity<sbyte, sbyte>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBinaryInteger<sbyte>.LeadingZeroCount(sbyte value)
             => (sbyte)(BitOperations.LeadingZeroCount((byte)value) - 24);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBinaryInteger<sbyte>.PopCount(sbyte value)
             => (sbyte)BitOperations.PopCount((byte)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBinaryInteger<sbyte>.RotateLeft(sbyte value, int rotateAmount)
             => (sbyte)((value << (rotateAmount & 7)) | ((byte)value >> ((8 - rotateAmount) & 7)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBinaryInteger<sbyte>.RotateRight(sbyte value, int rotateAmount)
             => (sbyte)(((byte)value >> (rotateAmount & 7)) | (value << ((8 - rotateAmount) & 7)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBinaryInteger<sbyte>.TrailingZeroCount(sbyte value)
             => (sbyte)(BitOperations.TrailingZeroCount(value << 24) - 24);
 
@@ -340,11 +340,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<sbyte>.IsPow2(sbyte value)
             => BitOperations.IsPow2(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBinaryNumber<sbyte>.Log2(sbyte value)
         {
             if (value < 0)
@@ -358,19 +358,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator &(sbyte left, sbyte right)
             => (sbyte)(left & right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator |(sbyte left, sbyte right)
             => (sbyte)(left | right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ^(sbyte left, sbyte right)
             => (sbyte)(left ^ right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ~(sbyte value)
             => (sbyte)(~value);
 
@@ -378,19 +378,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<sbyte, sbyte>.operator <(sbyte left, sbyte right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<sbyte, sbyte>.operator <=(sbyte left, sbyte right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<sbyte, sbyte>.operator >(sbyte left, sbyte right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<sbyte, sbyte>.operator >=(sbyte left, sbyte right)
             => left >= right;
 
@@ -398,11 +398,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IDecrementOperators<sbyte>.operator --(sbyte value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IDecrementOperators<sbyte>.operator --(sbyte value)
         //     => checked(--value);
 
@@ -410,11 +410,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right)
             => (sbyte)(left / right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right)
         //     => checked((sbyte)(left / right));
 
@@ -422,11 +422,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<sbyte, sbyte>.operator ==(sbyte left, sbyte right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<sbyte, sbyte>.operator !=(sbyte left, sbyte right)
             => left != right;
 
@@ -434,11 +434,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IIncrementOperators<sbyte>.operator ++(sbyte value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IIncrementOperators<sbyte>.operator ++(sbyte value)
         //     => checked(++value);
 
@@ -446,21 +446,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IMinMaxValue<sbyte>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IMinMaxValue<sbyte>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right)
             => (sbyte)(left % right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right)
         //     => checked((sbyte)(left % right));
 
@@ -468,18 +468,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IMultiplicativeIdentity<sbyte, sbyte>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right)
             => (sbyte)(left * right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right)
         //     => checked((sbyte)(left * right));
 
@@ -487,21 +487,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Abs(sbyte value)
             => Math.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Clamp(sbyte value, sbyte min, sbyte max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static sbyte INumber<sbyte>.Create<TOther>(TOther value)
         {
@@ -568,7 +568,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static sbyte INumber<sbyte>.CreateSaturating<TOther>(TOther value)
         {
@@ -655,7 +655,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static sbyte INumber<sbyte>.CreateTruncating<TOther>(TOther value)
         {
@@ -722,31 +722,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (sbyte Quotient, sbyte Remainder) INumber<sbyte>.DivRem(sbyte left, sbyte right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Max(sbyte x, sbyte y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Min(sbyte x, sbyte y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte INumber<sbyte>.Sign(sbyte value)
             => (sbyte)Math.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<sbyte>.TryCreate<TOther>(TOther value, out sbyte result)
         {
@@ -932,11 +932,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<sbyte>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out sbyte result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<sbyte>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out sbyte result)
             => TryParse(s, style, provider, out result);
 
@@ -944,11 +944,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IParseable<sbyte>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<sbyte>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out sbyte result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -956,15 +956,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IShiftOperators<sbyte, sbyte>.operator <<(sbyte value, int shiftAmount)
             => (sbyte)(value << shiftAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IShiftOperators<sbyte, sbyte>.operator >>(sbyte value, int shiftAmount)
             => (sbyte)(value >> shiftAmount);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static sbyte IShiftOperators<sbyte, sbyte>.operator >>>(sbyte value, int shiftAmount)
         //     => (sbyte)((byte)value >> shiftAmount);
 
@@ -972,18 +972,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte ISignedNumber<sbyte>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte ISpanParseable<sbyte>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<sbyte>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out sbyte result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -991,11 +991,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator -(sbyte left, sbyte right)
             => (sbyte)(left - right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator -(sbyte left, sbyte right)
         //     => checked((sbyte)(left - right));
 
@@ -1003,11 +1003,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IUnaryNegationOperators<sbyte, sbyte>.operator -(sbyte value)
             => (sbyte)(-value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IUnaryNegationOperators<sbyte, sbyte>.operator -(sbyte value)
         //     => checked((sbyte)(-value));
 
@@ -1015,11 +1015,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static sbyte IUnaryPlusOperators<sbyte, sbyte>.operator +(sbyte value)
             => (sbyte)(+value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked sbyte IUnaryPlusOperators<sbyte, sbyte>.operator +(sbyte value)
         //     => checked((sbyte)(+value));
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -447,11 +447,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IAdditionOperators<float, float, float>.operator +(float left, float right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IAdditionOperators<float, float, float>.operator +(float left, float right)
         //     => checked(left + right);
 
@@ -459,14 +459,14 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IAdditiveIdentity<float, float>.AdditiveIdentity => 0.0f;
 
         //
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<float>.IsPow2(float value)
         {
             uint bits = BitConverter.SingleToUInt32Bits(value);
@@ -479,7 +479,7 @@ namespace System
                 && (significand == MinSignificand);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IBinaryNumber<float>.Log2(float value)
             => MathF.Log2(value);
 
@@ -487,28 +487,28 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IBitwiseOperators<float, float, float>.operator &(float left, float right)
         {
             uint bits = BitConverter.SingleToUInt32Bits(left) & BitConverter.SingleToUInt32Bits(right);
             return BitConverter.UInt32BitsToSingle(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IBitwiseOperators<float, float, float>.operator |(float left, float right)
         {
             uint bits = BitConverter.SingleToUInt32Bits(left) | BitConverter.SingleToUInt32Bits(right);
             return BitConverter.UInt32BitsToSingle(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IBitwiseOperators<float, float, float>.operator ^(float left, float right)
         {
             uint bits = BitConverter.SingleToUInt32Bits(left) ^ BitConverter.SingleToUInt32Bits(right);
             return BitConverter.UInt32BitsToSingle(bits);
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IBitwiseOperators<float, float, float>.operator ~(float value)
         {
             uint bits = ~BitConverter.SingleToUInt32Bits(value);
@@ -519,19 +519,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<float, float>.operator <(float left, float right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<float, float>.operator <=(float left, float right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<float, float>.operator >(float left, float right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<float, float>.operator >=(float left, float right)
             => left >= right;
 
@@ -539,11 +539,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IDecrementOperators<float>.operator --(float value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IDecrementOperators<float>.operator --(float value)
         //     => checked(--value);
 
@@ -551,11 +551,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IDivisionOperators<float, float, float>.operator /(float left, float right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IDivisionOperators<float, float, float>.operator /(float left, float right)
         //     => checked(left / right);
 
@@ -563,11 +563,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<float, float>.operator ==(float left, float right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<float, float>.operator !=(float left, float right)
             => left != right;
 
@@ -575,200 +575,200 @@ namespace System
         // IFloatingPoint
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.E => MathF.E;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Epsilon => Epsilon;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.NaN => NaN;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.NegativeInfinity => NegativeInfinity;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.NegativeZero => -0.0f;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Pi => MathF.PI;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.PositiveInfinity => PositiveInfinity;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Tau => MathF.Tau;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Acos(float x)
             => MathF.Acos(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Acosh(float x)
             => MathF.Acosh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Asin(float x)
             => MathF.Asin(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Asinh(float x)
             => MathF.Asinh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Atan(float x)
             => MathF.Atan(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Atan2(float y, float x)
             => MathF.Atan2(y, x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Atanh(float x)
             => MathF.Atanh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.BitIncrement(float x)
             => MathF.BitIncrement(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.BitDecrement(float x)
             => MathF.BitDecrement(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Cbrt(float x)
             => MathF.Cbrt(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Ceiling(float x)
             => MathF.Ceiling(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.CopySign(float x, float y)
             => MathF.CopySign(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Cos(float x)
             => MathF.Cos(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Cosh(float x)
             => MathF.Cosh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Exp(float x)
             => MathF.Exp(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Floor(float x)
             => MathF.Floor(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.FusedMultiplyAdd(float left, float right, float addend)
             => MathF.FusedMultiplyAdd(left, right, addend);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.IEEERemainder(float left, float right)
             => MathF.IEEERemainder(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TInteger IFloatingPoint<float>.ILogB<TInteger>(float x)
             => TInteger.Create(MathF.ILogB(x));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Log(float x)
             => MathF.Log(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Log(float x, float newBase)
             => MathF.Log(x, newBase);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Log2(float x)
             => MathF.Log2(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Log10(float x)
             => MathF.Log10(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.MaxMagnitude(float x, float y)
             => MathF.MaxMagnitude(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.MinMagnitude(float x, float y)
             => MathF.MinMagnitude(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Pow(float x, float y)
             => MathF.Pow(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Round(float x)
             => MathF.Round(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits)
             => MathF.Round(x, int.Create(digits));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Round(float x, MidpointRounding mode)
             => MathF.Round(x, mode);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits, MidpointRounding mode)
             => MathF.Round(x, int.Create(digits), mode);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.ScaleB<TInteger>(float x, TInteger n)
             => MathF.ScaleB(x, int.Create(n));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Sin(float x)
             => MathF.Sin(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Sinh(float x)
             => MathF.Sinh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Sqrt(float x)
             => MathF.Sqrt(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Tan(float x)
             => MathF.Tan(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Tanh(float x)
             => MathF.Tanh(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IFloatingPoint<float>.Truncate(float x)
             => MathF.Truncate(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsFinite(float x) => IsFinite(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsInfinity(float x) => IsInfinity(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsNaN(float x) => IsNaN(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsNegative(float x) => IsNegative(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsNegativeInfinity(float x) => IsNegativeInfinity(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsNormal(float x) => IsNormal(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsPositiveInfinity(float x) => IsPositiveInfinity(x);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IFloatingPoint<float>.IsSubnormal(float x) => IsSubnormal(x);
 
         // static float IFloatingPoint<float>.AcosPi(float x)
@@ -841,11 +841,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IIncrementOperators<float>.operator ++(float value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IIncrementOperators<float>.operator ++(float value)
         //     => checked(++value);
 
@@ -853,21 +853,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IMinMaxValue<float>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IMinMaxValue<float>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IModulusOperators<float, float, float>.operator %(float left, float right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IModulusOperators<float, float, float>.operator %(float left, float right)
         //     => checked(left % right);
 
@@ -875,18 +875,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IMultiplicativeIdentity<float, float>.MultiplicativeIdentity => 1.0f;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IMultiplyOperators<float, float, float>.operator *(float left, float right)
             => (float)(left * right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IMultiplyOperators<float, float, float>.operator *(float left, float right)
         //     => checked((float)(left * right));
 
@@ -894,21 +894,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.One => 1.0f;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Zero => 0.0f;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Abs(float value)
             => MathF.Abs(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Clamp(float value, float min, float max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static float INumber<float>.Create<TOther>(TOther value)
         {
@@ -975,7 +975,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static float INumber<float>.CreateSaturating<TOther>(TOther value)
         {
@@ -1042,7 +1042,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static float INumber<float>.CreateTruncating<TOther>(TOther value)
         {
@@ -1109,31 +1109,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (float Quotient, float Remainder) INumber<float>.DivRem(float left, float right)
             => (left / right, left % right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Max(float x, float y)
             => MathF.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Min(float x, float y)
             => MathF.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float INumber<float>.Sign(float value)
             => MathF.Sign(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<float>.TryCreate<TOther>(TOther value, out float result)
         {
@@ -1215,11 +1215,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<float>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out float result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<float>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out float result)
             => TryParse(s, style, provider, out result);
 
@@ -1227,11 +1227,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IParseable<float>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<float>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out float result)
             => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
@@ -1239,18 +1239,18 @@ namespace System
         // ISignedNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float ISignedNumber<float>.NegativeOne => -1;
 
         //
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float ISpanParseable<float>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<float>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out float result)
             => TryParse(s, NumberStyles.Float | NumberStyles.AllowThousands, provider, out result);
 
@@ -1258,11 +1258,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float ISubtractionOperators<float, float, float>.operator -(float left, float right)
             => (float)(left - right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float ISubtractionOperators<float, float, float>.operator -(float left, float right)
         //     => checked((float)(left - right));
 
@@ -1270,20 +1270,20 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IUnaryNegationOperators<float, float>.operator -(float value) => (float)(-value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IUnaryNegationOperators<float, float>.operator -(float value) => checked((float)(-value));
 
         //
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static float IUnaryPlusOperators<float, float>.operator +(float value) => (float)(+value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked float IUnaryPlusOperators<float, float>.operator +(float value) => checked((float)(+value));
 #endif // FEATURE_GENERIC_MATH
     }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -911,19 +911,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeOnly, TimeOnly>.operator <(TimeOnly left, TimeOnly right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeOnly, TimeOnly>.operator <=(TimeOnly left, TimeOnly right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeOnly, TimeOnly>.operator >(TimeOnly left, TimeOnly right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeOnly, TimeOnly>.operator >=(TimeOnly left, TimeOnly right)
             => left >= right;
 
@@ -931,11 +931,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<TimeOnly, TimeOnly>.operator ==(TimeOnly left, TimeOnly right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<TimeOnly, TimeOnly>.operator !=(TimeOnly left, TimeOnly right)
             => left != right;
 
@@ -943,11 +943,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeOnly IParseable<TimeOnly>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider, DateTimeStyles.None);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<TimeOnly>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out TimeOnly result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 
@@ -955,11 +955,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeOnly ISpanParseable<TimeOnly>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, provider, DateTimeStyles.None);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<TimeOnly>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out TimeOnly result)
             => TryParse(s, provider, DateTimeStyles.None, out result);
 
@@ -967,18 +967,18 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan ISubtractionOperators<TimeOnly, TimeOnly, TimeSpan>.operator -(TimeOnly left, TimeOnly right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan ISubtractionOperators<TimeOnly, TimeOnly, TimeSpan>.operator -(TimeOnly left, TimeOnly right)
         //     => checked(left - right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeOnly IMinMaxValue<TimeOnly>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeOnly IMinMaxValue<TimeOnly>.MaxValue => MaxValue;
 
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -510,11 +510,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IAdditionOperators<TimeSpan, TimeSpan, TimeSpan>.operator +(TimeSpan left, TimeSpan right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan IAdditionOperators<TimeSpan, TimeSpan, TimeSpan>.operator +(TimeSpan left, TimeSpan right)
         //     => checked(left + right);
 
@@ -522,26 +522,26 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IAdditiveIdentity<TimeSpan, TimeSpan>.AdditiveIdentity => default;
 
         //
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeSpan, TimeSpan>.operator <(TimeSpan left, TimeSpan right)
             => left<right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeSpan, TimeSpan>.operator <=(TimeSpan left, TimeSpan right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeSpan, TimeSpan>.operator >(TimeSpan left, TimeSpan right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<TimeSpan, TimeSpan>.operator >=(TimeSpan left, TimeSpan right)
             => left >= right;
 
@@ -549,19 +549,19 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IDivisionOperators<TimeSpan, double, TimeSpan>.operator /(TimeSpan left, double right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan IDivisionOperators<TimeSpan, double, TimeSpan>.operator /(TimeSpan left, double right)
         //     => checked(left / right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IDivisionOperators<TimeSpan, TimeSpan, double>.operator /(TimeSpan left, TimeSpan right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked double IDivisionOperators<TimeSpan, TimeSpan, double>.operator /(TimeSpan left, TimeSpan right)
         //     => checked(left / right);
 
@@ -569,11 +569,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<TimeSpan, TimeSpan>.operator ==(TimeSpan left, TimeSpan right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<TimeSpan, TimeSpan>.operator !=(TimeSpan left, TimeSpan right)
             => left != right;
 
@@ -581,28 +581,28 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IMinMaxValue<TimeSpan>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IMinMaxValue<TimeSpan>.MaxValue => MaxValue;
 
         //
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static double IMultiplicativeIdentity<TimeSpan, double>.MultiplicativeIdentity => 1.0;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IMultiplyOperators<TimeSpan, double, TimeSpan>.operator *(TimeSpan left, double right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan IMultiplyOperators<TimeSpan, double, TimeSpan>.operator *(TimeSpan left, double right)
         //     => checked(left * right);
 
@@ -610,11 +610,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IParseable<TimeSpan>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<TimeSpan>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out TimeSpan result)
             => TryParse(s, provider, out result);
 
@@ -622,11 +622,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan ISpanParseable<TimeSpan>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<TimeSpan>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out TimeSpan result)
             => TryParse(s, provider, out result);
 
@@ -634,11 +634,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan ISubtractionOperators<TimeSpan, TimeSpan, TimeSpan>.operator -(TimeSpan left, TimeSpan right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan ISubtractionOperators<TimeSpan, TimeSpan, TimeSpan>.operator -(TimeSpan left, TimeSpan right)
         //     => checked(left - right);
 
@@ -646,11 +646,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IUnaryNegationOperators<TimeSpan, TimeSpan>.operator -(TimeSpan value)
             => -value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan IUnaryNegationOperators<TimeSpan, TimeSpan>.operator -(TimeSpan value)
         //     => checked(-value);
 
@@ -658,11 +658,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static TimeSpan IUnaryPlusOperators<TimeSpan, TimeSpan>.operator +(TimeSpan value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked TimeSpan IUnaryPlusOperators<TimeSpan, TimeSpan>.operator +(TimeSpan value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -279,11 +279,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IAdditionOperators<ushort, ushort, ushort>.operator +(ushort left, ushort right)
             => (ushort)(left + right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IAdditionOperators<ushort, ushort, ushort>.operator +(ushort left, ushort right)
         //     => checked((ushort)(left + right));
 
@@ -291,30 +291,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IAdditiveIdentity<ushort, ushort>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBinaryInteger<ushort>.LeadingZeroCount(ushort value)
             => (ushort)(BitOperations.LeadingZeroCount(value) - 16);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBinaryInteger<ushort>.PopCount(ushort value)
             => (ushort)BitOperations.PopCount(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBinaryInteger<ushort>.RotateLeft(ushort value, int rotateAmount)
             => (ushort)((value << (rotateAmount & 15)) | (value >> ((16 - rotateAmount) & 15)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBinaryInteger<ushort>.RotateRight(ushort value, int rotateAmount)
             => (ushort)((value >> (rotateAmount & 15)) | (value << ((16 - rotateAmount) & 15)));
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBinaryInteger<ushort>.TrailingZeroCount(ushort value)
             => (ushort)(BitOperations.TrailingZeroCount(value << 16) - 16);
 
@@ -322,11 +322,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<ushort>.IsPow2(ushort value)
             => BitOperations.IsPow2((uint)value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBinaryNumber<ushort>.Log2(ushort value)
             => (ushort)BitOperations.Log2(value);
 
@@ -334,19 +334,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator &(ushort left, ushort right)
             => (ushort)(left & right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator |(ushort left, ushort right)
             => (ushort)(left | right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ^(ushort left, ushort right)
             => (ushort)(left ^ right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ~(ushort value)
             => (ushort)(~value);
 
@@ -354,19 +354,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ushort, ushort>.operator <(ushort left, ushort right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ushort, ushort>.operator <=(ushort left, ushort right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ushort, ushort>.operator >(ushort left, ushort right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ushort, ushort>.operator >=(ushort left, ushort right)
             => left >= right;
 
@@ -374,11 +374,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IDecrementOperators<ushort>.operator --(ushort value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IDecrementOperators<ushort>.operator --(ushort value)
         //     => checked(--value);
 
@@ -386,11 +386,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right)
             => (ushort)(left / right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right)
         //     => checked((ushort)(left / right));
 
@@ -398,11 +398,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<ushort, ushort>.operator ==(ushort left, ushort right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<ushort, ushort>.operator !=(ushort left, ushort right)
             => left != right;
 
@@ -410,11 +410,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IIncrementOperators<ushort>.operator ++(ushort value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IIncrementOperators<ushort>.operator ++(ushort value)
         //     => checked(++value);
 
@@ -422,21 +422,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IMinMaxValue<ushort>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IMinMaxValue<ushort>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right)
             => (ushort)(left % right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right)
         //     => checked((ushort)(left % right));
 
@@ -444,18 +444,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IMultiplicativeIdentity<ushort, ushort>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right)
             => (ushort)(left * right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right)
         //     => checked((ushort)(left * right));
 
@@ -463,21 +463,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Abs(ushort value)
             => value;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Clamp(ushort value, ushort min, ushort max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ushort INumber<ushort>.Create<TOther>(TOther value)
         {
@@ -544,7 +544,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ushort INumber<ushort>.CreateSaturating<TOther>(TOther value)
         {
@@ -628,7 +628,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ushort INumber<ushort>.CreateTruncating<TOther>(TOther value)
         {
@@ -695,31 +695,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (ushort Quotient, ushort Remainder) INumber<ushort>.DivRem(ushort left, ushort right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Max(ushort x, ushort y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Min(ushort x, ushort y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort INumber<ushort>.Sign(ushort value)
             => (ushort)((value == 0) ? 0 : 1);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<ushort>.TryCreate<TOther>(TOther value, out ushort result)
         {
@@ -889,11 +889,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<ushort>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out ushort result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<ushort>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out ushort result)
             => TryParse(s, style, provider, out result);
 
@@ -901,11 +901,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IParseable<ushort>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<ushort>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out ushort result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -913,15 +913,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IShiftOperators<ushort, ushort>.operator <<(ushort value, int shiftAmount)
             => (ushort)(value << shiftAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IShiftOperators<ushort, ushort>.operator >>(ushort value, int shiftAmount)
             => (ushort)(value >> shiftAmount);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static ushort IShiftOperators<ushort, ushort>.operator >>>(ushort value, int shiftAmount)
         //     => (ushort)(value >> shiftAmount);
 
@@ -929,11 +929,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort ISpanParseable<ushort>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<ushort>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ushort result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -941,11 +941,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort ISubtractionOperators<ushort, ushort, ushort>.operator -(ushort left, ushort right)
             => (ushort)(left - right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort ISubtractionOperators<ushort, ushort, ushort>.operator -(ushort left, ushort right)
         //     => checked((ushort)(left - right));
 
@@ -953,11 +953,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IUnaryNegationOperators<ushort, ushort>.operator -(ushort value)
             => (ushort)(-value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IUnaryNegationOperators<ushort, ushort>.operator -(ushort value)
         //     => checked((ushort)(-value));
 
@@ -965,11 +965,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ushort IUnaryPlusOperators<ushort, ushort>.operator +(ushort value)
             => (ushort)(+value);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ushort IUnaryPlusOperators<ushort, ushort>.operator +(ushort value)
         //     => checked((ushort)(+value));
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -265,11 +265,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IAdditionOperators<uint, uint, uint>.operator +(uint left, uint right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IAdditionOperators<uint, uint, uint>.operator +(uint left, uint right)
         //     => checked(left + right);
 
@@ -277,30 +277,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IAdditiveIdentity<uint, uint>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBinaryInteger<uint>.LeadingZeroCount(uint value)
             => (uint)BitOperations.LeadingZeroCount(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBinaryInteger<uint>.PopCount(uint value)
             => (uint)BitOperations.PopCount(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBinaryInteger<uint>.RotateLeft(uint value, int rotateAmount)
             => BitOperations.RotateLeft(value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBinaryInteger<uint>.RotateRight(uint value, int rotateAmount)
             => BitOperations.RotateRight(value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBinaryInteger<uint>.TrailingZeroCount(uint value)
             => (uint)BitOperations.TrailingZeroCount(value);
 
@@ -308,11 +308,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<uint>.IsPow2(uint value)
             => BitOperations.IsPow2(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBinaryNumber<uint>.Log2(uint value)
             => (uint)BitOperations.Log2(value);
 
@@ -320,19 +320,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBitwiseOperators<uint, uint, uint>.operator &(uint left, uint right)
             => left & right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBitwiseOperators<uint, uint, uint>.operator |(uint left, uint right)
             => left | right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBitwiseOperators<uint, uint, uint>.operator ^(uint left, uint right)
             => left ^ right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IBitwiseOperators<uint, uint, uint>.operator ~(uint value)
             => ~value;
 
@@ -340,19 +340,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<uint, uint>.operator <(uint left, uint right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<uint, uint>.operator <=(uint left, uint right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<uint, uint>.operator >(uint left, uint right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<uint, uint>.operator >=(uint left, uint right)
             => left >= right;
 
@@ -360,11 +360,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IDecrementOperators<uint>.operator --(uint value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IDecrementOperators<uint>.operator --(uint value)
         //     => checked(--value);
 
@@ -372,11 +372,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right)
         //     => checked(left / right);
 
@@ -384,11 +384,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<uint, uint>.operator ==(uint left, uint right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<uint, uint>.operator !=(uint left, uint right)
             => left != right;
 
@@ -396,11 +396,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IIncrementOperators<uint>.operator ++(uint value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IIncrementOperators<uint>.operator ++(uint value)
         //     => checked(++value);
 
@@ -408,21 +408,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IMinMaxValue<uint>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IMinMaxValue<uint>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IModulusOperators<uint, uint, uint>.operator %(uint left, uint right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IModulusOperators<uint, uint, uint>.operator %(uint left, uint right)
         //     => checked(left % right);
 
@@ -430,18 +430,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IMultiplicativeIdentity<uint, uint>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right)
         //     => checked(left * right);
 
@@ -449,21 +449,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Abs(uint value)
             => value;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Clamp(uint value, uint min, uint max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static uint INumber<uint>.Create<TOther>(TOther value)
         {
@@ -530,7 +530,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static uint INumber<uint>.CreateSaturating<TOther>(TOther value)
         {
@@ -612,7 +612,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static uint INumber<uint>.CreateTruncating<TOther>(TOther value)
         {
@@ -679,31 +679,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (uint Quotient, uint Remainder) INumber<uint>.DivRem(uint left, uint right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Max(uint x, uint y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Min(uint x, uint y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint INumber<uint>.Sign(uint value)
             => (uint)((value == 0) ? 0 : 1);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<uint>.TryCreate<TOther>(TOther value, out uint result)
         {
@@ -865,11 +865,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<uint>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out uint result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<uint>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out uint result)
             => TryParse(s, style, provider, out result);
 
@@ -877,11 +877,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IParseable<uint>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<uint>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out uint result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -889,15 +889,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IShiftOperators<uint, uint>.operator <<(uint value, int shiftAmount)
             => value << (int)shiftAmount;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IShiftOperators<uint, uint>.operator >>(uint value, int shiftAmount)
             => value >> (int)shiftAmount;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static uint IShiftOperators<uint, uint>.operator >>>(uint value, int shiftAmount)
         //     => value >> (int)shiftAmount;
 
@@ -905,11 +905,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint ISpanParseable<uint>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<uint>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out uint result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -917,11 +917,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint ISubtractionOperators<uint, uint, uint>.operator -(uint left, uint right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint ISubtractionOperators<uint, uint, uint>.operator -(uint left, uint right)
         //     => checked(left - right);
 
@@ -929,11 +929,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IUnaryNegationOperators<uint, uint>.operator -(uint value)
             => 0u - value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IUnaryNegationOperators<uint, uint>.operator -(uint value)
         //     => checked(0u - value);
 
@@ -941,11 +941,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static uint IUnaryPlusOperators<uint, uint>.operator +(uint value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked uint IUnaryPlusOperators<uint, uint>.operator +(uint value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -264,11 +264,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IAdditionOperators<ulong, ulong, ulong>.operator +(ulong left, ulong right)
             => left + right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IAdditionOperators<ulong, ulong, ulong>.operator +(ulong left, ulong right)
         //     => checked(left + right);
 
@@ -276,30 +276,30 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IAdditiveIdentity<ulong, ulong>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBinaryInteger<ulong>.LeadingZeroCount(ulong value)
             => (ulong)BitOperations.LeadingZeroCount(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBinaryInteger<ulong>.PopCount(ulong value)
             => (ulong)BitOperations.PopCount(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBinaryInteger<ulong>.RotateLeft(ulong value, int rotateAmount)
             => BitOperations.RotateLeft(value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBinaryInteger<ulong>.RotateRight(ulong value, int rotateAmount)
             => BitOperations.RotateRight(value, rotateAmount);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBinaryInteger<ulong>.TrailingZeroCount(ulong value)
             => (ulong)BitOperations.TrailingZeroCount(value);
 
@@ -307,11 +307,11 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<ulong>.IsPow2(ulong value)
             => BitOperations.IsPow2(value);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBinaryNumber<ulong>.Log2(ulong value)
             => (ulong)BitOperations.Log2(value);
 
@@ -319,19 +319,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator &(ulong left, ulong right)
             => left & right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator |(ulong left, ulong right)
             => left | right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ^(ulong left, ulong right)
             => left ^ right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ~(ulong value)
             => ~value;
 
@@ -339,19 +339,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ulong, ulong>.operator <(ulong left, ulong right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ulong, ulong>.operator <=(ulong left, ulong right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ulong, ulong>.operator >(ulong left, ulong right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<ulong, ulong>.operator >=(ulong left, ulong right)
             => left >= right;
 
@@ -359,11 +359,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IDecrementOperators<ulong>.operator --(ulong value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IDecrementOperators<ulong>.operator --(ulong value)
         //     => checked(--value);
 
@@ -371,11 +371,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right)
         //     => checked(left / right);
 
@@ -383,11 +383,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<ulong, ulong>.operator ==(ulong left, ulong right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<ulong, ulong>.operator !=(ulong left, ulong right)
             => left != right;
 
@@ -395,11 +395,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IIncrementOperators<ulong>.operator ++(ulong value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IIncrementOperators<ulong>.operator ++(ulong value)
         //     => checked(++value);
 
@@ -407,21 +407,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IMinMaxValue<ulong>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IMinMaxValue<ulong>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right)
         //     => checked(left % right);
 
@@ -429,18 +429,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IMultiplicativeIdentity<ulong, ulong>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right)
         //     => checked(left * right);
 
@@ -448,21 +448,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Abs(ulong value)
             => value;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Clamp(ulong value, ulong min, ulong max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ulong INumber<ulong>.Create<TOther>(TOther value)
         {
@@ -529,7 +529,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ulong INumber<ulong>.CreateSaturating<TOther>(TOther value)
         {
@@ -607,7 +607,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static ulong INumber<ulong>.CreateTruncating<TOther>(TOther value)
         {
@@ -674,31 +674,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (ulong Quotient, ulong Remainder) INumber<ulong>.DivRem(ulong left, ulong right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Max(ulong x, ulong y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Min(ulong x, ulong y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong INumber<ulong>.Sign(ulong value)
             => (ulong)((value == 0) ? 0 : 1);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<ulong>.TryCreate<TOther>(TOther value, out ulong result)
         {
@@ -844,11 +844,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<ulong>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out ulong result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<ulong>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out ulong result)
             => TryParse(s, style, provider, out result);
 
@@ -856,11 +856,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IParseable<ulong>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<ulong>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out ulong result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -868,15 +868,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IShiftOperators<ulong, ulong>.operator <<(ulong value, int shiftAmount)
             => value << (int)shiftAmount;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IShiftOperators<ulong, ulong>.operator >>(ulong value, int shiftAmount)
             => value >> (int)shiftAmount;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static ulong IShiftOperators<ulong, ulong>.operator >>>(ulong value, int shiftAmount)
         //     => value >> (int)shiftAmount;
 
@@ -884,11 +884,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong ISpanParseable<ulong>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<ulong>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out ulong result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -896,11 +896,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong ISubtractionOperators<ulong, ulong, ulong>.operator -(ulong left, ulong right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong ISubtractionOperators<ulong, ulong, ulong>.operator -(ulong left, ulong right)
         //     => checked(left - right);
 
@@ -908,11 +908,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IUnaryNegationOperators<ulong, ulong>.operator -(ulong value)
             => 0UL - value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IUnaryNegationOperators<ulong, ulong>.operator -(ulong value)
         //     => checked(0UL - value);
 
@@ -920,11 +920,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static ulong IUnaryPlusOperators<ulong, ulong>.operator +(ulong value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked ulong IUnaryPlusOperators<ulong, ulong>.operator +(ulong value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -246,11 +246,11 @@ namespace System
         // IAdditionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right)
             => (nuint)(left + right);
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right)
         //     => checked((nuint)(left + right));
 
@@ -258,14 +258,14 @@ namespace System
         // IAdditiveIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IAdditiveIdentity<nuint, nuint>.AdditiveIdentity => 0;
 
         //
         // IBinaryInteger
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBinaryInteger<nuint>.LeadingZeroCount(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -278,7 +278,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBinaryInteger<nuint>.PopCount(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -291,7 +291,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBinaryInteger<nuint>.RotateLeft(nuint value, int rotateAmount)
         {
             if (Environment.Is64BitProcess)
@@ -304,7 +304,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBinaryInteger<nuint>.RotateRight(nuint value, int rotateAmount)
         {
             if (Environment.Is64BitProcess)
@@ -317,7 +317,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBinaryInteger<nuint>.TrailingZeroCount(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -334,7 +334,7 @@ namespace System
         // IBinaryNumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IBinaryNumber<nuint>.IsPow2(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -347,7 +347,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBinaryNumber<nuint>.Log2(nuint value)
         {
             if (Environment.Is64BitProcess)
@@ -364,19 +364,19 @@ namespace System
         // IBitwiseOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator &(nuint left, nuint right)
             => left & right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator |(nuint left, nuint right)
             => left | right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ^(nuint left, nuint right)
             => left ^ right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ~(nuint value)
             => ~value;
 
@@ -384,19 +384,19 @@ namespace System
         // IComparisonOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nuint, nuint>.operator <(nuint left, nuint right)
             => left < right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nuint, nuint>.operator <=(nuint left, nuint right)
             => left <= right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nuint, nuint>.operator >(nuint left, nuint right)
             => left > right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IComparisonOperators<nuint, nuint>.operator >=(nuint left, nuint right)
             => left >= right;
 
@@ -404,11 +404,11 @@ namespace System
         // IDecrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IDecrementOperators<nuint>.operator --(nuint value)
             => --value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IDecrementOperators<nuint>.operator --(nuint value)
         //     => checked(--value);
 
@@ -416,11 +416,11 @@ namespace System
         // IDivisionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right)
             => left / right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right)
         //     => checked(left / right);
 
@@ -428,11 +428,11 @@ namespace System
         // IEqualityOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<nuint, nuint>.operator ==(nuint left, nuint right)
             => left == right;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IEqualityOperators<nuint, nuint>.operator !=(nuint left, nuint right)
             => left != right;
 
@@ -440,11 +440,11 @@ namespace System
         // IIncrementOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IIncrementOperators<nuint>.operator ++(nuint value)
             => ++value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IIncrementOperators<nuint>.operator ++(nuint value)
         //     => checked(++value);
 
@@ -452,21 +452,21 @@ namespace System
         // IMinMaxValue
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IMinMaxValue<nuint>.MinValue => MinValue;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IMinMaxValue<nuint>.MaxValue => MaxValue;
 
         //
         // IModulusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right)
             => left % right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right)
         //     => checked(left % right);
 
@@ -474,18 +474,18 @@ namespace System
         // IMultiplicativeIdentity
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IMultiplicativeIdentity<nuint, nuint>.MultiplicativeIdentity => 1;
 
         //
         // IMultiplyOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right)
             => left * right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right)
         //     => checked(left * right);
 
@@ -493,21 +493,21 @@ namespace System
         // INumber
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.One => 1;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Zero => 0;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Abs(nuint value)
             => value;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Clamp(nuint value, nuint min, nuint max)
             => Math.Clamp(value, min, max);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nuint INumber<nuint>.Create<TOther>(TOther value)
         {
@@ -574,7 +574,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nuint INumber<nuint>.CreateSaturating<TOther>(TOther value)
         {
@@ -655,7 +655,7 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static nuint INumber<nuint>.CreateTruncating<TOther>(TOther value)
         {
@@ -722,31 +722,31 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static (nuint Quotient, nuint Remainder) INumber<nuint>.DivRem(nuint left, nuint right)
             => Math.DivRem(left, right);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Max(nuint x, nuint y)
             => Math.Max(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Min(nuint x, nuint y)
             => Math.Min(x, y);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Parse(string s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
             => Parse(s, style, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint INumber<nuint>.Sign(nuint value)
             => (nuint)((value == 0) ? 0 : 1);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool INumber<nuint>.TryCreate<TOther>(TOther value, out nuint result)
         {
@@ -900,11 +900,11 @@ namespace System
             }
         }
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<nuint>.TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out nuint result)
             => TryParse(s, style, provider, out result);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool INumber<nuint>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out nuint result)
             => TryParse(s, style, provider, out result);
 
@@ -912,11 +912,11 @@ namespace System
         // IParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IParseable<nuint>.Parse(string s, IFormatProvider? provider)
             => Parse(s, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool IParseable<nuint>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out nuint result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -924,15 +924,15 @@ namespace System
         // IShiftOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IShiftOperators<nuint, nuint>.operator <<(nuint value, int shiftAmount)
             => value << (int)shiftAmount;
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IShiftOperators<nuint, nuint>.operator >>(nuint value, int shiftAmount)
             => value >> (int)shiftAmount;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static nuint IShiftOperators<nuint, nuint>.operator >>>(nuint value, int shiftAmount)
         //     => value >> (int)shiftAmount;
 
@@ -940,11 +940,11 @@ namespace System
         // ISpanParseable
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint ISpanParseable<nuint>.Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
             => Parse(s, NumberStyles.Integer, provider);
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static bool ISpanParseable<nuint>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out nuint result)
             => TryParse(s, NumberStyles.Integer, provider, out result);
 
@@ -952,11 +952,11 @@ namespace System
         // ISubtractionOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint ISubtractionOperators<nuint, nuint, nuint>.operator -(nuint left, nuint right)
             => left - right;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint ISubtractionOperators<nuint, nuint, nuint>.operator -(nuint left, nuint right)
         //     => checked(left - right);
 
@@ -964,11 +964,11 @@ namespace System
         // IUnaryNegationOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IUnaryNegationOperators<nuint, nuint>.operator -(nuint value)
             => (nuint)0 - value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IUnaryNegationOperators<nuint, nuint>.operator -(nuint value)
         //     => checked((nuint)0 - value);
 
@@ -976,11 +976,11 @@ namespace System
         // IUnaryPlusOperators
         //
 
-        [RequiresPreviewFeatures]
+        [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         static nuint IUnaryPlusOperators<nuint, nuint>.operator +(nuint value)
             => +value;
 
-        // [RequiresPreviewFeatures]
+        // [RequiresPreviewFeatures(Number.PreviewFeatureMessage, Url = Number.PreviewFeatureUrl)]
         // static checked nuint IUnaryPlusOperators<nuint, nuint>.operator +(nuint value)
         //     => checked(+value);
 #endif // FEATURE_GENERIC_MATH

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -3,7 +3,6 @@
 // ------------------------------------------------------------------------------
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
-using System.Runtime.Versioning;
 
 namespace System.Runtime.Intrinsics
 {
@@ -3371,7 +3370,7 @@ namespace System.Runtime.Intrinsics.X86
     }
 
     [System.CLSCompliantAttribute(false)]
-    [RequiresPreviewFeatures]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public abstract class AvxVnni : System.Runtime.Intrinsics.X86.Avx2
     {
         internal AvxVnni() { }

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -3370,7 +3370,7 @@ namespace System.Runtime.Intrinsics.X86
     }
 
     [System.CLSCompliantAttribute(false)]
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("AvxVnni is in preview.")]
     public abstract class AvxVnni : System.Runtime.Intrinsics.X86.Avx2
     {
         internal AvxVnni() { }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -754,130 +754,130 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Byte result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IAdditiveIdentity<byte, byte>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IMinMaxValue<byte>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IMinMaxValue<byte>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IMultiplicativeIdentity<byte, byte>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IAdditionOperators<byte, byte, byte>.operator +(byte left, byte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBinaryInteger<byte>.LeadingZeroCount(byte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBinaryInteger<byte>.PopCount(byte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBinaryInteger<byte>.RotateLeft(byte value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBinaryInteger<byte>.RotateRight(byte value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBinaryInteger<byte>.TrailingZeroCount(byte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<byte>.IsPow2(byte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBinaryNumber<byte>.Log2(byte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBitwiseOperators<byte, byte, byte>.operator &(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBitwiseOperators<byte, byte, byte>.operator |(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBitwiseOperators<byte, byte, byte>.operator ^(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IBitwiseOperators<byte, byte, byte>.operator ~(byte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<byte, byte>.operator <(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<byte, byte>.operator <=(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<byte, byte>.operator >(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<byte, byte>.operator >=(byte left, byte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IDecrementOperators<byte>.operator --(byte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IDivisionOperators<byte, byte, byte>.operator /(byte left, byte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<byte, byte>.operator ==(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<byte, byte>.operator !=(byte left, byte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IIncrementOperators<byte>.operator ++(byte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IModulusOperators<byte, byte, byte>.operator %(byte left, byte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IMultiplyOperators<byte, byte, byte>.operator *(byte left, byte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Abs(byte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Clamp(byte value, byte min, byte max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (byte Quotient, byte Remainder) INumber<byte>.DivRem(byte left, byte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Max(byte x, byte y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Min(byte x, byte y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte INumber<byte>.Sign(byte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<byte>.TryCreate<TOther>(TOther value, out byte result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<byte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out byte result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<byte>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out byte result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IParseable<byte>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<byte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out byte result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IShiftOperators<byte, byte>.operator <<(byte value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IShiftOperators<byte, byte>.operator >>(byte value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte ISpanParseable<byte>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<byte>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out byte result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte ISubtractionOperators<byte, byte, byte>.operator -(byte left, byte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IUnaryNegationOperators<byte, byte>.operator -(byte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static byte IUnaryPlusOperators<byte, byte>.operator +(byte value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -974,130 +974,130 @@ namespace System
         string System.IFormattable.ToString(string? format, IFormatProvider? formatProvider) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IAdditiveIdentity<char, char>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IMinMaxValue<char>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IMinMaxValue<char>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IMultiplicativeIdentity<char, char>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IAdditionOperators<char, char, char>.operator +(char left, char right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBinaryInteger<char>.LeadingZeroCount(char value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBinaryInteger<char>.PopCount(char value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBinaryInteger<char>.RotateLeft(char value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBinaryInteger<char>.RotateRight(char value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBinaryInteger<char>.TrailingZeroCount(char value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<char>.IsPow2(char value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBinaryNumber<char>.Log2(char value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBitwiseOperators<char, char, char>.operator &(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBitwiseOperators<char, char, char>.operator |(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBitwiseOperators<char, char, char>.operator ^(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IBitwiseOperators<char, char, char>.operator ~(char value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<char, char>.operator <(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<char, char>.operator <=(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<char, char>.operator >(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<char, char>.operator >=(char left, char right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IDecrementOperators<char>.operator --(char value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IDivisionOperators<char, char, char>.operator /(char left, char right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<char, char>.operator ==(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<char, char>.operator !=(char left, char right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IIncrementOperators<char>.operator ++(char value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IModulusOperators<char, char, char>.operator %(char left, char right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IMultiplyOperators<char, char, char>.operator *(char left, char right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Abs(char value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Clamp(char value, char min, char max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (char Quotient, char Remainder) INumber<char>.DivRem(char left, char right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Max(char x, char y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Min(char x, char y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char INumber<char>.Sign(char value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<char>.TryCreate<TOther>(TOther value, out char result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<char>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out char result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IParseable<char>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<char>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out char result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IShiftOperators<char, char>.operator <<(char value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures, System.Runtime.CompilerServices.SpecialNameAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeatures("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview"), System.Runtime.CompilerServices.SpecialNameAttribute]
         static char IShiftOperators<char, char>.operator >>(char value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char ISpanParseable<char>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<char>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out char result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char ISubtractionOperators<char, char, char>.operator -(char left, char right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IUnaryNegationOperators<char, char>.operator -(char value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static char IUnaryPlusOperators<char, char>.operator +(char value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -1656,33 +1656,33 @@ namespace System
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateOnly IMinMaxValue<System.DateOnly>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateOnly IMinMaxValue<System.DateOnly>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator <(System.DateOnly left, System.DateOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator <=(System.DateOnly left, System.DateOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator >(System.DateOnly left, System.DateOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateOnly, System.DateOnly>.operator >=(System.DateOnly left, System.DateOnly right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.DateOnly, System.DateOnly>.operator ==(System.DateOnly left, System.DateOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.DateOnly, System.DateOnly>.operator !=(System.DateOnly left, System.DateOnly right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateOnly IParseable<System.DateOnly>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<System.DateOnly>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateOnly result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateOnly ISpanParseable<System.DateOnly>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<System.DateOnly>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateOnly result) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -1820,44 +1820,44 @@ namespace System
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? provider, System.Globalization.DateTimeStyles style, out System.DateTime result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IAdditiveIdentity<System.DateTime, System.TimeSpan>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTime IMinMaxValue<System.DateTime>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTime IMinMaxValue<System.DateTime>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTime IAdditionOperators<System.DateTime, System.TimeSpan, System.DateTime>.operator +(System.DateTime left, System.TimeSpan right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTime, System.DateTime>.operator <(System.DateTime left, System.DateTime right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTime, System.DateTime>.operator <=(System.DateTime left, System.DateTime right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTime, System.DateTime>.operator >(System.DateTime left, System.DateTime right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTime, System.DateTime>.operator >=(System.DateTime left, System.DateTime right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.DateTime, System.DateTime>.operator ==(System.DateTime left, System.DateTime right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.DateTime, System.DateTime>.operator !=(System.DateTime left, System.DateTime right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTime IParseable<System.DateTime>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<System.DateTime>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateTime result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTime ISpanParseable<System.DateTime>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<System.DateTime>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateTime result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTime ISubtractionOperators<System.DateTime, System.TimeSpan, System.DateTime>.operator -(System.DateTime left, System.TimeSpan right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan ISubtractionOperators<System.DateTime, System.DateTime, System.TimeSpan>.operator -(System.DateTime left, System.DateTime right) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -1972,44 +1972,44 @@ namespace System
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? formatProvider, System.Globalization.DateTimeStyles styles, out System.DateTimeOffset result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IAdditiveIdentity<System.DateTimeOffset, System.TimeSpan>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTimeOffset IMinMaxValue<System.DateTimeOffset>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTimeOffset IMinMaxValue<System.DateTimeOffset>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTimeOffset IAdditionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>.operator +(System.DateTimeOffset left, System.TimeSpan right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator <(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator <=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator >(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.DateTimeOffset, System.DateTimeOffset>.operator >=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.DateTimeOffset, System.DateTimeOffset>.operator ==(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.DateTimeOffset, System.DateTimeOffset>.operator !=(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTimeOffset IParseable<System.DateTimeOffset>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<System.DateTimeOffset>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.DateTimeOffset result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTimeOffset ISpanParseable<System.DateTimeOffset>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<System.DateTimeOffset>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.DateTimeOffset result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.DateTimeOffset ISubtractionOperators<System.DateTimeOffset, System.TimeSpan, System.DateTimeOffset>.operator -(System.DateTimeOffset left, System.TimeSpan right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan ISubtractionOperators<System.DateTimeOffset, System.DateTimeOffset, System.TimeSpan>.operator -(System.DateTimeOffset left, System.DateTimeOffset right) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -2195,103 +2195,103 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Decimal result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IAdditiveIdentity<decimal, decimal>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IMinMaxValue<decimal>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IMinMaxValue<decimal>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IMultiplicativeIdentity<decimal, decimal>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IAdditionOperators<decimal, decimal, decimal>.operator +(decimal left, decimal right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<decimal, decimal>.operator <(decimal left, decimal right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<decimal, decimal>.operator <=(decimal left, decimal right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<decimal, decimal>.operator >(decimal left, decimal right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<decimal, decimal>.operator >=(decimal left, decimal right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IDecrementOperators<decimal>.operator --(decimal value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IDivisionOperators<decimal, decimal, decimal>.operator /(decimal left, decimal right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<decimal, decimal>.operator ==(decimal left, decimal right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<decimal, decimal>.operator !=(decimal left, decimal right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IIncrementOperators<decimal>.operator ++(decimal value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IModulusOperators<decimal, decimal, decimal>.operator %(decimal left, decimal right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IMultiplyOperators<decimal, decimal, decimal>.operator *(decimal left, decimal right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Abs(decimal value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Clamp(decimal value, decimal min, decimal max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (decimal Quotient, decimal Remainder) INumber<decimal>.DivRem(decimal left, decimal right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Max(decimal x, decimal y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Min(decimal x, decimal y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal INumber<decimal>.Sign(decimal value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<decimal>.TryCreate<TOther>(TOther value, out decimal result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<decimal>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out decimal result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<decimal>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out decimal result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IParseable<decimal>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<decimal>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out decimal result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal ISignedNumber<decimal>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal ISpanParseable<decimal>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<decimal>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out decimal result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal ISubtractionOperators<decimal, decimal, decimal>.operator -(decimal left, decimal right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IUnaryNegationOperators<decimal, decimal>.operator -(decimal value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static decimal IUnaryPlusOperators<decimal, decimal>.operator +(decimal value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -2407,226 +2407,226 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Double result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IAdditiveIdentity<double, double>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.E { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Epsilon { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.NaN { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.NegativeInfinity { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.NegativeZero { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Pi { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.PositiveInfinity { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Tau { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IMinMaxValue<double>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IMinMaxValue<double>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IMultiplicativeIdentity<double, double>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IAdditionOperators<double, double, double>.operator +(double left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<double>.IsPow2(double value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IBinaryNumber<double>.Log2(double value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IBitwiseOperators<double, double, double>.operator &(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IBitwiseOperators<double, double, double>.operator |(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IBitwiseOperators<double, double, double>.operator ^(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IBitwiseOperators<double, double, double>.operator ~(double value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<double, double>.operator <(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<double, double>.operator <=(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<double, double>.operator >(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<double, double>.operator >=(double left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IDecrementOperators<double>.operator --(double value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IDivisionOperators<double, double, double>.operator /(double left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<double, double>.operator ==(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<double, double>.operator !=(double left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Acos(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Acosh(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Asin(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Asinh(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Atan(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Atan2(double y, double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Atanh(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.BitIncrement(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.BitDecrement(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Cbrt(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Ceiling(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.CopySign(double x, double y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Cos(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Cosh(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Exp(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Floor(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.FusedMultiplyAdd(double left, double right, double addend) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.IEEERemainder(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static TInteger IFloatingPoint<double>.ILogB<TInteger>(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Log(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Log(double x, double newBase) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Log2(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Log10(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.MaxMagnitude(double x, double y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.MinMagnitude(double x, double y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Pow(double x, double y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Round(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Round(double x, System.MidpointRounding mode) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Round<TInteger>(double x, TInteger digits, System.MidpointRounding mode) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.ScaleB<TInteger>(double x, TInteger n) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Sin(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Sinh(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Sqrt(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Tan(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Tanh(double x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IFloatingPoint<double>.Truncate(double x) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsFinite(double d) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsInfinity(double d) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsNaN(double d) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsNegative(double d) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsNegativeInfinity(double d) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsNormal(double d) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsPositiveInfinity(double d) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<double>.IsSubnormal(double d) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IIncrementOperators<double>.operator ++(double value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IModulusOperators<double, double, double>.operator %(double left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IMultiplyOperators<double, double, double>.operator *(double left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Abs(double value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Clamp(double value, double min, double max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (double Quotient, double Remainder) INumber<double>.DivRem(double left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Max(double x, double y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Min(double x, double y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double INumber<double>.Sign(double value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<double>.TryCreate<TOther>(TOther value, out double result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<double>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out double result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<double>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out double result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IParseable<double>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<double>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out double result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double ISignedNumber<double>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double ISpanParseable<double>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<double>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out double result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double ISubtractionOperators<double, double, double>.operator -(double left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IUnaryNegationOperators<double, double>.operator -(double value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IUnaryPlusOperators<double, double>.operator +(double value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -3062,28 +3062,28 @@ namespace System
         bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Guid, System.Guid>.operator <(System.Guid left, System.Guid right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Guid, System.Guid>.operator <=(System.Guid left, System.Guid right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Guid, System.Guid>.operator >(System.Guid left, System.Guid right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Guid, System.Guid>.operator >=(System.Guid left, System.Guid right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.Guid, System.Guid>.operator ==(System.Guid left, System.Guid right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.Guid, System.Guid>.operator !=(System.Guid left, System.Guid right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Guid IParseable<System.Guid>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<System.Guid>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Guid result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Guid ISpanParseable<System.Guid>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<System.Guid>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Guid result) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -3141,226 +3141,226 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Half result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IAdditiveIdentity<System.Half, System.Half>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.E { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Epsilon { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.NaN { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.NegativeInfinity { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.NegativeZero { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Pi { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.PositiveInfinity { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Tau { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IMinMaxValue<System.Half>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IMinMaxValue<System.Half>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IMultiplicativeIdentity<System.Half, System.Half>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IAdditionOperators<System.Half, System.Half, System.Half>.operator +(System.Half left, System.Half right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<System.Half>.IsPow2(System.Half value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IBinaryNumber<System.Half>.Log2(System.Half value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator &(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator |(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator ^(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IBitwiseOperators<System.Half, System.Half, System.Half>.operator ~(System.Half value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Half, System.Half>.operator <(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Half, System.Half>.operator <=(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Half, System.Half>.operator >(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.Half, System.Half>.operator >=(System.Half left, System.Half right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IDecrementOperators<System.Half>.operator --(System.Half value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IDivisionOperators<System.Half, System.Half, System.Half>.operator /(System.Half left, System.Half right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.Half, System.Half>.operator ==(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.Half, System.Half>.operator !=(System.Half left, System.Half right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Acos(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Acosh(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Asin(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Asinh(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Atan(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Atan2(System.Half y, System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Atanh(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.BitIncrement(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.BitDecrement(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Cbrt(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Ceiling(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.CopySign(System.Half x, System.Half y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Cos(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Cosh(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Exp(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Floor(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.FusedMultiplyAdd(System.Half left, System.Half right, System.Half addend) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.IEEERemainder(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static TInteger IFloatingPoint<System.Half>.ILogB<TInteger>(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Log(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Log(System.Half x, System.Half newBase) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Log2(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Log10(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.MaxMagnitude(System.Half x, System.Half y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.MinMagnitude(System.Half x, System.Half y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Pow(System.Half x, System.Half y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Round(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Round<TInteger>(System.Half x, TInteger digits) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Round(System.Half x, System.MidpointRounding mode) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Round<TInteger>(System.Half x, TInteger digits, System.MidpointRounding mode) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.ScaleB<TInteger>(System.Half x, TInteger n) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Sin(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Sinh(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Sqrt(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Tan(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Tanh(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IFloatingPoint<System.Half>.Truncate(System.Half x) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsFinite(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsInfinity(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsNaN(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsNegative(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsNegativeInfinity(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsNormal(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsPositiveInfinity(System.Half x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<System.Half>.IsSubnormal(System.Half x) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IIncrementOperators<System.Half>.operator ++(System.Half value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IModulusOperators<System.Half, System.Half, System.Half>.operator %(System.Half left, System.Half right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IMultiplyOperators<System.Half, System.Half, System.Half>.operator *(System.Half left, System.Half right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Abs(System.Half value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Clamp(System.Half value, System.Half min, System.Half max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (System.Half Quotient, System.Half Remainder) INumber<System.Half>.DivRem(System.Half left, System.Half right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Max(System.Half x, System.Half y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Min(System.Half x, System.Half y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half INumber<System.Half>.Sign(System.Half value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<System.Half>.TryCreate<TOther>(TOther value, out System.Half result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<System.Half>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Half result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<System.Half>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.Half result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IParseable<System.Half>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<System.Half>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.Half result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half ISignedNumber<System.Half>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half ISpanParseable<System.Half>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<System.Half>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.Half result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half ISubtractionOperators<System.Half, System.Half, System.Half>.operator -(System.Half left, System.Half right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IUnaryNegationOperators<System.Half, System.Half>.operator -(System.Half value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.Half IUnaryPlusOperators<System.Half, System.Half>.operator +(System.Half value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -3391,24 +3391,24 @@ namespace System
         public HttpStyleUriParser() { }
     }
 #if FEATURE_GENERIC_MATH
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IAdditionOperators<TSelf, TOther, TResult>
         where TSelf : System.IAdditionOperators<TSelf, TOther, TResult>
     {
         static abstract TResult operator +(TSelf left, TOther right);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IAdditiveIdentity<TSelf, TResult>
         where TSelf : System.IAdditiveIdentity<TSelf, TResult>
     {
         static abstract TResult AdditiveIdentity { get; }
     }
-[System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+[System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IBinaryFloatingPoint<TSelf> : System.IBinaryNumber<TSelf>, System.IFloatingPoint<TSelf>
         where TSelf : IBinaryFloatingPoint<TSelf>
     {
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IBinaryInteger<TSelf> : System.IBinaryNumber<TSelf>, System.IShiftOperators<TSelf, TSelf>
         where TSelf : IBinaryInteger<TSelf>
     {
@@ -3418,14 +3418,14 @@ namespace System
         static abstract TSelf RotateRight(TSelf value, int rotateAmount);
         static abstract TSelf TrailingZeroCount(TSelf value);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IBinaryNumber<TSelf> : System.IBitwiseOperators<TSelf, TSelf, TSelf>, System.INumber<TSelf>
         where TSelf : IBinaryNumber<TSelf>
     {
         static abstract bool IsPow2(TSelf value);
         static abstract TSelf Log2(TSelf value);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IBitwiseOperators<TSelf, TOther, TResult>
         where TSelf : System.IBitwiseOperators<TSelf, TOther, TResult>
     {
@@ -3434,7 +3434,7 @@ namespace System
         static abstract TResult operator ^(TSelf left, TOther right);
         static abstract TResult operator ~(TSelf value);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IComparisonOperators<TSelf, TOther> : System.IComparable, System.IComparable<TOther>, System.IEqualityOperators<TSelf, TOther>
         where TSelf : IComparisonOperators<TSelf, TOther>
     {
@@ -3443,26 +3443,26 @@ namespace System
         static abstract bool operator >(TSelf left, TOther right);
         static abstract bool operator >=(TSelf left, TOther right);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IDecrementOperators<TSelf>
         where TSelf : System.IDecrementOperators<TSelf>
     {
         static abstract TSelf operator --(TSelf value);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IDivisionOperators<TSelf, TOther, TResult>
         where TSelf : System.IDivisionOperators<TSelf, TOther, TResult>
     {
         static abstract TResult operator /(TSelf left, TOther right);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IEqualityOperators<TSelf, TOther> : IEquatable<TOther>
         where TSelf : System.IEqualityOperators<TSelf, TOther>
     {
         static abstract bool operator ==(TSelf left, TOther right);
         static abstract bool operator !=(TSelf left, TOther right);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IFloatingPoint<TSelf> : System.ISignedNumber<TSelf>
         where TSelf : System.IFloatingPoint<TSelf>
     {
@@ -3520,38 +3520,38 @@ namespace System
         static abstract TSelf Tanh(TSelf x);
         static abstract TSelf Truncate(TSelf x);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IIncrementOperators<TSelf>
         where TSelf : System.IIncrementOperators<TSelf>
     {
         static abstract TSelf operator ++(TSelf value);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IMinMaxValue<TSelf>
         where TSelf : System.IMinMaxValue<TSelf>
     {
         static abstract TSelf MinValue { get; }
         static abstract TSelf MaxValue { get; }
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IModulusOperators<TSelf, TOther, TResult>
         where TSelf : System.IModulusOperators<TSelf, TOther, TResult>
     {
         static abstract TResult operator %(TSelf left, TOther right);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IMultiplicativeIdentity<TSelf, TResult>
         where TSelf : System.IMultiplicativeIdentity<TSelf, TResult>
     {
         static abstract TResult MultiplicativeIdentity { get; }
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IMultiplyOperators<TSelf, TOther, TResult>
         where TSelf : System.IMultiplyOperators<TSelf, TOther, TResult>
     {
         static abstract TResult operator *(TSelf left, TOther right);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface INumber<TSelf> : System.IAdditionOperators<TSelf, TSelf, TSelf>, System.IAdditiveIdentity<TSelf, TSelf>, System.IComparable, System.IComparable<TSelf>, System.IComparisonOperators<TSelf, TSelf>, System.IDecrementOperators<TSelf>, System.IDivisionOperators<TSelf, TSelf, TSelf>, System.IEquatable<TSelf>, System.IEqualityOperators<TSelf, TSelf>, System.IFormattable, System.IIncrementOperators<TSelf>, System.IModulusOperators<TSelf, TSelf, TSelf>, System.IMultiplicativeIdentity<TSelf, TSelf>, System.IMultiplyOperators<TSelf, TSelf, TSelf>, System.IParseable<TSelf>, System.ISpanFormattable, System.ISpanParseable<TSelf>, System.ISubtractionOperators<TSelf, TSelf, TSelf>, System.IUnaryNegationOperators<TSelf, TSelf>, System.IUnaryPlusOperators<TSelf, TSelf>
         where TSelf : System.INumber<TSelf>
     {
@@ -3572,52 +3572,52 @@ namespace System
         static abstract bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out TSelf result);
         static abstract bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, IFormatProvider? provider, out TSelf result);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IParseable<TSelf>
         where TSelf : System.IParseable<TSelf>
     {
         static abstract TSelf Parse(string s, System.IFormatProvider? provider);
         static abstract bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out TSelf result);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IShiftOperators<TSelf, TResult>
         where TSelf : System.IShiftOperators<TSelf, TResult>
     {
         static abstract TResult operator <<(TSelf value, int shiftAmount);
         static abstract TResult operator >>(TSelf value, int shiftAmount);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface ISignedNumber<TSelf> : System.INumber<TSelf>, System.IUnaryNegationOperators<TSelf, TSelf>
         where TSelf : System.ISignedNumber<TSelf>
     {
         static abstract TSelf NegativeOne { get; }
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface ISpanParseable<TSelf> : System.IParseable<TSelf>
         where TSelf : System.ISpanParseable<TSelf>
     {
         static abstract TSelf Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider);
         static abstract bool TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out TSelf result);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface ISubtractionOperators<TSelf, TOther, TResult>
         where TSelf : System.ISubtractionOperators<TSelf, TOther, TResult>
     {
         static abstract TResult operator -(TSelf left, TOther right);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IUnaryNegationOperators<TSelf, TResult>
         where TSelf : System.IUnaryNegationOperators<TSelf, TResult>
     {
         static abstract TResult operator -(TSelf value);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IUnaryPlusOperators<TSelf, TResult>
         where TSelf : System.IUnaryPlusOperators<TSelf, TResult>
     {
         static abstract TResult operator +(TSelf value);
     }
-    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
     public partial interface IUnsignedNumber<TSelf> : System.INumber<TSelf>
         where TSelf : IUnsignedNumber<TSelf>
     {
@@ -3771,133 +3771,133 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int16 result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IAdditiveIdentity<short, short>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IMinMaxValue<short>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IMinMaxValue<short>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IMultiplicativeIdentity<short, short>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IAdditionOperators<short, short, short>.operator +(short left, short right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBinaryInteger<short>.LeadingZeroCount(short value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBinaryInteger<short>.PopCount(short value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBinaryInteger<short>.RotateLeft(short value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBinaryInteger<short>.RotateRight(short value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBinaryInteger<short>.TrailingZeroCount(short value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<short>.IsPow2(short value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBinaryNumber<short>.Log2(short value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBitwiseOperators<short, short, short>.operator &(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBitwiseOperators<short, short, short>.operator |(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBitwiseOperators<short, short, short>.operator ^(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IBitwiseOperators<short, short, short>.operator ~(short value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<short, short>.operator <(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<short, short>.operator <=(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<short, short>.operator >(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<short, short>.operator >=(short left, short right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IDecrementOperators<short>.operator --(short value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IDivisionOperators<short, short, short>.operator /(short left, short right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<short, short>.operator ==(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<short, short>.operator !=(short left, short right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IIncrementOperators<short>.operator ++(short value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IModulusOperators<short, short, short>.operator %(short left, short right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IMultiplyOperators<short, short, short>.operator *(short left, short right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Abs(short value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Clamp(short value, short min, short max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (short Quotient, short Remainder) INumber<short>.DivRem(short left, short right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Max(short x, short y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Min(short x, short y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short INumber<short>.Sign(short value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<short>.TryCreate<TOther>(TOther value, out short result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<short>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out short result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<short>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out short result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IParseable<short>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<short>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out short result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IShiftOperators<short, short>.operator <<(short value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IShiftOperators<short, short>.operator >>(short value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short ISignedNumber<short>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short ISpanParseable<short>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<short>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out short result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short ISubtractionOperators<short, short, short>.operator -(short left, short right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IUnaryNegationOperators<short, short>.operator -(short value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static short IUnaryPlusOperators<short, short>.operator +(short value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -3950,133 +3950,133 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int32 result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IAdditiveIdentity<int, int>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IMinMaxValue<int>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IMinMaxValue<int>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IMultiplicativeIdentity<int, int>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IAdditionOperators<int, int, int>.operator +(int left, int right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBinaryInteger<int>.LeadingZeroCount(int value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBinaryInteger<int>.PopCount(int value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBinaryInteger<int>.RotateLeft(int value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBinaryInteger<int>.RotateRight(int value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBinaryInteger<int>.TrailingZeroCount(int value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<int>.IsPow2(int value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBinaryNumber<int>.Log2(int value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBitwiseOperators<int, int, int>.operator &(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBitwiseOperators<int, int, int>.operator |(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBitwiseOperators<int, int, int>.operator ^(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IBitwiseOperators<int, int, int>.operator ~(int value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<int, int>.operator <(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<int, int>.operator <=(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<int, int>.operator >(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<int, int>.operator >=(int left, int right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IDecrementOperators<int>.operator --(int value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IDivisionOperators<int, int, int>.operator /(int left, int right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<int, int>.operator ==(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<int, int>.operator !=(int left, int right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IIncrementOperators<int>.operator ++(int value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IModulusOperators<int, int, int>.operator %(int left, int right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IMultiplyOperators<int, int, int>.operator *(int left, int right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Abs(int value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Clamp(int value, int min, int max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (int Quotient, int Remainder) INumber<int>.DivRem(int left, int right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Max(int x, int y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Min(int x, int y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int INumber<int>.Sign(int value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<int>.TryCreate<TOther>(TOther value, out int result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<int>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out int result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<int>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out int result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IParseable<int>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<int>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out int result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IShiftOperators<int, int>.operator <<(int value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IShiftOperators<int, int>.operator >>(int value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int ISignedNumber<int>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int ISpanParseable<int>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<int>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out int result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int ISubtractionOperators<int, int, int>.operator -(int left, int right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IUnaryNegationOperators<int, int>.operator -(int value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static int IUnaryPlusOperators<int, int>.operator +(int value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -4129,133 +4129,133 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Int64 result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IAdditiveIdentity<long, long>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IMinMaxValue<long>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IMinMaxValue<long>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IMultiplicativeIdentity<long, long>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IAdditionOperators<long, long, long>.operator +(long left, long right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBinaryInteger<long>.LeadingZeroCount(long value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBinaryInteger<long>.PopCount(long value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBinaryInteger<long>.RotateLeft(long value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBinaryInteger<long>.RotateRight(long value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBinaryInteger<long>.TrailingZeroCount(long value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<long>.IsPow2(long value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBinaryNumber<long>.Log2(long value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBitwiseOperators<long, long, long>.operator &(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBitwiseOperators<long, long, long>.operator |(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBitwiseOperators<long, long, long>.operator ^(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IBitwiseOperators<long, long, long>.operator ~(long value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<long, long>.operator <(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<long, long>.operator <=(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<long, long>.operator >(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<long, long>.operator >=(long left, long right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IDecrementOperators<long>.operator --(long value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IDivisionOperators<long, long, long>.operator /(long left, long right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<long, long>.operator ==(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<long, long>.operator !=(long left, long right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IIncrementOperators<long>.operator ++(long value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IModulusOperators<long, long, long>.operator %(long left, long right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IMultiplyOperators<long, long, long>.operator *(long left, long right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Abs(long value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Clamp(long value, long min, long max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (long Quotient, long Remainder) INumber<long>.DivRem(long left, long right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Max(long x, long y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Min(long x, long y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long INumber<long>.Sign(long value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<long>.TryCreate<TOther>(TOther value, out long result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<long>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out long result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<long>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out long result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IParseable<long>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<long>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out long result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IShiftOperators<long, long>.operator <<(long value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IShiftOperators<long, long>.operator >>(long value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long ISignedNumber<long>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long ISpanParseable<long>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<long>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out long result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long ISubtractionOperators<long, long, long>.operator -(long left, long right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IUnaryNegationOperators<long, long>.operator -(long value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static long IUnaryPlusOperators<long, long>.operator +(long value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -4317,133 +4317,133 @@ namespace System
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.IntPtr result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IAdditiveIdentity<nint, nint>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IMinMaxValue<nint>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IMinMaxValue<nint>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IMultiplicativeIdentity<nint, nint>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IAdditionOperators<nint, nint, nint>.operator +(nint left, nint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBinaryInteger<nint>.LeadingZeroCount(nint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBinaryInteger<nint>.PopCount(nint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBinaryInteger<nint>.RotateLeft(nint value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBinaryInteger<nint>.RotateRight(nint value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBinaryInteger<nint>.TrailingZeroCount(nint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<nint>.IsPow2(nint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBinaryNumber<nint>.Log2(nint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBitwiseOperators<nint, nint, nint>.operator &(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBitwiseOperators<nint, nint, nint>.operator |(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBitwiseOperators<nint, nint, nint>.operator ^(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IBitwiseOperators<nint, nint, nint>.operator ~(nint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nint, nint>.operator <(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nint, nint>.operator <=(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nint, nint>.operator >(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nint, nint>.operator >=(nint left, nint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IDecrementOperators<nint>.operator --(nint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IDivisionOperators<nint, nint, nint>.operator /(nint left, nint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<nint, nint>.operator ==(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<nint, nint>.operator !=(nint left, nint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IIncrementOperators<nint>.operator ++(nint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IModulusOperators<nint, nint, nint>.operator %(nint left, nint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IMultiplyOperators<nint, nint, nint>.operator *(nint left, nint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Abs(nint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Clamp(nint value, nint min, nint max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (nint Quotient, nint Remainder) INumber<nint>.DivRem(nint left, nint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Max(nint x, nint y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Min(nint x, nint y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint INumber<nint>.Sign(nint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<nint>.TryCreate<TOther>(TOther value, out nint result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<nint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nint result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<nint>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IParseable<nint>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<nint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out nint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IShiftOperators<nint, nint>.operator <<(nint value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IShiftOperators<nint, nint>.operator >>(nint value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint ISignedNumber<nint>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint ISpanParseable<nint>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<nint>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out nint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint ISubtractionOperators<nint, nint, nint>.operator -(nint left, nint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IUnaryNegationOperators<nint, nint>.operator -(nint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nint IUnaryPlusOperators<nint, nint>.operator +(nint value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -5282,133 +5282,133 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.SByte result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IAdditiveIdentity<sbyte, sbyte>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IMinMaxValue<sbyte>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IMinMaxValue<sbyte>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IMultiplicativeIdentity<sbyte, sbyte>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IAdditionOperators<sbyte, sbyte, sbyte>.operator +(sbyte left, sbyte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBinaryInteger<sbyte>.LeadingZeroCount(sbyte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBinaryInteger<sbyte>.PopCount(sbyte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBinaryInteger<sbyte>.RotateLeft(sbyte value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBinaryInteger<sbyte>.RotateRight(sbyte value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBinaryInteger<sbyte>.TrailingZeroCount(sbyte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<sbyte>.IsPow2(sbyte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBinaryNumber<sbyte>.Log2(sbyte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator &(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator |(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ^(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IBitwiseOperators<sbyte, sbyte, sbyte>.operator ~(sbyte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<sbyte, sbyte>.operator <(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<sbyte, sbyte>.operator <=(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<sbyte, sbyte>.operator >(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<sbyte, sbyte>.operator >=(sbyte left, sbyte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IDecrementOperators<sbyte>.operator --(sbyte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IDivisionOperators<sbyte, sbyte, sbyte>.operator /(sbyte left, sbyte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<sbyte, sbyte>.operator ==(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<sbyte, sbyte>.operator !=(sbyte left, sbyte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IIncrementOperators<sbyte>.operator ++(sbyte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IModulusOperators<sbyte, sbyte, sbyte>.operator %(sbyte left, sbyte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IMultiplyOperators<sbyte, sbyte, sbyte>.operator *(sbyte left, sbyte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Abs(sbyte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Clamp(sbyte value, sbyte min, sbyte max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (sbyte Quotient, sbyte Remainder) INumber<sbyte>.DivRem(sbyte left, sbyte right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Max(sbyte x, sbyte y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Min(sbyte x, sbyte y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte INumber<sbyte>.Sign(sbyte value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<sbyte>.TryCreate<TOther>(TOther value, out sbyte result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<sbyte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out sbyte result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<sbyte>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out sbyte result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IParseable<sbyte>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<sbyte>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out sbyte result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IShiftOperators<sbyte, sbyte>.operator <<(sbyte value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IShiftOperators<sbyte, sbyte>.operator >>(sbyte value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte ISignedNumber<sbyte>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte ISpanParseable<sbyte>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<sbyte>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out sbyte result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte ISubtractionOperators<sbyte, sbyte, sbyte>.operator -(sbyte left, sbyte right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IUnaryNegationOperators<sbyte, sbyte>.operator -(sbyte value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static sbyte IUnaryPlusOperators<sbyte, sbyte>.operator +(sbyte value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -5483,226 +5483,226 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.Single result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IAdditiveIdentity<float, float>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.E { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Epsilon { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.NaN { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.NegativeInfinity { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.NegativeZero { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Pi { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.PositiveInfinity { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Tau { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IMinMaxValue<float>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IMinMaxValue<float>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IMultiplicativeIdentity<float, float>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IAdditionOperators<float, float, float>.operator +(float left, float right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<float>.IsPow2(float value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IBinaryNumber<float>.Log2(float value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IBitwiseOperators<float, float, float>.operator &(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IBitwiseOperators<float, float, float>.operator |(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IBitwiseOperators<float, float, float>.operator ^(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IBitwiseOperators<float, float, float>.operator ~(float value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<float, float>.operator <(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<float, float>.operator <=(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<float, float>.operator >(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<float, float>.operator >=(float left, float right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IDecrementOperators<float>.operator --(float value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IDivisionOperators<float, float, float>.operator /(float left, float right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<float, float>.operator ==(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<float, float>.operator !=(float left, float right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Acos(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Acosh(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Asin(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Asinh(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Atan(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Atan2(float y, float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Atanh(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.BitIncrement(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.BitDecrement(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Cbrt(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Ceiling(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.CopySign(float x, float y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Cos(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Cosh(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Exp(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Floor(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.FusedMultiplyAdd(float left, float right, float addend) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.IEEERemainder(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static TInteger IFloatingPoint<float>.ILogB<TInteger>(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Log(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Log(float x, float newBase) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Log2(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Log10(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.MaxMagnitude(float x, float y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.MinMagnitude(float x, float y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Pow(float x, float y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Round(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Round(float x, System.MidpointRounding mode) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Round<TInteger>(float x, TInteger digits, System.MidpointRounding mode) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.ScaleB<TInteger>(float x, TInteger n) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Sin(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Sinh(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Sqrt(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Tan(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Tanh(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IFloatingPoint<float>.Truncate(float x) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsFinite(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsInfinity(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsNaN(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsNegative(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsNegativeInfinity(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsNormal(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsPositiveInfinity(float x) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IFloatingPoint<float>.IsSubnormal(float x) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IIncrementOperators<float>.operator ++(float value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IModulusOperators<float, float, float>.operator %(float left, float right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IMultiplyOperators<float, float, float>.operator *(float left, float right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Abs(float value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Clamp(float value, float min, float max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (float Quotient, float Remainder) INumber<float>.DivRem(float left, float right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Max(float x, float y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Min(float x, float y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float INumber<float>.Sign(float value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<float>.TryCreate<TOther>(TOther value, out float result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<float>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out float result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<float>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out float result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IParseable<float>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<float>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out float result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float ISignedNumber<float>.NegativeOne { get; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float ISpanParseable<float>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<float>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out float result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float ISubtractionOperators<float, float, float>.operator -(float left, float right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IUnaryNegationOperators<float, float>.operator -(float value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static float IUnaryPlusOperators<float, float>.operator +(float value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -6087,36 +6087,36 @@ namespace System
         public bool TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format = default(System.ReadOnlySpan<char>), System.IFormatProvider? provider = null) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator <(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator <=(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator >(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeOnly, System.TimeOnly>.operator >=(System.TimeOnly left, System.TimeOnly right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.TimeOnly, System.TimeOnly>.operator ==(System.TimeOnly left, System.TimeOnly right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.TimeOnly, System.TimeOnly>.operator !=(System.TimeOnly left, System.TimeOnly right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeOnly IParseable<System.TimeOnly>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<System.TimeOnly>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.TimeOnly result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeOnly ISpanParseable<System.TimeOnly>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<System.TimeOnly>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.TimeOnly result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan ISubtractionOperators<System.TimeOnly, System.TimeOnly, System.TimeSpan>.operator -(System.TimeOnly left, System.TimeOnly right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeOnly IMinMaxValue<System.TimeOnly>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeOnly IMinMaxValue<System.TimeOnly>.MaxValue { get { throw null; } }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -6230,59 +6230,59 @@ namespace System
         public static bool TryParseExact([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? input, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string?[]? formats, System.IFormatProvider? formatProvider, out System.TimeSpan result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IAdditiveIdentity<System.TimeSpan, System.TimeSpan>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IMinMaxValue<System.TimeSpan>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IMinMaxValue<System.TimeSpan>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IMultiplicativeIdentity<System.TimeSpan, double>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IAdditionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>.operator +(System.TimeSpan left, System.TimeSpan right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator <(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator <=(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator >(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<System.TimeSpan, System.TimeSpan>.operator >=(System.TimeSpan left, System.TimeSpan right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IDivisionOperators<System.TimeSpan, double, System.TimeSpan>.operator /(System.TimeSpan left, double right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static double IDivisionOperators<System.TimeSpan, System.TimeSpan, double>.operator /(System.TimeSpan left, System.TimeSpan right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.TimeSpan, System.TimeSpan>.operator ==(System.TimeSpan left, System.TimeSpan right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<System.TimeSpan, System.TimeSpan>.operator !=(System.TimeSpan left, System.TimeSpan right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IMultiplyOperators<System.TimeSpan, double, System.TimeSpan>.operator *(System.TimeSpan left, double right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IParseable<System.TimeSpan>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<System.TimeSpan>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out System.TimeSpan result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan ISpanParseable<System.TimeSpan>.Parse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<System.TimeSpan>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out System.TimeSpan result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan ISubtractionOperators<System.TimeSpan, System.TimeSpan, System.TimeSpan>.operator -(System.TimeSpan left, System.TimeSpan right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IUnaryNegationOperators<System.TimeSpan, System.TimeSpan>.operator -(System.TimeSpan value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static System.TimeSpan IUnaryPlusOperators<System.TimeSpan, System.TimeSpan>.operator +(System.TimeSpan value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -7017,130 +7017,130 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt16 result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IAdditiveIdentity<ushort, ushort>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IMinMaxValue<ushort>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IMinMaxValue<ushort>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IMultiplicativeIdentity<ushort, ushort>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IAdditionOperators<ushort, ushort, ushort>.operator +(ushort left, ushort right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBinaryInteger<ushort>.LeadingZeroCount(ushort value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBinaryInteger<ushort>.PopCount(ushort value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBinaryInteger<ushort>.RotateLeft(ushort value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBinaryInteger<ushort>.RotateRight(ushort value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBinaryInteger<ushort>.TrailingZeroCount(ushort value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<ushort>.IsPow2(ushort value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBinaryNumber<ushort>.Log2(ushort value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator &(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator |(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ^(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IBitwiseOperators<ushort, ushort, ushort>.operator ~(ushort value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ushort, ushort>.operator <(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ushort, ushort>.operator <=(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ushort, ushort>.operator >(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ushort, ushort>.operator >=(ushort left, ushort right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IDecrementOperators<ushort>.operator --(ushort value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IDivisionOperators<ushort, ushort, ushort>.operator /(ushort left, ushort right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<ushort, ushort>.operator ==(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<ushort, ushort>.operator !=(ushort left, ushort right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IIncrementOperators<ushort>.operator ++(ushort value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IModulusOperators<ushort, ushort, ushort>.operator %(ushort left, ushort right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IMultiplyOperators<ushort, ushort, ushort>.operator *(ushort left, ushort right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Abs(ushort value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Clamp(ushort value, ushort min, ushort max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (ushort Quotient, ushort Remainder) INumber<ushort>.DivRem(ushort left, ushort right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Max(ushort x, ushort y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Min(ushort x, ushort y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort INumber<ushort>.Sign(ushort value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<ushort>.TryCreate<TOther>(TOther value, out ushort result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<ushort>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ushort result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<ushort>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ushort result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IParseable<ushort>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<ushort>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out ushort result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IShiftOperators<ushort, ushort>.operator <<(ushort value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IShiftOperators<ushort, ushort>.operator >>(ushort value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort ISpanParseable<ushort>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<ushort>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out ushort result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort ISubtractionOperators<ushort, ushort, ushort>.operator -(ushort left, ushort right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IUnaryNegationOperators<ushort, ushort>.operator -(ushort value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ushort IUnaryPlusOperators<ushort, ushort>.operator +(ushort value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -7194,130 +7194,130 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt32 result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IAdditiveIdentity<uint, uint>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IMinMaxValue<uint>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IMinMaxValue<uint>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IMultiplicativeIdentity<uint, uint>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IAdditionOperators<uint, uint, uint>.operator +(uint left, uint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBinaryInteger<uint>.LeadingZeroCount(uint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBinaryInteger<uint>.PopCount(uint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBinaryInteger<uint>.RotateLeft(uint value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBinaryInteger<uint>.RotateRight(uint value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBinaryInteger<uint>.TrailingZeroCount(uint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<uint>.IsPow2(uint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBinaryNumber<uint>.Log2(uint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBitwiseOperators<uint, uint, uint>.operator &(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBitwiseOperators<uint, uint, uint>.operator |(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBitwiseOperators<uint, uint, uint>.operator ^(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IBitwiseOperators<uint, uint, uint>.operator ~(uint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<uint, uint>.operator <(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<uint, uint>.operator <=(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<uint, uint>.operator >(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<uint, uint>.operator >=(uint left, uint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IDecrementOperators<uint>.operator --(uint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IDivisionOperators<uint, uint, uint>.operator /(uint left, uint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<uint, uint>.operator ==(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<uint, uint>.operator !=(uint left, uint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IIncrementOperators<uint>.operator ++(uint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IModulusOperators<uint, uint, uint>.operator %(uint left, uint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IMultiplyOperators<uint, uint, uint>.operator *(uint left, uint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Abs(uint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Clamp(uint value, uint min, uint max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (uint Quotient, uint Remainder) INumber<uint>.DivRem(uint left, uint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Max(uint x, uint y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Min(uint x, uint y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint INumber<uint>.Sign(uint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<uint>.TryCreate<TOther>(TOther value, out uint result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<uint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out uint result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<uint>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out uint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IParseable<uint>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<uint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out uint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IShiftOperators<uint, uint>.operator <<(uint value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IShiftOperators<uint, uint>.operator >>(uint value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint ISpanParseable<uint>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<uint>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out uint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint ISubtractionOperators<uint, uint, uint>.operator -(uint left, uint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IUnaryNegationOperators<uint, uint>.operator -(uint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static uint IUnaryPlusOperators<uint, uint>.operator +(uint value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -7371,130 +7371,130 @@ namespace System
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, out System.UInt64 result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IAdditiveIdentity<ulong, ulong>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IMinMaxValue<ulong>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IMinMaxValue<ulong>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IMultiplicativeIdentity<ulong, ulong>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IAdditionOperators<ulong, ulong, ulong>.operator +(ulong left, ulong right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBinaryInteger<ulong>.LeadingZeroCount(ulong value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBinaryInteger<ulong>.PopCount(ulong value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBinaryInteger<ulong>.RotateLeft(ulong value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBinaryInteger<ulong>.RotateRight(ulong value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBinaryInteger<ulong>.TrailingZeroCount(ulong value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<ulong>.IsPow2(ulong value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBinaryNumber<ulong>.Log2(ulong value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator &(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator |(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ^(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IBitwiseOperators<ulong, ulong, ulong>.operator ~(ulong value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ulong, ulong>.operator <(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ulong, ulong>.operator <=(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ulong, ulong>.operator >(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<ulong, ulong>.operator >=(ulong left, ulong right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IDecrementOperators<ulong>.operator --(ulong value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IDivisionOperators<ulong, ulong, ulong>.operator /(ulong left, ulong right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<ulong, ulong>.operator ==(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<ulong, ulong>.operator !=(ulong left, ulong right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IIncrementOperators<ulong>.operator ++(ulong value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IModulusOperators<ulong, ulong, ulong>.operator %(ulong left, ulong right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IMultiplyOperators<ulong, ulong, ulong>.operator *(ulong left, ulong right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Abs(ulong value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Clamp(ulong value, ulong min, ulong max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (ulong Quotient, ulong Remainder) INumber<ulong>.DivRem(ulong left, ulong right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Max(ulong x, ulong y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Min(ulong x, ulong y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong INumber<ulong>.Sign(ulong value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<ulong>.TryCreate<TOther>(TOther value, out ulong result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<ulong>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ulong result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<ulong>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out ulong result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IParseable<ulong>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<ulong>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out ulong result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IShiftOperators<ulong, ulong>.operator <<(ulong value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IShiftOperators<ulong, ulong>.operator >>(ulong value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong ISpanParseable<ulong>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<ulong>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out ulong result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong ISubtractionOperators<ulong, ulong, ulong>.operator -(ulong left, ulong right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IUnaryNegationOperators<ulong, ulong>.operator -(ulong value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static ulong IUnaryPlusOperators<ulong, ulong>.operator +(ulong value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -7553,129 +7553,129 @@ namespace System
         public static bool TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out System.UIntPtr result) { throw null; }
 
 #if FEATURE_GENERIC_MATH
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IAdditiveIdentity<nuint, nuint>.AdditiveIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IMinMaxValue<nuint>.MinValue { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IMinMaxValue<nuint>.MaxValue { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IMultiplicativeIdentity<nuint, nuint>.MultiplicativeIdentity { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.One { get { throw null; } }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Zero { get { throw null; } }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IAdditionOperators<nuint, nuint, nuint>.operator +(nuint left, nuint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBinaryInteger<nuint>.LeadingZeroCount(nuint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBinaryInteger<nuint>.PopCount(nuint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBinaryInteger<nuint>.RotateLeft(nuint value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBinaryInteger<nuint>.RotateRight(nuint value, int rotateAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBinaryInteger<nuint>.TrailingZeroCount(nuint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IBinaryNumber<nuint>.IsPow2(nuint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBinaryNumber<nuint>.Log2(nuint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator &(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator |(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ^(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IBitwiseOperators<nuint, nuint, nuint>.operator ~(nuint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nuint, nuint>.operator <(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nuint, nuint>.operator <=(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nuint, nuint>.operator >(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IComparisonOperators<nuint, nuint>.operator >=(nuint left, nuint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IDecrementOperators<nuint>.operator --(nuint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IDivisionOperators<nuint, nuint, nuint>.operator /(nuint left, nuint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<nuint, nuint>.operator ==(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IEqualityOperators<nuint, nuint>.operator !=(nuint left, nuint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IIncrementOperators<nuint>.operator ++(nuint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IModulusOperators<nuint, nuint, nuint>.operator %(nuint left, nuint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IMultiplyOperators<nuint, nuint, nuint>.operator *(nuint left, nuint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Abs(nuint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Clamp(nuint value, nuint min, nuint max) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Create<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.CreateSaturating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.CreateTruncating<TOther>(TOther value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static (nuint Quotient, nuint Remainder) INumber<nuint>.DivRem(nuint left, nuint right) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Max(nuint x, nuint y) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static nuint INumber<nuint>.Min(nuint x, nuint y) { throw null; }[System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
+        static nuint INumber<nuint>.Min(nuint x, nuint y) { throw null; }[System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Parse(string s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Parse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint INumber<nuint>.Sign(nuint value) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<nuint>.TryCreate<TOther>(TOther value, out nuint result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<nuint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nuint result) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool INumber<nuint>.TryParse(System.ReadOnlySpan<char> s, System.Globalization.NumberStyles style, System.IFormatProvider? provider, out nuint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IParseable<nuint>.Parse(string s, System.IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool IParseable<nuint>.TryParse([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? s, System.IFormatProvider? provider, out nuint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IShiftOperators<nuint, nuint>.operator <<(nuint value, int shiftAmount) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeatures]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IShiftOperators<nuint, nuint>.operator >>(nuint value, int shiftAmount) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint ISpanParseable<nuint>.Parse(System.ReadOnlySpan<char> s, IFormatProvider? provider) { throw null; }
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static bool ISpanParseable<nuint>.TryParse(System.ReadOnlySpan<char> s, System.IFormatProvider? provider, out nuint result) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint ISubtractionOperators<nuint, nuint, nuint>.operator -(nuint left, nuint right) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IUnaryNegationOperators<nuint, nuint>.operator -(nuint value) { throw null; }
 
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         static nuint IUnaryPlusOperators<nuint, nuint>.operator +(nuint value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
@@ -13078,7 +13078,7 @@ namespace System.Runtime.CompilerServices
         public const string DefaultImplementationsOfInterfaces = "DefaultImplementationsOfInterfaces";
         public const string UnmanagedSignatureCallingConvention = "UnmanagedSignatureCallingConvention";
         public const string PortablePdb = "PortablePdb";
-        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Generic Math is in preview.", Url = "https://aka.ms/dotnet-warnings/generic-math-preview")]
         public const string VirtualStaticsInInterfaces = "VirtualStaticsInInterfaces";
         public static bool IsDynamicCodeCompiled { get { throw null; } }
         public static bool IsDynamicCodeSupported { get { throw null; } }


### PR DESCRIPTION
Backport of #60379. Due to conflicts in `eng/Versions.props` from differences between main and release/6.0, this backport was crafted manually by cherry-picking the commits from #60379. The package version for the NetAnalyzers was set to be the latest version number from the dotnet6 feed.

## Customer Impact

With #56498, we have added `Message` and `Url` properties to the `RequiresPreviewFeatures` attribute. With dotnet/roslyn-analyzers#5502, the analyzer now includes those `Message` and `Url` properties in the diagnostic messages raised. This change updates the existing `[RequiresPreviewFeatures]` attributes across the `dotnet/runtime` repo to apply custom messages and urls.

When we sought approval for dotnet/roslyn-analyzers#5502, we stated that we would be following up with this PR. With this change, diagnostics reported will now provide more information about the preview feature that was used. For example, references to Generic Math APIs will now result in:

> Generic Math is in preview. Using 'IAdditionOperators' requires opting into preview features. See https://aka.ms/dotnet-warnings/generic-math-preview for more information.

Without this change, all diagnostic messages from the preview APIs in dotnet/runtime are reported using the standard message:

> Using 'IAdditionOperators' requires opting into preview features. See https://aka.ms/dotnet-warnings/preview-features for more information.

The Kestrel HTTP/3 support for .NET 6 is already using custom messages/urls.

## Testing

Local testing validated the custom messages are now produced as expected.

## Risk

Minimal. Additional properties added into attribute metadata, but no runtime behavior changes.