### PR TITLE
[hackathon] CreateSpan<T> support of a RVA field of a primitive type

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3650,9 +3650,17 @@ GenTree* Compiler::impCreateSpanIntrinsic(CORINFO_SIG_INFO* sig)
 
     CORINFO_CLASS_HANDLE fieldClsHnd;
     var_types fieldElementType = JITtype2varType(info.compCompHnd->getFieldType(fieldToken, &fieldClsHnd, fieldOwnerHnd));
-    assert(fieldElementType == var_types::TYP_STRUCT);
+    unsigned totalFieldSize;
 
-    const unsigned totalFieldSize = info.compCompHnd->getClassSize(fieldClsHnd);
+    // Most static initialization data fields are of some structure, but it is possible for them to be of various primitive types as well
+    if (fieldElementType == var_types::TYP_STRUCT)
+    {
+        totalFieldSize = info.compCompHnd->getClassSize(fieldClsHnd);
+    }
+    else
+    {
+        totalFieldSize = genTypeSize(fieldElementType);
+    }
 
     // Limit to primitive or enum type - see ArrayNative::GetSpanDataFrom()
     CORINFO_CLASS_HANDLE targetElemHnd  = sig->sigInst.methInst[0];


### PR DESCRIPTION
Most static initialization data fields are of a structure type, but it is legal for them to be of a primitive type. Fix the CreateSpan intrinsic to handle that case