### PR TITLE
[hackathon] `ValueArray` - a compliment type to the `Span`, which owns its data without indirections.

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -809,7 +809,7 @@ enum CorInfoFlag
     CORINFO_FLG_ARRAY                 = 0x00080000, // class is an array class (initialized differently)
     CORINFO_FLG_OVERLAPPING_FIELDS    = 0x00100000, // struct or class has fields that overlap (aka union)
     CORINFO_FLG_INTERFACE             = 0x00200000, // it is an interface
-    CORINFO_FLG_DONT_PROMOTE          = 0x00400000, // don't try to promote fields (used for types outside of AOT compilation version bubble)
+    CORINFO_FLG_DONT_PROMOTE          = 0x00400000, // don't try to promote fields (used for ValueArray and types outside of AOT compilation version bubble)
     CORINFO_FLG_CUSTOMLAYOUT          = 0x00800000, // does this struct have custom layout?
     CORINFO_FLG_CONTAINS_GC_PTR       = 0x01000000, // does the class contain a gc ptr ?
     CORINFO_FLG_DELEGATE              = 0x02000000, // is this a subclass of delegate or multicast delegate ?

--- a/src/coreclr/inc/dacvars.h
+++ b/src/coreclr/inc/dacvars.h
@@ -168,6 +168,7 @@ DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pMulticastDelegateClass, ::g_p
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pFreeObjectMethodTable, ::g_pFreeObjectMethodTable)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pOverlappedDataClass, ::g_pOverlappedDataClass)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pValueTypeClass, ::g_pValueTypeClass)
+DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pValueArrayClass, ::g_pValueArrayClass)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pEnumClass, ::g_pEnumClass)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pThreadClass, ::g_pThreadClass)
 DEFINE_DACVAR(ULONG, UNKNOWN_POINTER_TYPE, dac__g_pPredefinedArrayTypes, ::g_pPredefinedArrayTypes)

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedCanonicalizationAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedCanonicalizationAlgorithm.cs
@@ -127,6 +127,12 @@ namespace Internal.TypeSystem
                 }
                 else if (typeToConvert.IsArray)
                 {
+                    TypeDesc elementType = ((ArrayType)typeToConvert).ElementType;
+                    if (elementType.IsObject)
+                    {
+                        return typeToConvert;
+                    }
+
                     return context.CanonType;
                 }
                 else

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1441,6 +1441,8 @@ void SystemDomain::LoadBaseSystemClasses()
     g_pICastableInterface = CoreLibBinder::GetClass(CLASS__ICASTABLE);
 #endif // FEATURE_ICASTABLE
 
+    g_pValueArrayClass = CoreLibBinder::GetClass(CLASS__VALUE_ARRAY);
+
     // Make sure that FCall mapping for Monitor.Enter is initialized. We need it in case Monitor.Enter is used only as JIT helper.
     // For more details, see comment in code:JITutil_MonEnterWorker around "__me = GetEEFuncEntryPointMacro(JIT_MonEnter)".
     ECall::GetFCallImpl(CoreLibBinder::GetMethod(METHOD__MONITOR__ENTER));

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -1975,7 +1975,7 @@ class ArrayClass : public EEClass
 private:
 
     DAC_ALIGNAS(EEClass) // Align the first member to the alignment of the base class
-    unsigned char   m_rank;
+    DWORD m_rank;
     CorElementType  m_ElementType;// Cache of element type in m_ElementTypeHnd
 
 public:
@@ -1986,10 +1986,7 @@ public:
     }
     void SetRank (unsigned Rank) {
         LIMITED_METHOD_CONTRACT;
-        // The only code path calling this function is code:ClassLoader::CreateTypeHandleForTypeKey, which has
-        // checked the rank already.  Assert that the rank is less than MAX_RANK and that it fits in one byte.
-        _ASSERTE((Rank <= MAX_RANK) && (Rank <= (unsigned char)(-1)));
-        m_rank = (unsigned char)Rank;
+        m_rank = Rank;
     }
 
     CorElementType GetArrayElementType() {

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -1342,6 +1342,18 @@ public:
         LIMITED_METHOD_CONTRACT;
         m_VMFlags |= (DWORD)VMFLAG_HAS_FIELDS_WHICH_MUST_BE_INITED;
     }
+
+    BOOL HasNoPromotionFlagSet()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (m_VMFlags & VMFLAG_DONT_PROMOTE);
+    }
+    void SetNoPromotionFlag()
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_VMFlags |= (DWORD)VMFLAG_DONT_PROMOTE;
+    }
+
     void SetCannotBeBlittedByObjectCloner()
     {
         /* no op */
@@ -1669,7 +1681,8 @@ public:
         VMFLAG_BESTFITMAPPING                  = 0x00004000, // BestFitMappingAttribute.Value
         VMFLAG_THROWONUNMAPPABLECHAR           = 0x00008000, // BestFitMappingAttribute.ThrowOnUnmappableChar
 
-        // unused                              = 0x00010000,
+        // suppress struct promotion (used by ValueArrays)
+        VMFLAG_DONT_PROMOTE                    = 0x00010000,
         VMFLAG_NO_GUID                         = 0x00020000,
         VMFLAG_HASNONPUBLICFIELDS              = 0x00040000,
         // unused                              = 0x00080000,

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -3046,10 +3046,6 @@ TypeHandle ClassLoader::CreateTypeHandleForTypeKey(TypeKey* pKey, AllocMemTracke
                 }
             }
 
