### PR TITLE
Use SDK's .NETFramework refpack version

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -40,7 +40,6 @@
       <InnerBuildArgs>$(InnerBuildArgs) --verbosity $(LogVerbosity)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) --nodereuse false</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) --warnAsError false</InnerBuildArgs>
-      <InnerBuildArgs>$(InnerBuildArgs) /p:MicrosoftNetFrameworkReferenceAssembliesVersion=1.0.0</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:PackageRid=$(TargetRid)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:NoPgoOptimize=true</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) /p:KeepNativeSymbols=true</InnerBuildArgs>

--- a/src/libraries/shims/ApiCompat.proj
+++ b/src/libraries/shims/ApiCompat.proj
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="microsoft.netcore.app.ref" Version="[$(NetCoreAppLatestStablePackageBaselineVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(NetCoreAppLatestStablePackageBaselineVersion)]" />
     <PackageDownload Include="NETStandard.Library.Ref" Version="[$(NETStandardLibraryRefVersion)]" />
     <PackageDownload Include="NETStandard.Library" Version="[$(NetStandardLibraryVersion)]" />
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="$(MicrosoftDotNetApiCompatVersion)" IsImplicitlyDefined="true" />

--- a/src/libraries/shims/Directory.Build.props
+++ b/src/libraries/shims/Directory.Build.props
@@ -3,12 +3,6 @@
   <Import Project="..\Directory.Build.props" />
   <Import Project="netfxreference.props" />
 
-  <PropertyGroup>
-    <NETFrameworkReferenceAssemblyTFM>net48</NETFrameworkReferenceAssemblyTFM>
-    <NetFxRefPath>$(NuGetPackageRoot)microsoft.netframework.referenceassemblies.$(NETFrameworkReferenceAssemblyTFM)\$(MicrosoftNetFrameworkReferenceAssembliesVersion)\build\.NETFramework\v4.8\</NetFxRefPath>
-    <NETStandard21RefPath>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'netstandard.library.ref', '$(NETStandardLibraryRefVersion)', 'ref', 'netstandard2.1'))</NETStandard21RefPath>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(IsFrameworkSupportFacade)' == 'true'">
     <IsNETCoreAppSrc>true</IsNETCoreAppSrc>
     <IsNETCoreAppRef>true</IsNETCoreAppRef>

--- a/src/libraries/shims/Directory.Build.targets
+++ b/src/libraries/shims/Directory.Build.targets
@@ -1,7 +1,22 @@
 <Project>
-  <ItemGroup Condition="'$(IsFrameworkSupportFacade)' == 'true'">
-    <ResolvedMatchingContract Include="$(ContractAssemblyPath)" />
+  <Import Project="..\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <NETFrameworkReferenceAssemblyTFM>net48</NETFrameworkReferenceAssemblyTFM>
+    <NetFxRefPath>$(NuGetPackageRoot)microsoft.netframework.referenceassemblies.$(NETFrameworkReferenceAssemblyTFM)\$(MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion)\build\.NETFramework\v4.8\</NetFxRefPath>
+    <NETStandard21RefPath>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', 'netstandard.library.ref', '$(NETStandardLibraryRefVersion)', 'ref', 'netstandard2.1'))</NETStandard21RefPath>
+  </PropertyGroup>
+
+  <!-- Download the corresponding targeting pack to build against the contract. -->
+  <ItemGroup Condition="'$(IsFrameworkSupportFacade)' == 'true' and '$(MSBuildProjectName)' == 'netstandard'">
+    <PackageDownload Include="NETStandard.Library.Ref"
+                     Version="[$(NETStandardLibraryRefVersion)]" />
+    <ResolvedMatchingContract Include="$(NETStandard21RefPath)$(MSBuildProjectName).dll" />
   </ItemGroup>
 
-  <Import Project="..\Directory.Build.targets" />
+  <ItemGroup Condition="'$(IsFrameworkSupportFacade)' == 'true' and '$(MSBuildProjectName)' != 'netstandard'">
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.$(NETFrameworkReferenceAssemblyTFM)"
+                     Version="[$(MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion)]" />
+    <ResolvedMatchingContract Include="$(NetFxRefPath)$(MSBuildProjectName).dll" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/shims/generateShims.proj
+++ b/src/libraries/shims/generateShims.proj
@@ -13,7 +13,6 @@
        <_contractName>%(GenFacadesContracts.Identity)</_contractName>
        <_contractStrongNameKeyId>%(GenFacadesContracts.StrongNameKeyId)</_contractStrongNameKeyId>
        <_contractStrongNameKeyId Condition="'$(_contractStrongNameKeyId)' == ''">Microsoft</_contractStrongNameKeyId>
