### PR TITLE
[release/6.0] Update NetFramework.ReferenceAssemblies version to 1.0.2

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -40,7 +40,7 @@
       <InnerBuildArgs>$(InnerBuildArgs) --verbosity $(LogVerbosity)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) --nodereuse false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) --warnAsError false</InnerBuildArgs>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:MicrosoftNetFrameworkReferenceAssembliesVersion=1.0.0</InnerBuildArgs>
+      <InnerBuildArgs>$(InnerBuildArgs) /p:MicrosoftNetFrameworkReferenceAssembliesVersion=1.0.2</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:PackageRid=$(TargetRid)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:NoPgoOptimize=true</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:KeepNativeSymbols=true</InnerBuildArgs>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/2529.

https://github.com/dotnet/source-build/issues/2533 is adding v1.0.2 to SBRP, so we need to use the same version so it isn't a pre-built.