-            if (rank > MAX_RANK)
-            {
-                ThrowTypeLoadException(pKey, IDS_CLASSLOAD_RANK_TOOLARGE);
-            }
 
             templateMT = pLoaderModule->CreateArrayMethodTable(paramType, kind, rank, pamTracker);
             typeHnd = TypeHandle(templateMT);

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -980,6 +980,8 @@ DEFINE_CLASS(VALUE_TYPE,            System,                 ValueType)
 DEFINE_METHOD(VALUE_TYPE,           GET_HASH_CODE,          GetHashCode,            IM_RetInt)
 DEFINE_METHOD(VALUE_TYPE,           EQUALS,                 Equals,                 IM_Obj_RetBool)
 
+DEFINE_CLASS(VALUE_ARRAY,           System,                 ValueArray`1)
+
 DEFINE_CLASS(GC,                    System,                 GC)
 DEFINE_METHOD(GC,                   KEEP_ALIVE,             KeepAlive,                  SM_Obj_RetVoid)
 DEFINE_METHOD(GC,                   COLLECT,                Collect,                    SM_RetVoid)

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -980,7 +980,7 @@ DEFINE_CLASS(VALUE_TYPE,            System,                 ValueType)
 DEFINE_METHOD(VALUE_TYPE,           GET_HASH_CODE,          GetHashCode,            IM_RetInt)
 DEFINE_METHOD(VALUE_TYPE,           EQUALS,                 Equals,                 IM_Obj_RetBool)
 
-DEFINE_CLASS(VALUE_ARRAY,           System,                 ValueArray`1)
+DEFINE_CLASS(VALUE_ARRAY,           System,                 ValueArray`2)
 
 DEFINE_CLASS(GC,                    System,                 GC)
 DEFINE_METHOD(GC,                   KEEP_ALIVE,             KeepAlive,                  SM_Obj_RetVoid)

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -38,6 +38,14 @@ TypeHandle ClassLoader::CanonicalizeGenericArg(TypeHandle thGenericArg)
 #if defined(FEATURE_SHARE_GENERIC_CODE)
     CorElementType et = thGenericArg.GetSignatureCorElementType();
 
+    //TODO: we can narrow the scenario
+    //      by requiring a special/unspeakable/unusable element type
+    if (et == ELEMENT_TYPE_ARRAY &&
+        thGenericArg.GetArrayElementTypeHandle() == TypeHandle(g_pObjectClass))
+    {
+        RETURN(thGenericArg);
+    }
+
     // Note that generic variables do not share
 
     if (CorTypeInfo::IsObjRef_NoThrow(et))

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -38,8 +38,7 @@ TypeHandle ClassLoader::CanonicalizeGenericArg(TypeHandle thGenericArg)
 #if defined(FEATURE_SHARE_GENERIC_CODE)
     CorElementType et = thGenericArg.GetSignatureCorElementType();
 
-    //TODO: we can narrow the scenario
-    //      by requiring a special/unspeakable/unusable element type
+    // canonical form of MD object array is an MD object array - do not lose the rank
     if (et == ELEMENT_TYPE_ARRAY &&
         thGenericArg.GetArrayElementTypeHandle() == TypeHandle(g_pObjectClass))
     {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -3719,8 +3719,13 @@ uint32_t CEEInfo::getClassAttribsInternal (CORINFO_CLASS_HANDLE clsHnd)
             if (pClass->IsUnsafeValueClass())
                 ret |= CORINFO_FLG_UNSAFE_VALUECLASS;
         }
+
         if (pClass->HasExplicitFieldOffsetLayout() && pClass->HasOverLayedField())
             ret |= CORINFO_FLG_OVERLAPPING_FIELDS;
+
+        if (pClass->HasNoPromotionFlagSet())
+            ret |= CORINFO_FLG_DONT_PROMOTE;
+
         if (VMClsHnd.IsCanonicalSubtype())
             ret |= CORINFO_FLG_SHAREDINST;
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1719,6 +1719,21 @@ MethodTableBuilder::BuildMethodTableThrowing(
         &pByValueClassCache, bmtMFDescs, bmtFP,
         &totalDeclaredFieldSize);
 
+    // TODO: VS this is a complete hack which works only in Debug
+    //       ValueArray<> should be bound at load time and
+    //       here we should compare it with constructed-from type.
+    //
+    SString cname = SString(SString::Utf8, this->GetHalfBakedClass()->m_szDebugClassName);
+    if (cname.BeginsWith(SString(SString::Utf8Literal, "System.ValueArray`1[")))
+    {
+        if (!bmtGenericsInfo->fContainsGenericVariables)
+        {
+            bmtFP->NumValueArrayElements = 42;
+        }
+
+        printf("Loading: %s \n", this->GetHalfBakedClass()->m_szDebugClassName);
+    }
+
     // Place regular static fields
     PlaceRegularStaticFields();
 
@@ -1737,6 +1752,11 @@ MethodTableBuilder::BuildMethodTableThrowing(
         bmtFP->NumInstanceGCPointerFields = 0;
 
         _ASSERTE(HasLayout());
+
+        if (bmtFP->NumValueArrayElements)
+        {
+            GetLayoutInfo()->m_cbManagedSize *= bmtFP->NumValueArrayElements;
+        }
 
         bmtFP->NumInstanceFieldBytes = GetLayoutInfo()->m_cbManagedSize;
 
@@ -8277,6 +8297,18 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
             BuildMethodTableThrowException(IDS_CLASSLOAD_FIELDTOOLARGE);
         }
 
+        if (bmtFP->NumValueArrayElements > 0)
+        {
+            dwNumInstanceFieldBytes *= bmtFP->NumValueArrayElements;
+
+            // TODO: VS we will repeat GC series for struct elements for now
+            //       it may be possible to encode them as a repeat pattern (like in arrays)
+            if (pFieldDescList[0].IsByValue())
+            {
+                dwNumGCPointerSeries *= bmtFP->NumValueArrayElements;
+            }
+        }
+
         bmtFP->NumInstanceFieldBytes = dwNumInstanceFieldBytes;
 
         bmtFP->NumGCPointerSeries = dwNumGCPointerSeries;
@@ -11341,12 +11373,19 @@ VOID MethodTableBuilder::HandleGCForValueClasses(MethodTable ** pByValueClassCac
 
         }
 
+        DWORD repeat = 1;
+        if (bmtFP->NumValueArrayElements > 0)
+        {
+            _ASSERTE(bmtEnumFields->dwNumInstanceFields == 1);
+            repeat = bmtFP->NumValueArrayElements;
+        }
+
         // Build the pointer series map for this pointers in this instance
         pSeries = ((CGCDesc*)pMT)->GetLowestSeries();
         if (bmtFP->NumInstanceGCPointerFields)
         {
             // See gcdesc.h for an explanation of why we adjust by subtracting BaseSize
-            pSeries->SetSeriesSize( (size_t) (bmtFP->NumInstanceGCPointerFields * TARGET_POINTER_SIZE) - (size_t) pMT->GetBaseSize());
+            pSeries->SetSeriesSize((size_t)(bmtFP->NumInstanceGCPointerFields * repeat * TARGET_POINTER_SIZE) - (size_t)pMT->GetBaseSize());
             pSeries->SetSeriesOffset(bmtFP->GCPointerFieldStart + OBJECT_SIZE);
             pSeries++;
         }
@@ -11356,44 +11395,51 @@ VOID MethodTableBuilder::HandleGCForValueClasses(MethodTable ** pByValueClassCac
         {
             if (pFieldDescList[i].IsByValue())
             {
-                MethodTable *pByValueMT = pByValueClassCache[i];
+                MethodTable* pByValueMT = pByValueClassCache[i];
 
                 if (pByValueMT->ContainsPointers())
                 {
                     // Offset of the by value class in the class we are building, does NOT include Object
                     DWORD       dwCurrentOffset = pFieldDescList[i].GetOffset_NoLogging();
+                    DWORD       dwElementSize = pByValueMT->GetBaseSize() - OBJECT_BASESIZE;
 
-                    // The by value class may have more than one pointer series
-                    CGCDescSeries * pByValueSeries = CGCDesc::GetCGCDescFromMT(pByValueMT)->GetLowestSeries();
-                    SIZE_T dwNumByValueSeries = CGCDesc::GetCGCDescFromMT(pByValueMT)->GetNumSeries();
-
-                    for (SIZE_T j = 0; j < dwNumByValueSeries; j++)
+                    for (DWORD r = 0; r < repeat; r++)
                     {
-                        size_t cbSeriesSize;
-                        size_t cbSeriesOffset;
+                        // The by value class may have more than one pointer series
+                        CGCDescSeries* pByValueSeries = CGCDesc::GetCGCDescFromMT(pByValueMT)->GetLowestSeries();
+                        SIZE_T dwNumByValueSeries = CGCDesc::GetCGCDescFromMT(pByValueMT)->GetNumSeries();
 
-                        _ASSERTE(pSeries <= CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries());
+                        for (SIZE_T j = 0; j < dwNumByValueSeries; j++)
+                        {
+                            size_t cbSeriesSize;
+                            size_t cbSeriesOffset;
 
-                        cbSeriesSize = pByValueSeries->GetSeriesSize();
+                            _ASSERTE(pSeries <= CGCDesc::GetCGCDescFromMT(pMT)->GetHighestSeries());
 
-                        // Add back the base size of the by value class, since it's being transplanted to this class
-                        cbSeriesSize += pByValueMT->GetBaseSize();
+                            cbSeriesSize = pByValueSeries->GetSeriesSize();
 
-                        // Subtract the base size of the class we're building
-                        cbSeriesSize -= pMT->GetBaseSize();
+                            // Add back the base size of the by value class, since it's being transplanted to this class
+                            cbSeriesSize += pByValueMT->GetBaseSize();
 
-                        // Set current series we're building
-                        pSeries->SetSeriesSize(cbSeriesSize);
+                            // Subtract the base size of the class we're building
+                            cbSeriesSize -= pMT->GetBaseSize();
 
-                        // Get offset into the value class of the first pointer field (includes a +Object)
-                        cbSeriesOffset = pByValueSeries->GetSeriesOffset();
+                            // Set current series we're building
+                            pSeries->SetSeriesSize(cbSeriesSize);
 
-                        // Add it to the offset of the by value class in our class
-                        cbSeriesOffset += dwCurrentOffset;
+                            // Get offset into the value class of the first pointer field (includes a +Object)
+                            cbSeriesOffset = pByValueSeries->GetSeriesOffset();
 
-                        pSeries->SetSeriesOffset(cbSeriesOffset); // Offset of field
-                        pSeries++;
-                        pByValueSeries++;
+                            // Add element N offset
+                            cbSeriesOffset += r * dwElementSize;
+
+                            // Add it to the offset of the by value class in our class
+                            cbSeriesOffset += dwCurrentOffset;
+
+                            pSeries->SetSeriesOffset(cbSeriesOffset); // Offset of field
+                            pSeries++;
+                            pByValueSeries++;
+                        }
                     }
                 }
             }

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1724,10 +1724,16 @@ MethodTableBuilder::BuildMethodTableThrowing(
         g_pValueArrayClass->GetCl() == GetCl() &&
         g_pValueArrayClass->GetModule() == bmtInternal->pType->GetModule())
     {
-        TypeHandle R = bmtGenericsInfo->GetInstantiation()[1];
-        if (R.IsArray())
+        TypeHandle lengthMarker = bmtGenericsInfo->GetInstantiation()[1];
+        if (lengthMarker.IsArray())
         {
-            bmtFP->NumValueArrayElements = bmtGenericsInfo->GetInstantiation()[1].GetRank();
+            DWORD rank = lengthMarker.GetRank();
+            if (rank > 1)
+            {
+                bmtFP->NumValueArrayElements = rank;
+                // there is no scenario when tearing a value array into pieces is desirable.
+                GetHalfBakedClass()->SetNoPromotionFlag();
+            }
         }
     }
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1724,7 +1724,11 @@ MethodTableBuilder::BuildMethodTableThrowing(
         g_pValueArrayClass->GetCl() == GetCl() &&
         g_pValueArrayClass->GetModule() == bmtInternal->pType->GetModule())
     {
-        bmtFP->NumValueArrayElements = 42;
+        TypeHandle R = bmtGenericsInfo->GetInstantiation()[1];
+        if (R.IsArray())
+        {
+            bmtFP->NumValueArrayElements = bmtGenericsInfo->GetInstantiation()[1].GetRank();
+        }
     }
 
     // Place regular static fields

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1719,19 +1719,12 @@ MethodTableBuilder::BuildMethodTableThrowing(
         &pByValueClassCache, bmtMFDescs, bmtFP,
         &totalDeclaredFieldSize);
 
-    // TODO: VS this is a complete hack which works only in Debug
-    //       ValueArray<> should be bound at load time and
-    //       here we should compare it with constructed-from type.
-    //
-    SString cname = SString(SString::Utf8, this->GetHalfBakedClass()->m_szDebugClassName);
-    if (cname.BeginsWith(SString(SString::Utf8Literal, "System.ValueArray`1[")))
+    if (!bmtGenericsInfo->fContainsGenericVariables &&
+        g_pValueArrayClass != NULL &&
+        g_pValueArrayClass->GetCl() == GetCl() &&
+        g_pValueArrayClass->GetModule() == bmtInternal->pType->GetModule())
     {
-        if (!bmtGenericsInfo->fContainsGenericVariables)
-        {
-            bmtFP->NumValueArrayElements = 42;
-        }
-
-        printf("Loading: %s \n", this->GetHalfBakedClass()->m_szDebugClassName);
+        bmtFP->NumValueArrayElements = 42;
     }
 
     // Place regular static fields

--- a/src/coreclr/vm/methodtablebuilder.h
+++ b/src/coreclr/vm/methodtablebuilder.h
@@ -2043,6 +2043,8 @@ private:
         DWORD NumGCPointerSeries;
         DWORD NumInstanceFieldBytes;
 
+        DWORD NumValueArrayElements;
+
         bool  fIsByRefLikeType;
         bool  fHasFixedAddressValueTypes;
         bool  fHasSelfReferencingStaticValueTypeField_WithRVA;

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -1365,6 +1365,15 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                             if (tmpEType == ELEMENT_TYPE_CLASS)
                                 typeHnd = TypeHandle(g_pCanonMethodTableClass);
                         }
+                        if (elemType == ELEMENT_TYPE_ARRAY)
+                        {
+                            IfFailThrowBF(tempsig.GetElemType(&elemType), BFA_BAD_SIGNATURE, pModule);
+                            // canonical form of MD object array is an MD object array - do not lose the rank
+                            if (elemType != ELEMENT_TYPE_OBJECT)
+                            {
+                                typeHnd = TypeHandle(g_pCanonMethodTableClass);
+                            }
+                        }
                         else if ((elemType == (CorElementType)ELEMENT_TYPE_CANON_ZAPSIG) ||
                                  (CorTypeInfo::GetGCType_NoThrow(elemType) == TYPE_GC_REF))
                         {

--- a/src/coreclr/vm/vars.cpp
+++ b/src/coreclr/vm/vars.cpp
@@ -71,6 +71,7 @@ GPTR_IMPL(MethodTable,      g_pExecutionEngineExceptionClass);
 GPTR_IMPL(MethodTable,      g_pDelegateClass);
 GPTR_IMPL(MethodTable,      g_pMulticastDelegateClass);
 GPTR_IMPL(MethodTable,      g_pValueTypeClass);
+GPTR_IMPL(MethodTable,      g_pValueArrayClass);
 GPTR_IMPL(MethodTable,      g_pEnumClass);
 GPTR_IMPL(MethodTable,      g_pThreadClass);
 GPTR_IMPL(MethodTable,      g_pFreeObjectMethodTable);

--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -378,6 +378,7 @@ GPTR_DECL(MethodTable,      g_pDelegateClass);
 GPTR_DECL(MethodTable,      g_pMulticastDelegateClass);
 GPTR_DECL(MethodTable,      g_pFreeObjectMethodTable);
 GPTR_DECL(MethodTable,      g_pValueTypeClass);
+GPTR_DECL(MethodTable,      g_pValueArrayClass);
 GPTR_DECL(MethodTable,      g_pEnumClass);
 GPTR_DECL(MethodTable,      g_pThreadClass);
 GPTR_DECL(MethodTable,      g_pOverlappedDataClass);

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1126,6 +1126,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\UnhandledExceptionEventHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\UnitySerializationHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\ValueTuple.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\ValueArray.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Version.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Void.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\WeakReference.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
@@ -11,8 +11,8 @@ namespace System
     {
         public static int Length => RankOf<R>.Value;
 
-        // For the array of Length N, we will have N+1 elements immdiately follow.
-        public T Element0;
+        // For the array of Length N, runtime will add N-1 elements immediately after this one.
+        private T Element0;
 
         /// <summary>
         /// Gets or sets the element at the specified index.

--- a/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Internal.Runtime.CompilerServices;
+
+namespace System
+{
+    //    [Obsolete("Never use this type directly as that would be an array of unknown length.")]
+    //    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct ValueArray<T>
+    {
+        // For the array of Length N, we will have N+1 elements immdiately follow.
+        public T Element0;
+
+        /// <summary>
+        /// NOTE: I am not sure we need the indexer in the final impl.
+        ///       We may not want to JIT it for every length.
+        ///       It may be better to just let C# compiler code-gen the accesses.
+        /// </summary>
+        public T this[int index]
+        {
+            get => this.Address(index);
+            set => this.Address(index) = value;
+        }
+    }
+
+    public static class ValueArrayHelpers
+    {
+        /// <summary>
+        /// Returns an address to an element of the ValueArray.
+        /// Caller must statically know the Length and ensure the "index" is within bounds.
+        /// </summary>
+        public static ref T Address<T>(this ref ValueArray<T> array, int index)
+        {
+            return ref Unsafe.Add(ref array.Element0, (nint)(uint)index /* force zero-extension */);
+        }
+
+        /// <summary>
+        /// Returns a slice of the ValueArray.
+        /// Caller must statically know the Length and ensure the "length" is within bounds.
+        /// </summary>
+        public static Span<T> Slice<T>(this ref ValueArray<T> array, int length)
+        {
+            return new Span<T>(ref array.Element0, length);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
@@ -9,7 +9,7 @@ namespace System
 {
     public struct ValueArray<T, R> // where R : System.Array
     {
-        public static readonly int Length = typeof(R).GetArrayRank();
+        public static int Length => RankOf<R>.Value;
 
         // For the array of Length N, we will have N+1 elements immdiately follow.
         public T Element0;
@@ -45,6 +45,24 @@ namespace System
                 ThrowHelper.ThrowIndexOutOfRangeException();
 
             return new Span<T>(ref Element0, length);
+        }
+    }
+
+    // internal helper to compute and cache the Rank of an object array.
+    internal static class RankOf<R>
+    {
+        public static readonly int Value = GetRank();
+
+        private static int GetRank()
+        {
+            var type = typeof(R);
+            if (!type.IsArray)
+                throw new ArgumentException("R must be an array");
+
+            if (type.GetElementType() != typeof(object))
+                throw new ArgumentException("R must be an object array");
+
+            return type.GetArrayRank();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
@@ -15,7 +15,7 @@ namespace System
         public T Element0;
 
         /// <summary>
-        /// Indexer.
+        /// Gets or sets the element at the specified index.
         /// </summary>
         public T this[int index]
         {
@@ -24,8 +24,7 @@ namespace System
         }
 
         /// <summary>
-        /// Returns an address to an element of the ValueArray.
-        /// Caller must statically know the upperBound and pass it in.
+        /// Gets an element address at the specified index.
         /// </summary>
         public ref T Address(int index)
         {
@@ -37,7 +36,6 @@ namespace System
 
         /// <summary>
         /// Returns a slice of the ValueArray.
-        /// Caller must statically know the upperBound and pass it in.
         /// </summary>
         public Span<T> Slice(int length)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ValueArray.cs
@@ -7,30 +7,29 @@ using Internal.Runtime.CompilerServices;
 
 namespace System
 {
-    //    [Obsolete("Never use this type directly as that would be an array of unknown length.")]
-    //    [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct ValueArray<T>
+    public struct ValueArray<T, R> // where R : System.Array
     {
+        public static readonly int Length = typeof(R).GetArrayRank();
+
         // For the array of Length N, we will have N+1 elements immdiately follow.
         public T Element0;
 
         /// <summary>
         /// Indexer.
-        /// Caller must statically know the upperBound and pass it in.
         /// </summary>
-        public T this[int index, int upperBound = 42]
+        public T this[int index]
         {
-            get => Address(index, upperBound);
-            set => Address(index, upperBound) = value;
+            get => Address(index);
+            set => Address(index) = value;
         }
 
         /// <summary>
         /// Returns an address to an element of the ValueArray.
         /// Caller must statically know the upperBound and pass it in.
         /// </summary>
-        public ref T Address(int index, int upperBound = 42)
+        public ref T Address(int index)
         {
-            if ((uint)index >= (uint)upperBound)
+            if ((uint)index >= (uint)Length)
                 ThrowHelper.ThrowIndexOutOfRangeException();
 
             return ref Unsafe.Add(ref new ByReference<T>(ref Element0).Value, (nint)(uint)index /* force zero-extension */);
@@ -40,9 +39,9 @@ namespace System
         /// Returns a slice of the ValueArray.
         /// Caller must statically know the upperBound and pass it in.
         /// </summary>
-        public Span<T> Slice(int length, int upperBound = 42)
+        public Span<T> Slice(int length)
         {
-            if ((uint)length >= (uint)upperBound)
+            if ((uint)length >= (uint)Length)
                 ThrowHelper.ThrowIndexOutOfRangeException();
 
             return new Span<T>(ref Element0, length);

--- a/src/libraries/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
+++ b/src/libraries/System.Reflection.TypeExtensions/tests/ConstructorInfo/ConstructorInfoInvokeArrayTests.cs
@@ -226,7 +226,6 @@ namespace System.Reflection.Tests
             Type type = Type.GetType("System.Type[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]");
             ConstructorInfo[] cia = TypeExtensions.GetConstructors(type);
             Assert.Equal(2, cia.Length);
-            Assert.Throws<TypeLoadException>(() => Type.GetType("System.Type[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]"));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7899,11 +7899,10 @@ namespace System
     }
     public partial struct ValueArray<T, R> // where R : System.Array
     {
-        public static int Length { get { throw null; } }
+        public int Length { get { throw null; } }
         private T Element0;
-        public T this[int index] { get { throw null; } set { } }
-        public ref T Address(int index) { throw null; }
-        public Span<T> Slice(int length) { throw null; }
+        public ref T this[int index] { get { throw null; } }
+        public Span<T> Slice(int start) { throw null; }
     }
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7900,7 +7900,9 @@ namespace System
     public partial struct ValueArray<T>
     {
         public T Element0;
-        public T this[int index] { get { throw null; } set { } }
+        public T this[int index, int upperBound = 42] { get { throw null; } set { } }
+        public ref T Address(int index, int upperBound = 42) { throw null; }
+        public Span<T> Slice(int length, int upperBound = 42) { throw null; }
     }
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7899,7 +7899,7 @@ namespace System
     }
     public partial struct ValueArray<T, R> // where R : System.Array
     {
-        public static readonly int Length;
+        public static int Length { get { throw null; } }
         public T Element0;
         public T this[int index] { get { throw null; } set { } }
         public ref T Address(int index) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7897,6 +7897,11 @@ namespace System
         Path = 2,
         Query = 3,
     }
+    public partial struct ValueArray<T>
+    {
+        public T Element0;
+        public T this[int index] { get { throw null; } set { } }
+    }
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {
         object? System.Runtime.CompilerServices.ITuple.this[int index] { get { throw null; } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7897,12 +7897,13 @@ namespace System
         Path = 2,
         Query = 3,
     }
-    public partial struct ValueArray<T>
+    public partial struct ValueArray<T, R> // where R : System.Array
     {
+        public static readonly int Length;
         public T Element0;
-        public T this[int index, int upperBound = 42] { get { throw null; } set { } }
-        public ref T Address(int index, int upperBound = 42) { throw null; }
-        public Span<T> Slice(int length, int upperBound = 42) { throw null; }
+        public T this[int index] { get { throw null; } set { } }
+        public ref T Address(int index) { throw null; }
+        public Span<T> Slice(int length) { throw null; }
     }
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7898,11 +7898,16 @@ namespace System
         Query = 3,
     }
     public partial struct ValueArray<T, R> // where R : System.Array
+        : System.IEquatable<ValueArray<T, R>>
     {
         public int Length { get { throw null; } }
+        public ref T GetPinnableReference() { throw null; }
         private T Element0;
         public ref T this[int index] { get { throw null; } }
         public Span<T> Slice(int start) { throw null; }
+        public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
+        public bool Equals(ValueArray<T, R> other) { throw null; }
+        public override int GetHashCode() { throw null; }
     }
     public partial struct ValueTuple : System.Collections.IStructuralComparable, System.Collections.IStructuralEquatable, System.IComparable, System.IComparable<System.ValueTuple>, System.IEquatable<System.ValueTuple>, System.Runtime.CompilerServices.ITuple
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7900,7 +7900,7 @@ namespace System
     public partial struct ValueArray<T, R> // where R : System.Array
     {
         public static int Length { get { throw null; } }
-        public T Element0;
+        private T Element0;
         public T this[int index] { get { throw null; } set { } }
         public ref T Address(int index) { throw null; }
         public Span<T> Slice(int length) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7901,6 +7901,7 @@ namespace System
         : System.IEquatable<ValueArray<T, R>>
     {
         public int Length { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public ref T GetPinnableReference() { throw null; }
         private T Element0;
         public ref T this[int index] { get { throw null; } }

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -2010,7 +2010,9 @@ namespace System.Tests
         {
             var lengths = new int[length];
             var lowerBounds = new int[length];
-            Assert.Throws<TypeLoadException>(() => Array.CreateInstance(typeof(int), lengths, lowerBounds));
+
+            // does not throw
+            Array.CreateInstance(typeof(int), lengths, lowerBounds);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]

--- a/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
@@ -319,6 +319,7 @@ namespace System.Tests
             Assert.Throws<IndexOutOfRangeException>(() => t.MakeArrayType(rank));
         }
 
+        [ActiveIssue("HACKATHON: right now this works on a special version of CoreCLR only")]
         [Theory]
         [InlineData(33)]
         [InlineData(256)]

--- a/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
+++ b/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
@@ -1,8 +1,8 @@
 
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 public class Program
 {
@@ -12,7 +12,7 @@ public class Program
     {
         TestSizeOf();
         TestLength();
-        TestValueSemantic();
+        TestByValueSemantic();
         TestIndexing();
         TestSlice();
         TestGCRootsRef();
@@ -20,15 +20,25 @@ public class Program
         TestListT();
         TestAsField();
 
-        Console.WriteLine("DONE");
+        if (returnVal == 100)
+            Console.WriteLine("PASS");
+
         return returnVal;
     }
 
     class QuadTree
     {
+        // embedded indexable data with no indirections!!
         private ValueArray<QuadTree, object[,,,]> _nodes;
 
-        public ValueArray<QuadTree, object[,,,]> Nodes { get => _nodes; }
+        // NB: intentionally returning byval here - just to test byval returning.
+        public ValueArray<QuadTree, object[,,,]> Nodes
+        {
+            get
+            {
+                return _nodes;
+            }
+        }
 
         public QuadTree(int depth)
         {
@@ -55,8 +65,9 @@ public class Program
 
     private static void TestAsField()
     {
+        Console.WriteLine(nameof(TestAsField));
         QuadTree tree = new QuadTree(10);
-        Test(10, tree.CountNodes());
+        Test(1398101, tree.CountNodes());
     }
 
     private unsafe static void TestSizeOf()
@@ -113,9 +124,9 @@ public class Program
         Test(42, new ValueArray<int, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>().Length);
     }
 
-    private static void TestValueSemantic()
+    private static void TestByValueSemantic()
     {
-        Console.WriteLine(nameof(TestValueSemantic));
+        Console.WriteLine(nameof(TestByValueSemantic));
 
         var arr1 = new ValueArray<int, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>();
         for (int i = 0; i < arr1.Length; i++)
@@ -124,7 +135,6 @@ public class Program
         }
 
         var arr2 = arr1;
-
         for (int i = 0; i < arr1.Length; i++)
         {
             arr1[i]++;
@@ -135,6 +145,17 @@ public class Program
             Test(i, arr2[i]);
             Test(i + 1, arr1[i]);
         }
+
+        // NB: also testing boxing here.
+        IEquatable<ValueArray<int, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>> ieq = arr1;
+
+        var arr3 = arr1;
+        Test(true, ieq.Equals(arr3));
+        Test(arr3, arr1);
+        arr3[10] = -1;
+
+        Test(false, ieq.Equals(arr3));
+        Test(false, arr1.Equals(arr3));
     }
 
     private static void TestGCRootsRef()
@@ -168,7 +189,7 @@ public class Program
         }
     }
 
-    internal struct BSI
+    public struct BSI
     {
         public byte B;
         public string S;

--- a/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
+++ b/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Collections.Generic;
 
 public class Program
 {
@@ -17,9 +18,45 @@ public class Program
         TestGCRootsRef();
         TestGCRootsStruct();
         TestListT();
+        TestAsField();
 
         Console.WriteLine("DONE");
         return returnVal;
+    }
+
+    class QuadTree
+    {
+        private ValueArray<QuadTree, object[,,,]> _nodes;
+
+        public ValueArray<QuadTree, object[,,,]> Nodes { get => _nodes; }
+
+        public QuadTree(int depth)
+        {
+            if (depth > 0)
+            {
+                for (int i = 0; i < _nodes.Length; i++)
+                {
+                    _nodes[i] = new QuadTree(depth - 1);
+                }
+            }
+        }
+
+        public int CountNodes()
+        {
+            int val = 1;
+            for (int i = 0; i < Nodes.Length; i++)
+            {
+                val += Nodes[i]?.CountNodes() ?? 0;
+            }
+
+            return val;
+        }
+    }
+
+    private static void TestAsField()
+    {
+        QuadTree tree = new QuadTree(10);
+        Test(10, tree.CountNodes());
     }
 
     private unsafe static void TestSizeOf()

--- a/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
+++ b/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
@@ -19,6 +19,7 @@ public class Program
         TestGCRootsStruct();
         TestListT();
         TestAsField();
+        TestInFixed();
 
         if (returnVal == 100)
             Console.WriteLine("PASS");
@@ -26,9 +27,32 @@ public class Program
         return returnVal;
     }
 
+    private unsafe static void TestInFixed()
+    {
+        Console.WriteLine(nameof(TestInFixed));
+
+        var arr1 = new ValueArray<long, object[,,,,,,,,]>();
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            arr1[i] = i;
+        }
+
+        fixed (long* p = arr1)
+        {
+            for (long* pElement = p; pElement < p + 9; pElement++)
+            {
+                *pElement = *pElement + 1;
+            }
+        }
+
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            Test(i + 1, arr1[i]);
+        }
+    }
+
     class QuadTree
     {
-        // embedded indexable data with no indirections!!
         private ValueArray<QuadTree, object[,,,]> _nodes;
 
         // NB: intentionally returning byval here - just to test byval returning.

--- a/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
+++ b/src/tests/CoreMangLib/system/valuearray/ValueArray.cs
@@ -1,0 +1,210 @@
+
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    private static int returnVal = 100;
+
+    public static int Main(string[] args)
+    {
+        TestSizeOf();
+        TestLength();
+        TestValueSemantic();
+        TestIndexing();
+        TestSlice();
+        TestGCRootsRef();
+        TestGCRootsStruct();
+        TestListT();
+
+        Console.WriteLine("DONE");
+        return returnVal;
+    }
+
+    private unsafe static void TestSizeOf()
+    {
+        Console.WriteLine(nameof(TestSizeOf));
+
+        Test(sizeof(int) * 4, sizeof(ValueArray<int, object[,,,]>));
+        Test(sizeof(nint) * 5, sizeof(ValueArray<nint, object[,,,,]>));
+        Test(sizeof(ValueArray<byte, object[,,,,]>) * 6, sizeof(ValueArray<ValueArray<byte, object[,,,,]>, object[,,,,,]>));
+    }
+
+    private static void TestIndexing()
+    {
+        Console.WriteLine(nameof(TestIndexing));
+
+        var arr1 = new ValueArray<bool, object[,,,,,,,,]>();
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            arr1[i] = i % 2 == 0;
+        }
+
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            Test(i % 2 == 0, arr1[i]);
+        }
+    }
+
+    private static void TestSlice()
+    {
+        Console.WriteLine(nameof(TestSlice));
+
+        var arr1 = new ValueArray<bool, object[,,,,,,,,]>();
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            arr1[i] = i % 2 == 0;
+        }
+
+        var span = arr1.Slice(0);
+        Test(9, span.Length);
+        for (int i = 0; i < span.Length; i++)
+        {
+            Test(i % 2 == 0, span[i]);
+        }
+    }
+
+    private static void TestLength()
+    {
+        Console.WriteLine(nameof(TestLength));
+
+        Test(1, new ValueArray<int, object[]>().Length);
+        Test(2, new ValueArray<int, object[,]>().Length);
+        Test(3, new ValueArray<int, object[,,]>().Length);
+        Test(4, new ValueArray<int, object[,,,]>().Length);
+        Test(42, new ValueArray<int, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>().Length);
+    }
+
+    private static void TestValueSemantic()
+    {
+        Console.WriteLine(nameof(TestValueSemantic));
+
+        var arr1 = new ValueArray<int, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>();
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            arr1[i] = i;
+        }
+
+        var arr2 = arr1;
+
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            arr1[i]++;
+        }
+
+        for (int i = 0; i < arr1.Length; i++)
+        {
+            Test(i, arr2[i]);
+            Test(i + 1, arr1[i]);
+        }
+    }
+
+    private static void TestGCRootsRef()
+    {
+        Console.WriteLine(nameof(TestGCRootsRef));
+
+        var arrStr1 = new ValueArray<string, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>();
+        for (int i = 0; i < arrStr1.Length; i++)
+        {
+            arrStr1[i] = (i * 10000).ToString();
+        }
+
+        var junk = arrStr1;
+        for (int i = 0; i < arrStr1.Length; i++)
+        {
+            Test((i * 10000).ToString(), junk[i]);
+        }
+
+        GC.Collect();
+        GC.Collect();
+
+        var arrStr2 = new ValueArray<string, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>();
+        for (int i = 0; i < arrStr2.Length; i++)
+        {
+            arrStr2[i] = (i * 12345).ToString();
+        }
+
+        for (int i = 0; i < 42; i++)
+        {
+            Test((i * 10000).ToString(), arrStr1[i]);
+        }
+    }
+
+    internal struct BSI
+    {
+        public byte B;
+        public string S;
+        public int I;
+    }
+
+    private static void TestGCRootsStruct()
+    {
+        Console.WriteLine(nameof(TestGCRootsStruct));
+
+        var arrS1 = new ValueArray<BSI, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>();
+        for (int i = 0; i < 42; i++)
+        {
+            arrS1[i] = new BSI { S = (i * 10000).ToString() };
+        }
+
+        var arrS11 = arrS1;
+        for (int i = 0; i < 42; i++)
+        {
+            Test((i * 10000).ToString(), arrS11[i].S);
+        }
+
+        GC.Collect();
+        GC.Collect();
+
+        var arrS2 = new ValueArray<BSI, object[,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,]>();
+        for (int i = 0; i < 42; i++)
+        {
+            arrS2[i] = new BSI { S = (i * 12345).ToString() };
+        }
+
+        for (int i = 0; i < 42; i++)
+        {
+            Test((i * 10000).ToString(), arrS1[i].S);
+        }
+    }
+
+    private static void TestListT()
+    {
+        Console.WriteLine(nameof(TestListT));
+
+        var list = new List<ValueArray<BSI, object[,,,,,,,,]>>();
+
+        for (int j = 0; j < 100; j++)
+        {
+            var arrS1 = new ValueArray<BSI, object[,,,,,,,,]>();
+            for (int i = 0; i < arrS1.Length; i++)
+            {
+                arrS1[i] = new BSI { S = (i * j).ToString() };
+            }
+
+            list.Add(arrS1);
+        }
+
+        for (int j = 0; j < 100; j++)
+        {
+            var arrS1 = list[j];
+            int i = 0;
+            foreach (ref var refS in arrS1.Slice(0))
+            {
+                GC.Collect();
+
+                Test((i++ * j).ToString(), refS.S);
+            }
+        }
+    }
+
+    public static void Test<T>(T expected, T actual) where T : IEquatable<T>
+    {
+        if (!expected.Equals(actual))
+        {
+            Console.WriteLine($"Fail: {expected}, {actual}");
+            returnVal++;
+        }
+    }
+}

--- a/src/tests/CoreMangLib/system/valuearray/ValueArray.csproj
+++ b/src/tests/CoreMangLib/system/valuearray/ValueArray.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>None</DebugType>
+    <Optimize />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ValueArray.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/CoreMangLib/system/valuearray/ValueArray_ro.csproj
+++ b/src/tests/CoreMangLib/system/valuearray/ValueArray_ro.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ValueArray.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -849,6 +849,10 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems in *all* runtime modes -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/CoreMangLib/system/valuearray/**">
+          <Issue>ValueArray NYI on mono</Issue>
+        </ExcludeList>
+      
         <ExcludeList Include = "$(XunitTestBinBase)/reflection/GenericAttribute/**">
             <Issue>https://github.com/dotnet/runtime/issues/56887</Issue>
         </ExcludeList>


### PR DESCRIPTION
`ValueArray<T, R>` is a data type that represents an indexable fixed-sized chunk of data containing N elements of type T.

The `R` type argument must be an object array type, that is not used for anything other than to convey the length of the value array declaratively - via the `R`'s rank.

The only "magical" part of the `ValueArray` type is that the VM logically replicates the storage N times and adjusts the instance layout and GC tracking accordingly.

In all other ways this is a regular struct - it can be copied by value, embedded in another struct/class, passed in/out of methods, stored on the heap, boxed...