### PR TITLE
[llvmonly] Optimize delegate invocation.

### DIFF
--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6137,7 +6137,7 @@ ves_icall_System_Delegate_AllocDelegateLike_internal (MonoDelegateHandle delegat
 	MonoMulticastDelegateHandle ret = MONO_HANDLE_CAST (MonoMulticastDelegate, mono_object_new_handle (klass, error));
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoMulticastDelegate, NULL_HANDLE));
 
-	MONO_HANDLE_SETVAL (MONO_HANDLE_CAST (MonoDelegate, ret), invoke_impl, gpointer, mono_runtime_create_delegate_trampoline (klass));
+	mono_get_runtime_callbacks ()->init_delegate (MONO_HANDLE_CAST (MonoDelegate, ret), NULL_HANDLE, NULL, NULL, error);
 
 	return ret;
 }

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -2198,6 +2198,29 @@ mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt
 	return res;
 }
 
+WrapperSubtype
+mono_marshal_get_delegate_invoke_subtype (MonoMethod *method, MonoDelegate *del)
+{
+	MonoMethodSignature *sig;
+
+	sig = mono_method_signature_internal (method);
+
+	if (!del || !del->method)
+		return WRAPPER_SUBTYPE_NONE;
+
+	if (!del->target && mono_method_signature_internal (del->method)->hasthis) {
+		if (!(del->method->flags & METHOD_ATTRIBUTE_VIRTUAL) && !m_class_is_valuetype (del->method->klass) && sig->param_count ==  mono_method_signature_internal (del->method)->param_count + 1)
+			return WRAPPER_SUBTYPE_NONE;
+		else
+			return WRAPPER_SUBTYPE_DELEGATE_INVOKE_VIRTUAL;
+	}
+
+	if (mono_method_signature_internal (del->method)->param_count == sig->param_count + 1 && (del->method->flags & METHOD_ATTRIBUTE_STATIC))
+		return WRAPPER_SUBTYPE_DELEGATE_INVOKE_BOUND;
+
+	return WRAPPER_SUBTYPE_NONE;
+}
+
 /**
  * mono_marshal_get_delegate_invoke:
  * The returned method invokes all methods in a multicast delegate.

--- a/src/mono/mono/metadata/marshal.h
+++ b/src/mono/mono/metadata/marshal.h
@@ -428,6 +428,9 @@ mono_marshal_get_delegate_invoke (MonoMethod *method, MonoDelegate *del);
 MonoMethod *
 mono_marshal_get_delegate_invoke_internal (MonoMethod *method, gboolean callvirt, gboolean static_method_with_first_arg_bound, MonoMethod *target_method);
 
+WrapperSubtype
+mono_marshal_get_delegate_invoke_subtype (MonoMethod *method, MonoDelegate *del);
+
 MonoMethod *
 mono_marshal_get_runtime_invoke_full (MonoMethod *method, gboolean virtual_, gboolean need_direct_wrapper);
 

--- a/src/mono/mono/mini/ee.h
+++ b/src/mono/mono/mini/ee.h
@@ -14,7 +14,7 @@
 #ifndef __MONO_EE_H__
 #define __MONO_EE_H__
 
-#define MONO_EE_API_VERSION 0x12
+#define MONO_EE_API_VERSION 0x13
 
 typedef struct _MonoInterpStackIter MonoInterpStackIter;
 
@@ -32,7 +32,7 @@ typedef gpointer MonoInterpFrameHandle;
 	MONO_EE_CALLBACK (MonoFtnDesc*, create_method_pointer_llvmonly, (MonoMethod *method, gboolean unbox, MonoError *error)) \
 	MONO_EE_CALLBACK (void, free_method, (MonoMethod *method)) \
 	MONO_EE_CALLBACK (MonoObject*, runtime_invoke, (MonoMethod *method, void *obj, void **params, MonoObject **exc, MonoError *error)) \
-	MONO_EE_CALLBACK (void, init_delegate, (MonoDelegate *del, MonoError *error)) \
+	MONO_EE_CALLBACK (void, init_delegate, (MonoDelegate *del, MonoDelegateTrampInfo **out_info, MonoError *error)) \
 	MONO_EE_CALLBACK (void, delegate_ctor, (MonoObjectHandle this_obj, MonoObjectHandle target, gpointer addr, MonoError *error)) \
 	MONO_EE_CALLBACK (void, set_resume_state, (MonoJitTlsData *jit_tls, MonoObject *ex, MonoJitExceptionInfo *ei, MonoInterpFrameHandle interp_frame, gpointer handler_ip)) \
 	MONO_EE_CALLBACK (void, get_resume_state, (const MonoJitTlsData *jit_tls, gboolean *has_resume_state, MonoInterpFrameHandle *interp_frame, gpointer *handler_ip)) \

--- a/src/mono/mono/mini/interp-stubs.c
+++ b/src/mono/mono/mini/interp-stubs.c
@@ -155,7 +155,7 @@ stub_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
 }
 
 static void
-stub_init_delegate (MonoDelegate *del, MonoError *error)
+stub_init_delegate (MonoDelegate *del, MonoDelegateTrampInfo **info, MonoError *error)
 {
 	g_assert_not_reached ();
 }

--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -130,6 +130,7 @@ struct InterpMethod {
 	MonoJitInfo *jinfo;
 	MonoFtnDesc *ftndesc;
 	MonoFtnDesc *ftndesc_unbox;
+	MonoDelegateTrampInfo *del_info;
 
 	guint32 locals_size;
 	guint32 alloca_size;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2026,6 +2026,20 @@ interp_entry (InterpEntryData *data)
 	sp_args = sp = (stackval*)context->stack_pointer;
 
 	method = rmethod->method;
+
+	if (m_class_get_parent (method->klass) == mono_defaults.multicastdelegate_class && !strcmp (method->name, "Invoke")) {
+		/*
+		 * This happens when AOT code for the invoke wrapper is not found.
+		 * Have to replace the method with the wrapper here, since the wrapper depends on the delegate.
+		 */
+		ERROR_DECL (error);
+		MonoDelegate *del = (MonoDelegate*)data->this_arg;
+		// FIXME: This is slow
+		method = mono_marshal_get_delegate_invoke (method, del);
+		data->rmethod = mono_interp_get_imethod (method, error);
+		mono_error_assert_ok (error);
+	}
+
 	sig = mono_method_signature_internal (method);
 
 	// FIXME: Optimize this

