### PR TITLE
Fix for #60532

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -46,6 +46,7 @@
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <!-- Override InformationalVersion during servicing as it's returned via public api. -->
     <InformationalVersion Condition="'$(PreReleaseVersionLabel)' == 'servicing'">$(ProductVersion)</InformationalVersion>
+    <InformationalVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</InformationalVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn),0419,0649,CA2249,CA1830</NoWarn>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
In stable package mode we should be setting CoreLib informational
version to the ProductVersion according to the discussion on the
issue thread. I have verified locally that this fixes the processinfo2
test for me that was previously failing in the StabilizePackageVersion
mode. Please let me know how to proceed with the fix, whether you
want me to just merge it into dotnet/runtime main, whether I should
pursue its backport into 6.0 release and / or whether Matt considers
cherry-picking my change to his stabilization PR.

Thanks

Tomas

Fixes #60532 

/cc @dotnet/runtime-infrastructure 