### PR TITLE
Fix for Ctor_Brush_Width test on Non-English Windows

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/PenTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/PenTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing.Drawing2D;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -38,10 +39,15 @@ namespace System.Drawing.Tests
                 yield return new object[] { data[0], 10, data[1] };
             }
 
-            yield return new object[] { new SolidBrush(Color.Red), 0, PenType.SolidColor };
-            yield return new object[] { new SolidBrush(Color.Red), -1, PenType.SolidColor };
+            // Issue on Non-English Windows with brush width < 1. See https://github.com/dotnet/runtime/issues/60480
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT || CultureInfo.InstalledUICulture.TwoLetterISOLanguageName == "en")
+            {
+                yield return new object[] { new SolidBrush(Color.Red), 0, PenType.SolidColor };
+                yield return new object[] { new SolidBrush(Color.Red), -1, PenType.SolidColor };
+                yield return new object[] { new SolidBrush(Color.Red), float.NegativeInfinity, PenType.SolidColor };
+            }
+
             yield return new object[] { new SolidBrush(Color.Red), float.PositiveInfinity, PenType.SolidColor };
-            yield return new object[] { new SolidBrush(Color.Red), float.NegativeInfinity, PenType.SolidColor };
             yield return new object[] { new SolidBrush(Color.Red), float.NaN, PenType.SolidColor };
             yield return new object[] { new SolidBrush(Color.Red), float.MaxValue, PenType.SolidColor };
         }


### PR DESCRIPTION
Fix for https://github.com/dotnet/runtime/issues/60480 issue