### PR TITLE
disable flaky ReadAllBytes_NonSeekableFileStream_InWindows

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -188,8 +188,8 @@ namespace System.IO.Tests
 
             using (var cts = new CancellationTokenSource())
             {
-                Task writingServerTask = WaitConnectionAndWritePipeStreamAsync(namedPipeWriterStream, contentBytes, cts.Token);
                 Task<byte[]> readTask = Task.Run(() => File.ReadAllBytes(pipePath), cts.Token);
+                Task writingServerTask = WaitConnectionAndWritePipeStreamAsync(namedPipeWriterStream, contentBytes, cts.Token);
                 cts.CancelAfter(TimeSpan.FromSeconds(3));
 
                 await writingServerTask;

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -188,8 +188,8 @@ namespace System.IO.Tests
 
             using (var cts = new CancellationTokenSource())
             {
-                Task<byte[]> readTask = Task.Run(() => File.ReadAllBytes(pipePath), cts.Token);
                 Task writingServerTask = WaitConnectionAndWritePipeStreamAsync(namedPipeWriterStream, contentBytes, cts.Token);
+                Task<byte[]> readTask = Task.Run(() => File.ReadAllBytes(pipePath), cts.Token);
                 cts.CancelAfter(TimeSpan.FromSeconds(3));
 
                 await writingServerTask;

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -178,6 +178,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // DOS device paths (\\.\ and \\?\) are a Windows concept
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60427")]
         public async Task ReadAllBytes_NonSeekableFileStream_InWindows()
         {
             string pipeName = FileSystemTest.GetNamedPipeServerStreamName();

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -190,7 +190,7 @@ namespace System.IO.Tests
             {
                 Task writingServerTask = WaitConnectionAndWritePipeStreamAsync(namedPipeWriterStream, contentBytes, cts.Token);
                 Task<byte[]> readTask = Task.Run(() => File.ReadAllBytes(pipePath), cts.Token);
-                cts.CancelAfter(TimeSpan.FromSeconds(50));
+                cts.CancelAfter(TimeSpan.FromSeconds(3));
 
                 await writingServerTask;
                 byte[] readBytes = await readTask;


### PR DESCRIPTION
tries to fix #60427

I can't repro it locally, so I will just try here..