### PR TITLE
[release/6.0][wasm] Fix publishing *blazorwasm* project with lazy loaded assembly

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,7 +163,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.100-rtm.21480.21</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>6.0.100-rtm.21515.27</SdkVersionForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20210916.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/src/libraries/workloads-testing.targets
+++ b/src/libraries/workloads-testing.targets
@@ -16,7 +16,6 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(_SourceFiles)" DestinationFolder="$(SdkWithWorkloadForTestingPath)\%(_SourceFiles.RecursiveDir)" />
-    <Copy SourceFiles="$(MonoProjectRoot)\wasm\BlazorOverwrite.targets" DestinationFiles="$(SdkWithWorkloadForTestingPath)\sdk\$(SdkVersionForWorkloadTesting)\Sdks\Microsoft.NET.Sdk.BlazorWebAssembly\targets\Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets" />
 
     <WriteLinesToFile File="$(SdkWithWorkloadStampPath)" Lines="" Overwrite="true" />
   </Target>
@@ -41,7 +40,6 @@
     <Exec Condition="$([MSBuild]::IsOSPlatform('windows'))"
           Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(SdkWithNoWorkloadForTestingPath) -Version $(SdkVersionForWorkloadTesting)"' />
 
-    <Copy SourceFiles="$(MonoProjectRoot)\wasm\BlazorOverwrite.targets" DestinationFiles="$(SdkWithNoWorkloadForTestingPath)\sdk\$(SdkVersionForWorkloadTesting)\Sdks\Microsoft.NET.Sdk.BlazorWebAssembly\targets\Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets" />
     <WriteLinesToFile File="$(SdkWithNoWorkloadStampPath)" Lines="" Overwrite="true" />
   </Target>
 

--- a/src/libraries/workloads-testing.targets
+++ b/src/libraries/workloads-testing.targets
@@ -16,6 +16,7 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(_SourceFiles)" DestinationFolder="$(SdkWithWorkloadForTestingPath)\%(_SourceFiles.RecursiveDir)" />
+    <Copy SourceFiles="$(MonoProjectRoot)\wasm\BlazorOverwrite.targets" DestinationFiles="$(SdkWithWorkloadForTestingPath)\sdk\$(SdkVersionForWorkloadTesting)\Sdks\Microsoft.NET.Sdk.BlazorWebAssembly\targets\Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets" />
 
     <WriteLinesToFile File="$(SdkWithWorkloadStampPath)" Lines="" Overwrite="true" />
   </Target>
@@ -40,6 +41,7 @@
     <Exec Condition="$([MSBuild]::IsOSPlatform('windows'))"
           Command='powershell -ExecutionPolicy ByPass -NoProfile -command "&amp; $(_DotNetInstallScriptPath) -InstallDir $(SdkWithNoWorkloadForTestingPath) -Version $(SdkVersionForWorkloadTesting)"' />
 
+    <Copy SourceFiles="$(MonoProjectRoot)\wasm\BlazorOverwrite.targets" DestinationFiles="$(SdkWithNoWorkloadForTestingPath)\sdk\$(SdkVersionForWorkloadTesting)\Sdks\Microsoft.NET.Sdk.BlazorWebAssembly\targets\Microsoft.NET.Sdk.BlazorWebAssembly.6_0.targets" />
     <WriteLinesToFile File="$(SdkWithNoWorkloadStampPath)" Lines="" Overwrite="true" />
   </Target>
 

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -91,7 +91,7 @@
     <WasmBuildAppAfterThisTarget Condition="'$(WasmBuildAppAfterThisTarget)' == '' and '$(DisableAutoWasmBuildApp)' != 'true'">Build</WasmBuildAppAfterThisTarget>
 
     <WasmTriggerPublishAppAfterThisTarget Condition="'$(DisableAutoWasmPublishApp)' != 'true' and '$(WasmBuildingForNestedPublish)' != 'true'">Publish</WasmTriggerPublishAppAfterThisTarget>
-    <_WasmNestedPublishAppPreTarget Condition="'$(DisableAutoWasmPublishApp)' != 'true'">Publish</_WasmNestedPublishAppPreTarget>
+    <WasmNestedPublishAppPreTarget Condition="'$(WasmNestedPublishAppPreTarget)' == '' and '$(DisableAutoWasmPublishApp)' != 'true'">Publish</WasmNestedPublishAppPreTarget>
 
     <EnableDefaultWasmAssembliesToBundle Condition="'$(EnableDefaultWasmAssembliesToBundle)' == ''">true</EnableDefaultWasmAssembliesToBundle>
     <WasmBuildOnlyAfterPublish Condition="'$(WasmBuildOnlyAfterPublish)' == '' and '$(DeployOnBuild)' == 'true'">true</WasmBuildOnlyAfterPublish>
