### PR TITLE
Properly type primary selectors in `fgMemoryVNForLoopSideEffects`

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7977,6 +7977,9 @@ public:
 
     bool eeIsValueClass(CORINFO_CLASS_HANDLE clsHnd);
     bool eeIsJitIntrinsic(CORINFO_METHOD_HANDLE ftn);
+    bool eeIsFieldStatic(CORINFO_FIELD_HANDLE fldHnd);
+
+    var_types eeGetFieldType(CORINFO_FIELD_HANDLE fldHnd);
 
 #if defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD) || defined(TRACK_LSRA_STATS)
 

--- a/src/coreclr/jit/ee_il_dll.hpp
+++ b/src/coreclr/jit/ee_il_dll.hpp
@@ -62,6 +62,18 @@ bool Compiler::eeIsJitIntrinsic(CORINFO_METHOD_HANDLE ftn)
 }
 
 FORCEINLINE
+bool Compiler::eeIsFieldStatic(CORINFO_FIELD_HANDLE fldHnd)
+{
+    return info.compCompHnd->isFieldStatic(fldHnd);
+}
+
+FORCEINLINE
+var_types Compiler::eeGetFieldType(CORINFO_FIELD_HANDLE fldHnd)
+{
+    return JITtype2varType(info.compCompHnd->getFieldType(fldHnd));
+}
+
+FORCEINLINE
 void Compiler::eeGetSig(unsigned               sigTok,
                         CORINFO_MODULE_HANDLE  scope,
                         CORINFO_CONTEXT_HANDLE context,

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6786,9 +6786,8 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
             for (Compiler::LoopDsc::FieldHandleSet::KeyIterator ki = fieldsMod->Begin(); !ki.Equal(fieldsMod->End());
                  ++ki)
             {
-                CORINFO_FIELD_HANDLE fldHnd    = ki.Get();
-                ValueNum             fldHndVN  = vnStore->VNForHandle(ssize_t(fldHnd), GTF_ICON_FIELD_HDL);
-                var_types            fieldType = JITtype2varType(info.compCompHnd->getFieldType(fldHnd));
+                CORINFO_FIELD_HANDLE fldHnd   = ki.Get();
+                ValueNum             fldHndVN = vnStore->VNForHandle(ssize_t(fldHnd), GTF_ICON_FIELD_HDL);
 
 #ifdef DEBUG
                 if (verbose)
@@ -6798,8 +6797,13 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
                     printf("     VNForHandle(%s) is " FMT_VN "\n", fldName, fldHndVN);
                 }
 #endif // DEBUG
+
+                // Instance field maps get the placeholder TYP_REF - they do not represent "singular"
+                // values. Static field maps, on the other hand, do, and so must be given proper types.
+                var_types fldMapType = eeIsFieldStatic(fldHnd) ? eeGetFieldType(fldHnd) : TYP_REF;
+
                 newMemoryVN =
-                    vnStore->VNForMapStore(TYP_REF, newMemoryVN, fldHndVN, vnStore->VNForExpr(entryBlock, fieldType));
+                    vnStore->VNForMapStore(TYP_REF, newMemoryVN, fldHndVN, vnStore->VNForExpr(entryBlock, fldMapType));
             }
         }
         // Now do the array maps.
@@ -6810,11 +6814,11 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
                  !ki.Equal(elemTypesMod->End()); ++ki)
             {
                 CORINFO_CLASS_HANDLE elemClsHnd = ki.Get();
-                var_types            elemTyp    = DecodeElemType(elemClsHnd);
 
 #ifdef DEBUG
                 if (verbose)
                 {
+                    var_types elemTyp = DecodeElemType(elemClsHnd);
                     // If a valid class handle is given when the ElemType is set, DecodeElemType will
                     // return TYP_STRUCT, and elemClsHnd is that handle.
                     // Otherwise, elemClsHnd is NOT a valid class handle, and is the encoded var_types value.
@@ -6829,9 +6833,9 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
                 }
 #endif // DEBUG
 
-                ValueNum elemTypeEqVN = vnStore->VNForHandle(ssize_t(elemClsHnd), GTF_ICON_CLASS_HDL);
-                ValueNum elemTypeMap  = vnStore->VNForExpr(entryBlock, elemTyp);
-                newMemoryVN           = vnStore->VNForMapStore(TYP_REF, newMemoryVN, elemTypeEqVN, elemTypeMap);
+                ValueNum elemTypeVN = vnStore->VNForHandle(ssize_t(elemClsHnd), GTF_ICON_CLASS_HDL);
+                ValueNum uniqueVN   = vnStore->VNForExpr(entryBlock, TYP_REF);
+                newMemoryVN         = vnStore->VNForMapStore(TYP_REF, newMemoryVN, elemTypeVN, uniqueVN);
             }
         }
     }


### PR DESCRIPTION
When performing value numbering of the initial memory state for blocks, we treat single-entry loops specially. First, we walk the loop to determine if it contains non-analyzable (from VN's point of view, i. e. not stores to fields or arrays) memory-related side effects ("havoc"). While doing so, we collect the handles of fields and types of arrays, later to be used as primary selectors in VN. If the loop is determined to not have "havoc", we compute the initial memory VN (which would ordinarily consist of a `PHI` with one unknown input) as follows: take the outgoing VN of the non-loop predecessor, and reset all the maps corresponding to primary selectors that we know will be stored to in the loop from the previous walk to "new, unique" values.

This then allows us to find the values for locations that were not modified in the loop when walking the `MapStore` chains while numbering nodes in the loop.

This is all rather nice, but has one flaw: the VNs given to primary maps (corresponding to the values obtained via indexing into the heap with a primary selector) all have `TYP_REF` types, which is not correct for static fields, and this change fixes that.

No diffs for this change (as expected).

Part of #58312.