### PR TITLE
[arm64] JIT: Don't emit OVERFLOW and DIVIDED-BY-ZERO for "X div CNS"

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2498,7 +2498,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
     genConsumeOperands(tree);
 
     // Floating point divide never raises an exception
-    if (!varTypeIsFloating(targetType) && (tree->gtFlags & GTF_EXCEPT))
+    if (!varTypeIsFloating(targetType) && !(tree->gtFlags & GTF_SAFE_DIV))
     {
         GenTree* divisorOp = tree->gtGetOp2();
         emitAttr size      = EA_ATTR(genTypeSize(genActualType(tree->TypeGet())));

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2497,12 +2497,8 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
 
     genConsumeOperands(tree);
 
-    if (varTypeIsFloating(targetType))
-    {
-        // Floating point divide never raises an exception
-        genCodeForBinary(tree);
-    }
-    else // an integer divide operation
+    // Floating point divide never raises an exception
+    if (!varTypeIsFloating(targetType) && (tree->gtFlags & GTF_EXCEPT))
     {
         GenTree* divisorOp = tree->gtGetOp2();
         emitAttr size      = EA_ATTR(genTypeSize(genActualType(tree->TypeGet())));
@@ -2570,7 +2566,6 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
 
                     genDefineTempLabel(sdivLabel);
                 }
-                genCodeForBinary(tree); // Generate the sdiv instruction
             }
             else // (tree->gtOper == GT_UDIV)
             {
@@ -2587,9 +2582,9 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
                     emit->emitIns_R_I(INS_cmp, size, divisorReg, 0);
                     genJumpToThrowHlpBlk(EJ_eq, SCK_DIV_BY_ZERO);
                 }
-                genCodeForBinary(tree);
             }
         }
+        genCodeForBinary(tree);
     }
 }
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -576,6 +576,7 @@ enum GenTreeFlags : unsigned int
                                               // Requires an overflow check. Use gtOverflow(Ex)() to check this flag.
 
     GTF_DIV_BY_CNS_OPT          = 0x80000000, // GT_DIV -- Uses the division by constant optimization to compute this division
+    GTF_SAFE_DIV                = 0x20000000, // GT_DIV -- Uses the division that never throws DividedByZero or Overflow exceptions
 
     GTF_ARR_BOUND_INBND         = 0x80000000, // GT_ARR_BOUNDS_CHECK -- have proved this check is always in-bounds
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12241,8 +12241,6 @@ DONE_MORPHING_CHILDREN:
                 }
                 else
                 {
-                    // Update side-effects as DIV itself doesn't need GTF_EXCEPT now
-                    tree->SetAllEffectsFlags(op1, op2);
                     tree->gtFlags |= GTF_SAFE_DIV;
                 }
             }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12224,19 +12224,21 @@ DONE_MORPHING_CHILDREN:
 
 #ifdef TARGET_ARM64
         case GT_DIV:
-            if (!varTypeIsFloating(tree->gtType))
+        case GT_UDIV:
+            if (!varTypeIsFloating(tree->gtType) && fgGlobalMorph)
             {
                 // Codegen for this instruction needs to be able to throw two exceptions:
-                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW);
-                fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO);
+                if (tree->OperIs(GT_DIV) && (!op2->IsIntegralConst() || op2->IsIntegralConst(-1)))
+                {
+                    fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW);
+                }
+                if (!op2->IsIntegralConst() || op2->IsIntegralConst(0))
+                {
+                    fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO);
+                }
             }
             break;
-        case GT_UDIV:
-            // Codegen for this instruction needs to be able to throw one exception:
-            fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO);
-            break;
 #endif
-
         case GT_ADD:
 
         CM_OVF_OP:

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12243,6 +12243,7 @@ DONE_MORPHING_CHILDREN:
                 {
                     // Update side-effects as DIV itself doesn't need GTF_EXCEPT now
                     tree->SetAllEffectsFlags(op1, op2);
+                    tree->gtFlags |= GTF_SAFE_DIV;
                 }
             }
             break;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12241,7 +12241,8 @@ DONE_MORPHING_CHILDREN:
                 }
                 else
                 {
-                    tree->gtFlags &= ~GTF_EXCEPT;
+                    // Update side-effects as DIV itself doesn't need GTF_EXCEPT now
+                    tree->SetAllEffectsFlags(op1, op2);
                 }
             }
             break;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12228,13 +12228,20 @@ DONE_MORPHING_CHILDREN:
             if (!varTypeIsFloating(tree->gtType) && fgGlobalMorph)
             {
                 // Codegen for this instruction needs to be able to throw two exceptions:
-                if (tree->OperIs(GT_DIV) && (!op2->IsIntegralConst() || op2->IsIntegralConst(-1)))
-                {
-                    fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW);
-                }
-                if (!op2->IsIntegralConst() || op2->IsIntegralConst(0))
+                if (tree->OperIs(GT_DIV) &&
+                    (!op2->IsIntegralConst() || op2->IsIntegralConst(0) || op2->IsIntegralConst(-1)))
                 {
                     fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO);
+                    fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_OVERFLOW);
+                }
+                else if (tree->OperIs(GT_UDIV) && (!op2->IsIntegralConst() || op2->IsIntegralConst(0)))
+                {
+                    // Codegen for this instruction needs to be able to throw one exception:
+                    fgAddCodeRef(compCurBB, bbThrowIndex(compCurBB), SCK_DIV_BY_ZERO);
+                }
+                else
+                {
+                    tree->gtFlags &= ~GTF_EXCEPT;
                 }
             }
             break;


