### PR TITLE
[Mono] Add support for "byref of any type" to the type system

### DIFF
--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -122,6 +122,7 @@
     <DefineConstants Condition="'$(FeatureManagedEtwChannels)' == 'true'">$(DefineConstants);FEATURE_MANAGED_ETW_CHANNELS</DefineConstants>
     <DefineConstants Condition="'$(FeaturePerfTracing)' == 'true'">$(DefineConstants);FEATURE_PERFTRACING</DefineConstants>
     <DefineConstants Condition="'$(FeatureObjCMarshal)' == 'true'">$(DefineConstants);FEATURE_OBJCMARSHAL</DefineConstants>
+    <DefineConstants Condition="'$(MonoFeatureAnyByref)' == 'true'">$(DefineConstants);MONO_FEATURE_ANY_BYREF</DefineConstants>
   </PropertyGroup>
 
   <!-- ILLinker settings -->

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1902,8 +1902,10 @@ namespace System
 
         public override Type MakeByRefType()
         {
+#if !MONO_FEATURE_ANY_BYREF
             if (IsByRef)
                 throw new TypeLoadException("Can not call MakeByRefType on a ByRef type");
+#endif
             return make_byref_type();
         }
 

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -1025,6 +1025,9 @@
 /* Enable experiment 'Tiered Compilation' */
 #cmakedefine ENABLE_EXPERIMENT_TIERED 1
 
+/* Enable support for byref of any type */
+#cmakedefine ENABLE_EXPERIMENT_ANY_BYREF 1
+
 /* Enable checked build */
 #cmakedefine ENABLE_CHECKED_BUILD 1
 

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -440,11 +440,17 @@
       <_MonoCMakeArgs Include="-DENABLE_MSCORDBI=1" />
     </ItemGroup>
 
+    <!-- Experimental byref of any type support -->
+    <ItemGroup Condition="'$(MonoFeatureAnyByref)' == 'true'">
+      <_MonoCMakeArgs Include="-DMONO_EXPERIMENT_ANY_BYREF" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_PAL_TCP=1"/>
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_DISABLE_DEFAULT_LISTEN_PORT=1"/>
       <_MonoCMakeArgs Include="-DDISABLE_LINK_STATIC_COMPONENTS=1" Condition="!('$(TargetsiOSSimulator)' == 'true' or '$(TargetstvOSSimulator)' == 'true')"/>
     </ItemGroup>
+
 
     <ItemGroup Condition="'$(TargetsAndroid)' == 'true'">
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_PAL_TCP=1"/>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -442,7 +442,7 @@
 
     <!-- Experimental byref of any type support -->
     <ItemGroup Condition="'$(MonoFeatureAnyByref)' == 'true'">
-      <_MonoCMakeArgs Include="-DMONO_EXPERIMENT_ANY_BYREF" />
+      <_MonoCMakeArgs Include="-DMONO_EXPERIMENT_ANY_BYREF=1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1506,6 +1506,10 @@ mono_class_create_ptr (MonoType *type)
 MonoClass *
 mono_class_create_byref (MonoType *type)
 {
+#ifndef ENABLE_EXPERIMENT_ANY_BYREF
+	g_assert_not_reached ();
+#endif
+
 	MonoClass *result;
 	MonoClass *el_class;
 	MonoImage *image;
@@ -1535,7 +1539,7 @@ mono_class_create_byref (MonoType *type)
 		}
 		mono_image_unlock (image);
 	}
-	
+
 	result = mm ? (MonoClass *)mono_mem_manager_alloc0 (mm, sizeof (MonoClassPointer)) : (MonoClass *)mono_image_alloc0 (image, sizeof (MonoClassPointer));
 
 	UnlockedAdd (&classes_size, sizeof (MonoClassPointer));
@@ -4126,8 +4130,10 @@ mono_classes_init (void)
 							MONO_COUNTER_METADATA | MONO_COUNTER_INT, &class_array_count);
 	mono_counters_register ("MonoClassPointer count",
 							MONO_COUNTER_METADATA | MONO_COUNTER_INT, &class_pointer_count);
+#ifdef ENABLE_EXPERIMENT_ANY_BYREF
 	mono_counters_register ("MonoClassPointer (byref) count",
 							MONO_COUNTER_METADATA | MONO_COUNTER_INT, &class_byref_count);
