### PR TITLE
always populate TargetHostName on SslStream

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -506,9 +506,7 @@ namespace System.Net.Security
                     }
                     break;
                 case TlsContentType.Handshake:
-                    if (!_isRenego && _handshakeBuffer.ActiveReadOnlySpan[TlsFrameHelper.HeaderSize] == (byte)TlsHandshakeType.ClientHello &&
-                        (_sslAuthenticationOptions!.ServerCertSelectionDelegate != null ||
-                        _sslAuthenticationOptions!.ServerOptionDelegate != null))
+                    if (!_isRenego && _handshakeBuffer.ActiveReadOnlySpan[TlsFrameHelper.HeaderSize] == (byte)TlsHandshakeType.ClientHello)
                     {
                         TlsFrameHelper.ProcessingOptions options = NetEventSource.Log.IsEnabled() ?
                                                                     TlsFrameHelper.ProcessingOptions.All :
@@ -528,7 +526,7 @@ namespace System.Net.Security
                                 _sslAuthenticationOptions!.TargetHost = _lastFrame.TargetName;
                             }
 
-                            if (_sslAuthenticationOptions.ServerOptionDelegate != null)
+                            if (_sslAuthenticationOptions!.ServerOptionDelegate != null)
                             {
                                 SslServerAuthenticationOptions userOptions =
                                     await _sslAuthenticationOptions.ServerOptionDelegate(this, new SslClientHelloInfo(_sslAuthenticationOptions.TargetHost, _lastFrame.SupportedVersions),

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -506,8 +506,9 @@ namespace System.Net.Security
                     }
                     break;
                 case TlsContentType.Handshake:
-                    if (!_isRenego && _handshakeBuffer.ActiveReadOnlySpan[TlsFrameHelper.HeaderSize] == (byte)TlsHandshakeType.ClientHello)
-                    {
+                    if (!_isRenego && _handshakeBuffer.ActiveReadOnlySpan[TlsFrameHelper.HeaderSize] == (byte)TlsHandshakeType.ClientHello &&
+                        _sslAuthenticationOptions!.IsServer) // guard against malicious endpoints. We should not see ClientHello on client.
+                     {
                         TlsFrameHelper.ProcessingOptions options = NetEventSource.Log.IsEnabled() ?
                                                                     TlsFrameHelper.ProcessingOptions.All :
                                                                     TlsFrameHelper.ProcessingOptions.ServerName;
@@ -526,7 +527,7 @@ namespace System.Net.Security
                                 _sslAuthenticationOptions!.TargetHost = _lastFrame.TargetName;
                             }
 
-                            if (_sslAuthenticationOptions!.ServerOptionDelegate != null)
+                            if (_sslAuthenticationOptions.ServerOptionDelegate != null)
                             {
                                 SslServerAuthenticationOptions userOptions =
                                     await _sslAuthenticationOptions.ServerOptionDelegate(this, new SslClientHelloInfo(_sslAuthenticationOptions.TargetHost, _lastFrame.SupportedVersions),


### PR DESCRIPTION
When `TargetHostName` it was primarily meant for client side. (#27619) However we start using it in some other cases on server as well and that creates inconsistent and undocumented behavior. 

This change will set `SslStream.TargetHostName` always when present since that is now public property. That will lead to allocation of one more string in certain scenarios on server (when certificate selection callback is not used) 
The perf impact seems negligible. All the numbers are within noise level of my VM.

fixes  #57105
contributes to #60431

|                           Method |        Job |           Toolchain | protocol |        Mean |      Error |     StdDev |      Median |         Min |         Max | Ratio | RatioSD |  Gen 0 | Allocated |
|--------------------------------- |----------- |-------------------- |--------- |------------:|-----------:|-----------:|------------:|------------:|------------:|------:|--------:|-------:|----------:|
| DefaultHandshakeContextIPv4Async | Job-AAFNIN | /7.0.0-main/corerun |        ? | 4,720.92 us | 118.536 us | 136.506 us | 4,708.11 us | 4,530.20 us | 5,017.75 us |  1.00 |    0.00 |      - |  20,298 B |
| DefaultHandshakeContextIPv4Async | Job-ZEEMXS |      /7.0.0/corerun |        ? | 4,625.31 us |  63.086 us |  55.924 us | 4,648.38 us | 4,524.53 us | 4,707.69 us |  0.98 |    0.04 |      - |  20,300 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
| DefaultHandshakeContextIPv6Async | Job-AAFNIN | /7.0.0-main/corerun |        ? | 4,710.17 us |  94.171 us |  96.707 us | 4,701.76 us | 4,531.63 us | 4,875.23 us |  1.00 |    0.00 |      - |  20,298 B |
| DefaultHandshakeContextIPv6Async | Job-ZEEMXS |      /7.0.0/corerun |        ? | 4,656.26 us |  92.505 us |  82.003 us | 4,658.06 us | 4,500.28 us | 4,794.43 us |  0.99 |    0.03 |      - |  20,285 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        DefaultHandshakeIPv4Async | Job-AAFNIN | /7.0.0-main/corerun |        ? | 4,994.74 us |  69.364 us |  64.883 us | 5,002.70 us | 4,909.13 us | 5,098.83 us |  1.00 |    0.00 |      - |  23,005 B |
|        DefaultHandshakeIPv4Async | Job-ZEEMXS |      /7.0.0/corerun |        ? | 5,040.96 us | 129.068 us | 143.459 us | 5,041.11 us | 4,800.99 us | 5,348.24 us |  1.01 |    0.03 |      - |  23,590 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        DefaultHandshakeIPv6Async | Job-AAFNIN | /7.0.0-main/corerun |        ? | 4,959.17 us |  95.743 us |  89.558 us | 4,969.91 us | 4,846.20 us | 5,112.33 us |  1.00 |    0.00 |      - |  23,004 B |
|        DefaultHandshakeIPv6Async | Job-ZEEMXS |      /7.0.0/corerun |        ? | 4,934.59 us |  66.702 us |  62.393 us | 4,932.26 us | 4,820.21 us | 5,035.71 us |  1.00 |    0.02 |      - |  23,565 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        DefaultHandshakePipeAsync | Job-AAFNIN | /7.0.0-main/corerun |        ? | 5,038.04 us |  98.557 us |  96.796 us | 4,997.29 us | 4,939.30 us | 5,215.37 us |  1.00 |    0.00 |      - |  23,649 B |
|        DefaultHandshakePipeAsync | Job-ZEEMXS |      /7.0.0/corerun |        ? | 4,979.58 us |  63.578 us |  59.471 us | 4,962.04 us | 4,893.93 us | 5,096.40 us |  0.99 |    0.02 |      - |  23,924 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|                   WriteReadAsync | Job-AAFNIN | /7.0.0-main/corerun |        ? |    15.69 us |   0.667 us |   0.768 us |    15.58 us |    14.25 us |    17.05 us |  1.00 |    0.00 |      - |         - |
|                   WriteReadAsync | Job-ZEEMXS |      /7.0.0/corerun |        ? |    16.19 us |   0.662 us |   0.763 us |    16.31 us |    14.55 us |    17.61 us |  1.03 |    0.07 |      - |         - |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|                   ReadWriteAsync | Job-AAFNIN | /7.0.0-main/corerun |        ? |    28.03 us |   0.516 us |   0.431 us |    27.97 us |    27.20 us |    28.99 us |  1.00 |    0.00 | 0.0400 |     336 B |
|                   ReadWriteAsync | Job-ZEEMXS |      /7.0.0/corerun |        ? |    29.98 us |   1.450 us |   1.669 us |    30.42 us |    26.89 us |    32.49 us |  1.07 |    0.04 | 0.0400 |     336 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|              ConcurrentReadWrite | Job-AAFNIN | /7.0.0-main/corerun |        ? |    28.91 us |   0.749 us |   0.863 us |    29.06 us |    27.44 us |    30.37 us |  1.00 |    0.00 |      - |     150 B |
|              ConcurrentReadWrite | Job-ZEEMXS |      /7.0.0/corerun |        ? |    30.20 us |   0.865 us |   0.996 us |    30.37 us |    27.63 us |    31.81 us |  1.05 |    0.05 |      - |     146 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|   ConcurrentReadWriteLargeBuffer | Job-AAFNIN | /7.0.0-main/corerun |        ? |    33.92 us |   1.020 us |   1.175 us |    34.30 us |    31.65 us |    35.65 us |  1.00 |    0.00 |      - |     112 B |
|   ConcurrentReadWriteLargeBuffer | Job-ZEEMXS |      /7.0.0/corerun |        ? |    36.20 us |   1.244 us |   1.432 us |    35.79 us |    34.22 us |    39.01 us |  1.07 |    0.06 |      - |     143 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|            HandshakeContosoAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls12 | 5,466.54 us |  87.570 us |  81.913 us | 5,430.84 us | 5,394.70 us | 5,655.12 us |  1.00 |    0.00 |      - |  24,162 B |
|            HandshakeContosoAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls12 | 5,023.19 us | 323.566 us | 372.619 us | 5,070.43 us | 4,536.02 us | 5,629.07 us |  0.91 |    0.08 |      - |  24,721 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|       HandshakeECDSA256CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls12 | 1,783.02 us |  18.275 us |  15.260 us | 1,788.38 us | 1,749.44 us | 1,804.51 us |  1.00 |    0.00 |      - |  21,626 B |
|       HandshakeECDSA256CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls12 | 1,599.27 us |  41.131 us |  47.366 us | 1,588.78 us | 1,508.47 us | 1,693.79 us |  0.89 |    0.03 |      - |  21,628 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|       HandshakeECDSA512CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls12 | 3,014.47 us |  28.531 us |  23.825 us | 3,013.08 us | 2,968.06 us | 3,060.11 us |  1.00 |    0.00 |      - |  21,838 B |
|       HandshakeECDSA512CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls12 | 3,084.13 us |  86.121 us |  95.723 us | 3,053.38 us | 2,953.51 us | 3,282.53 us |  1.03 |    0.03 |      - |  21,843 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        HandshakeRSA1024CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls12 | 1,466.16 us |  26.874 us |  27.598 us | 1,468.39 us | 1,418.68 us | 1,525.02 us |  1.00 |    0.00 |      - |  21,764 B |
|        HandshakeRSA1024CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls12 | 1,568.98 us |  80.329 us |  92.507 us | 1,526.79 us | 1,449.57 us | 1,690.78 us |  1.08 |    0.07 |      - |  21,754 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        HandshakeRSA2048CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls12 | 1,960.51 us |  57.693 us |  66.440 us | 1,939.08 us | 1,873.29 us | 2,086.91 us |  1.00 |    0.00 |      - |  22,158 B |
|        HandshakeRSA2048CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls12 | 1,902.99 us |  36.726 us |  39.297 us | 1,900.33 us | 1,845.93 us | 1,976.23 us |  0.97 |    0.04 |      - |  22,432 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        HandshakeRSA4096CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls12 | 5,220.76 us | 338.570 us | 389.898 us | 5,285.81 us | 4,685.57 us | 5,739.64 us |  1.00 |    0.00 |      - |  22,963 B |
|        HandshakeRSA4096CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls12 | 5,081.98 us | 397.044 us | 457.236 us | 4,859.50 us | 4,565.53 us | 5,934.31 us |  0.98 |    0.10 |      - |  22,963 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|            HandshakeContosoAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls13 | 4,960.61 us | 269.857 us | 299.945 us | 4,818.23 us | 4,551.77 us | 5,651.49 us |  1.00 |    0.00 |      - |  24,733 B |
|            HandshakeContosoAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls13 | 4,684.07 us |  96.246 us | 106.978 us | 4,662.18 us | 4,550.67 us | 4,904.21 us |  0.95 |    0.07 |      - |  24,730 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|       HandshakeECDSA256CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls13 | 1,849.50 us |  33.630 us |  28.082 us | 1,854.12 us | 1,803.81 us | 1,902.43 us |  1.00 |    0.00 |      - |  21,625 B |
|       HandshakeECDSA256CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls13 | 1,643.21 us |  52.508 us |  60.468 us | 1,634.01 us | 1,564.29 us | 1,763.01 us |  0.88 |    0.04 |      - |  21,623 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|       HandshakeECDSA512CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls13 | 3,539.71 us | 170.630 us | 189.655 us | 3,582.55 us | 2,923.72 us | 3,759.16 us |  1.00 |    0.00 |      - |  21,855 B |
|       HandshakeECDSA512CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls13 | 3,043.48 us |  50.543 us |  42.206 us | 3,043.45 us | 2,989.87 us | 3,119.63 us |  0.87 |    0.06 |      - |  21,875 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        HandshakeRSA1024CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls13 | 1,598.78 us |  73.961 us |  85.173 us | 1,609.05 us | 1,472.40 us | 1,701.52 us |  1.00 |    0.00 |      - |  21,775 B |
|        HandshakeRSA1024CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls13 | 1,624.58 us |  88.600 us | 102.032 us | 1,690.33 us | 1,455.38 us | 1,747.79 us |  1.02 |    0.09 |      - |  21,761 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        HandshakeRSA2048CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls13 | 2,195.36 us |  40.186 us |  33.557 us | 2,186.88 us | 2,145.74 us | 2,258.40 us |  1.00 |    0.00 |      - |  21,578 B |
|        HandshakeRSA2048CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls13 | 1,941.60 us |  53.841 us |  59.844 us | 1,931.15 us | 1,863.14 us | 2,095.16 us |  0.89 |    0.04 |      - |  22,150 B |
|                                  |            |                     |          |             |            |            |             |             |             |       |         |        |           |
|        HandshakeRSA4096CertAsync | Job-AAFNIN | /7.0.0-main/corerun |    Tls13 | 4,944.42 us | 244.889 us | 282.015 us | 4,849.69 us | 4,646.26 us | 5,587.04 us |  1.00 |    0.00 |      - |  23,056 B |
|        HandshakeRSA4096CertAsync | Job-ZEEMXS |      /7.0.0/corerun |    Tls13 | 4,784.31 us | 106.213 us | 118.056 us | 4,761.53 us | 4,644.60 us | 5,033.37 us |  0.97 |    0.06 |      - |  22,961 B | 