### PR TITLE
[wasm] encapsulate emscripten js runtime

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -221,6 +221,8 @@
     <PlatformManifestFileEntry Include="runtime.iffe.js" IsNative="true" />
     <PlatformManifestFileEntry Include="dotnet.d.ts" IsNative="true" />
     <PlatformManifestFileEntry Include="library-dotnet.js" IsNative="true" />
+    <PlatformManifestFileEntry Include="modularize-dotnet.pre.js" IsNative="true" />
+    <PlatformManifestFileEntry Include="modularize-dotnet.post.js" IsNative="true" />
     <PlatformManifestFileEntry Include="pal_random.js" IsNative="true" />
     <PlatformManifestFileEntry Include="corebindings.c" IsNative="true" />
     <PlatformManifestFileEntry Include="driver.c" IsNative="true" />

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -98,7 +98,7 @@ internal static partial class Interop
         {
         }
 
-        // Called by the AOT profiler to save profile data into INTERNAL.aot_profile_data
+        // Called by the AOT profiler to save profile data into Module.INTERNAL.aot_profile_data
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static unsafe void DumpAotProfileData(ref byte buf, int len, string extraArg)
         {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -283,7 +283,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (200);
             ");
 
@@ -295,7 +295,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intPtrValue = IntPtr.Zero;
             Runtime.InvokeJS(@$"
-                var invoke_int_ptr = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeIntPtr"");
+                var invoke_int_ptr = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeIntPtr"");
                 invoke_int_ptr (42);
             ");
             Assert.Equal(42, (int)HelperMarshal._intPtrValue);
@@ -306,7 +306,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._marshaledIntPtrValue = IntPtr.Zero;
             Runtime.InvokeJS(@$"
-                var invokeMarshalIntPtr = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeMarshalIntPtr"");
+                var invokeMarshalIntPtr = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeMarshalIntPtr"");
                 var r = invokeMarshalIntPtr ();
 
                 if (r != 42) throw `Invalid int_ptr value`;
@@ -319,7 +319,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                INTERNAL.call_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"", [ 300 ]);
+                Module.INTERNAL.call_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"", [ 300 ]);
             ");
 
             Assert.Equal(300, HelperMarshal._intValue);