+#endif
 	mono_counters_register ("Inflated methods size",
 							MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &mono_inflated_methods_size);
 	mono_counters_register ("Inflated classes size",

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1581,9 +1581,9 @@ mono_class_create_byref (MonoType *type)
 	}
 
 	/* The MonoType for ElementType&&. */
-	result->_this_arg.type = MONO_TYPE_BYREF;
-	result->_this_arg.data.type = &result->_byval_arg;
-	result->_this_arg.byref__ = TRUE;
+	result->this_arg.type = MONO_TYPE_BYREF;
+	result->this_arg.data.type = &result->_byval_arg;
+	result->this_arg.byref__ = TRUE;
 	
 	mono_class_setup_supertypes (result);
 

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1516,7 +1516,7 @@ mono_class_create_byref (MonoType *type)
 	char *name;
 	MonoMemoryManager *mm;
 
-	el_class = mono_class_from_mono_type_internal (type);
+	el_class = mono_class_from_mono_type2 (type, FALSE);
 	image = el_class->image;
 	// FIXME: Optimize this
 	mm = class_kind_may_contain_generic_instances ((MonoTypeKind)el_class->class_kind) ? mono_metadata_get_mem_manager_for_class (el_class) : NULL;

--- a/src/mono/mono/metadata/class-init.h
+++ b/src/mono/mono/metadata/class-init.h
@@ -37,6 +37,9 @@ mono_class_create_ptr (MonoType *type);
 MonoClass *
 mono_class_create_fnptr (MonoMethodSignature *sig);
 
+MonoClass *
+mono_class_create_byref (MonoType *type);
+
 void
 mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int onum, GList *in_setup);
 

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1303,6 +1303,9 @@ mono_class_from_mono_type_internal (MonoType *type);
 MonoClass *
 mono_class_from_mono_type2 (MonoType *type, gboolean strip_byref);
 
+gboolean
+mono_class_is_byref (MonoClass *klass);
+
 MONO_COMPONENT_API MonoClassField*
 mono_field_from_token_checked (MonoImage *image, uint32_t token, MonoClass **retklass, MonoGenericContext *context, MonoError *error);
 

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -247,7 +247,7 @@ typedef enum {
 	MONO_CLASS_GINST, /* generic instantiation */
 	MONO_CLASS_GPARAM, /* generic parameter */
 	MONO_CLASS_ARRAY, /* vector or array, bounded or not */
-	MONO_CLASS_POINTER, /* pointer or function pointer*/
+	MONO_CLASS_POINTER, /* pointer or function pointer or byref */
 	MONO_CLASS_GC_FILLER = 0xAC /* not a real class kind - used for sgen nursery filler arrays */
 } MonoTypeKind;
 
@@ -1299,6 +1299,9 @@ mono_class_from_name_case_checked (MonoImage *image, const char* name_space, con
 
 MONO_PROFILER_API MonoClass *
 mono_class_from_mono_type_internal (MonoType *type);
+
+MonoClass *
+mono_class_from_mono_type2 (MonoType *type, gboolean strip_byref);
 
 MONO_COMPONENT_API MonoClassField*
 mono_field_from_token_checked (MonoImage *image, uint32_t token, MonoClass **retklass, MonoGenericContext *context, MonoError *error);

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -6731,3 +6731,17 @@ mono_class_has_default_constructor (MonoClass *klass, gboolean public_only)
 	}
 	return FALSE;
 }
+
+gboolean
+mono_class_is_byref (MonoClass *klass)
+{
+#ifndef ENABLE_EXPERIMENT_ANY_BYREF
+	g_assert_not_reached ();
+#endif
+	if (G_LIKELY (m_class_get_class_kind (klass) != MONO_CLASS_POINTER))
+		return FALSE;
+	MonoType *t = m_class_get_byval_arg (klass);
+	if (t->type == MONO_TYPE_BYREF || m_type_is_byref (t))
+		return TRUE;
+	return FALSE;
+}

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2177,9 +2177,11 @@ mono_class_from_mono_type2 (MonoType *type, gboolean strip_byref)
 	g_assert (type);
 	if (!strip_byref) {
 		if (m_type_is_byref (type)) {
-			if (type->type != MONO_TYPE_BYREF)
-				return mono_class_create_byref (type);
-			else
+			if (type->type != MONO_TYPE_BYREF) {
+				/* strip off the byref bit and get a class */
+				MonoClass *el_class = mono_class_from_mono_type2 (type, TRUE);
+				return mono_class_create_byref (m_class_get_byval_arg (el_class));
+			} else
 				return mono_class_create_byref (type->data.type);
 		}
 		g_assert (!m_type_is_byref (type) && type->type != MONO_TYPE_BYREF);

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -875,6 +875,9 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		nt->data.generic_class = gclass;
 		return nt;
 	}
