### PR TITLE
S.IO.StringReader: Use ReadOnlySpan.IndexOfAny in ReadLine() for performance

### DIFF
--- a/src/libraries/System.IO/tests/StringReader/StringReader.CtorTests.cs
+++ b/src/libraries/System.IO/tests/StringReader/StringReader.CtorTests.cs
@@ -59,7 +59,7 @@ namespace System.IO.Tests
 
             using (StringReader sr = new StringReader(str1))
             {
-                Assert.Equal(str1, sr.ReadLine());
+                Assert.Same(str1, sr.ReadLine());
             }
             using (StringReader sr = new StringReader(str2))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -187,7 +187,9 @@ namespace System.IO
             }
             int pos = _pos;
             if ((uint)pos >= (uint)s.Length)
+            {
                 return null;
+            }
 
             ReadOnlySpan<char> remaining = s.AsSpan(pos);
             int foundLineLength = remaining.IndexOfAny('\r', '\n');

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -193,9 +193,7 @@ namespace System.IO
             int foundLineLength = remaining.IndexOfAny('\r', '\n');
             if (foundLineLength >= 0)
             {
-                string result = foundLineLength == 0
-                    ? string.Empty
-                    : new string(remaining.Slice(0, foundLineLength));
+                string result = s.Substring(pos, foundLineLength);
 
                 char ch = remaining[foundLineLength];
                 pos += foundLineLength + 1;
@@ -207,17 +205,12 @@ namespace System.IO
                     }
                 }
                 _pos = pos;
+
                 return result;
-            }
-            else if (remaining.Length == s.Length)
-            {
-                // Return source string if only one line avoiding allocation
-                _pos = s.Length;
-                return s;
             }
             else
             {
-                string result = new string(remaining);
+                string result = s.Substring(pos);
                 _pos = s.Length;
                 return result;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -129,12 +129,13 @@ namespace System.IO
                 return base.Read(buffer);
             }
 
-            if (_s == null)
+            string? s = _s;
+            if (s == null)
             {
                 ThrowObjectDisposedException_ReaderClosed();
             }
 
-            int n = _s.Length - _pos;
+            int n = s.Length - _pos;
             if (n > 0)
             {
                 if (n > buffer.Length)
@@ -142,7 +143,7 @@ namespace System.IO
                     n = buffer.Length;
                 }
 
-                _s.AsSpan(_pos, n).CopyTo(buffer);
+                s.AsSpan(_pos, n).CopyTo(buffer);
                 _pos += n;
             }
 