--- a/src/mono/mono/mini/llvmonly-runtime.c
+++ b/src/mono/mono/mini/llvmonly-runtime.c
@@ -651,16 +651,31 @@ mini_llvmonly_init_vtable_slot (MonoVTable *vtable, int slot)
  * Similar to mono_delegate_ctor ().
  */
 void
-mini_llvmonly_init_delegate (MonoDelegate *del)
+mini_llvmonly_init_delegate (MonoDelegate *del, MonoDelegateTrampInfo *info)
 {
 	ERROR_DECL (error);
-	MonoFtnDesc *ftndesc = *(MonoFtnDesc**)del->method_code;
+	MonoFtnDesc *ftndesc;
 
-	/*
-	 * We store a MonoFtnDesc in del->method_code.
-	 * It would be better to store an ftndesc in del->method_ptr too,
-	 * but we don't have a a structure which could own its memory.
-	 */
+	if (!info && !del->method) {
+		// Multicast delegate init
+		// Have to set the invoke_impl field
+		// FIXME: Cache
+		MonoMethod *invoke_impl = mono_marshal_get_delegate_invoke (mono_get_delegate_invoke_internal (del->object.vtable->klass), NULL);
+		gpointer arg = NULL;
+		gpointer addr = mini_llvmonly_load_method_delegate (invoke_impl, FALSE, FALSE, &arg, error);
+		mono_error_assert_ok (error);
+		del->invoke_impl = mini_llvmonly_create_ftndesc (invoke_impl, addr, arg);
+		return;
+	}
+
+	if (G_UNLIKELY (!info)) {
+		g_assert (del->method);
+		info = mono_create_delegate_trampoline_info (del->object.vtable->klass, del->method);
+	}
+
+	/* Cache the target method address in MonoDelegateTrampInfo */
+	ftndesc = (MonoFtnDesc*)info->method_ptr;
+
 	if (G_UNLIKELY (!ftndesc)) {
 		MonoMethod *m = del->method;
 		gboolean need_unbox = FALSE;
@@ -668,7 +683,7 @@ mini_llvmonly_init_delegate (MonoDelegate *del)
 		if (m->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
 			m = mono_marshal_get_synchronized_wrapper (m);
 
-		if (m_class_is_valuetype (m->klass) && mono_method_signature_internal (m)->hasthis)
+		if (m_class_is_valuetype (m->klass) && mono_method_signature_internal (m)->hasthis && !(info->invoke_sig->param_count > info->sig->param_count))
 			need_unbox = TRUE;
 
 		gpointer arg = NULL;
@@ -677,33 +692,40 @@ mini_llvmonly_init_delegate (MonoDelegate *del)
 			return;
 		ftndesc = mini_llvmonly_create_ftndesc (m, addr, arg);
 		mono_memory_barrier ();
-		*del->method_code = (guint8*)ftndesc;
+		//*del->method_code = (guint8*)ftndesc;
+		info->method_ptr = ftndesc;
 	}
 	del->method_ptr = ftndesc->addr;
 	del->extra_arg = ftndesc->arg;
+
+	WrapperSubtype subtype = mono_marshal_get_delegate_invoke_subtype (info->invoke, del);
+
+	ftndesc = info->invoke_impl;
+	if (G_UNLIKELY (!ftndesc) || subtype != WRAPPER_SUBTYPE_NONE) {
+		ERROR_DECL (error);
+		MonoMethod *invoke_impl = mono_marshal_get_delegate_invoke (info->invoke, del);
+		gpointer arg = NULL;
+		gpointer addr = mini_llvmonly_load_method_delegate (invoke_impl, FALSE, FALSE, &arg, error);
+		mono_error_assert_ok (error);
+		ftndesc = mini_llvmonly_create_ftndesc (invoke_impl, addr, arg);
+		if (subtype == WRAPPER_SUBTYPE_NONE) {
+			mono_memory_barrier ();
+			info->invoke_impl = ftndesc;
+		} else {
+			// FIXME: Cache
+		}
+	}
+	del->invoke_impl = ftndesc;
 }
 
 void
 mini_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, MonoMethod *method)
 {
-	ERROR_DECL (error);
-	gpointer addr, arg;
-	gboolean need_unbox;
-
 	g_assert (target);
 
-	method = mono_object_get_virtual_method_internal (target, method);
+	del->method = mono_object_get_virtual_method_internal (target, method);
 
-	if (method->iflags & METHOD_IMPL_ATTRIBUTE_SYNCHRONIZED)
-		method = mono_marshal_get_synchronized_wrapper (method);
-	need_unbox = m_class_is_valuetype (method->klass);
-
-	del->method = method;
-	addr = mini_llvmonly_load_method_delegate (method, FALSE, need_unbox, &arg, error);
-	if (mono_error_set_pending_exception (error))
-		return;
-	del->method_ptr = addr;
-	del->extra_arg = arg;
+	mini_llvmonly_init_delegate (del, NULL);
 }
 
 /*

--- a/src/mono/mono/mini/llvmonly-runtime.h
+++ b/src/mono/mono/mini/llvmonly-runtime.h
@@ -25,7 +25,7 @@ G_EXTERN_C gpointer mini_llvmonly_resolve_vcall_gsharedvt (MonoObject *this_obj,
 G_EXTERN_C gpointer mini_llvmonly_resolve_iface_call_gsharedvt (MonoObject *this_obj, int imt_slot, MonoMethod *imt_method, gpointer *out_arg);
 G_EXTERN_C MonoFtnDesc* mini_llvmonly_resolve_generic_virtual_call (MonoVTable *vt, int slot, MonoMethod *imt_method);
 G_EXTERN_C MonoFtnDesc* mini_llvmonly_resolve_generic_virtual_iface_call (MonoVTable *vt, int imt_slot, MonoMethod *imt_method);
-G_EXTERN_C void mini_llvmonly_init_delegate (MonoDelegate *del);
+G_EXTERN_C void mini_llvmonly_init_delegate (MonoDelegate *del, MonoDelegateTrampInfo *info);
 G_EXTERN_C void mini_llvmonly_init_delegate_virtual (MonoDelegate *del, MonoObject *target, MonoMethod *method);
 
 /* Used for regular llvm as well */

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3887,7 +3887,7 @@ mini_init_delegate (MonoDelegateHandle delegate, MonoObjectHandle target, gpoint
 	MonoDelegateTrampInfo *info = NULL;
 
 	if (mono_use_interpreter) {
-		mini_get_interp_callbacks ()->init_delegate (del, error);
+		mini_get_interp_callbacks ()->init_delegate (del, &info, error);
 		return_if_nok (error);
 	}
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3848,6 +3848,16 @@ mini_init_delegate (MonoDelegateHandle delegate, MonoObjectHandle target, gpoint
 {
 	MonoDelegate *del = MONO_HANDLE_RAW (delegate);
 
+	if (!method && !addr) {
+		// Multicast delegate init
+		if (!mono_llvm_only) {
+			MONO_HANDLE_SETVAL (delegate, invoke_impl, gpointer, mono_create_delegate_trampoline (mono_handle_class (delegate)));
+		} else {
+			mini_llvmonly_init_delegate (del, NULL);
+		}
+		return;
+	}
+
 	if (!method) {
 		MonoJitInfo *ji;
 		gpointer lookup_addr = MINI_FTNPTR_TO_ADDR (addr);
@@ -3874,6 +3884,8 @@ mini_init_delegate (MonoDelegateHandle delegate, MonoObjectHandle target, gpoint
 	MONO_HANDLE_SET (delegate, target, target);
 	MONO_HANDLE_SETVAL (delegate, invoke_impl, gpointer, mono_create_delegate_trampoline (mono_handle_class (delegate)));
 
+	MonoDelegateTrampInfo *info = NULL;
+
 	if (mono_use_interpreter) {
 		mini_get_interp_callbacks ()->init_delegate (del, error);
 		return_if_nok (error);
@@ -3881,8 +3893,8 @@ mini_init_delegate (MonoDelegateHandle delegate, MonoObjectHandle target, gpoint
 
 	if (mono_llvm_only) {
 		g_assert (del->method);
-		/* del->method_ptr might already be set to no_llvmonly_interp_method_pointer if the delegate was created from the interpreter */
-		del->method_ptr = mini_llvmonly_load_method_delegate (del->method, FALSE, FALSE, &del->extra_arg, error);
+		mini_llvmonly_init_delegate (del, info);
+		//del->method_ptr = mini_llvmonly_load_method_delegate (del->method, FALSE, FALSE, &del->extra_arg, error);
 	} else if (!del->method_ptr) {
 		del->method_ptr = create_delegate_method_ptr (del->method, error);
 		return_if_nok (error);
@@ -4884,7 +4896,7 @@ register_icalls (void)
 	register_icall_no_wrapper (mini_llvmonly_resolve_generic_virtual_iface_call, mono_icall_sig_ptr_ptr_int_ptr);
 	/* This needs a wrapper so it can have a preserveall cconv */
 	register_icall (mini_llvmonly_init_vtable_slot, mono_icall_sig_ptr_ptr_int, FALSE);
-	register_icall (mini_llvmonly_init_delegate, mono_icall_sig_void_object, TRUE);
+	register_icall (mini_llvmonly_init_delegate, mono_icall_sig_void_object_ptr, TRUE);
 	register_icall (mini_llvmonly_init_delegate_virtual, mono_icall_sig_void_object_object_ptr, TRUE);
 	register_icall (mini_llvmonly_throw_nullref_exception, mono_icall_sig_void, TRUE);
 	register_icall (mini_llvmonly_throw_aot_failed_exception, mono_icall_sig_void_ptr, TRUE);

--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -1424,12 +1424,15 @@ mono_create_delegate_trampoline_info (MonoClass *klass, MonoMethod *method)
 	g_assert (invoke);
 
 	tramp_info = (MonoDelegateTrampInfo *)mono_mem_manager_alloc0 (jit_mm->mem_manager, sizeof (MonoDelegateTrampInfo));
+	tramp_info->klass = klass;
 	tramp_info->invoke = invoke;
 	tramp_info->invoke_sig = mono_method_signature_internal (invoke);
 	// FIXME: Use a different conditional
 #ifndef HOST_WASM
-	tramp_info->impl_this = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), TRUE);
-	tramp_info->impl_nothis = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), FALSE);
+	if (!mono_llvm_only) {
+		tramp_info->impl_this = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), TRUE);
+		tramp_info->impl_nothis = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), FALSE);
+	}
 #endif
 	tramp_info->method = method;
 	if (method) {
@@ -1438,9 +1441,11 @@ mono_create_delegate_trampoline_info (MonoClass *klass, MonoMethod *method)
 		tramp_info->need_rgctx_tramp = mono_method_needs_static_rgctx_invoke (method, FALSE);
 	}
 #ifndef HOST_WASM