@@ -123,7 +123,7 @@
 
   <!-- Public target. Do not depend on this target, as it is meant to be run by a msbuild task -->
   <Target Name="WasmNestedPublishApp"
-          DependsOnTargets="ResolveRuntimePackAssets;$(_WasmNestedPublishAppPreTarget);$(WasmNestedPublishAppDependsOn)"
+          DependsOnTargets="ResolveRuntimePackAssets;$(WasmNestedPublishAppPreTarget);$(WasmNestedPublishAppDependsOn)"
           Condition="'$(WasmBuildingForNestedPublish)' == 'true'"
           Returns="@(WasmNativeAsset);@(WasmAssembliesFinal);@(FileWrites)">
 

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
@@ -3,9 +3,11 @@
 
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 #nullable enable
 
@@ -223,6 +225,57 @@ namespace Wasm.Build.Tests
                 Assert.True(Regex.IsMatch(pinvokeTableHContents, pattern),
                                 $"Could not find {pattern} in {pinvokeTableHPath}");
             }
+        }
+
+        [ConditionalFact(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        public void BugRegression_60479_WithRazorClassLib()
+        {
+            string id = "blz_razor_lib_top";
+
+            InitBlazorWasmProjectDir(id);
+
+            string wasmProjectDir = Path.Combine(_projectDir!, "wasm");
+            string wasmProjectFile = Path.Combine(wasmProjectDir, "wasm.csproj");
+            Directory.CreateDirectory(wasmProjectDir);
+            new DotNetCommand(s_buildEnv, useDefaultArgs: false)
+                    .WithWorkingDirectory(wasmProjectDir)
+                    .ExecuteWithCapturedOutput("new blazorwasm")
+                    .EnsureSuccessful();
+
+
+            string razorProjectDir = Path.Combine(_projectDir!, "RazorClassLibrary");
+            Directory.CreateDirectory(razorProjectDir);
+            new DotNetCommand(s_buildEnv, useDefaultArgs: false)
+                    .WithWorkingDirectory(razorProjectDir)
+                    .ExecuteWithCapturedOutput("new razorclasslib")
+                    .EnsureSuccessful();
+
+            AddItemsPropertiesToProject(wasmProjectFile, extraItems:@"
+                <ProjectReference Include=""..\RazorClassLibrary\RazorClassLibrary.csproj"" />
+                <BlazorWebAssemblyLazyLoad Include=""RazorClassLibrary.dll"" />
+            ");
+
+            _projectDir = wasmProjectDir;
+            string config = "Release";
+            // No relinking, no AOT
+            BlazorBuild(id, config, NativeFilesType.FromRuntimePack);
+
+            // will relink
+            BlazorPublish(id, config, NativeFilesType.Relinked);
+
+            // publish/wwwroot/_framework/blazor.boot.json
+            string frameworkDir = FindBlazorBinFrameworkDir(config, forPublish: true);
+            string bootJson = Path.Combine(frameworkDir, "blazor.boot.json");
+
+            Assert.True(File.Exists(bootJson), $"Could not find {bootJson}");
+            var jdoc = JsonDocument.Parse(File.ReadAllText(bootJson));
+            if (!jdoc.RootElement.TryGetProperty("resources", out JsonElement resValue) ||
+                !resValue.TryGetProperty("lazyAssembly", out JsonElement lazyVal))
+            {
+                throw new XunitException($"Could not find resources.lazyAssembly object in {bootJson}");
+            }
+
+            Assert.Contains("RazorClassLibrary.dll", lazyVal.EnumerateObject().Select(jp => jp.Name));
         }
 
         private string CreateProjectWithNativeReference(string id)


### PR DESCRIPTION
Fixes a user reported issue - https://github.com/dotnet/runtime/issues/60479

## Customer Impact

This fixes the  blazorwasm projects that use lazy loaded assemblies, when the `wasm-tools` workload is installed.

## Testing

Some manual testing, manually running blazor/sdk tests with the workload, and a new unit test.

## Risk

Medium.