### PR TITLE
[metadata] Cleanup some uses of m_class_get_this_arg

### DIFF
--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -3409,7 +3409,7 @@ emit_virtual_stelemref_ilgen (MonoMethodBuilder *mb, const char **param_names, M
 	mono_mb_set_param_names (mb, param_names);
 	MonoType *int_type = mono_get_int_type ();
 	MonoType *int32_type = m_class_get_byval_arg (mono_defaults.int32_class);
-	MonoType *object_type_byref = m_class_get_this_arg (mono_defaults.object_class);
+	MonoType *object_type_byref = mono_class_get_byref_type (mono_defaults.object_class);
 
 	/*For now simply call plain old stelemref*/
 	switch (kind) {
@@ -3817,7 +3817,7 @@ emit_stelemref_ilgen (MonoMethodBuilder *mb)
 	int array_slot_addr;
 	
 	MonoType *int_type = mono_get_int_type ();
-	MonoType *object_type_byref = m_class_get_this_arg (mono_defaults.object_class);
+	MonoType *object_type_byref = mono_class_get_byref_type (mono_defaults.object_class);
 
 	aklass = mono_mb_add_local (mb, int_type);
 	vklass = mono_mb_add_local (mb, int_type);
@@ -6093,7 +6093,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 #ifndef DISABLE_COM
 	MonoMethodBuilder *mb = m->mb;
 	MonoType *variant_type = m_class_get_byval_arg (mono_class_get_variant_class ());
-	MonoType *variant_type_byref = m_class_get_this_arg (mono_class_get_variant_class ());
+	MonoType *variant_type_byref = mono_class_get_byref_type (mono_class_get_variant_class ());
 	MonoType *object_type = mono_get_object_type ();
 
 	switch (action) {

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -2306,7 +2306,7 @@ get_runtime_invoke_type (MonoType *t, gboolean ret)
 			return t;
 
 		/* Can't share this with 'I' as that needs another indirection */
-		return m_class_get_this_arg (mono_defaults.int_class);
+		return mono_class_get_byref_type (mono_defaults.int_class);
 	}
 
 	if (MONO_TYPE_IS_REFERENCE (t))

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -2126,7 +2126,7 @@ mono_reflection_get_type_internal (MonoAssemblyLoadContext *alc, MonoImage *root
 	for (mod = info->modifiers; mod; mod = mod->next) {
 		modval = GPOINTER_TO_UINT (mod->data);
 		if (!modval) { /* byref: must be last modifier */
-			type = m_class_get_this_arg (klass);
+			type = mono_class_get_byref_type (klass);
 			goto leave;
 		} else if (modval == -1) {
 			klass = mono_class_create_ptr (m_class_get_byval_arg (klass));

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -8766,7 +8766,7 @@ get_concrete_sig (MonoMethodSignature *sig)
 	//printf ("%s\n", mono_signature_full_name (sig));
 
 	if (m_type_is_byref (sig->ret))
-		copy->ret = m_class_get_this_arg (mono_defaults.int_class);
+		copy->ret = mono_class_get_byref_type (mono_defaults.int_class);
 	else
 		copy->ret = mini_get_underlying_type (sig->ret);
 	if (!is_concrete_type (copy->ret))

--- a/src/mono/mono/mini/calls.c
+++ b/src/mono/mono/mini/calls.c
@@ -888,7 +888,7 @@ sig_to_rgctx_sig (MonoMethodSignature *sig)
 	res->param_count = sig->param_count + 1;
 	for (i = 0; i < sig->param_count; ++i)
 		res->params [i] = sig->params [i];
-	res->params [sig->param_count] = m_class_get_this_arg (mono_defaults.int_class);
+	res->params [sig->param_count] = mono_class_get_byref_type (mono_defaults.int_class);
 	return res;
 }
 

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -1261,7 +1261,7 @@ static MonoType*
 get_wrapper_shared_type_full (MonoType *t, gboolean is_field)
 {
 	if (m_type_is_byref (t))
-		return m_class_get_this_arg (mono_defaults.int_class);
+		return mono_class_get_byref_type (mono_defaults.int_class);
 	t = mini_get_underlying_type (t);
 
 	switch (t->type) {
@@ -1770,7 +1770,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 
 	for (i = 0; i < sig->param_count; i++) {
 		if (m_type_is_byref (sig->params [i]))
-			csig->params [i] = m_class_get_this_arg (mono_defaults.int_class);
+			csig->params [i] = mono_class_get_byref_type (mono_defaults.int_class);
 	}
 
 	MonoType *int_type = mono_get_int_type ();

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -153,7 +153,6 @@ mono_class_check_context_used (MonoClass *klass)
 {
 	int context_used = 0;
 
-	context_used |= type_check_context_used (m_class_get_this_arg (klass), FALSE);
 	context_used |= type_check_context_used (m_class_get_byval_arg (klass), FALSE);
 
 	if (mono_class_is_ginst (klass))

--- a/src/mono/mono/mini/mini-native-types.c
+++ b/src/mono/mono/mini/mini-native-types.c
@@ -471,12 +471,12 @@ mini_native_type_replace_type (MonoType *type)
 	klass = type->data.klass;
 
 	if (mono_class_is_magic_int (klass))
-		return m_type_is_byref (type) ? m_class_get_this_arg (mono_defaults.int_class) : mono_get_int_type ();
+		return m_type_is_byref (type) ? mono_class_get_byref_type (mono_defaults.int_class) : mono_get_int_type ();
 	if (mono_class_is_magic_float (klass))
 #if TARGET_SIZEOF_VOID_P == 8
-		return m_type_is_byref (type) ? m_class_get_this_arg (mono_defaults.double_class) : m_class_get_byval_arg (mono_defaults.double_class);
+		return m_type_is_byref (type) ? mono_class_get_byref_type (mono_defaults.double_class) : m_class_get_byval_arg (mono_defaults.double_class);
 #else
-		return m_type_is_byref (type) ? m_class_get_this_arg (mono_defaults.single_class) : m_class_get_byval_arg (mono_defaults.single_class);
+		return m_type_is_byref (type) ? mono_class_get_byref_type (mono_defaults.single_class) : m_class_get_byval_arg (mono_defaults.single_class);
 #endif
 	return type;
 }

--- a/src/mono/mono/mini/mini-x86.c
+++ b/src/mono/mono/mini/mini-x86.c
@@ -1649,7 +1649,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 						/* this */
 						if (call->need_unbox_trampoline)
 							/* The unbox trampoline transforms this into a managed pointer */
-							emit_gc_param_slot_def (cfg, ainfo->offset, m_class_get_this_arg (mono_defaults.int_class));
+							emit_gc_param_slot_def (cfg, ainfo->offset, mono_class_get_byref_type (mono_defaults.int_class));
 						else
 							emit_gc_param_slot_def (cfg, ainfo->offset, mono_get_object_type ());
 					} else {

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -836,7 +836,7 @@ type_from_stack_type (MonoInst *ins)
 		if (ins->klass)
 			return m_class_get_this_arg (ins->klass);
 		else
-			return m_class_get_this_arg (mono_defaults.object_class);
+			return mono_class_get_byref_type (mono_defaults.object_class);
 	case STACK_OBJ:
 		/* ins->klass may not be set for ldnull.
 		 * Also, if we have a boxed valuetype, we want an object lass,


### PR DESCRIPTION
Two cleanups:

1. In cases where `m_class_get_this_arg` is just used to create a byref `MonoType` - not to get a `MonoType` that will be used as a `this` argument, use `mono_class_get_byref_type` to indicate intent. No functional change.
2. Remove call to `type_check_context_used (m_class_get_this_arg (klass), FALSE);` in generic sharing - since `m_class_get_this_arg` and `m_class_get_byval_arg` just differ by the `byref` bit and `type_check_context_used` will return the same result both times.