### PR DESCRIPTION
Just a small improvement for `x / cns`:
```csharp
int div(int a) => a / 2;
```
diff:
```diff
; Method hello.Class1:div(int):int:this
G_M63695_IG01:
            stp     fp, lr, [sp,#-16]!
            mov     fp, sp
						;; bbWeight=1    PerfScore 1.50

G_M63695_IG02:
            lsr     w0, w1, #31
            add     w0, w0, w1
            asr     w0, w0, #1
						;; bbWeight=1    PerfScore 2.50

G_M63695_IG03:
            ldp     fp, lr, [sp],#16
            ret     lr
						;; bbWeight=1    PerfScore 2.00

-G_M63695_IG04:
-            bl      CORINFO_HELP_OVERFLOW
-						;; bbWeight=0    PerfScore 0.00
-
-G_M63695_IG05:
-            bl      CORINFO_HELP_THROWDIVZERO
-            bkpt    
-						;; bbWeight=0    PerfScore 0.00
-; Total bytes of code: 40
+; Total bytes of code: 28
```
Some nice diffs:

## coreclr_tests.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 166114700 (overridden on cmd)
Total bytes of diff: 166086844 (overridden on cmd)
Total bytes of delta: -27856 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         288 : 228141.dasm (1.45% of base)
          52 : 242470.dasm (0.92% of base)
          24 : 227180.dasm (0.56% of base)
          12 : 84381.dasm (1.71% of base)
           8 : 247302.dasm (0.58% of base)
           4 : 253461.dasm (1.14% of base)
           4 : 248599.dasm (0.29% of base)

Top file improvements (bytes):
        -720 : 229114.dasm (-2.79% of base)
        -464 : 217919.dasm (-3.05% of base)
        -360 : 231125.dasm (-1.42% of base)
         -48 : 213681.dasm (-1.38% of base)
         -32 : 85558.dasm (-2.20% of base)
         -28 : 87824.dasm (-6.14% of base)
         -28 : 85969.dasm (-0.23% of base)
         -24 : 232870.dasm (-0.25% of base)
         -20 : 227325.dasm (-2.29% of base)
         -20 : 248737.dasm (-0.81% of base)
         -20 : 207017.dasm (-4.27% of base)
         -20 : 207041.dasm (-0.91% of base)
         -20 : 82764.dasm (-2.54% of base)
         -20 : 108387.dasm (-1.54% of base)
         -16 : 243392.dasm (-0.62% of base)
         -16 : 83025.dasm (-4.08% of base)
         -12 : 129463.dasm (-12.50% of base)
         -12 : 129467.dasm (-13.04% of base)
         -12 : 129543.dasm (-8.33% of base)
         -12 : 129547.dasm (-8.33% of base)

3962 total files with Code Size differences (3955 improved, 7 regressed), 731 unchanged.

Top method regressions (bytes):
         288 ( 1.45% of base) : 228141.dasm - lclflddiv:Main():int
          52 ( 0.92% of base) : 242470.dasm - Tests.Operators:Main():int
          24 ( 0.56% of base) : 227180.dasm - GCSimulator.ClientSimulator:RunTest()
          12 ( 1.71% of base) : 84381.dasm - ILGEN_0x38e574ea:main():int
           8 ( 0.58% of base) : 247302.dasm - GCTest.GCTestC:LoadData(int):this
           4 ( 0.29% of base) : 248599.dasm - GCTest.GCTestC:LoadData(int):this
           4 ( 1.14% of base) : 253461.dasm - Test:Allocate()

Top method improvements (bytes):
        -720 (-2.79% of base) : 229114.dasm - lclfldrem:Main():int
        -464 (-3.05% of base) : 217919.dasm - Class1:foo(int)
        -360 (-1.42% of base) : 231125.dasm - lclfldrem:Main():int
         -48 (-1.38% of base) : 213681.dasm - System.MathBenchmarks.DivideByConst:<Test>g__Verify|0_0(long,long,int,int)
         -32 (-2.20% of base) : 85558.dasm - ILGEN_0x1dd8d826:Method_0x1830b93d(int):int
         -28 (-6.14% of base) : 87824.dasm - ILGEN_0x38e6c42a:main():int
         -28 (-0.23% of base) : 85969.dasm - JitTest.Test:Main():int
         -24 (-0.25% of base) : 232870.dasm - SmallLoop1:Main():int
         -20 (-2.54% of base) : 82764.dasm - DefaultNamespace.VarAryStress:Main(System.String[]):int
         -20 (-0.81% of base) : 248737.dasm - EHTest:f1(int,long,long,int):int
         -20 (-2.29% of base) : 227325.dasm - Mainy:AllocStart()
         -20 (-4.27% of base) : 207017.dasm - ReliabilityConfig:ConvertTimeValueToTestRunTime(System.String):int
         -20 (-0.91% of base) : 207041.dasm - ReliabilityFramework:TestStarter():this
         -20 (-1.54% of base) : 108387.dasm - testout1:Func_0_4_2_5_5():short
         -16 (-4.08% of base) : 83025.dasm - ArrayOOM:RunTest():bool:this
         -16 (-0.62% of base) : 243392.dasm - EHTest:f0(long,long):long
         -12 (-17.65% of base) : 88677.dasm - <Module>:main():int
         -12 (-27.27% of base) : 237527.dasm - ArrayLengthArithmeticTests:ArrayLengthDiv_cnsMinValue(System.Int32[]):int
         -12 (-25.00% of base) : 237526.dasm - ArrayLengthArithmeticTests:ArrayLengthDiv_cnsn2(System.Int32[]):int
         -12 (-21.43% of base) : 237499.dasm - ArrayLengthArithmeticTests:ArrayLengthMod_cnsMinValue(System.Int32[]):int