+#ifdef ENABLE_EXPERIMENT_ANY_BYREF
+	case MONO_TYPE_BYREF:
+#endif
 	case MONO_TYPE_PTR: {
 		MonoType *nt, *inflated = inflate_generic_type (image, type->data.type, context, error);
 		if ((!inflated && !changed) || !is_ok (error))

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2174,6 +2174,9 @@ mono_class_from_mono_type_internal (MonoType *type)
 MonoClass *
 mono_class_from_mono_type2 (MonoType *type, gboolean strip_byref)
 {
+#ifndef ENABLE_EXPERIMENT_ANY_BYREF
+	g_assert (strip_byref);
+#endif
 	g_assert (type);
 	if (!strip_byref) {
 		if (m_type_is_byref (type)) {
@@ -2231,6 +2234,10 @@ mono_class_from_mono_type2 (MonoType *type, gboolean strip_byref)
 	case MONO_TYPE_FNPTR:
 		return mono_class_create_fnptr (type->data.method);
 	case MONO_TYPE_BYREF:
+#ifndef ENABLE_EXPERIMENT_ANY_BYREF
+		g_warning ("mono_class_from_mono_type2: called on MONO_TYPE_BYREF");
+		g_assert_not_reached ();
+#endif
 		/* case where strip_byref is false is handled above.  if strip_byref is true, we
 		 * want to peel off one layer of "byref".
 		 */

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -707,6 +707,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		 * while the VAR/MVAR duplicates a type from the context.  So, we need to ensure that the
 		 * ->byref and ->attrs from @type are propagated to the returned type.
 		 */
+#ifdef ENABLE_EXPERIMENT_ANY_BYREF
 		if (G_UNLIKELY (m_type_is_byref (type) && m_type_is_byref (inst->type_argv[num]))) {
 			/* if the VAR/MVAR is a byref and the instance type is byref, make a byref
 			 * of byref. The outer byref has the attributes and cmods of the VAR */
@@ -716,7 +717,9 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 			nt = mono_metadata_type_dup (image, type);
 			nt->type = MONO_TYPE_BYREF;
 			nt->data.type = inner_type;
-		} else {
+		} else
+#endif
+		{
 			nt = mono_metadata_type_dup_with_cmods (image, inst->type_argv [num], type);
 			/* otherwise the type is byref if either the var or the type was byref */
 			nt->byref__ = type->byref__ || nt->byref__;
@@ -761,6 +764,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		}
 #endif
 
+#ifdef ENABLE_EXPERIMENT_ANY_BYREF
 		if (G_UNLIKELY (m_type_is_byref (type) && m_type_is_byref (inst->type_argv[num]))) {
 			/* if the VAR/MVAR is a byref and the instance type is byref, make a byref
 			 * of byref. The outer byref has the attributes and cmods of the VAR */
@@ -770,7 +774,9 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 			nt = mono_metadata_type_dup (image, type);
 			nt->type = MONO_TYPE_BYREF;
 			nt->data.type = inner_type;
-		} else {
+		} else
+#endif
+		{
 			nt = mono_metadata_type_dup_with_cmods (image, inst->type_argv [num], type);
 			nt->byref__ = type->byref__ || inst->type_argv[num]->byref__;
 			nt->attrs = type->attrs;

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6062,14 +6062,19 @@ ves_icall_RuntimeType_make_byref_type (MonoReflectionTypeHandle ref_type, MonoEr
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
+#ifndef ENABLE_EXPERIMENT_ANY_BYREF
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
+#else
+	MonoClass *klass = mono_class_from_mono_type2 (type, FALSE);
+#endif
 	mono_class_init_checked (klass, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 
 	check_for_invalid_byref_or_pointer_type (klass, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 
-	return mono_type_get_object_handle (m_class_get_this_arg (klass), error);
+	MonoType *byref_type = mono_class_get_byref_type (klass);
+	return mono_type_get_object_handle (byref_type, error);
 }
 
 MonoReflectionTypeHandle

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -181,7 +181,7 @@ struct _MonoMemoryManager {
 	MonoConcurrentHashTable *gclass_cache;
 
 	/* mirror caches of ones already on MonoImage. These ones contain generics */
-	GHashTable *szarray_cache, *array_cache, *ptr_cache;
+	GHashTable *szarray_cache, *array_cache, *ptr_cache, *byref_cache;
 
 	MonoWrapperCaches wrapper_caches;
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -21,10 +21,28 @@
 #include "mono/utils/mono-conc-hashtable.h"
 #include "mono/utils/refcount.h"
 
+/* Note "byref":
+ *   How are "byref"/"&"/"managed pointer" types represented?
+ *   For historical reasons, mono has a MonoType:byref__ bit that is used most of the time.  This
+ *   made sense when .NET only allowed a single byref modifier, but now that byref of byref is
+ *   possible, it doesn't make a lot of sense anymore.  But it's difficult now to get rid of it (and
+ *   there is a cost to creating a MonoClass to represent benign byref occurrences in method
+ *   signatures, etc).
+ *
+ *   So the representation is:
+ *     if the element type is not a byref type itself, just make a MonoType like the element type and set the byref__ bit.
+ *     if the element type is a byref type, make a MonoType with type == MONO_TYPE_BYREF and set the byref__ bit.
+ *
+ *   To get the element type of a byref type:
+ *     if the byref__ bit is not set, it's not a byref type.
+ *     if the byref__ bit is set and the type is MONO_TYPE_BYREF, return data.type;
+ *     otherwise, return a type like the input type, with byref__ cleared.
+ *
+ */
 struct _MonoType {
 	union {
 		MonoClass *klass; /* for VALUETYPE and CLASS */
-		MonoType *type;   /* for PTR */
+		MonoType *type;   /* for PTR or BYREF (see Note "byref")*/
 		MonoArrayType *array; /* for ARRAY */
 		MonoMethodSignature *method;
 		MonoGenericParam *generic_param; /* for VAR and MVAR */
@@ -434,6 +452,7 @@ struct _MonoImage {
 	 */
 	GHashTable *array_cache;
 	GHashTable *ptr_cache;
+	GHashTable *byref_cache;
 
 	GHashTable *szarray_cache;
 	/* This has a separate lock to improve scalability */


### PR DESCRIPTION
Add a `MonoFeatureAnyByref` MSBuild property to gate the work.  (Maps to `MONO_FEATURE_ANY_BYREF` in CoreLib, and `ENABLE_EXPERIMENT_ANY_BYREF` in the native runtime code).

The basic idea is not to drop our `MonoType:byref` and `MonoClass:this_arg` representation for representing IL `X&` types.  That way the majority of existing code continues to work.  Instead, we add a new representation (using `MonoType:type == MONO_TYPE_BYREF` and a `MonoClassPointer` with `byval_arg.type == MONO_TYPE_BYREF`) for `X &&` (or any greater number of byref modifiers).

The IL parsing code changes (which would go into `mono_metadata_parse_type_internal`) are not part of this PR.  That can be added separately.

The existing `mono_class_from_mono_type_internal` function has an unusual behavior: it doesn't look at the `MonoType:byref` bit - ie it strips the outermost `byref` from byref types.  This is actually useful because a lot of times it allows us to avoid creating a `MonoClass` representation for a byref version of a type - in fact previously we had no way of representing such things at all.  In the long term code should switch over to `mono_class_from_mono_type2` which takes a boolean flag to indicate whether to strip off the outermost `byref`.  In this PR, the only function that does that (assuming the feature flag is set)  is `ves_icall_RuntimeType_make_byref_type` - this allows `typeof(Foo).MakeByRefType().MakeByRefType()` to work correctly.

An implementation note: I kept most of the experimental code live, but gated by `g_assert_not_reached` - that will at least keep it compiling until we decide whether .NET will allow `ref`-of-`ref`.