### PR TITLE
Disable PerformanceCounter_NextValue_ProcessorCounter on Windows ARM64

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/PerformanceCounterTests.cs
@@ -151,6 +151,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60403", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows))]
         public static void PerformanceCounter_NextValue_ProcessorCounter()
         {
             using (PerformanceCounter counterSample = new PerformanceCounter("Processor", "Interrupts/sec", "_Total", "."))


### PR DESCRIPTION
Disables test from https://github.com/dotnet/runtime/issues/60403

This currently consistently fails on rolling builds.

I've already run the build for this: https://dev.azure.com/dnceng/public/_build/results?buildId=1427004&view=results - there are two unrelated failures there but non of them is related to the one I'm disabling here