Top method regressions (percentages):
          12 ( 1.71% of base) : 84381.dasm - ILGEN_0x38e574ea:main():int
         288 ( 1.45% of base) : 228141.dasm - lclflddiv:Main():int
           4 ( 1.14% of base) : 253461.dasm - Test:Allocate()
          52 ( 0.92% of base) : 242470.dasm - Tests.Operators:Main():int
           8 ( 0.58% of base) : 247302.dasm - GCTest.GCTestC:LoadData(int):this
          24 ( 0.56% of base) : 227180.dasm - GCSimulator.ClientSimulator:RunTest()
           4 ( 0.29% of base) : 248599.dasm - GCTest.GCTestC:LoadData(int):this

Top method improvements (percentages):
         -12 (-37.50% of base) : 88138.dasm - ILGEN_0x7a129ee8:Method_0x63d7449b():int
         -12 (-30.00% of base) : 248391.dasm - DivConst:I4_DivPow2_2(int):int
         -12 (-30.00% of base) : 248395.dasm - DivConst:I4_DivPow2_I4Min(int):int
         -12 (-30.00% of base) : 248409.dasm - DivConst:I8_DivUncontainedPow2_I8Min(long):long
         -12 (-30.00% of base) : 82923.dasm - Test:Main():int
         -12 (-30.00% of base) : 248257.dasm - TestIntLimits.Program:LongDivNegLongMinValue(long):long
         -12 (-30.00% of base) : 248264.dasm - TestIntLimits.Program:LongNegDivLongMinValue(long):long
          -8 (-28.57% of base) : 233746.dasm - MemCheck:BytesToMB(long):int
          -8 (-28.57% of base) : 233745.dasm - MemCheck:KBToMB(int):int
          -8 (-28.57% of base) : 251490.dasm - UDivConst:U4_DivPow2_16(int):int
          -8 (-28.57% of base) : 251491.dasm - UDivConst:U4_DivPow2_I4Min(int):int
          -8 (-28.57% of base) : 251498.dasm - UDivConst:U8_DivPow2_2(long):long
          -8 (-28.57% of base) : 251499.dasm - UDivConst:U8_DivUncontainedPow2_1Shl32(long):long
         -12 (-27.27% of base) : 237527.dasm - ArrayLengthArithmeticTests:ArrayLengthDiv_cnsMinValue(System.Int32[]):int
         -12 (-27.27% of base) : 248392.dasm - DivConst:I4_DivPow2_Minus2(int):int
         -12 (-27.27% of base) : 248406.dasm - DivConst:I8_DivPow2_4(long):long
         -12 (-27.27% of base) : 248408.dasm - DivConst:I8_DivUncontainedPow2_1Shl32(long):long
         -12 (-27.27% of base) : 248256.dasm - TestIntLimits.Program:DivNegIntMinValue(int):int
         -12 (-27.27% of base) : 248263.dasm - TestIntLimits.Program:NegDivIntMinValue(int):int
          -8 (-25.00% of base) : 237517.dasm - ArrayLengthArithmeticTests:ArrayLengthDiv_cns2(System.Int32[]):int