-	guint32 code_size = 0;
-	tramp_info->invoke_impl = mono_create_specific_trampoline (jit_mm->mem_manager, tramp_info, MONO_TRAMPOLINE_DELEGATE, &code_size);
-	g_assert (code_size);
+	if (!mono_llvm_only) {
+		guint32 code_size = 0;
+		tramp_info->invoke_impl = mono_create_specific_trampoline (jit_mm->mem_manager, tramp_info, MONO_TRAMPOLINE_DELEGATE, &code_size);
+		g_assert (code_size);
+	}
 #endif
 
 	dpair = (MonoClassMethodPair *)mono_mem_manager_alloc0 (jit_mm->mem_manager, sizeof (MonoClassMethodPair));

--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -1399,7 +1399,6 @@ mono_create_delegate_trampoline_info (MonoClass *klass, MonoMethod *method)
 	ERROR_DECL (error);
 	MonoDelegateTrampInfo *tramp_info;
 	MonoClassMethodPair pair, *dpair;
-	guint32 code_size = 0;
 	MonoMemoryManager *mm_class, *mm_method, *mm;
 	MonoJitMemoryManager *jit_mm;
 
@@ -1427,16 +1426,22 @@ mono_create_delegate_trampoline_info (MonoClass *klass, MonoMethod *method)
 	tramp_info = (MonoDelegateTrampInfo *)mono_mem_manager_alloc0 (jit_mm->mem_manager, sizeof (MonoDelegateTrampInfo));
 	tramp_info->invoke = invoke;
 	tramp_info->invoke_sig = mono_method_signature_internal (invoke);