-       <_contractDirProperty>%(GenFacadesContracts.ContractDir)</_contractDirProperty>
        <_contractAssembly>$(%(GenFacadesContracts.ContractDir))$(_contractName).dll</_contractAssembly>
        <_contractProjectFile>generated/$(_contractName).csproj</_contractProjectFile>
      </PropertyGroup>
@@ -37,7 +36,6 @@
   <PropertyGroup>
     <AssemblyVersion>$(_contractAssemblyVersion)</AssemblyVersion>
     <StrongNameKeyId>$(_contractStrongNameKeyId)</StrongNameKeyId>
-    <ContractAssemblyPath>%24($(_contractDirProperty))%24(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'%24(MSBuildProjectFullPath)' == '%24(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/Directory.Build.props
+++ b/src/libraries/shims/generated/Directory.Build.props
@@ -14,15 +14,8 @@
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- Download the .NET Framework RefPack to build against the contract. -->
+  <!-- System.Data.SqlClient is not live built anymore, reference it manually. -->
   <ItemGroup>
-    <PackageDownload Include="NETStandard.Library.Ref"
-                     Condition="'$(MSBuildProjectName)' == 'netstandard'"
-                     Version="[$(NETStandardLibraryRefVersion)]" />
-    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.$(NETFrameworkReferenceAssemblyTFM)"
-                     Condition="'$(MSBuildProjectName)' != 'netstandard'"
-                     Version="[$(MicrosoftNetFrameworkReferenceAssembliesVersion)]" />
-    <!-- System.Data.SqlClient is not live built anymore, reference it manually. -->
     <PackageReference Include="System.Data.SqlClient"
                       Version="$(SystemDataSqlClientVersion)" />
   </ItemGroup>

--- a/src/libraries/shims/generated/Microsoft.VisualBasic.csproj
+++ b/src/libraries/shims/generated/Microsoft.VisualBasic.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>10.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.ComponentModel.DataAnnotations.csproj
+++ b/src/libraries/shims/generated/System.ComponentModel.DataAnnotations.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Configuration.csproj
+++ b/src/libraries/shims/generated/System.Configuration.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Core.csproj
+++ b/src/libraries/shims/generated/System.Core.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Data.csproj
+++ b/src/libraries/shims/generated/System.Data.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Drawing.csproj
+++ b/src/libraries/shims/generated/System.Drawing.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.IO.Compression.FileSystem.csproj
+++ b/src/libraries/shims/generated/System.IO.Compression.FileSystem.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Net.csproj
+++ b/src/libraries/shims/generated/System.Net.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Numerics.csproj
+++ b/src/libraries/shims/generated/System.Numerics.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Runtime.Serialization.csproj
+++ b/src/libraries/shims/generated/System.Runtime.Serialization.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Security.csproj
+++ b/src/libraries/shims/generated/System.Security.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.ServiceModel.Web.csproj
+++ b/src/libraries/shims/generated/System.ServiceModel.Web.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.ServiceProcess.csproj
+++ b/src/libraries/shims/generated/System.ServiceProcess.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Transactions.csproj
+++ b/src/libraries/shims/generated/System.Transactions.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Web.csproj
+++ b/src/libraries/shims/generated/System.Web.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Windows.csproj
+++ b/src/libraries/shims/generated/System.Windows.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Xml.Linq.csproj
+++ b/src/libraries/shims/generated/System.Xml.Linq.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Xml.Serialization.csproj
+++ b/src/libraries/shims/generated/System.Xml.Serialization.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.Xml.csproj
+++ b/src/libraries/shims/generated/System.Xml.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/System.csproj
+++ b/src/libraries/shims/generated/System.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/WindowsBase.csproj
+++ b/src/libraries/shims/generated/WindowsBase.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/mscorlib.csproj
+++ b/src/libraries/shims/generated/mscorlib.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <ContractAssemblyPath>$(NetFxRefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/libraries/shims/generated/netstandard.csproj
+++ b/src/libraries/shims/generated/netstandard.csproj
@@ -6,7 +6,6 @@
   <PropertyGroup>
     <AssemblyVersion>2.1.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <ContractAssemblyPath>$(NETStandard21RefPath)$(MSBuildProjectName).dll</ContractAssemblyPath>
   </PropertyGroup>
   <Import Condition="'$(MSBuildProjectFullPath)' == '$(MSBuildThisFileFullPath)'" Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>


### PR DESCRIPTION
Use the MicrosoftNETFrameworkReferenceAssembliesLatestPackageVersion property which is exposed by the SDK instead of the one exposed by Arcade to make sure that we are always targeting the latest version.