### PR TITLE
[mono][llvmonly] Optimize virtual calls/rgctx fetches in gsharedvt methods.

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6925,6 +6925,9 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 			case MONO_PATCH_INFO_FIELD:
 				encode_field_info (acfg, (MonoClassField *)template_->data, p, &p);
 				break;
+			case MONO_PATCH_INFO_METHOD:
+				encode_method_ref (acfg, (MonoMethod*)template_->data, p, &p);
+				break;
 			default:
 				g_assert_not_reached ();
 				break;

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -3906,6 +3906,12 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 				if (!template_->data)
 					goto cleanup;
 				break;
+			case MONO_PATCH_INFO_METHOD:
+				template_->data = decode_resolve_method_ref (aot_module, p, &p, error);
+				mono_error_cleanup (error); /* FIXME don't swallow the error */
+				if (!template_->data)
+					goto cleanup;
+				break;
 			default:
 				g_assert_not_reached ();
 				break;

--- a/src/mono/mono/mini/calls.c
+++ b/src/mono/mono/mini/calls.c
@@ -703,7 +703,7 @@ mini_emit_llvmonly_virtual_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMeth
 		helper_sig_llvmonly_imt_trampoline = tmp;
 	}
 
-	if (!fsig->generic_param_count && !is_iface && !is_gsharedvt) {
+	if (!fsig->generic_param_count && !is_iface) {
 		/*
 		 * The simplest case, a normal virtual call.
 		 */
@@ -737,14 +737,22 @@ mini_emit_llvmonly_virtual_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMeth
 
 		/* Fastpath */
 		MONO_START_BB (cfg, non_null_bb);
-		/* Load the address + arg from the vtable slot */
-		EMIT_NEW_LOAD_MEMBASE (cfg, call_target, OP_LOAD_MEMBASE, addr_reg, slot_reg, 0);
-		MONO_EMIT_NEW_LOAD_MEMBASE (cfg, arg_reg, slot_reg, TARGET_SIZEOF_VOID_P);
-
-		return mini_emit_extra_arg_calli (cfg, fsig, sp, arg_reg, call_target);
+		if (cfg->gsharedvt && mini_is_gsharedvt_variable_signature (fsig)) {
+			MonoInst *wrapper_ins = mini_emit_get_rgctx_method (cfg, context_used, cmethod, MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT);
+			int arg_reg = alloc_preg (cfg);
+			EMIT_NEW_UNALU (cfg, ins, OP_MOVE, arg_reg, slot_reg);
+			int addr_reg = alloc_preg (cfg);
+			EMIT_NEW_LOAD_MEMBASE (cfg, call_target, OP_LOAD_MEMBASE, addr_reg, wrapper_ins->dreg, 0);
+			return mini_emit_extra_arg_calli (cfg, fsig, sp, arg_reg, call_target);
+		} else {
+			/* Load the address + arg from the vtable slot */
+			EMIT_NEW_LOAD_MEMBASE (cfg, call_target, OP_LOAD_MEMBASE, addr_reg, slot_reg, 0);
+			MONO_EMIT_NEW_LOAD_MEMBASE (cfg, arg_reg, slot_reg, TARGET_SIZEOF_VOID_P);
+			return mini_emit_extra_arg_calli (cfg, fsig, sp, arg_reg, call_target);
+		}
 	}
 
-	if (!fsig->generic_param_count && is_iface && !variant_iface && !is_gsharedvt && !special_array_interface) {
+	if (!fsig->generic_param_count && is_iface && !variant_iface && !special_array_interface) {
 		/*
 		 * A simple interface call
 		 *
@@ -780,10 +788,17 @@ mini_emit_llvmonly_virtual_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMeth
 												cmethod, MONO_RGCTX_INFO_METHOD);
 		ftndesc_ins = mini_emit_calli (cfg, helper_sig_llvmonly_imt_trampoline, icall_args, thunk_addr_ins, NULL, NULL);
 
-		return mini_emit_llvmonly_calli (cfg, fsig, sp, ftndesc_ins);
+		if (cfg->gsharedvt && mini_is_gsharedvt_variable_signature (fsig)) {
+			MonoInst *wrapper_ins = mini_emit_get_rgctx_method (cfg, context_used, cmethod, MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT);
+			int addr_reg = alloc_preg (cfg);
+			EMIT_NEW_LOAD_MEMBASE (cfg, call_target, OP_LOAD_MEMBASE, addr_reg, wrapper_ins->dreg, 0);
+			return mini_emit_extra_arg_calli (cfg, fsig, sp, ftndesc_ins->dreg, call_target);
+		} else {
+			return mini_emit_llvmonly_calli (cfg, fsig, sp, ftndesc_ins);
+		}
 	}
 
-	if ((fsig->generic_param_count || variant_iface || special_array_interface) && !is_gsharedvt) {
+	if (fsig->generic_param_count || variant_iface || special_array_interface) {
 		/*
 		 * This is similar to the interface case, the vtable slot points to an imt thunk which is
 		 * dynamically extended as more instantiations are discovered.
@@ -847,7 +862,15 @@ mini_emit_llvmonly_virtual_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMeth
 
 		/* Common case */
 		MONO_START_BB (cfg, end_bb);
-		return mini_emit_llvmonly_calli (cfg, fsig, sp, ftndesc_ins);
+
+		if (cfg->gsharedvt && mini_is_gsharedvt_variable_signature (fsig)) {
+			MonoInst *wrapper_ins = mini_emit_get_rgctx_method (cfg, context_used, cmethod, MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT);
+			int addr_reg = alloc_preg (cfg);
+			EMIT_NEW_LOAD_MEMBASE (cfg, call_target, OP_LOAD_MEMBASE, addr_reg, wrapper_ins->dreg, 0);
+			return mini_emit_extra_arg_calli (cfg, fsig, sp, ftndesc_ins->dreg, call_target);
+		} else {
+			return mini_emit_llvmonly_calli (cfg, fsig, sp, ftndesc_ins);
+		}
 	}
 
 	/*

--- a/src/mono/mono/mini/llvmonly-runtime.c
+++ b/src/mono/mono/mini/llvmonly-runtime.c
@@ -763,6 +763,7 @@ gpointer
 mini_llvmonly_resolve_iface_call_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg)
 {
 	ERROR_DECL (error);
+
 	gpointer res = resolve_iface_call (this_obj, imt_slot, imt_method, out_arg, TRUE, error);
 	if (!is_ok (error)) {
 		MonoException *ex = mono_error_convert_to_exception (error);

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -564,6 +564,7 @@ inflate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoTempl
 	case MONO_RGCTX_INFO_METHOD_FTNDESC:
 	case MONO_RGCTX_INFO_GENERIC_METHOD_CODE:
 	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER:
+	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT:
 	case MONO_RGCTX_INFO_METHOD_RGCTX:
 	case MONO_RGCTX_INFO_METHOD_CONTEXT:
 	case MONO_RGCTX_INFO_REMOTING_INVOKE_WITH_CHECK:
@@ -2231,6 +2232,17 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 			return mini_llvmonly_create_ftndesc (m, addr, arg);
 		}
 	}
+	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT: {
+		MonoMethod *m = (MonoMethod*)data;
+		gpointer addr;
+
+		/* A gsharedvt out wrapper for the signature of M */
+		g_assert (mono_llvm_only);
+		addr = mini_get_gsharedvt_wrapper (FALSE, NULL, mono_method_signature_internal (m), NULL, -1, FALSE);
+
+		/* Returns an ftndesc */
+		return mini_llvmonly_create_ftndesc (m, addr, NULL);
+	}
 	case MONO_RGCTX_INFO_VIRT_METHOD_CODE: {
 		MonoJumpInfoVirtMethod *info = (MonoJumpInfoVirtMethod *)data;
 		MonoClass *iface_class = info->method->klass;
@@ -2614,6 +2626,7 @@ mono_rgctx_info_type_to_str (MonoRgctxInfoType type)
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO: return "GSHAREDVT_INFO";
 	case MONO_RGCTX_INFO_GENERIC_METHOD_CODE: return "GENERIC_METHOD_CODE";
 	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER: return "GSHAREDVT_OUT_WRAPPER";
+	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT: return "GSHAREDVT_OUT_WRAPPER_VIRT";
 	case MONO_RGCTX_INFO_CLASS_FIELD: return "CLASS_FIELD";
 	case MONO_RGCTX_INFO_METHOD_RGCTX: return "METHOD_RGCTX";
 	case MONO_RGCTX_INFO_METHOD_CONTEXT: return "METHOD_CONTEXT";
@@ -2726,6 +2739,7 @@ info_equal (gpointer data1, gpointer data2, MonoRgctxInfoType info_type)
 	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO:
 	case MONO_RGCTX_INFO_GENERIC_METHOD_CODE:
 	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER:
+	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT:
 	case MONO_RGCTX_INFO_CLASS_FIELD:
 	case MONO_RGCTX_INFO_FIELD_OFFSET:
 	case MONO_RGCTX_INFO_METHOD_RGCTX:

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -2798,9 +2798,17 @@ mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
 	case MONO_RGCTX_INFO_NULLABLE_CLASS_UNBOX:
 	case MONO_RGCTX_INFO_LOCAL_OFFSET:
 		return MONO_PATCH_INFO_CLASS;
+	case MONO_RGCTX_INFO_CLASS_FIELD:
 	case MONO_RGCTX_INFO_FIELD_OFFSET:
 		return MONO_PATCH_INFO_FIELD;
+	case MONO_RGCTX_INFO_METHOD:
+	case MONO_RGCTX_INFO_METHOD_RGCTX:
+	case MONO_RGCTX_INFO_METHOD_FTNDESC:
+	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER:
+	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT:
+		return MONO_PATCH_INFO_METHOD;
 	default:
+		printf ("%d\n", info_type);
 		g_assert_not_reached ();
 		return (MonoJumpInfoType)-1;
 	}

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1063,7 +1063,9 @@ typedef enum {
 	/* Same as MONO_PATCH_INFO_METHOD_FTNDESC */
 	MONO_RGCTX_INFO_METHOD_FTNDESC                = 33,
 	/* mono_type_size () for a class */
-	MONO_RGCTX_INFO_CLASS_SIZEOF                  = 34
+	MONO_RGCTX_INFO_CLASS_SIZEOF                  = 34,
+	/* A gsharedvt_out wrapper for a method */
+	MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER_VIRT    = 35
 } MonoRgctxInfoType;
 
 /* How an rgctx is passed to a method */


### PR DESCRIPTION
Previously, these were all implemented using a slowpath to a JIT
icall. Instead, use the normal calling sequence and add a gsharedvt
out wrapper at the end if needed.