### PR TITLE
Rerun mobile target jobs when it fails for 4 known scenarios

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -127,8 +127,8 @@ namespace CoreclrTestLib
                             // 86 - PACKAGE_INSTALLATION_TIMEOUT
                             if (action == "install" && (exitCode == 78 || exitCode == 81|| exitCode == 85|| exitCode == 86))
                             {
-                                CreateRetryFile($"{testBinaryBase}/.retry", category, exitCode);
-                                CreateRetryFile($"{testBinaryBase}/.reboot", category, exitCode);
+                                CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
+                                CreateRetryFile($"{testBinaryBase}/.reboot", exitCode, category);
                                 return exitCode;
                             }
 

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -127,8 +127,8 @@ namespace CoreclrTestLib
                             // 86 - PACKAGE_INSTALLATION_TIMEOUT
                             if (action == "install" && (exitCode == 78 || exitCode == 81|| exitCode == 85|| exitCode == 86))
                             {
-                                CreateRetryFile($"{testBinaryBase}/.retry", exitCode);
-                                CreateRetryFile($"{testBinaryBase}/.reboot", exitCode);
+                                CreateRetryFile($"{testBinaryBase}/.retry", category, exitCode);
+                                CreateRetryFile($"{testBinaryBase}/.reboot", category, exitCode);
                                 return exitCode;
                             }
 
@@ -180,11 +180,11 @@ namespace CoreclrTestLib
             return $"{cmdPrefix} \"{cmd}\"";
         }
 
-        private static void CreateRetryFile(string fileName, int exitCode)
+        private static void CreateRetryFile(string fileName, int exitCode, string appName)
         {
             using (StreamWriter writer = new StreamWriter(fileName))  
             {
-                writer.WriteLine(exitCode); 
+                writer.WriteLine($"appName: {appName}; exitCode: {exitCode}"); 
             }
         }
     }

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -127,8 +127,8 @@ namespace CoreclrTestLib
                             // 86 - PACKAGE_INSTALLATION_TIMEOUT
                             if (action == "install" && (exitCode == 78 || exitCode == 81|| exitCode == 85|| exitCode == 86))
                             {
-                                File.Create($"{testBinaryBase}/.retry");
-                                File.Create($"{testBinaryBase}/.reboot");
+                                CreateRetryFile($"{testBinaryBase}/.retry", exitCode);
+                                CreateRetryFile($"{testBinaryBase}/.reboot", exitCode);
                                 return exitCode;
                             }
 
@@ -178,6 +178,14 @@ namespace CoreclrTestLib
             }
 
             return $"{cmdPrefix} \"{cmd}\"";
+        }
+
+        private static void CreateRetryFile(string fileName, int exitCode)
+        {
+            using (StreamWriter writer = new StreamWriter(fileName))  
+            {
+                writer.WriteLine(exitCode); 
+            }
         }
     }
 }

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -22,6 +22,12 @@ namespace CoreclrTestLib
         {
             //install or uninstall mobile app
             int exitCode = -100;
+
+            if (action == "install" && (File.Exists($"{testBinaryBase}/.retry") || File.Exists($"{testBinaryBase}/.reboot")))
+            {
+                return exitCode;
+            }
+
             string outputFile = Path.Combine(reportBase, action, $"{category}_{action}.output.txt");
             string errorFile = Path.Combine(reportBase, action, $"{category}_{action}.error.txt");
             bool platformValueFlag = true;
@@ -81,6 +87,11 @@ namespace CoreclrTestLib
                         }
                     }
 
+                    if (action == "install")
+                    {
+                        cmdStr += " --timeout 00:05:00";
+                    }
+
                     using (Process process = new Process())
                     {
                         if (OperatingSystem.IsWindows())
@@ -108,6 +119,19 @@ namespace CoreclrTestLib
                         {
                             // Process completed.
                             exitCode = process.ExitCode;
+
+                            // See https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+                            // 78 - PACKAGE_INSTALLATION_FAILURE
+                            // 81 - DEVICE_NOT_FOUND
+                            // 85 - ADB_DEVICE_ENUMERATION_FAILURE
+                            // 86 - PACKAGE_INSTALLATION_TIMEOUT
+                            if (action == "install" && (exitCode == 78 || exitCode == 81|| exitCode == 85|| exitCode == 86))
+                            {
+                                File.Create($"{testBinaryBase}/.retry");
+                                File.Create($"{testBinaryBase}/.reboot");
+                                return exitCode;
+                            }
+
                             Task.WaitAll(copyOutput, copyError);
                         }
                         else


### PR DESCRIPTION
The 4 known scenarios are
- 78 - PACKAGE_INSTALLATION_FAILURE
- 81 - DEVICE_NOT_FOUND
- 85 - ADB_DEVICE_ENUMERATION_FAILURE
- 86 - PACKAGE_INSTALLATION_TIMEOUT

More details regarding to the above exit code could be found at https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs

Fixes #59679