### PR TITLE
Fix Int32 overflow bug in buffering logic

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -16,6 +16,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
         public void NoInt32OverflowInTheBufferingLogic()
         {
             const long positon1 = 10;

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -14,5 +14,39 @@ namespace System.IO.Tests
             Assert.Throws<UnauthorizedAccessException>(() =>
                 new FileStream(Path.GetPathRoot(Directory.GetCurrentDirectory()), FileMode.Open, FileAccess.Read));
         }
+
+        [Fact]
+        public void NoInt32OverflowInTheBufferingLogic()
+        {
+            const long positon1 = 10;
+            const long positon2 = (1L << 32) + positon1;
+
+            string filePath = GetTestFilePath();
+            byte[] data1 = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] data2 = new byte[] { 6, 7, 8, 9, 10 };
+            byte[] buffer = new byte[5];
+
+            using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
+            {
+                stream.Seek(positon1, SeekOrigin.Begin);
+                stream.Write(data1, 0, data1.Length);
+
+                stream.Seek(positon2, SeekOrigin.Begin);
+                stream.Write(data2, 0, data2.Length);
+            }
+
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            {
+                stream.Seek(positon1, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data1, buffer);
+
+                Array.Clear(buffer);
+
+                stream.Seek(positon2, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data2, buffer);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -41,7 +41,16 @@ namespace System.IO.Tests
                 Assert.Equal(buffer.Length, stream.Read(buffer));
                 Assert.Equal(data1, buffer);
 
-                Array.Clear(buffer);
+                stream.Seek(positon2, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data2, buffer);
+            }
+
+            using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0)))
+            {
+                stream.Seek(positon1, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data1, buffer);
 
                 stream.Seek(positon2, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -19,8 +19,8 @@ namespace System.IO.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
         public void NoInt32OverflowInTheBufferingLogic()
         {
-            const long positon1 = 10;
-            const long positon2 = (1L << 32) + positon1;
+            const long position1 = 10;
+            const long position2 = (1L << 32) + position1;
 
             string filePath = GetTestFilePath();
             byte[] data1 = new byte[] { 1, 2, 3, 4, 5 };
@@ -29,31 +29,31 @@ namespace System.IO.Tests
 
             using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
             {
-                stream.Seek(positon1, SeekOrigin.Begin);
+                stream.Seek(position1, SeekOrigin.Begin);
                 stream.Write(data1, 0, data1.Length);
 
-                stream.Seek(positon2, SeekOrigin.Begin);
+                stream.Seek(position2, SeekOrigin.Begin);
                 stream.Write(data2, 0, data2.Length);
             }
 
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
             {
-                stream.Seek(positon1, SeekOrigin.Begin);
+                stream.Seek(position1, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));
                 Assert.Equal(data1, buffer);
 
-                stream.Seek(positon2, SeekOrigin.Begin);
+                stream.Seek(position2, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));
                 Assert.Equal(data2, buffer);
             }
 
             using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0)))
             {
-                stream.Seek(positon1, SeekOrigin.Begin);
+                stream.Seek(position1, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));
                 Assert.Equal(data1, buffer);
 
-                stream.Seek(positon2, SeekOrigin.Begin);
+                stream.Seek(position2, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));
                 Assert.Equal(data2, buffer);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BufferedStream.cs
@@ -1222,11 +1222,12 @@ namespace System.IO
             // Otherwise we will throw away the buffer. This can only happen on read, as we flushed write data above.
 
             // The offset of the new/updated seek pointer within _buffer:
-            _readPos = (int)(newPos - (oldPos - _readPos));
+            long readPos = (newPos - (oldPos - _readPos));
 
             // If the offset of the updated seek pointer in the buffer is still legal, then we can keep using the buffer:
-            if (0 <= _readPos && _readPos < _readLen)
+            if (0 <= readPos && readPos < _readLen)
             {
+                _readPos = (int)readPos;
                 // Adjust the seek pointer of the underlying stream to reflect the amount of useful bytes in the read buffer:
                 _stream.Seek(_readLen - _readPos, SeekOrigin.Current);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -974,11 +974,12 @@ namespace System.IO.Strategies
             // Otherwise we will throw away the buffer. This can only happen on read, as we flushed write data above.
 
             // The offset of the new/updated seek pointer within _buffer:
-            _readPos = (int)(newPos - (oldPos - _readPos));
+            long readPos = (newPos - (oldPos - _readPos));
 
             // If the offset of the updated seek pointer in the buffer is still legal, then we can keep using the buffer:
-            if (0 <= _readPos && _readPos < _readLen)
+            if (0 <= readPos && readPos < _readLen)
             {
+                _readPos = (int)readPos;
                 // Adjust the seek pointer of the underlying stream to reflect the amount of useful bytes in the read buffer:
                 _strategy.Seek(_readLen - _readPos, SeekOrigin.Current);
             }


### PR DESCRIPTION
fixes #60430

For the following code:

```cs
_readPos = (int)(newPos - (oldPos - _readPos));
```

For a `newPos > 4GB` and small `oldPos` and `_readPos` we had an int32 overflow. Sample C# app to demonstrate the problem:

```cs
long oldPos = 10L; // first read started at Position=10
long newPos = (1L << 32) + oldPos; // new position is larger than 4 GB
int _readPos = 5; // 5 bytes were read from the buffer so far
int readPosInteger = (int)(newPos - (oldPos - _readPos));
long readPosLong = (newPos - (oldPos - _readPos));

Console.WriteLine(readPosInteger);
Console.WriteLine(readPosLong);
```

```log
5
4294967301
```

It seems to be a very old bug that was always present in `BufferedStream` and I've copied it to `BufferedFileStreamStrategy` in 6.0.

1.0 branch:

https://github.com/dotnet/corefx/blob/c74ea81f2ddad07dc05d695d8244fb2ece7e398d/src/System.IO/src/System/IO/BufferedStream.cs#L1053-L1054

Since we are very close to 6.0 release I've focused on making smallest possible change instead of doing a refactor and providing code that would look better but would be harder to review.