@@ -330,7 +330,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_method_resolve (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_method_resolve (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 App.call_test_method (""InvokeInt"", [ invoke_int ]);
             ");
 
@@ -629,7 +629,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             HelperMarshal._intValue = 1;
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int ();
             ");
             Assert.Equal(0, HelperMarshal._intValue);
@@ -640,7 +640,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (200, 400);
             ");
             Assert.Equal(200, HelperMarshal._intValue);
@@ -654,13 +654,13 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (""200"");
             ");
             Assert.Equal(200, HelperMarshal._intValue);
 
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (400.5);
             ");
             Assert.Equal(400, HelperMarshal._intValue);
@@ -671,14 +671,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 100;
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (""hello"");
             ");
             Assert.Equal(0, HelperMarshal._intValue);
 
             // In this case at the very least, the leading "7" is not turned into the number 7
             Runtime.InvokeJS(@$"
-                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (""7apples"");
             ");
             Assert.Equal(0, HelperMarshal._intValue);
@@ -689,7 +689,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._uintValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_uint = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
+                var invoke_uint = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
                 invoke_uint (0xFFFFFFFE);
             ");
 
@@ -702,9 +702,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._uintValue = 0;
             HelperMarshal._enumValue = TestEnum.BigValue;
             Runtime.InvokeJS(@$"
-                var get_value = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetEnumValue"");
+                var get_value = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetEnumValue"");
                 var e = get_value ();
-                var invoke_uint = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
+                var invoke_uint = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
                 invoke_uint (e);
             ");
             Assert.Equal((uint)TestEnum.BigValue, HelperMarshal._uintValue);
@@ -715,7 +715,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._enumValue = TestEnum.Zero;
             Runtime.InvokeJS(@$"
-                var set_enum = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
+                var set_enum = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
                 set_enum (0xFFFFFFFE);
             ");
             Assert.Equal(TestEnum.BigValue, HelperMarshal._enumValue);
@@ -728,7 +728,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             // HACK: We're explicitly telling the bindings layer to pass an int here, not an enum
             // Because we know the enum is : uint, this is compatible, so it works.
             Runtime.InvokeJS(@$"
-                var set_enum = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""i"");
+                var set_enum = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""i"");
                 set_enum (0xFFFFFFFE);
             ");
             Assert.Equal(TestEnum.BigValue, HelperMarshal._enumValue);
@@ -740,7 +740,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._enumValue = TestEnum.Zero;
             var exc = Assert.Throws<JSException>( () => 
                 Runtime.InvokeJS(@$"
-                    var set_enum = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
+                    var set_enum = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
                     set_enum (""BigValue"");
                 ")
             );
@@ -752,7 +752,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             var exc = Assert.Throws<JSException>( () => 
                 Runtime.InvokeJS(@$"
-                    var get_u64 = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetUInt64"", """");
+                    var get_u64 = Module.INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetUInt64"", """");
                     var u64 = get_u64();
                 ")
             );
@@ -806,7 +806,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
             Runtime.InvokeJS(@"
-                var sym = INTERNAL.mono_intern_string(""interned string 3"");
+                var sym = Module.INTERNAL.mono_intern_string(""interned string 3"");
                 App.call_test_method (""InvokeString"", [ sym ], ""s"");
                 App.call_test_method (""InvokeString2"", [ sym ], ""s"");
             ");
@@ -823,7 +823,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var s = ""long interned string"";
                 for (var i = 0; i < 1024; i++)
                     s += String(i % 10);
-                var sym = INTERNAL.mono_intern_string(s);
+                var sym = Module.INTERNAL.mono_intern_string(s);
                 App.call_test_method (""InvokeString"", [ sym ], ""S"");
                 App.call_test_method (""InvokeString2"", [ sym ], ""s"");
             ");
@@ -837,7 +837,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._stringResource = null;
             Runtime.InvokeJS(@"
                 for (var i = 0; i < 10240; i++)
-                    INTERNAL.mono_intern_string('s' + i);
+                    Module.INTERNAL.mono_intern_string('s' + i);
                 App.call_test_method (""InvokeString"", [ 's5000' ], ""S"");
             ");
             Assert.Equal("s5000", HelperMarshal._stringResource);
@@ -864,8 +864,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
             var fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:StoreArgumentAndReturnLiteral";
             Runtime.InvokeJS(
-                $"var a = INTERNAL.mono_bind_static_method('{fqn}')('test');\r\n" +
-                $"var b = INTERNAL.mono_bind_static_method('{fqn}')(a);\r\n" +
+                $"var a = Module.INTERNAL.mono_bind_static_method('{fqn}')('test');\r\n" +
+                $"var b = Module.INTERNAL.mono_bind_static_method('{fqn}')(a);\r\n" +
                 "App.call_test_method ('InvokeString2', [ b ]);"
             );
             Assert.Equal("s: 1 length: 1", HelperMarshal._stringResource);

--- a/src/mono/sample/mbr/browser/index.html
+++ b/src/mono/sample/mbr/browser/index.html
@@ -2,37 +2,40 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. -->
 <!-- The .NET Foundation licenses this file to you under the MIT license. -->
 <html>
-  <head>
-    <title>TESTS</title>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  </head>
-  <body>
-    <h3 id="header">Wasm Browser Sample</h3>
-    Result from Sample.Test.TestMeaning: <span id="out"></span>
-    <div>
-      Click here (upto 2 times): <button id="update">Update</button>
-    </div>
-    <script type='text/javascript'>
-      var App = {
-        init: function () {
-	  var outElement = document.getElementById("out");
-          document.getElementById("update").addEventListener("click", function () {
-	    INTERNAL.call_static_method("[WasmDelta] Sample.Test:Update", []);
-	    console.log ("applied update");
-	    var ret = INTERNAL.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
-	    outElement.innerHTML = ret;
-	  })
-          var ret = INTERNAL.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
-	  outElement.innerHTML = ret;
-          console.log ("ready");
-        },
-      };
-    </script>
-    <script type="text/javascript" src="runtime.js"></script>
 
-    <script defer src="dotnet.js"></script>
+<head>
+  <title>TESTS</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+
+<body>
+  <h3 id="header">Wasm Browser Sample</h3>
+  Result from Sample.Test.TestMeaning: <span id="out"></span>
+  <div>
+    Click here (upto 2 times): <button id="update">Update</button>
+  </div>
+  <script type='text/javascript'>
+    var App = {
+      init: function () {
+        var outElement = document.getElementById("out");
+        document.getElementById("update").addEventListener("click", function () {
+          Module.INTERNAL.call_static_method("[WasmDelta] Sample.Test:Update", []);
+          console.log("applied update");
+          var ret = Module.INTERNAL.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
+          outElement.innerHTML = ret;
+        })
+        var ret = Module.INTERNAL.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
+        outElement.innerHTML = ret;
+        console.log("ready");
+      },
+    };
+  </script>
+  <script type="text/javascript" src="runtime.js"></script>
+
+  <script defer src="dotnet.js"></script>
 
 
-  </body>
+</body>
+
 </html>

--- a/src/mono/sample/mbr/browser/runtime.js
+++ b/src/mono/sample/mbr/browser/runtime.js
@@ -3,29 +3,30 @@
 
 "use strict";
 var Module = {
+    no_global_exports: true,
     config: null,
 
     preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+        await Module.MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
+        if (!Module.MONO.config || Module.MONO.config.error) {
             console.log("An error occured while loading the config file");
             return;
         }
 
-        MONO.config.loaded_cb = function () {
+        Module.MONO.config.loaded_cb = function () {
             App.init();
         };
-        MONO.config.environment_variables = {
+        Module.MONO.config.environment_variables = {
             "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
         };
-        MONO.config.fetch_file_cb = function (asset) {
+        Module.MONO.config.fetch_file_cb = function (asset) {
             return fetch(asset, { credentials: 'same-origin' });
         }
 
-        MONO.mono_load_runtime_and_bcl_args(MONO.config);
+        Module.MONO.mono_load_runtime_and_bcl_args(Module.MONO.config);
     },
 };

--- a/src/mono/sample/wasm/browser-bench/index.html
+++ b/src/mono/sample/wasm/browser-bench/index.html
@@ -2,64 +2,66 @@
 <!--  Licensed to the .NET Foundation under one or more agreements. -->
 <!-- The .NET Foundation licenses this file to you under the MIT license. -->
 <html>
-  <head>
-    <title>TESTS</title>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  </head>
-  <body onload="onLoad()">
-    <h3 id="header">Wasm Browser Sample - Simple Benchmark</h3>
-    Output:<br><br> <span id="out"></span>
-    <script type='text/javascript'>
-      var is_testing = false;
-      var tasks = '';
-      var onLoad = function() {
-        var url = new URL(decodeURI(window.location));
-        let args = url.searchParams.getAll('arg');
-        is_testing = args !== undefined && (args.find(arg => arg == '--testing') !== undefined);
-        tasks = url.searchParams.getAll('task');
-      };
 
-      var test_exit = function(exit_code)
-      {
-        if (!is_testing) {
-          console.log(`test_exit: ${exit_code}`);
-          return;
-        }
+<head>
+  <title>TESTS</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
 
-        /* Set result in a tests_done element, to be read by xharness */
-        var tests_done_elem = document.createElement("label");
-        tests_done_elem.id = "tests_done";
-        tests_done_elem.innerHTML = exit_code.toString();
-        document.body.appendChild(tests_done_elem);
+<body onload="onLoad()">
+  <h3 id="header">Wasm Browser Sample - Simple Benchmark</h3>
+  Output:<br><br> <span id="out"></span>
+  <script type='text/javascript'>
+    var is_testing = false;
+    var tasks = '';
+    var onLoad = function () {
+      var url = new URL(decodeURI(window.location));
+      let args = url.searchParams.getAll('arg');
+      is_testing = args !== undefined && (args.find(arg => arg == '--testing') !== undefined);
+      tasks = url.searchParams.getAll('task');
+    };
 
-        console.log(`WASM EXIT ${exit_code}`);
-      };
-
-      function yieldBench () {
-        let promise = INTERNAL.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:RunBenchmark", []);
-        promise.then(ret => {
-          document.getElementById("out").innerHTML += ret;
-          if (ret.length > 0) {
-              document.getElementById("out").innerHTML += "<br>";
-              setTimeout(function () { yieldBench(); }, 0);
-          } else {
-              document.getElementById("out").innerHTML += "<br>Finished";
-          }
-        });
+    var test_exit = function (exit_code) {
+      if (!is_testing) {
+        console.log(`test_exit: ${exit_code}`);
+        return;
       }
 
-      var App = {
-        init: function () {
-          if (tasks != '')
-            INTERNAL.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:SetTasks", tasks);
-          yieldBench ();
+      /* Set result in a tests_done element, to be read by xharness */
+      var tests_done_elem = document.createElement("label");
+      tests_done_elem.id = "tests_done";
+      tests_done_elem.innerHTML = exit_code.toString();
+      document.body.appendChild(tests_done_elem);
+
+      console.log(`WASM EXIT ${exit_code}`);
+    };
+
+    function yieldBench() {
+      let promise = Module.INTERNAL.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:RunBenchmark", []);
+      promise.then(ret => {
+        document.getElementById("out").innerHTML += ret;
+        if (ret.length > 0) {
+          document.getElementById("out").innerHTML += "<br>";
+          setTimeout(function () { yieldBench(); }, 0);
+        } else {
+          document.getElementById("out").innerHTML += "<br>Finished";
         }
-      };
-    </script>
-    <script type="text/javascript" src="runtime.js"></script>
+      });
+    }
 
-    <script defer src="dotnet.js"></script>
+    var App = {
+      init: function () {
+        if (tasks != '')
+          Module.INTERNAL.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:SetTasks", tasks);
+        yieldBench();
+      }
+    };
+  </script>
+  <script type="text/javascript" src="runtime.js"></script>
 
-  </body>
+  <script defer src="dotnet.js"></script>
+
+</body>
+
 </html>

--- a/src/mono/sample/wasm/browser-bench/runtime.js
+++ b/src/mono/sample/wasm/browser-bench/runtime.js
@@ -3,20 +3,21 @@
 
 "use strict";
 var Module = {
+    no_global_exports: true,
     config: null,
 
     preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+        await Module.MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
+        if (!Module.MONO.config || Module.MONO.config.error) {
             console.log("An error occured while loading the config file");
             return;
         }
 
-        MONO.config.loaded_cb = function () {
+        Module.MONO.config.loaded_cb = function () {
             try {
                 App.init();
             } catch (error) {
@@ -24,19 +25,19 @@ var Module = {
                 throw (error);
             }
         };
-        MONO.config.fetch_file_cb = function (asset) {
+        Module.MONO.config.fetch_file_cb = function (asset) {
             return fetch(asset, { credentials: 'same-origin' });
         }
 
-        if (MONO.config.enable_profiler) {
-            MONO.config.aot_profiler_options = {
+        if (Module.MONO.config.enable_profiler) {
+            Module.MONO.config.aot_profiler_options = {
                 write_at: "Sample.Test::StopProfile",
                 send_to: "System.Runtime.InteropServices.JavaScript.Runtime::DumpAotProfileData"
             }
         }
 
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            Module.MONO.mono_load_runtime_and_bcl_args(Module.MONO.config);
         } catch (error) {
             test_exit(1);
             throw (error);

--- a/src/mono/sample/wasm/browser-profile/runtime.js
+++ b/src/mono/sample/wasm/browser-profile/runtime.js
@@ -3,21 +3,22 @@
 
 "use strict";
 var Module = {
+    no_global_exports: true,
     is_testing: false,
     config: null,
 
     preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+        await Module.MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
+        if (!Module.MONO.config || Module.MONO.config.error) {
             console.log("An error occured while loading the config file");
             return;
         }
 
-        MONO.config.loaded_cb = function () {
+        Module.MONO.config.loaded_cb = function () {
             try {
                 Module.init();
             } catch (error) {
@@ -25,19 +26,19 @@ var Module = {
                 throw (error);
             }
         };
-        MONO.config.fetch_file_cb = function (asset) {
+        Module.MONO.config.fetch_file_cb = function (asset) {
             return fetch(asset, { credentials: 'same-origin' });
         }
 
-        if (MONO.config.enable_profiler) {
-            MONO.config.aot_profiler_options = {
+        if (Module.MONO.config.enable_profiler) {
+            Module.MONO.config.aot_profiler_options = {
                 write_at: "Sample.Test::StopProfile",
                 send_to: "System.Runtime.InteropServices.JavaScript.Runtime::DumpAotProfileData"
             }
         }
 
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            Module.MONO.mono_load_runtime_and_bcl_args(Module.MONO.config);
         } catch (error) {
             Module.test_exit(1);
             throw (error);
@@ -46,7 +47,7 @@ var Module = {
 
     init: function () {
         console.log("not ready yet")
-        const ret = INTERNAL.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:TestMeaning", []);
+        const ret = Module.INTERNAL.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:TestMeaning", []);
         document.getElementById("out").innerHTML = ret;
         console.log("ready");
 
@@ -56,8 +57,8 @@ var Module = {
             Module.test_exit(exit_code);
         }
 
-        if (MONO.config.enable_profiler) {
-            INTERNAL.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:StopProfile", []);
+        if (Module.MONO.config.enable_profiler) {
+            Module.INTERNAL.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:StopProfile", []);
             Module.saveProfile();
         }
     },
@@ -85,7 +86,7 @@ var Module = {
 
     saveProfile: function () {
         const a = document.createElement('a');
-        const blob = new Blob([INTERNAL.aot_profile_data]);
+        const blob = new Blob([Module.INTERNAL.aot_profile_data]);
         a.href = URL.createObjectURL(blob);
         a.download = "data.aotprofile";
         // Append anchor to body.

--- a/src/mono/sample/wasm/browser/index.html
+++ b/src/mono/sample/wasm/browser/index.html
@@ -36,7 +36,7 @@
 
       var App = {
         init: function () {
-          var ret = INTERNAL.call_static_method("[Wasm.Browser.Sample] Sample.Test:TestMeaning", []);
+          var ret = Module.INTERNAL.call_static_method("[Wasm.Browser.Sample] Sample.Test:TestMeaning", []);
           document.getElementById("out").innerHTML = ret;
 
           if (is_testing)

--- a/src/mono/sample/wasm/browser/runtime.js
+++ b/src/mono/sample/wasm/browser/runtime.js
@@ -3,21 +3,21 @@
 
 "use strict";
 var Module = {
-
+    no_global_exports: true,
     config: null,
 
     preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+        await Module.MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
+        if (!Module.MONO.config || Module.MONO.config.error) {
             console.log("No config found");
             return;
         }
 
-        MONO.config.loaded_cb = function () {
+        Module.MONO.config.loaded_cb = function () {
             try {
                 App.init();
             } catch (error) {
@@ -25,12 +25,12 @@ var Module = {
                 throw (error);
             }
         };
-        MONO.config.fetch_file_cb = function (asset) {
+        Module.MONO.config.fetch_file_cb = function (asset) {
             return fetch(asset, { credentials: 'same-origin' });
         }
 
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            Module.MONO.mono_load_runtime_and_bcl_args(Module.MONO.config);
         } catch (error) {
             test_exit(1);
             throw (error);

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -221,8 +221,10 @@
 
       <_WasmRuntimePackSrcFile ObjectFile="$(_WasmIntermediateOutputPath)%(FileName).o" />
 
-      <_DotnetJSSrcFile Include="$(_WasmRuntimePackSrcDir)\*.js" Exclude="$(_WasmRuntimePackSrcDir)\*.iffe.js"/>
+      <_DotnetJSSrcFile Include="$(_WasmRuntimePackSrcDir)\*.js" Exclude="$(_WasmRuntimePackSrcDir)\*.iffe.js;$(_WasmRuntimePackSrcDir)\*.pre.js;$(_WasmRuntimePackSrcDir)\*.post.js"/>
+      <_WasmExtraJSFile Include="$(_WasmRuntimePackSrcDir)\*.pre.js" Kind="pre-js" />
       <_WasmExtraJSFile Include="$(_WasmRuntimePackSrcDir)\*.iffe.js" Kind="pre-js" />
+      <_WasmExtraJSFile Include="$(_WasmRuntimePackSrcDir)\*.post.js" Kind="post-js" />
       <_WasmNativeFileForLinking Include="@(NativeFileReference)" />
     </ItemGroup>
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -172,31 +172,31 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public MonoCommands(string expression) => this.expression = expression;
 
-        public static MonoCommands GetDebuggerAgentBufferReceived() => new MonoCommands("INTERNAL.mono_wasm_get_dbg_command_info()");
+        public static MonoCommands GetDebuggerAgentBufferReceived() => new MonoCommands("Module.INTERNAL.mono_wasm_get_dbg_command_info()");
 
-        public static MonoCommands IsRuntimeReady() => new MonoCommands("INTERNAL.mono_wasm_runtime_is_ready");
+        public static MonoCommands IsRuntimeReady() => new MonoCommands("Module.INTERNAL.mono_wasm_runtime_is_ready");
 
-        public static MonoCommands GetLoadedFiles() => new MonoCommands("INTERNAL.mono_wasm_get_loaded_files()");
+        public static MonoCommands GetLoadedFiles() => new MonoCommands("Module.INTERNAL.mono_wasm_get_loaded_files()");
 
         public static MonoCommands SendDebuggerAgentCommand(int id, int command_set, int command, string command_parameters)
         {
-            return new MonoCommands($"INTERNAL.mono_wasm_send_dbg_command ({id}, {command_set}, {command},'{command_parameters}')");
+            return new MonoCommands($"Module.INTERNAL.mono_wasm_send_dbg_command ({id}, {command_set}, {command},'{command_parameters}')");
         }
 
         public static MonoCommands SendDebuggerAgentCommandWithParms(int id, int command_set, int command, string command_parameters, int len, int type, string parm)
         {
-            return new MonoCommands($"INTERNAL.mono_wasm_send_dbg_command_with_parms ({id}, {command_set}, {command},'{command_parameters}', {len}, {type}, '{parm}')");
+            return new MonoCommands($"Module.INTERNAL.mono_wasm_send_dbg_command_with_parms ({id}, {command_set}, {command},'{command_parameters}', {len}, {type}, '{parm}')");
         }
 
-        public static MonoCommands CallFunctionOn(JToken args) => new MonoCommands($"INTERNAL.mono_wasm_call_function_on ({args})");
+        public static MonoCommands CallFunctionOn(JToken args) => new MonoCommands($"Module.INTERNAL.mono_wasm_call_function_on ({args})");
 
-        public static MonoCommands GetDetails(int objectId, JToken args = null) => new MonoCommands($"INTERNAL.mono_wasm_get_details ({objectId}, {(args ?? "{ }")})");
+        public static MonoCommands GetDetails(int objectId, JToken args = null) => new MonoCommands($"Module.INTERNAL.mono_wasm_get_details ({objectId}, {(args ?? "{ }")})");
 
-        public static MonoCommands Resume() => new MonoCommands($"INTERNAL.mono_wasm_debugger_resume ()");
+        public static MonoCommands Resume() => new MonoCommands($"Module.INTERNAL.mono_wasm_debugger_resume ()");
 
-        public static MonoCommands DetachDebugger() => new MonoCommands($"INTERNAL.mono_wasm_detach_debugger()");
+        public static MonoCommands DetachDebugger() => new MonoCommands($"Module.INTERNAL.mono_wasm_detach_debugger()");
 
-        public static MonoCommands ReleaseObject(DotnetObjectId objectId) => new MonoCommands($"INTERNAL.mono_wasm_release_object('{objectId}')");
+        public static MonoCommands ReleaseObject(DotnetObjectId objectId) => new MonoCommands($"Module.INTERNAL.mono_wasm_release_object('{objectId}')");
     }
 
     internal enum MonoErrorCodes

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -36,7 +36,7 @@ namespace DebuggerTests
         {
             // Test that js breakpoints get set correctly
             // 13 24
-            // 13 33
+            // 13 40
             var bp1_res = await SetBreakpoint("/debugger-driver.html", 13, 24);
 
             Assert.EndsWith("debugger-driver.html", bp1_res.Value["breakpointId"].ToString());
@@ -48,7 +48,7 @@ namespace DebuggerTests
             Assert.Equal(13, loc["lineNumber"]);
             Assert.Equal(24, loc["columnNumber"]);
 
-            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 33);
+            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 40);
 
             Assert.EndsWith("debugger-driver.html", bp2_res.Value["breakpointId"].ToString());
             Assert.Equal(1, bp2_res.Value["locations"]?.Value<JArray>()?.Count);
@@ -57,14 +57,14 @@ namespace DebuggerTests
 
             Assert.NotNull(loc2["scriptId"]);
             Assert.Equal(13, loc2["lineNumber"]);
-            Assert.Equal(33, loc2["columnNumber"]);
+            Assert.Equal(40, loc2["columnNumber"]);
         }
 
         [Fact]
         public async Task CreateJS0Breakpoint()
         {
             // 13 24
-            // 13 33
+            // 13 40
             var bp1_res = await SetBreakpoint("/debugger-driver.html", 13, 0);
 
             Assert.EndsWith("debugger-driver.html", bp1_res.Value["breakpointId"].ToString());
@@ -76,7 +76,7 @@ namespace DebuggerTests
             Assert.Equal(13, loc["lineNumber"]);
             Assert.Equal(24, loc["columnNumber"]);
 
-            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 33);
+            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 40);
 
             Assert.EndsWith("debugger-driver.html", bp2_res.Value["breakpointId"].ToString());
             Assert.Equal(1, bp2_res.Value["locations"]?.Value<JArray>()?.Count);
@@ -85,7 +85,7 @@ namespace DebuggerTests
 
             Assert.NotNull(loc2["scriptId"]);
             Assert.Equal(13, loc2["lineNumber"]);
-            Assert.Equal(33, loc2["columnNumber"]);
+            Assert.Equal(40, loc2["columnNumber"]);
         }
 
         [Theory]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
@@ -18,12 +18,12 @@ namespace DebuggerTests
         {
             var bad_expressions = new[]
             {
-                    "INTERNAL.mono_wasm_raise_debug_event('')",
-                    "INTERNAL.mono_wasm_raise_debug_event(undefined)",
-                    "INTERNAL.mono_wasm_raise_debug_event({})",
+                    "Module.INTERNAL.mono_wasm_raise_debug_event('')",
+                    "Module.INTERNAL.mono_wasm_raise_debug_event(undefined)",
+                    "Module.INTERNAL.mono_wasm_raise_debug_event({})",
 
-                    "INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, '')",
-                    "INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, 12)"
+                    "Module.INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, '')",
+                    "Module.INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, 12)"
                 };
 
             foreach (var expression in bad_expressions)
@@ -58,7 +58,7 @@ namespace DebuggerTests
             });
 
             var trace_str = trace.HasValue ? $"trace: {trace.ToString().ToLower()}" : String.Empty;
-            var expression = $"INTERNAL.mono_wasm_raise_debug_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
+            var expression = $"Module.INTERNAL.mono_wasm_raise_debug_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
             var res = await cli.SendCommand($"Runtime.evaluate", JObject.FromObject(new { expression }), token);
             Assert.True(res.IsOk, $"Expected to pass for {expression}");
 
@@ -139,7 +139,7 @@ namespace DebuggerTests
                 pdb_base64 = Convert.ToBase64String(bytes);
             }
 
-            var expression = $@"INTERNAL.mono_wasm_raise_debug_event({{
+            var expression = $@"Module.INTERNAL.mono_wasm_raise_debug_event({{
                     eventName: 'AssemblyLoaded',
                     assembly_name: '{asm_name}',
                     assembly_b64: '{asm_base64}',

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
@@ -6,14 +6,14 @@
 	<script type='text/javascript'>
 		var App = {
 			init: function () {
-				this.int_add = INTERNAL.mono_bind_static_method ("[debugger-test] Math:IntAdd");
-				this.use_complex = INTERNAL.mono_bind_static_method ("[debugger-test] Math:UseComplex");
-				this.delegates_test = INTERNAL.mono_bind_static_method ("[debugger-test] Math:DelegatesTest");
-				this.generic_types_test = INTERNAL.mono_bind_static_method ("[debugger-test] Math:GenericTypesTest");
-				this.outer_method = INTERNAL.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
-				this.async_method = INTERNAL.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
-				this.method_with_structs = INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTests.ValueTypesTest:MethodWithLocalStructs");
-				this.run_all = INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTest:run_all");
+				this.int_add = Module.INTERNAL.mono_bind_static_method ("[debugger-test] Math:IntAdd");
+				this.use_complex = Module.INTERNAL.mono_bind_static_method ("[debugger-test] Math:UseComplex");
+				this.delegates_test = Module.INTERNAL.mono_bind_static_method ("[debugger-test] Math:DelegatesTest");
+				this.generic_types_test = Module.INTERNAL.mono_bind_static_method ("[debugger-test] Math:GenericTypesTest");
+				this.outer_method = Module.INTERNAL.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
+				this.async_method = Module.INTERNAL.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
+				this.method_with_structs = Module.INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTests.ValueTypesTest:MethodWithLocalStructs");
+				this.run_all = Module.INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTest:run_all");
 				this.static_method_table = {};
 				console.log ("ready");
 			},
@@ -21,7 +21,7 @@
 		function invoke_static_method (method_name, ...args) {
 			var method = App.static_method_table [method_name];
 			if (method == undefined)
-				method = App.static_method_table [method_name] = INTERNAL.mono_bind_static_method (method_name);
+				method = App.static_method_table [method_name] = Module.INTERNAL.mono_bind_static_method (method_name);
 
 			return method (...args);
 		}
@@ -29,7 +29,7 @@
 		async function invoke_static_method_async (method_name, ...args) {
 			var method = App.static_method_table [method_name];
 			if (method == undefined) {
-				method = App.static_method_table [method_name] = INTERNAL.mono_bind_static_method (method_name);
+				method = App.static_method_table [method_name] = Module.INTERNAL.mono_bind_static_method (method_name);
 			}
 
 			return await method (...args);

--- a/src/mono/wasm/debugger/tests/debugger-test/runtime-debugger.js
+++ b/src/mono/wasm/debugger/tests/debugger-test/runtime-debugger.js
@@ -4,35 +4,36 @@
 "use strict";
 
 var Module = {
+	no_global_exports: true,
 	config: null,
 
 	preInit: async function () {
-		await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+		await Module.MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.MONO.config implicitly
 	},
 
 	// Called when the runtime is initialized and wasm is ready
 	onRuntimeInitialized: function () {
-		if (!MONO.config || MONO.config.error) {
+		if (!Module.MONO.config || Module.MONO.config.error) {
 			console.log("An error occured while loading the config file");
 			return;
 		}
 
-		MONO.config.loaded_cb = function () {
+		Module.MONO.config.loaded_cb = function () {
 			App.init();
 		};
 		// For custom logging patch the functions below
 		/*
-		INTERNAL.logging = {
+		Module.INTERNAL.logging = {
 			trace: function (domain, log_level, message, isFatal, dataPtr) {},
 			debugger: function (level, message) {}
 		};
-		MONO.mono_wasm_setenv ("MONO_LOG_LEVEL", "debug");
-		MONO.mono_wasm_setenv ("MONO_LOG_MASK", "all");
+		Module.MONO.mono_wasm_setenv ("MONO_LOG_LEVEL", "debug");
+		Module.MONO.mono_wasm_setenv ("MONO_LOG_MASK", "all");
 		*/
 
-		MONO.config.environment_variables = {
+		Module.MONO.config.environment_variables = {
 			"DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
 		};
-		MONO.mono_load_runtime_and_bcl_args(MONO.config)
+		Module.MONO.mono_load_runtime_and_bcl_args(Module.MONO.config)
 	},
 };

--- a/src/mono/wasm/runtime/.eslintrc.js
+++ b/src/mono/wasm/runtime/.eslintrc.js
@@ -16,7 +16,11 @@ module.exports = {
     "plugins": [
         "@typescript-eslint"
     ],
-    "ignorePatterns": ["node_modules/**/*.*", "bin/**/*.*"],
+    "ignorePatterns": [
+        "node_modules/**/*.*",
+        "bin/**/*.*",
+        "modularize*.js"
+    ],
     "rules": {
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-non-null-assertion": "off",

--- a/src/mono/wasm/runtime/CMakeLists.txt
+++ b/src/mono/wasm/runtime/CMakeLists.txt
@@ -24,8 +24,8 @@ target_link_libraries(dotnet
     ${NATIVE_BIN_DIR}/libSystem.IO.Compression.Native.a)
 
 set_target_properties(dotnet PROPERTIES
-    LINK_DEPENDS "${NATIVE_BIN_DIR}/src/emcc-default.rsp;${NATIVE_BIN_DIR}/src/runtime.iffe.js;${SOURCE_DIR}/library-dotnet.js;${SYSTEM_NATIVE_DIR}/pal_random.js"
-    LINK_FLAGS "@${NATIVE_BIN_DIR}/src/emcc-default.rsp ${CONFIGURATION_LINK_FLAGS} -DENABLE_NETCORE=1 --pre-js ${NATIVE_BIN_DIR}/src/runtime.iffe.js --js-library ${SOURCE_DIR}/library-dotnet.js --js-library ${SYSTEM_NATIVE_DIR}/pal_random.js"
+    LINK_DEPENDS "${NATIVE_BIN_DIR}/src/emcc-default.rsp;${NATIVE_BIN_DIR}/src/runtime.iffe.js;${SOURCE_DIR}/library-dotnet.js;${SOURCE_DIR}/modularize-dotnet.pre.js;${SOURCE_DIR}/modularize-dotnet.post.js;${SYSTEM_NATIVE_DIR}/pal_random.js"
+    LINK_FLAGS "@${NATIVE_BIN_DIR}/src/emcc-default.rsp ${CONFIGURATION_LINK_FLAGS} -DENABLE_NETCORE=1 --pre-js ${SOURCE_DIR}/modularize-dotnet.pre.js --pre-js ${NATIVE_BIN_DIR}/src/runtime.iffe.js --js-library ${SOURCE_DIR}/library-dotnet.js --js-library ${SYSTEM_NATIVE_DIR}/pal_random.js --post-js ${SOURCE_DIR}/modularize-dotnet.post.js"
     RUNTIME_OUTPUT_DIRECTORY "${NATIVE_BIN_DIR}")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -30,47 +30,7 @@ extern MonoObject* mono_wasm_web_socket_send (int webSocket_js_handle, void* buf
 extern MonoObject* mono_wasm_web_socket_receive (int webSocket_js_handle, void* buffer_ptr, int offset, int length, void* response_ptr, int *thenable_js_handle, int *is_exception);
 extern MonoObject* mono_wasm_web_socket_close (int webSocket_js_handle, int code, MonoString * reason, int wait_for_close_received, int *thenable_js_handle, int *is_exception);
 extern MonoString* mono_wasm_web_socket_abort (int webSocket_js_handle, int *is_exception);
-
-// Compiles a JavaScript function from the function data passed.
-// Note: code snippet is not a function definition. Instead it must create and return a function instance.
-EM_JS(MonoObject*, compile_function, (int snippet_ptr, int len, int *is_exception), {
-	try {
-		var data = INTERNAL.string_decoder.decode (snippet_ptr, snippet_ptr + len);
-		var wrapper = '(function () { ' + data + ' })';
-		var funcFactory = eval(wrapper);
-		var func = funcFactory();
-		if (typeof func !== 'function') {
-			throw new Error('Code must return an instance of a JavaScript function. '
-				+ 'Please use `return` statement to return a function.');
-		}
-		setValue (is_exception, 0, "i32");
-		return BINDING.js_to_mono_obj (func, true);	
-	}
-	catch (e)
-	{
-		res = e.toString ();
-		setValue (is_exception, 1, "i32");
-		if (res === null || res === undefined)
-			res = "unknown exception";
-		return BINDING.js_to_mono_obj (res, true);
-	}
-});
-
-static MonoObject*
-mono_wasm_compile_function (MonoString *str, int *is_exception)
-{
-	if (str == NULL)
-	 	return NULL;
-	//char *native_val = mono_string_to_utf8 (str);
-	mono_unichar2 *native_val = mono_string_chars (str);
-	int native_len = mono_string_length (str) * 2;
-
-	MonoObject* native_res =  compile_function((int)native_val, native_len, is_exception);
-	mono_free (native_val);
-	if (native_res == NULL)
-	 	return NULL;
-	return native_res;
-}
+extern MonoObject* mono_wasm_compile_function (MonoString *str, int *is_exception);
 
 void core_initialize_internals ()
 {

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -30,11 +30,10 @@
 void core_initialize_internals ();
 #endif
 
+extern MonoString* mono_wasm_invoke_js (MonoString *str, int *is_exception);
+
 // Blazor specific custom routines - see dotnet_support.js for backing code
 extern void* mono_wasm_invoke_js_blazor (MonoString **exceptionMessage, void *callInfo, void* arg0, void* arg1, void* arg2);
-// The following two are for back-compat and will eventually be removed
-extern void* mono_wasm_invoke_js_marshalled (MonoString **exceptionMessage, void *asyncHandleLongPtr, MonoString *funcName, MonoString *argsJson);
-extern void* mono_wasm_invoke_js_unmarshalled (MonoString **exceptionMessage, MonoString *funcName, void* arg0, void* arg1, void* arg2);
 
 void mono_wasm_enable_debugging (int);
 
@@ -94,55 +93,6 @@ void mono_trace_init (void);
 static MonoDomain *root_domain;
 
 #define RUNTIMECONFIG_BIN_FILE "runtimeconfig.bin"
-
-static MonoString*
-mono_wasm_invoke_js (MonoString *str, int *is_exception)
-{
-	if (str == NULL)
-		return NULL;
-
-	int native_res_len = 0;
-	int *p_native_res_len = &native_res_len;
-
-	mono_unichar2 *native_res = (mono_unichar2*)EM_ASM_INT ({
-		var js_str = INTERNAL.string_decoder.copy ($0);
-
-		try {
-			var res = eval (js_str);
-			setValue ($2, 0, "i32");
-			if (res === null || res === undefined)
-				return 0;
-			else
-				res = res.toString ();
-		} catch (e) {
-			res = e.toString();
-			setValue ($2, 1, "i32");
-			if (res === null || res === undefined)
-				res = "unknown exception";
-
-			var stack = e.stack;
-			if (stack) {
-				// Some JS runtimes insert the error message at the top of the stack, some don't,
-				//  so normalize it by using the stack as the result if it already contains the error
-				if (stack.startsWith(res))
-					res = stack;
-				else
- 					res += "\n" + stack;
- 			}
-		}
-		var buff = Module._malloc((res.length + 1) * 2);
-		stringToUTF16 (res, buff, (res.length + 1) * 2);
-		setValue ($1, res.length, "i32");
-		return buff;
-	}, (int)str, p_native_res_len, is_exception);
-
-	if (native_res == NULL)
-		return NULL;
-
-	MonoString *res = mono_string_new_utf16 (mono_domain_get (), native_res, native_res_len);
-	free (native_res);
-	return res;
-}
 
 static void
 wasm_trace_logger (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data)
@@ -450,9 +400,6 @@ void mono_initialize_internals ()
 
 	// Blazor specific custom routines - see dotnet_support.js for backing code
 	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJS", mono_wasm_invoke_js_blazor);
-	// The following two are for back-compat and will eventually be removed
-	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJSMarshalled", mono_wasm_invoke_js_marshalled);
-	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJSUnmarshalled", mono_wasm_invoke_js_unmarshalled);
 
 #ifdef CORE_BINDINGS
 	core_initialize_internals();

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -26,7 +26,7 @@ import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
     mono_wasm_load_data_archive, mono_wasm_asm_loaded,
-    mono_wasm_invoke_js_blazor, mono_wasm_invoke_js_marshalled, mono_wasm_invoke_js_unmarshalled, mono_wasm_set_main_args
+    mono_wasm_set_main_args
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
@@ -39,7 +39,10 @@ import {
 import {
     call_static_method, mono_bind_static_method, mono_call_assembly_entry_point,
     mono_method_resolve,
+    mono_wasm_compile_function,
     mono_wasm_get_by_index, mono_wasm_get_global_object, mono_wasm_get_object_property,
+    mono_wasm_invoke_js,
+    mono_wasm_invoke_js_blazor,
     mono_wasm_invoke_js_with_args, mono_wasm_set_by_index, mono_wasm_set_object_property,
     _get_args_root_buffer_for_method_call, _get_buffer_for_method_call,
     _handle_exception_for_call, _teardown_after_call
@@ -64,6 +67,10 @@ export const MONO: MONO = <any>{
     mono_wasm_new_root_buffer,
     mono_wasm_new_root,
     mono_wasm_release_roots,
+
+    // for Blazor's future!
+    mono_wasm_add_assembly: cwraps.mono_wasm_add_assembly,
+    mono_wasm_load_runtime: cwraps.mono_wasm_load_runtime,
 
     config: runtimeHelpers.config,
     loaded_files: runtimeHelpers.loaded_files,
@@ -121,11 +128,28 @@ function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: an
 
     // here we expose objects used in tests to global namespace
     if (!module.no_global_exports) {
-        (<any>globalThis).DOTNET = dotnet;
-        (<any>globalThis).MONO = mono;
-        (<any>globalThis).BINDING = binding;
-        (<any>globalThis).INTERNAL = internal;
         (<any>globalThis).Module = module;
+        const warnWrap = (name: string, value: any) => {
+            let warnOnce = true;
+            Object.defineProperty(globalThis, name, {
+                get: () => {
+                    if (warnOnce) {
+                        const stack = (new Error()).stack;
+                        const nextLine = stack ? stack.substr(stack.indexOf("\n", 8) + 1) : "";
+                        console.warn(`global ${name} is obsolete, please use Module.${name} instead ${nextLine}`);
+                        warnOnce = false;
+                    }
+                    return value;
+                }
+            });
+        };
+        warnWrap("MONO", mono);
+        warnWrap("BINDING", binding);
+
+        // Blazor back compat
+        warnWrap("cwrap", Module.cwrap);
+        warnWrap("addRunDependency", Module.addRunDependency);
+        warnWrap("removeRunDependency", Module.removeRunDependency);
     }
 }
 
@@ -143,9 +167,8 @@ const linker_exports = {
     schedule_background_exec,
 
     // also keep in sync with driver.c
+    mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
-    mono_wasm_invoke_js_marshalled,
-    mono_wasm_invoke_js_unmarshalled,
 
     // also keep in sync with corebindings.c
     mono_wasm_invoke_js_with_args,
@@ -168,6 +191,7 @@ const linker_exports = {
     mono_wasm_web_socket_receive,
     mono_wasm_web_socket_close,
     mono_wasm_web_socket_abort,
+    mono_wasm_compile_function,
 
     //  also keep in sync with pal_icushim_static.c
     mono_wasm_load_icu_data,
@@ -231,6 +255,10 @@ export interface MONO {
     mono_wasm_new_root_buffer: typeof mono_wasm_new_root_buffer;
     mono_wasm_new_root: typeof mono_wasm_new_root;
     mono_wasm_release_roots: typeof mono_wasm_release_roots;
+
+    // for Blazor's future!
+    mono_wasm_add_assembly: typeof cwraps.mono_wasm_add_assembly,
+    mono_wasm_load_runtime: typeof cwraps.mono_wasm_load_runtime,
 
     loaded_files: string[];
     config: MonoConfig | MonoConfigError,

--- a/src/mono/wasm/runtime/library-dotnet.js
+++ b/src/mono/wasm/runtime/library-dotnet.js
@@ -5,13 +5,9 @@
 "use strict";
 
 const DotNetSupportLib = {
-    // this will become globalThis.DOTNET
     $DOTNET: {},
-    // this will become globalThis.MONO
     $MONO: {},
-    // this will become globalThis.BINDING
     $BINDING: {},
-    // this will become globalThis.INTERNAL
     $INTERNAL: {},
     // this line will be executed on runtime, populating the objects with methods
     $DOTNET__postset: "__dotnet_runtime.INTERNAL.export_to_emscripten (DOTNET, MONO, BINDING, INTERNAL, Module);",
@@ -31,9 +27,8 @@ const linked_functions = [
     "schedule_background_exec",
 
     // driver.c
+    "mono_wasm_invoke_js",
     "mono_wasm_invoke_js_blazor",
-    "mono_wasm_invoke_js_marshalled",
-    "mono_wasm_invoke_js_unmarshalled",
 
     // corebindings.c
     "mono_wasm_invoke_js_with_args",
@@ -56,6 +51,7 @@ const linked_functions = [
     "mono_wasm_web_socket_receive",
     "mono_wasm_web_socket_close",
     "mono_wasm_web_socket_abort",
+    "mono_wasm_compile_function",
 
     // pal_icushim_static.c
     "mono_wasm_load_icu_data",

--- a/src/mono/wasm/runtime/modularize-dotnet.post.js
+++ b/src/mono/wasm/runtime/modularize-dotnet.post.js
@@ -1,0 +1,10 @@
+
+Object.defineProperty(Module, '__esModule', { value: true });
+}());
+
+if (typeof exports === 'object' && typeof module === 'object')
+    module.exports = Module;
+else if (typeof define === 'function' && define['amd'])
+    define([], function () { return Module; });
+else if (typeof exports === 'object')
+    exports["Module"] = Module;

--- a/src/mono/wasm/runtime/modularize-dotnet.pre.js
+++ b/src/mono/wasm/runtime/modularize-dotnet.pre.js
@@ -1,0 +1,1 @@
+(function () {

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -66,7 +66,7 @@
       <_EmccCommonFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
       <_EmccCommonFlags Include="-s NO_EXIT_RUNTIME=1" />
       <_EmccCommonFlags Include="-s FORCE_FILESYSTEM=1" />
-      <_EmccCommonFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency']&quot;" />
+      <_EmccCommonFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['DOTNET','MONO','BINDING','INTERNAL','FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency']&quot;" />
       <_EmccCommonFlags Include="-s EXPORTED_FUNCTIONS=&quot;['_free','_malloc']&quot;" />
       <_EmccCommonFlags Include="--source-map-base http://example.com" />
 
@@ -182,6 +182,8 @@
                        runtime/pinvoke.c;
                        runtime/corebindings.c;
                        runtime/library-dotnet.js;
+                       runtime/modularize-dotnet.pre.js;
+                       runtime/modularize-dotnet.post.js;
                        $(SystemNativeDir)\pal_random.js;"
           DestinationFolder="$(NativeBinDir)src"
           SkipUnchangedFiles="true" />

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
@@ -36,7 +36,7 @@
 
       var App = {
         init: function () {
-          var exit_code = INTERNAL.call_static_method("[WebAssembly.Browser.HotReload.Test] Sample.Test:TestMeaning", []);
+          var exit_code = Module.INTERNAL.call_static_method("[WebAssembly.Browser.HotReload.Test] Sample.Test:TestMeaning", []);
           document.getElementById("out").innerHTML = exit_code;
 
           if (is_testing)

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/runtime.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/runtime.js
@@ -2,21 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 var Module = {
-
+    no_global_exports: true,
     config: null,
 
     preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+        await Module.MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.MONO.config implicitly
     },
 
     onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
+        if (!Module.MONO.config || Module.MONO.config.error) {
             console.log("No config found");
             test_exit(1);
-            throw (MONO.config.error);
+            throw (Module.MONO.config.error);
         }
 
-        MONO.config.loaded_cb = function () {
+        Module.MONO.config.loaded_cb = function () {
             try {
                 App.init();
             } catch (error) {
@@ -24,20 +24,20 @@ var Module = {
                 throw (error);
             }
         };
-        MONO.config.fetch_file_cb = function (asset) {
+        Module.MONO.config.fetch_file_cb = function (asset) {
             return fetch(asset, { credentials: 'same-origin' });
         }
 
-        if (MONO.config.environment_variables !== undefined) {
-            console.log("expected environment variables to be undefined, but they're: ", MONO.config.environment_variables);
+        if (Module.MONO.config.environment_variables !== undefined) {
+            console.log("expected environment variables to be undefined, but they're: ", Module.MONO.config.environment_variables);
             test_exit(1);
         }
-        MONO.config.environment_variables = {
+        Module.MONO.config.environment_variables = {
             "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
         };
 
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            Module.MONO.mono_load_runtime_and_bcl_args(Module.MONO.config);
         } catch (error) {
             test_exit(1);
             throw (error);

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
@@ -36,7 +36,7 @@
 
       var App = {
         init: function () {
-          var exit_code = INTERNAL.call_static_method("[WebAssembly.Browser.RuntimeConfig.Test] Sample.Test:TestMeaning", []);
+          var exit_code = Module.INTERNAL.call_static_method("[WebAssembly.Browser.RuntimeConfig.Test] Sample.Test:TestMeaning", []);
           document.getElementById("out").innerHTML = exit_code;
 
           if (is_testing)

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/runtime.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/runtime.js
@@ -2,21 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 var Module = {
-
+    no_global_exports: true,
     config: null,
 
     preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+        await Module.MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.MONO.config implicitly
     },
 
     onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
+        if (!Module.MONO.config || Module.MONO.config.error) {
             console.log("No config found");
             test_exit(1);
-            throw (MONO.config.error);
+            throw (Module.MONO.config.error);
         }
 
-        MONO.config.loaded_cb = function () {
+        Module.MONO.config.loaded_cb = function () {
             try {
                 App.init();
             } catch (error) {
@@ -24,12 +24,12 @@ var Module = {
                 throw (error);
             }
         };
-        MONO.config.fetch_file_cb = function (asset) {
+        Module.MONO.config.fetch_file_cb = function (asset) {
             return fetch(asset, { credentials: 'same-origin' });
         }
 
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            Module.MONO.mono_load_runtime_and_bcl_args(Module.MONO.config);
         } catch (error) {
             test_exit(1);
             throw (error);


### PR DESCRIPTION
- encapsulate emscripten js runtime into IFFE, so that it doesn't leak into global namespace
- keep `Module` object in the global namespace
- keep `MONO`, `BINDING`, `cwrap`, `addRunDependency`, `removeRunDependency` in the global namespace with deprecation warning
- improve test loading script