3962 total methods with Code Size differences (3955 improved, 7 regressed), 731 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 48198644 (overridden on cmd)
Total bytes of diff: 48171260 (overridden on cmd)
Total bytes of delta: -27384 (-0.06 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         108 : 114008.dasm (2.49% of base)

Top file improvements (bytes):
         -68 : 118766.dasm (-12.41% of base)
         -68 : 118772.dasm (-7.73% of base)
         -68 : 35406.dasm (-32.69% of base)
         -68 : 190774.dasm (-42.50% of base)
         -68 : 21789.dasm (-4.55% of base)
         -64 : 85131.dasm (-10.06% of base)
         -64 : 50642.dasm (-10.53% of base)
         -64 : 32685.dasm (-14.68% of base)
         -64 : 21788.dasm (-4.88% of base)
         -60 : 21791.dasm (-5.36% of base)
         -60 : 183863.dasm (-4.89% of base)
         -40 : 30974.dasm (-5.85% of base)
         -40 : 190242.dasm (-4.29% of base)
         -40 : 40120.dasm (-7.75% of base)
         -40 : 179089.dasm (-6.13% of base)
         -40 : 14266.dasm (-6.13% of base)
         -40 : 146873.dasm (-2.64% of base)
         -40 : 146874.dasm (-3.83% of base)
         -36 : 11234.dasm (-19.15% of base)
         -36 : 13185.dasm (-10.84% of base)

964 total files with Code Size differences (963 improved, 1 regressed), 259 unchanged.

Top method regressions (bytes):
         108 ( 2.49% of base) : 114008.dasm - Microsoft.Diagnostics.Tracing.TraceEvent:PayloadString(int,System.IFormatProvider):System.String:this

Top method improvements (bytes):
         -68 (-4.55% of base) : 21789.dasm - System.Collections.Generic.HashSet`1:SymmetricExceptWithEnumerable(System.Collections.Generic.IEnumerable`1[System.__Canon]):this
         -68 (-42.50% of base) : 190774.dasm - System.Numerics.Complex:GetHashCode():int:this
         -68 (-32.69% of base) : 35406.dasm - System.TimeOnly:AddTicks(long,byref):System.TimeOnly:this
         -68 (-7.73% of base) : 118772.dasm - System.Xml.ValueHandle:ToByteArray():System.Byte[]:this
         -68 (-12.41% of base) : 118766.dasm - System.Xml.ValueHandle:TryReadBase64(System.Byte[],int,int,byref):bool:this
         -64 (-10.53% of base) : 50642.dasm - Newtonsoft.Json.Utilities.DateTimeUtils:GetDateValues(System.DateTime,byref,byref,byref)
         -64 (-4.88% of base) : 21788.dasm - System.Collections.Generic.HashSet`1:CheckUniqueAndUnfoundElements(System.Collections.Generic.IEnumerable`1[System.__Canon],bool):System.ValueTuple`2[System.Int32, System.Int32]:this
         -64 (-14.68% of base) : 32685.dasm - System.Globalization.PersianCalendar:.cctor()
         -64 (-10.06% of base) : 85131.dasm - System.Xml.Schema.XsdDateTime:GetYearMonthDay(byref,byref,byref):this
         -60 (-5.36% of base) : 21791.dasm - System.Collections.Generic.HashSet`1:IntersectWithEnumerable(System.Collections.Generic.IEnumerable`1[System.__Canon]):this
         -60 (-4.89% of base) : 183863.dasm - System.Collections.Generic.SortedSet`1:CheckUniqueAndUnfoundElements(System.Collections.Generic.IEnumerable`1[System.__Canon],bool):System.Collections.Generic.SortedSet`1+ElementCount[System.__Canon]:this
         -40 (-3.83% of base) : 146874.dasm - ObjectGraphFormatter:mapSetValueL(int,int,System.Type,System.Object):Microsoft.FSharp.Text.StructuredPrintfImpl.Layout:this
         -40 (-2.64% of base) : 146873.dasm - ObjectGraphFormatter:sequenceValueL(Microsoft.FSharp.Text.StructuredPrintfImpl.Display+ShowMode,int,int,System.Collections.IEnumerable):Microsoft.FSharp.Text.StructuredPrintfImpl.Layout:this
         -40 (-6.13% of base) : 14266.dasm - System.Net.Http.AuthenticationHelper:ComputeHash(System.String,System.String):System.String
         -40 (-4.29% of base) : 190242.dasm - System.Runtime.Caching.CacheExpires:EnableExpirationTimer(bool):this
         -40 (-6.13% of base) : 179089.dasm - System.Runtime.InteropServices.HandleCollector:Add():this
         -40 (-7.75% of base) : 40120.dasm - System.String:GetNonRandomizedHashCodeOrdinalIgnoreCase():int:this
         -40 (-5.85% of base) : 30974.dasm - System.Threading.PortableThreadPool:AdjustMaxWorkersActive():this
         -36 (-34.62% of base) : 22851.dasm - <>c:<OnEventCommand>b__32_1():double:this
         -36 (-32.14% of base) : 22839.dasm - <>c:<OnEventCommand>b__32_13():double:this

Top method regressions (percentages):
         108 ( 2.49% of base) : 114008.dasm - Microsoft.Diagnostics.Tracing.TraceEvent:PayloadString(int,System.IFormatProvider):System.String:this

Top method improvements (percentages):
         -36 (-56.25% of base) : 195615.dasm - System.Formats.Asn1.BMPEncoding:GetMaxCharCount(int):int:this
         -36 (-50.00% of base) : 13783.dasm - Http2StreamWindowManager:get_StreamWindowThreshold():int:this
         -36 (-50.00% of base) : 180057.dasm - Internal.Cryptography.AsymmetricAlgorithmHelpers:BitsToBytes(int):int
         -20 (-50.00% of base) : 14899.dasm - System.Net.MultiMemory:GetBlockIndex(int):int
         -36 (-50.00% of base) : 91245.dasm - System.Xml.Ucs4Encoding:GetMaxCharCount(int):int:this
         -36 (-47.37% of base) : 29567.dasm - EncodingByteBuffer:get_CharsUsed():int:this
         -36 (-47.37% of base) : 36590.dasm - System.SpanHelpers:UnalignedCountVector(byref):long
         -36 (-47.37% of base) : 36589.dasm - System.SpanHelpers:UnalignedCountVector128(byref):long
         -36 (-47.37% of base) : 21297.dasm - System.Text.EncodingByteBuffer:get_CharsUsed():int:this
         -20 (-45.45% of base) : 91244.dasm - System.Xml.Ucs4Encoding:GetCharCount(System.Byte[]):int:this
         -36 (-45.00% of base) : 24630.dasm - System.IO.RandomAccess:GetNumberOfBytesToWrite(int):int
         -36 (-42.86% of base) : 171711.dasm - System.Data.Common.ADP:TimerToMilliseconds(long):long
         -68 (-42.50% of base) : 190774.dasm - System.Numerics.Complex:GetHashCode():int:this
         -20 (-41.67% of base) : 14898.dasm - System.Net.MultiMemory:GetOffsetInBlock(int):int
         -36 (-40.91% of base) : 207583.dasm - Internal.Cryptography.RC2Implementation:GetPaddingSize():int:this
         -36 (-40.91% of base) : 3858.dasm - VersionResourceSerializer:KEYSIZE(System.String):int
         -36 (-39.13% of base) : 181572.dasm - Database:RoundUpToEven(int):int
         -36 (-39.13% of base) : 33751.dasm - System.Globalization.CalendricalCalculationsHelper:GetNumberOfDays(System.DateTime):long
         -36 (-39.13% of base) : 35325.dasm - System.TimeSpan:get_Days():int:this
         -36 (-39.13% of base) : 91222.dasm - System.Xml.Ucs4Decoder:GetCharCount(System.Byte[],int,int):int:this

964 total methods with Code Size differences (963 improved, 1 regressed), 259 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 47235704 (overridden on cmd)
Total bytes of diff: 47227488 (overridden on cmd)
Total bytes of delta: -8216 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          32 : 63152.dasm (3.38% of base)
          20 : 81223.dasm (1.08% of base)
          12 : 76761.dasm (0.39% of base)
           4 : 204989.dasm (0.04% of base)

Top file improvements (bytes):
         -40 : 122216.dasm (-12.05% of base)
         -40 : 81225.dasm (-6.49% of base)
         -40 : 144684.dasm (-7.30% of base)
         -20 : 162848.dasm (-1.05% of base)
         -20 : 139413.dasm (-4.31% of base)
         -20 : 139407.dasm (-2.91% of base)
         -20 : 34964.dasm (-1.55% of base)
         -20 : 162849.dasm (-1.04% of base)
         -20 : 163006.dasm (-0.84% of base)
         -16 : 131164.dasm (-1.15% of base)
         -16 : 162836.dasm (-0.98% of base)
         -16 : 153151.dasm (-4.55% of base)
         -16 : 131163.dasm (-1.99% of base)
         -16 : 36360.dasm (-0.37% of base)
         -16 : 210187.dasm (-2.30% of base)
         -12 : 136340.dasm (-3.61% of base)
         -12 : 155465.dasm (-4.62% of base)
         -12 : 170245.dasm (-3.26% of base)
         -12 : 175969.dasm (-6.38% of base)
         -12 : 186459.dasm (-1.45% of base)

1125 total files with Code Size differences (1121 improved, 4 regressed), 278 unchanged.

Top method regressions (bytes):
          32 ( 3.38% of base) : 63152.dasm - Microsoft.CodeAnalysis.Text.LargeEncodedText:Decode(System.IO.Stream,System.Text.Encoding,int,bool):Microsoft.CodeAnalysis.Text.SourceText
          20 ( 1.08% of base) : 81223.dasm - System.Xml.Schema.XsdDateTime:ToString():System.String:this
          12 ( 0.39% of base) : 76761.dasm - <ReadDataAsync>d__504:MoveNext():this
           4 ( 0.04% of base) : 204989.dasm - System.Formats.Asn1.AsnWriter:WriteGeneralizedTimeCore(System.Formats.Asn1.Asn1Tag,System.DateTimeOffset,bool):this

Top method improvements (bytes):
         -40 (-7.30% of base) : 144684.dasm - Newtonsoft.Json.Utilities.DateTimeUtils:GetDateValues(System.DateTime,byref,byref,byref)
         -40 (-12.05% of base) : 122216.dasm - System.Data.SqlTypes.SqlDateTime:FromTimeSpan(System.TimeSpan):System.Data.SqlTypes.SqlDateTime
         -40 (-6.49% of base) : 81225.dasm - System.Xml.Schema.XsdDateTime:GetYearMonthDay(byref,byref,byref):this
         -20 (-1.04% of base) : 162849.dasm - Internal.Cryptography.Pal.CachedSystemStoreProvider:ContentWriteTime(System.IO.DirectoryInfo):System.DateTime
         -20 (-1.05% of base) : 162848.dasm - Internal.Cryptography.Pal.CachedSystemStoreProvider:ContentWriteTime(System.IO.FileInfo):System.DateTime
         -20 (-0.84% of base) : 163006.dasm - Internal.Cryptography.Pal.OpenSslX509ChainProcessor:FinishRevocation(int,int,int):this
         -20 (-1.55% of base) : 34964.dasm - System.Collections.Generic.HashSet`1[Byte][System.Byte]:SymmetricExceptWithEnumerable(System.Collections.Generic.IEnumerable`1[Byte]):this
         -20 (-2.91% of base) : 139407.dasm - System.Xml.ValueHandle:ToByteArray():System.Byte[]:this
         -20 (-4.31% of base) : 139413.dasm - System.Xml.ValueHandle:TryReadBase64(System.Byte[],int,int,byref):bool:this
         -16 (-0.98% of base) : 162836.dasm - Internal.Cryptography.Pal.CachedDirectoryStoreProvider:GetNativeCollection():Microsoft.Win32.SafeHandles.SafeX509StackHandle:this
         -16 (-0.37% of base) : 36360.dasm - Microsoft.Diagnostics.Tracing.TraceEvent:PayloadString(int,System.IFormatProvider):System.String:this
         -16 (-4.55% of base) : 153151.dasm - Microsoft.VisualBasic.Strings:FormatDateTime(System.DateTime,int):System.String
         -16 (-1.99% of base) : 131163.dasm - ObjectGraphFormatter:mapSetValueL(int,int,System.Type,System.Object):Microsoft.FSharp.Text.StructuredPrintfImpl.Layout:this
         -16 (-1.15% of base) : 131164.dasm - ObjectGraphFormatter:sequenceValueL(ShowMode,int,int,System.Collections.IEnumerable):Microsoft.FSharp.Text.StructuredPrintfImpl.Layout:this
         -16 (-2.30% of base) : 210187.dasm - System.Runtime.Caching.CacheExpires:EnableExpirationTimer(bool):this
         -12 (-1.29% of base) : 180039.dasm - <>c__DisplayClass0_0:<CompileSubtree>b__0(System.String):this
         -12 (-5.00% of base) : 177901.dasm - BenchmarkIteratorImpl:get_DoneIterating():bool:this
         -12 (-5.00% of base) : 81728.dasm - BigInteger:MulPow5(int):this
         -12 (-21.43% of base) : 218634.dasm - Crypto:DsaKeySize(Microsoft.Win32.SafeHandles.SafeDsaHandle):int
         -12 (-21.43% of base) : 217046.dasm - Crypto:DsaKeySize(Microsoft.Win32.SafeHandles.SafeDsaHandle):int

Top method regressions (percentages):
          32 ( 3.38% of base) : 63152.dasm - Microsoft.CodeAnalysis.Text.LargeEncodedText:Decode(System.IO.Stream,System.Text.Encoding,int,bool):Microsoft.CodeAnalysis.Text.SourceText
          20 ( 1.08% of base) : 81223.dasm - System.Xml.Schema.XsdDateTime:ToString():System.String:this
          12 ( 0.39% of base) : 76761.dasm - <ReadDataAsync>d__504:MoveNext():this
           4 ( 0.04% of base) : 204989.dasm - System.Formats.Asn1.AsnWriter:WriteGeneralizedTimeCore(System.Formats.Asn1.Asn1Tag,System.DateTimeOffset,bool):this

Top method improvements (percentages):
         -12 (-30.00% of base) : 163042.dasm - ErrorCollection:AddRevocationUnknown():this
         -12 (-30.00% of base) : 163037.dasm - ErrorCollection:ClearRevoked():this
         -12 (-30.00% of base) : 204836.dasm - System.Formats.Asn1.BMPEncoding:GetMaxCharCount(int):int:this
          -8 (-28.57% of base) : 153712.dasm - System.Net.MultiMemory:GetBlockIndex(int):int
         -12 (-27.27% of base) : 163038.dasm - ErrorCollection:IsRevoked():bool:this
         -12 (-25.00% of base) : 154863.dasm - Http2StreamWindowManager:get_StreamWindowThreshold():int:this
         -12 (-25.00% of base) : 217271.dasm - Internal.Cryptography.AsymmetricAlgorithmHelpers:BitsToBytes(int):int
         -12 (-25.00% of base) : 217218.dasm - Internal.Cryptography.RC2Implementation:GetPaddingSize():int:this
          -8 (-25.00% of base) : 75086.dasm - System.Xml.Ucs4Encoding:GetCharCount(System.Byte[]):int:this
         -12 (-25.00% of base) : 75085.dasm - System.Xml.Ucs4Encoding:GetMaxCharCount(int):int:this
         -12 (-23.08% of base) : 69586.dasm - System.Text.EncodingByteBuffer:get_CharsUsed():int:this
         -12 (-23.08% of base) : 75108.dasm - System.Xml.Ucs4Decoder:GetCharCount(System.Byte[],int,int):int:this
          -8 (-22.22% of base) : 153713.dasm - System.Net.MultiMemory:GetOffsetInBlock(int):int
         -12 (-21.43% of base) : 218634.dasm - Crypto:DsaKeySize(Microsoft.Win32.SafeHandles.SafeDsaHandle):int
         -12 (-21.43% of base) : 217046.dasm - Crypto:DsaKeySize(Microsoft.Win32.SafeHandles.SafeDsaHandle):int
         -12 (-20.00% of base) : 163039.dasm - ErrorCollection:HasCorruptRevocation():bool:this
          -8 (-20.00% of base) : 202180.dasm - System.Collections.BitArray:Div4Rem(int,byref):int
         -12 (-20.00% of base) : 170449.dasm - System.Data.Common.ADP:TimerToMilliseconds(long):long
         -12 (-20.00% of base) : 191626.dasm - System.IO.Compression.InputBuffer:get_AvailableBytes():int:this
          -8 (-20.00% of base) : 88035.dasm - System.Text.Json.BitStack:Div32Rem(int,byref):int

1125 total methods with Code Size differences (1121 improved, 4 regressed), 278 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 112410996 (overridden on cmd)
Total bytes of diff: 112387628 (overridden on cmd)
Total bytes of delta: -23368 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          40 : 136051.dasm (12.50% of base)
          40 : 136013.dasm (12.50% of base)
          40 : 106143.dasm (12.50% of base)
          40 : 191239.dasm (12.50% of base)
          40 : 106181.dasm (12.50% of base)
          40 : 38142.dasm (12.50% of base)
          40 : 38180.dasm (12.50% of base)
          40 : 191277.dasm (12.50% of base)
          36 : 267276.dasm (1.38% of base)
          20 : 160965.dasm (2.70% of base)
          20 : 160949.dasm (2.86% of base)
          20 : 160951.dasm (2.86% of base)
          16 : 248071.dasm (0.32% of base)
          16 : 160953.dasm (2.27% of base)
          16 : 160963.dasm (2.15% of base)
          16 : 160947.dasm (2.27% of base)
          16 : 160928.dasm (1.77% of base)
          12 : 242188.dasm (0.22% of base)
          12 : 196078.dasm (0.22% of base)
           8 : 266821.dasm (2.22% of base)

Top file improvements (bytes):
        -712 : 292858.dasm (-14.80% of base)
        -332 : 99292.dasm (-5.45% of base)
        -264 : 99300.dasm (-4.58% of base)
        -168 : 292859.dasm (-11.86% of base)
         -76 : 298343.dasm (-3.48% of base)
         -72 : 321808.dasm (-6.69% of base)
         -72 : 321814.dasm (-6.02% of base)
         -72 : 321815.dasm (-2.79% of base)
         -72 : 321844.dasm (-6.02% of base)
         -72 : 321845.dasm (-2.78% of base)
         -72 : 321769.dasm (-2.11% of base)
         -72 : 321785.dasm (-4.15% of base)
         -72 : 321790.dasm (-3.36% of base)
         -72 : 321801.dasm (-2.97% of base)
         -72 : 321737.dasm (-3.61% of base)
         -44 : 98277.dasm (-17.19% of base)
         -40 : 97999.dasm (-2.29% of base)
         -40 : 98002.dasm (-1.89% of base)
         -40 : 98003.dasm (-1.87% of base)
         -40 : 160686.dasm (-3.77% of base)

2747 total files with Code Size differences (2703 improved, 44 regressed), 932 unchanged.

Top method regressions (bytes):
          40 (12.50% of base) : 136013.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 106143.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 191239.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 38142.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 136051.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 106181.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 38180.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 191277.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          36 ( 1.38% of base) : 267276.dasm - System.IO.Ports.Tests.ReadBufferSize_Property:VerifyReadBufferSizeBeforeOpen(int):this
          20 ( 2.86% of base) : 160949.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenBy_Reversed(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          20 ( 2.86% of base) : 160951.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenByDescending(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          20 ( 2.70% of base) : 160965.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenByDescending_CustomComparer(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          16 ( 0.32% of base) : 248071.dasm - Microsoft.DotNet.RemoteExecutor.RemoteInvokeHandle:Dispose(bool):this
          16 ( 1.77% of base) : 160928.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:StableSort(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          16 ( 2.27% of base) : 160947.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenBy(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          16 ( 2.15% of base) : 160963.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenBy_CustomComparer(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          16 ( 2.27% of base) : 160953.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenByDescending_Reversed(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          12 ( 0.22% of base) : 242188.dasm - System.Data.SqlClient.TdsParser:TdsLogin(System.Data.SqlClient.SqlLogin,int,System.Data.SqlClient.SessionData,System.Nullable`1[FederatedAuthenticationFeatureExtensionData]):this
          12 ( 0.22% of base) : 196078.dasm - System.Data.SqlClient.TdsParser:TdsLogin(System.Data.SqlClient.SqlLogin,int,System.Data.SqlClient.SessionData,System.Nullable`1[FederatedAuthenticationFeatureExtensionData]):this
           8 ( 2.22% of base) : 266821.dasm - Legacy.Support.TestEventHandler`1[__Canon][System.__Canon]:WaitForEvent(int,int):bool:this

Top method improvements (bytes):
        -712 (-14.80% of base) : 292858.dasm - System.Xml.Tests.ToTypeTests:ToType43():int:this
        -332 (-5.45% of base) : 99292.dasm - System.Tests.TimeOnlyTests:AddTest()
        -264 (-4.58% of base) : 99300.dasm - System.Tests.TimeOnlyTests:BasicFormatParseTest()
        -168 (-11.86% of base) : 292859.dasm - System.Xml.Tests.ToTypeTests:ToType44():int:this
         -76 (-3.48% of base) : 298343.dasm - <PayloadShouldHaveSimilarSizeWhenSplitIntoSegments>d__18:MoveNext():this
         -72 (-3.61% of base) : 321737.dasm - Humanizer.Localisation.NumberToWords.BrazilianPortugueseNumberToWordsConverter:ConvertToOrdinal(int,int):System.String:this
         -72 (-2.11% of base) : 321769.dasm - Humanizer.Localisation.NumberToWords.FrenchNumberToWordsConverterBase:Convert(long,int):System.String:this
         -72 (-4.15% of base) : 321785.dasm - Humanizer.Localisation.NumberToWords.GermanNumberToWordsConverter:ConvertToOrdinal(int,int):System.String:this
         -72 (-3.36% of base) : 321790.dasm - Humanizer.Localisation.NumberToWords.HebrewNumberToWordsConverter:Convert(long,int):System.String:this
         -72 (-2.97% of base) : 321801.dasm - Humanizer.Localisation.NumberToWords.NorwegianBokmalNumberToWordsConverter:Convert(int,bool,int):System.String:this
         -72 (-6.69% of base) : 321808.dasm - Humanizer.Localisation.NumberToWords.PolishNumberToWordsConverter:Convert(long):System.String:this
         -72 (-6.02% of base) : 321814.dasm - Humanizer.Localisation.NumberToWords.RussianNumberToWordsConverter:Convert(long,int):System.String:this
         -72 (-2.79% of base) : 321815.dasm - Humanizer.Localisation.NumberToWords.RussianNumberToWordsConverter:ConvertToOrdinal(int,int):System.String:this
         -72 (-6.02% of base) : 321844.dasm - Humanizer.Localisation.NumberToWords.UkrainianNumberToWordsConverter:Convert(long,int):System.String:this
         -72 (-2.78% of base) : 321845.dasm - Humanizer.Localisation.NumberToWords.UkrainianNumberToWordsConverter:ConvertToOrdinal(int,int):System.String:this
         -44 (-17.19% of base) : 98277.dasm - System.Tests.DateTimeOffsetTests:FromUnixTimeSeconds(TestTime)
         -40 (-0.71% of base) : 298330.dasm - <Duplex>d__13:MoveNext():this
         -40 (-3.77% of base) : 160686.dasm - System.Linq.Parallel.Tests.GroupByTests:GroupBy_ElementSelector(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
         -40 (-1.89% of base) : 98002.dasm - System.Tests.DateOnlyTests:AddMonthsTest()
         -40 (-1.87% of base) : 98003.dasm - System.Tests.DateOnlyTests:AddYearsTest()

Top method regressions (percentages):
          40 (12.50% of base) : 136013.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 106143.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 191239.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 38142.dasm - <>c__DisplayClass29_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 136051.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 106181.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 38180.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          40 (12.50% of base) : 191277.dasm - <>c__DisplayClass45_0[__Canon][System.__Canon]:<IEnumerable_Generic_Enumerator_Reset_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[__Canon]):this
          20 ( 2.86% of base) : 160949.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenBy_Reversed(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          20 ( 2.86% of base) : 160951.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenByDescending(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          20 ( 2.70% of base) : 160965.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenByDescending_CustomComparer(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          16 ( 2.27% of base) : 160947.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenBy(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          16 ( 2.27% of base) : 160953.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenByDescending_Reversed(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
           8 ( 2.22% of base) : 266821.dasm - Legacy.Support.TestEventHandler`1[__Canon][System.__Canon]:WaitForEvent(int,int):bool:this
           8 ( 2.22% of base) : 266835.dasm - Legacy.Support.TestEventHandler`1[Byte][System.Byte]:WaitForEvent(int,int):bool:this
          16 ( 2.15% of base) : 160963.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:ThenBy_CustomComparer(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          16 ( 1.77% of base) : 160928.dasm - System.Linq.Parallel.Tests.OrderByThenByTests:StableSort(System.Linq.Parallel.Tests.Labeled`1[[System.Linq.ParallelQuery`1[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Linq.Parallel, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int)
          36 ( 1.38% of base) : 267276.dasm - System.IO.Ports.Tests.ReadBufferSize_Property:VerifyReadBufferSizeBeforeOpen(int):this
           4 ( 1.28% of base) : 136014.dasm - <>c__DisplayClass29_0[Byte][System.Byte]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[Byte]):this
           4 ( 1.28% of base) : 106144.dasm - <>c__DisplayClass29_0[Byte][System.Byte]:<IEnumerable_Generic_Enumerator_MoveNext_ModifiedDuringEnumeration_Succeeds>b__0(ModifyEnumerable[Byte]):this

Top method improvements (percentages):
         -12 (-30.00% of base) : 161462.dasm - <>c:<Distinct_Unordered>b__264_0(int):int:this
         -12 (-30.00% of base) : 196928.dasm - SqlUnicodeDecoder:GetCharCount(System.Byte[],int,int):int:this
          -8 (-28.57% of base) : 86940.dasm - System.Net.MultiMemory:GetBlockIndex(int):int
         -12 (-27.27% of base) : 161467.dasm - <>c:<BinaryOperators>b__251_4(int,int):int:this
         -12 (-27.27% of base) : 161463.dasm - <>c:<GroupBy_Unordered>b__269_0(int):int:this
         -12 (-27.27% of base) : 163097.dasm - <>c:<Join_InnerJoin_Ordered>b__33_0(int):int:this
         -12 (-27.27% of base) : 52945.dasm - PooledStream:GetChunkIndex(long):int
         -12 (-27.27% of base) : 56241.dasm - VArray:get_Offset():int:this
         -12 (-25.00% of base) : 52943.dasm - PooledStream:get_CurrentChunkIndex():int:this
         -12 (-25.00% of base) : 36362.dasm - System.Collections.Tests.BadIntEqualityComparer:GetHashCode(int):int:this
         -12 (-25.00% of base) : 207992.dasm - System.Security.Cryptography.Dsa.Tests.DsaSpanSignatureFormatTests:GetExpectedSize(int):int
         -12 (-23.08% of base) : 102356.dasm - <>c:<Find>b__102_2(int):bool:this
         -12 (-23.08% of base) : 16968.dasm - <>c:<GetBatteryTextEncoder>b__0_0(int):bool:this
         -12 (-23.08% of base) : 162934.dasm - <>c:<GroupBy_Unordered>b__1_0(int):int:this
         -12 (-23.08% of base) : 162976.dasm - <>c:<GroupJoin_CustomComparator_LeftWithOrderingColisions>b__23_2(int):int:this
         -12 (-23.08% of base) : 171625.dasm - <>c:<PredicateManyFalseOnSecondIndex>b__10_0(int,int):bool:this
         -12 (-23.08% of base) : 171990.dasm - <>c:<SourceEmptyIndexedPredicate>b__70_0(int,int):bool:this
         -12 (-23.08% of base) : 164151.dasm - <>c__DisplayClass4_0:<Where_Unordered_NotPipelined>b__1(int):this
         -12 (-23.08% of base) : 52946.dasm - PooledStream:GetChunkOffset(long):int
         -12 (-23.08% of base) : 168285.dasm - System.Linq.Tests.EnumerableTests:IsEven(int):bool

2747 total methods with Code Size differences (2703 improved, 44 regressed), 932 unchanged.

```

</details>

--------------------------------------------------------------------------------



There is a separate issue for such unreachable useless basic blocks with BBF_DONT_REMOVE, but it still makes sense to avoid emitting them where they definitely not needed.