+	// FIXME: Use a different conditional
+#ifndef HOST_WASM
 	tramp_info->impl_this = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), TRUE);
 	tramp_info->impl_nothis = mono_arch_get_delegate_invoke_impl (mono_method_signature_internal (invoke), FALSE);
+#endif
 	tramp_info->method = method;
 	if (method) {
 		error_init (error);
 		tramp_info->sig = mono_method_signature_checked (method, error);
 		tramp_info->need_rgctx_tramp = mono_method_needs_static_rgctx_invoke (method, FALSE);
 	}
+#ifndef HOST_WASM
+	guint32 code_size = 0;
 	tramp_info->invoke_impl = mono_create_specific_trampoline (jit_mm->mem_manager, tramp_info, MONO_TRAMPOLINE_DELEGATE, &code_size);
 	g_assert (code_size);
+#endif
 
 	dpair = (MonoClassMethodPair *)mono_mem_manager_alloc0 (jit_mm->mem_manager, sizeof (MonoClassMethodPair));
 	memcpy (dpair, &pair, sizeof (MonoClassMethodPair));

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1125,6 +1125,7 @@ typedef struct {
 
 typedef struct
 {
+	MonoClass *klass;
 	MonoMethod *invoke;
 	MonoMethod *method;
 	MonoMethodSignature *invoke_sig;


### PR DESCRIPTION
* Pass a MonoDelegateTrampInfo structure to mini_llvmonly_init_delegate (), use it to
  cache various data.
* Modify interp_delegate_init () to compute a MonoDelegateTrampInfo so it can
be passed to mini_llvmonly_init_delegate () if the delegate is created from the
interpreter.
* Invoke delegates similarly to the non-llvmonly case, by making an indirect
call through del->invoke_impl, which is initialized in mini_llvmonly_init_delegate ().
This also fixes some special cases like bound delegates, since init_delegate ()
has access to the delegate instance, so it can use the appropriate wrapper.