### PR TITLE
Fix invalid behavior of MoveToAttribute methods

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNodeReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNodeReader.cs
@@ -1360,32 +1360,23 @@ namespace System.Xml
         // Moves to the attribute with the specified name.
         public override bool MoveToAttribute(string name)
         {
-            if (!IsInReadingStates())
-                return false;
-            _readerNav.ResetMove(ref _curDepth, ref _nodeType);
-            if (_readerNav.MoveToAttribute(name))
-            { //, ref curDepth ) ) {
-                _curDepth++;
-                _nodeType = _readerNav.NodeType;
-                if (_bInReadBinary)
-                {
-                    FinishReadBinary();
-                }
-                return true;
-            }
-            _readerNav.RollBackMove(ref _curDepth);
-            return false;
+            return MoveToAttribute(name, string.Empty);
         }
 
         // Moves to the attribute with the specified name and namespace.
         public override bool MoveToAttribute(string name, string? namespaceURI)
         {
             if (!IsInReadingStates())
+            {
                 return false;
+            }
+
+            XmlNodeType savedNodeType = _nodeType;
+
             _readerNav.ResetMove(ref _curDepth, ref _nodeType);
-            string ns = (namespaceURI == null) ? string.Empty : namespaceURI;
+            string ns = namespaceURI ?? string.Empty;
             if (_readerNav.MoveToAttribute(name, ns))
-            { //, ref curDepth ) ) {
+            {
                 _curDepth++;
                 _nodeType = _readerNav.NodeType;
                 if (_bInReadBinary)
@@ -1395,6 +1386,7 @@ namespace System.Xml
                 return true;
             }
             _readerNav.RollBackMove(ref _curDepth);
+            _nodeType = savedNodeType;
             return false;
         }
 

--- a/src/libraries/System.Private.Xml/tests/XmlNodeReader/System.Xml.XmlNodeReader.Tests/XmlNodeReaderMoveToAttributeTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlNodeReader/System.Xml.XmlNodeReader.Tests/XmlNodeReaderMoveToAttributeTests.cs
@@ -123,7 +123,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34443")]
         public void XmlNodeReaderMoveToUnexistedAttribute()
         {
             string xml = "<root><child attr1='value1'><other /></child></root>";

--- a/src/libraries/System.Private.Xml/tests/XmlNodeReader/System.Xml.XmlNodeReader.Tests/XmlNodeReaderMoveToAttributeTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlNodeReader/System.Xml.XmlNodeReader.Tests/XmlNodeReaderMoveToAttributeTests.cs
@@ -121,5 +121,23 @@ namespace System.Xml.Tests
             nodeReader.ReadContentAsBase64(new byte[33], 10, 10);
             Assert.True(nodeReader.MoveToElement());
         }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34443")]
+        public void XmlNodeReaderMoveToUnexistedAttribute()
+        {
+            string xml = "<root><child attr1='value1'><other /></child></root>";
+
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+            using (var nodeReader = new XmlNodeReader(doc.DocumentElement.FirstChild))
+            {
+                Assert.True(nodeReader.IsStartElement("child"));
+                Assert.True(nodeReader.MoveToAttribute("attr1"));
+                Assert.False(nodeReader.MoveToAttribute("attr2"));
+                Exception exception = Record.Exception(() => nodeReader.ReadStartElement("child"));
+                Assert.Null(exception);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fix [Issue-34443](https://github.com/dotnet/runtime/issues/34443).