@@ -153,22 +154,20 @@ namespace System.IO
 
         public override string ReadToEnd()
         {
-            if (_s == null)
+            string? s = _s;
+            if (s == null)
             {
                 ThrowObjectDisposedException_ReaderClosed();
             }
 
-            string s;
-            if (_pos == 0)
+            int pos = _pos;
+            _pos = s.Length;
+
+            if (pos != 0)
             {
-                s = _s;
-            }
-            else
-            {
-                s = _s.Substring(_pos);
+                s = s.Substring(pos);
             }
 
-            _pos = _s.Length;
             return s;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -202,7 +202,7 @@ namespace System.IO
                 pos += foundLineLength + 1;
                 if (ch == '\r')
                 {
-                    if ((uint)pos < s.Length && s[pos] == '\n')
+                    if ((uint)pos < (uint)s.Length && s[pos] == '\n')
                     {
                         pos++;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -284,6 +284,5 @@ namespace System.IO
         {
             throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
         }
-
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -69,7 +69,7 @@ namespace System.IO
             }
 
             int pos = _pos;
-            if ((uint)pos < s.Length)
+            if ((uint)pos < (uint)s.Length)
             {
                 _pos++;
                 return s[pos];

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -49,7 +49,7 @@ namespace System.IO
             }
 
             int pos = _pos;
-            if ((uint)pos < s.Length)
+            if ((uint)pos < (uint)s.Length)
             {
                 return s[pos];
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -185,7 +185,7 @@ namespace System.IO
             {
                 ThrowObjectDisposedException_ReaderClosed();
             }
-            var pos = _pos;
+            int pos = _pos;
             if ((uint)pos >= (uint)s.Length)
                 return null;
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -185,6 +185,7 @@ namespace System.IO
             {
                 ThrowObjectDisposedException_ReaderClosed();
             }
+
             int pos = _pos;
             if ((uint)pos >= (uint)s.Length)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -61,16 +61,20 @@ namespace System.IO
         //
         public override int Read()
         {
-            if (_s == null)
+            string? s = _s;
+            if (s == null)
             {
                 ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
-            if (_pos == _s.Length)
+
+            int pos = _pos;
+            if ((uint)pos < s.Length)
             {
-                return -1;
+                _pos++;
+                return s[pos];
             }
 
-            return _s[_pos++];
+            return -1;
         }
 
         // Reads a block of characters. This method will read up to count

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -44,7 +45,7 @@ namespace System.IO
             string? s = _s;
             if (s == null)
             {
-                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
+                ThrowObjectDisposedException_ReaderClosed();
             }
 
             int pos = _pos;
@@ -64,7 +65,7 @@ namespace System.IO
             string? s = _s;
             if (s == null)
             {
-                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
+                ThrowObjectDisposedException_ReaderClosed();
             }
 
             int pos = _pos;
@@ -102,7 +103,7 @@ namespace System.IO
             }
             if (_s == null)
             {
-                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
+                ThrowObjectDisposedException_ReaderClosed();
             }
 
             int n = _s.Length - _pos;
@@ -130,7 +131,7 @@ namespace System.IO
 
             if (_s == null)
             {
-                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
+                ThrowObjectDisposedException_ReaderClosed();
             }
 
             int n = _s.Length - _pos;
@@ -154,7 +155,7 @@ namespace System.IO
         {
             if (_s == null)
             {
-                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
+                ThrowObjectDisposedException_ReaderClosed();
             }
 
             string s;
@@ -164,7 +165,7 @@ namespace System.IO
             }
             else
             {
-                s = _s.Substring(_pos, _s.Length - _pos);
+                s = _s.Substring(_pos);
             }
 
             _pos = _s.Length;
@@ -182,7 +183,7 @@ namespace System.IO
             string? s = _s;
             if (s == null)
             {
-                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
+                ThrowObjectDisposedException_ReaderClosed();
             }
             var pos = _pos;
             if ((uint)pos >= (uint)s.Length)
@@ -202,7 +203,7 @@ namespace System.IO
                 {
                     if ((uint)pos < s.Length && s[pos] == '\n')
                     {
-                        ++pos;
+                        pos++;
                     }
                 }
                 _pos = pos;
@@ -277,5 +278,12 @@ namespace System.IO
             cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) :
             new ValueTask<int>(Read(buffer.Span));
         #endregion
+
+        [DoesNotReturn]
+        private static void ThrowObjectDisposedException_ReaderClosed()
+        {
+            throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+        }
+
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Internal.Runtime.CompilerServices;
 
 namespace System.IO
 {
@@ -12,7 +11,6 @@ namespace System.IO
     {
         private string? _s;
         private int _pos;
-        private int _length;
 
         public StringReader(string s)
         {
@@ -22,7 +20,6 @@ namespace System.IO
             }
 
             _s = s;
-            _length = s.Length;
         }
 
         public override void Close()
@@ -34,7 +31,6 @@ namespace System.IO
         {
             _s = null;
             _pos = 0;
-            _length = 0;
             base.Dispose(disposing);
         }
 
@@ -49,7 +45,7 @@ namespace System.IO
             {
                 ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
-            if (_pos == _length)
+            if (_pos == _s.Length)
             {
                 return -1;
             }
@@ -66,7 +62,7 @@ namespace System.IO
             {
                 ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
-            if (_pos == _length)
+            if (_pos == _s.Length)
             {
                 return -1;
             }
@@ -102,7 +98,7 @@ namespace System.IO
                 ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
 
-            int n = _length - _pos;
+            int n = _s.Length - _pos;
             if (n > 0)
             {
                 if (n > count)
@@ -130,7 +126,7 @@ namespace System.IO
                 ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
 
-            int n = _length - _pos;
+            int n = _s.Length - _pos;
             if (n > 0)
             {
                 if (n > buffer.Length)
@@ -161,10 +157,10 @@ namespace System.IO
             }
             else
             {
-                s = _s.Substring(_pos, _length - _pos);
+                s = _s.Substring(_pos, _s.Length - _pos);
             }
 
-            _pos = _length;
+            _pos = _s.Length;
             return s;
         }
 
@@ -176,24 +172,25 @@ namespace System.IO
         //
         public override string? ReadLine()
         {
-            if (_s == null)
+            string? s = _s;
+            if (s == null)
             {
                 ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
-            if ((uint)_pos >= (uint)_length)
+            if ((uint)_pos >= (uint)s.Length)
                 return null;
 
-            ReadOnlySpan<char> remaining = _s.AsSpan(_pos);
+            ReadOnlySpan<char> remaining = s.AsSpan(_pos);
             int foundLineLength = remaining.IndexOfAny('\r', '\n');
             if (foundLineLength >= 0)
             {
                 string result = foundLineLength == 0
                     ? string.Empty
-                    : new string(new ReadOnlySpan<char>(ref Unsafe.AsRef(remaining.GetPinnableReference()), foundLineLength)); //_s.Substring(_pos, foundLineLength);
+                    : new string(remaining.Slice(0, foundLineLength));
 
                 char ch = remaining[foundLineLength];
                 _pos += foundLineLength + 1;
-                if (ch == '\r' && _pos < _length && _s[_pos] == '\n')
+                if (ch == '\r' && _pos < s.Length && s[_pos] == '\n')
                 {
                     _pos++;
                 }
@@ -202,8 +199,8 @@ namespace System.IO
             }
             else
             {
-                string result = new string(remaining); // _s.Substring(_pos, _length - _pos);
-                _pos = _length;
+                string result = new string(remaining);
+                _pos = s.Length;
                 return result;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -46,7 +46,7 @@ namespace System.IO
         {
             if (_s == null)
             {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
             if (_pos == _length)
             {
@@ -63,7 +63,7 @@ namespace System.IO
         {
             if (_s == null)
             {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
             if (_pos == _length)
             {
@@ -98,7 +98,7 @@ namespace System.IO
             }
             if (_s == null)
             {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
 
             int n = _length - _pos;
@@ -126,7 +126,7 @@ namespace System.IO
 
             if (_s == null)
             {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
 
             int n = _length - _pos;
@@ -150,7 +150,7 @@ namespace System.IO
         {
             if (_s == null)
             {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
 
             string s;
@@ -177,7 +177,7 @@ namespace System.IO
         {
             if (_s == null)
             {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+                ThrowHelper.ThrowObjectDisposedException_ReaderClosed();
             }
             if ((uint)_pos >= (uint)_length)
                 return null;
@@ -186,7 +186,9 @@ namespace System.IO
             int foundLineLength = remaining.IndexOfAny('\r', '\n');
             if (foundLineLength >= 0)
             {
-                string result = _s.Substring(_pos, foundLineLength);
+                string result = foundLineLength == 0
+                    ? string.Empty
+                    : _s.Substring(_pos, foundLineLength);
 
                 char ch = remaining[foundLineLength];
                 _pos += foundLineLength + 1;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Internal.Runtime.CompilerServices;
 
 namespace System.IO
 {
@@ -188,7 +189,7 @@ namespace System.IO
             {
                 string result = foundLineLength == 0
                     ? string.Empty
-                    : _s.Substring(_pos, foundLineLength);
+                    : new string(new ReadOnlySpan<char>(ref Unsafe.AsRef(remaining.GetPinnableReference()), foundLineLength)); //_s.Substring(_pos, foundLineLength);
 
                 char ch = remaining[foundLineLength];
                 _pos += foundLineLength + 1;
@@ -201,7 +202,7 @@ namespace System.IO
             }
             else
             {
-                string result = _s.Substring(_pos, _length - _pos);
+                string result = new string(remaining); // _s.Substring(_pos, _length - _pos);
                 _pos = _length;
                 return result;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -393,12 +393,6 @@ namespace System
         }
 
         [DoesNotReturn]
-        internal static void ThrowObjectDisposedException_ReaderClosed()
-        {
-            throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
-        }
-
-        [DoesNotReturn]
         internal static void ThrowObjectDisposedException(ExceptionResource resource)
         {
             throw new ObjectDisposedException(null, GetResourceString(resource));

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -393,6 +393,12 @@ namespace System
         }
 
         [DoesNotReturn]
+        internal static void ThrowObjectDisposedException_ReaderClosed()
+        {
+            throw new ObjectDisposedException(null, SR.ObjectDisposed_ReaderClosed);
+        }
+
+        [DoesNotReturn]
         internal static void ThrowObjectDisposedException(ExceptionResource resource)
         {
             throw new ObjectDisposedException(null, GetResourceString(resource));


### PR DESCRIPTION
Have not done benchmarks of this yet, as I wanted to know first if this could be an acceptable change. The premise is `IndexOfAny` is highly optimized and uses vectorization if possible. Also untested.