### PR TITLE
fix rid processing on macOS

### DIFF
--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -595,7 +595,7 @@ pal::string_t pal::get_current_os_rid_platform()
             }
             else
             {
-                // for 10.x the significant relases are actully the second digit
+                // for 10.x the significant releases are actually the second digit
                 pos = strchr(pos + 1, '.');
 
                 if (pos != NULL)

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -587,7 +587,7 @@ pal::string_t pal::get_current_os_rid_platform()
                 *pos = 0;
 
             }
-            else if (major == 11)
+            else if (major == 12)
             {
                 // for 11.x we publish RID as 11.0
                 // if wwe return anytrhing else, it would brek the graph porocessing
@@ -602,7 +602,6 @@ pal::string_t pal::get_current_os_rid_platform()
                 {
                     // strip anything after second dot and return something like 10.5
                     *pos = 0;
-                    size = pos - str - 1;
                 }
             }
         }

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -590,7 +590,7 @@ pal::string_t pal::get_current_os_rid_platform()
             else if (major == 11)
             {
                 // for 11.x we publish RID as 11.0
-                // if wwe return anytrhing else, it would brek the graph porocessing
+                // if we return anything else, it would break the RID graph processing
                 strcpy(str, "11.0");
             }
             else

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -570,26 +570,44 @@ pal::string_t pal::get_current_os_rid_platform()
     char str[256];
     size_t size = sizeof(str);
 
-    // returns something like 10.5.2
+    // returns something like 10.5.2 or 11.6
     int ret = sysctlbyname("kern.osproductversion", str, &size, nullptr, 0);
     if (ret == 0)
     {
         // the value _should_ be null terminated but let's make sure
         str[size - 1] = 0;
+
         char* pos = strchr(str, '.');
         if (pos != NULL)
         {
-            pos = strchr(pos + 1, '.');
-
-            if (pos != NULL)
+            int major = atoi(str);
+            if (major > 11)
             {
-                // strip anything after second dot and return something like 10.5
+                // starting with 12.0 we track only major release
                 *pos = 0;
-                size = pos - str;
+
+            }
+            else if (major == 11)
+            {
+                // for 11.x we publish RID as 11.0
+                // if wwe return anytrhing else, it would brek the graph porocessing
+                strcpy(str, "11.0");
+            }
+            else
+            {
+                // for 10.x the significant relases are actully the second digit
+                pos = strchr(pos + 1, '.');
+
+                if (pos != NULL)
+                {
+                    // strip anything after second dot and return something like 10.5
+                    *pos = 0;
+                    size = pos - str - 1;
+                }
             }
         }
 
-        std::string release(str, size);
+        std::string release(str, strlen(str));
         ridOS.append(_X("osx."));
         ridOS.append(release);
     }


### PR DESCRIPTION
 #59066 made some changes how we calculate RID on macOS and it was not quite right. 

The test was failing because there was embedded '\0'. So even if we add the architecture, that would be stripped with `.c_str`. It actually worked for `11.2.3` I started with but failed on `11.2` (no real ARM dependency IMHO)

There is still another problem. The way how the old code was written we would always return `osx.11.0` from `get_current_os_rid_platform` even for 11.6. That does not break the test but then when we walk the graph we would end up with generic `osx-arm64`. So to maintain compatibility, I added special processing for 11.x (and verified with dotnet --info)

For 12.0+ the rid will be `osx.12-arm64` and that match `<Versions>10.10;10.11;10.12;10.13;10.14;10.15;10.16;11.0;12</Versions>`

fixes #60341