### PR TITLE
[DllImportGenerator] Don't generate a full stub body when the body does nothing

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportAnalyzer.cs
@@ -64,55 +64,7 @@ namespace Microsoft.Interop.Analyzers
             if (dllImportData.ModuleName == "QCall")
                 return;
 
-            if (RequiresMarshalling(method, dllImportData, dllImportAttrType))
-            {
-                context.ReportDiagnostic(method.CreateDiagnostic(ConvertToGeneratedDllImport, method.Name));
-            }
-        }
-
-        private static bool RequiresMarshalling(IMethodSymbol method, DllImportData dllImportData, INamedTypeSymbol dllImportAttrType)
-        {
-            // SetLastError=true requires marshalling
-            if (dllImportData.SetLastError)
-                return true;
-
-            // Check if return value requires marshalling
-            if (!method.ReturnsVoid && !method.ReturnType.IsConsideredBlittable())
-                return true;
-
-            // Check if parameters require marshalling
-            foreach (IParameterSymbol paramType in method.Parameters)
-            {
-                if (paramType.RefKind != RefKind.None)
-                    return true;
-
-                if (!paramType.Type.IsConsideredBlittable())
-                    return true;
-            }
-
-            // DllImportData does not expose all information (e.g. PreserveSig), so we still need to get the attribute data
-            AttributeData? dllImportAttr = null;
-            foreach (AttributeData attr in method.GetAttributes())
-            {
-                if (!SymbolEqualityComparer.Default.Equals(attr.AttributeClass, dllImportAttrType))
-                    continue;
-
-                dllImportAttr = attr;
-                break;
-            }
-
-            Debug.Assert(dllImportAttr != null);
-            foreach (KeyValuePair<string, TypedConstant> namedArg in dllImportAttr!.NamedArguments)
-            {
-                if (namedArg.Key != nameof(DllImportAttribute.PreserveSig))
-                    continue;
-
-                // PreserveSig=false requires marshalling
-                if (!(bool)namedArg.Value.Value!)
-                    return true;
-            }
-
-            return false;
+            context.ReportDiagnostic(method.CreateDiagnostic(ConvertToGeneratedDllImport, method.Name));
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -504,19 +504,10 @@ namespace Microsoft.Interop
 
         private MemberDeclarationSyntax PrintForwarderStub(MethodDeclarationSyntax userDeclaredMethod, IncrementalStubGenerationContext stub)
         {
-            SyntaxTokenList originalModifiers = StripTriviaFromModifiers(userDeclaredMethod.Modifiers);
-            SyntaxTokenList modifiers = TokenList();
-            foreach (var modifier in originalModifiers)
-            {
-                if (modifier.Kind() != SyntaxKind.PartialKeyword)
-                {
-                    modifiers = modifiers.Add(modifier);
-                }
-            }
-            modifiers = modifiers.Add(Token(SyntaxKind.ExternKeyword)).Add(Token(SyntaxKind.PartialKeyword));
+            SyntaxTokenList modifiers = StripTriviaFromModifiers(userDeclaredMethod.Modifiers);
+            modifiers = modifiers.Insert(modifiers.IndexOf(SyntaxKind.PartialKeyword), Token(SyntaxKind.ExternKeyword));
             // Create stub function
             MethodDeclarationSyntax stubMethod = MethodDeclaration(stub.StubContext.StubReturnType, userDeclaredMethod.Identifier)
-                .AddAttributeLists(stub.StubContext.AdditionalAttributes.ToArray())
                 .WithModifiers(modifiers)
                 .WithParameterList(ParameterList(SeparatedList(stub.StubContext.StubParameters)))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Interop
         {
             if (options.GenerateForwarders)
             {
-                return (PrintForwarderStub(originalSyntax, dllImportStub), ImmutableArray<Diagnostic>.Empty);
+                return (PrintForwarderStub(originalSyntax, dllImportStub), dllImportStub.Diagnostics);
             }
 
             var diagnostics = new GeneratorDiagnostics();
@@ -476,7 +476,7 @@ namespace Microsoft.Interop
 
             if (stubGenerator.StubIsBasicForwarder)
             {
-                return (PrintForwarderStub(originalSyntax, dllImportStub), ImmutableArray<Diagnostic>.Empty);
+                return (PrintForwarderStub(originalSyntax, dllImportStub), dllImportStub.Diagnostics.AddRange(diagnostics.Diagnostics));
             }
 
             ImmutableArray<AttributeSyntax> forwardedAttributes = dllImportStub.ForwardedAttributes;

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -256,6 +256,13 @@ namespace Microsoft.Interop
                 .WithParameterList(ParameterList(SeparatedList(stub.StubParameters)))
                 .WithBody(stubCode);
 
+            MemberDeclarationSyntax toPrint = WrapMethodInContainingScopes(stub, stubMethod);
+
+            return toPrint;
+        }
+
+        private static MemberDeclarationSyntax WrapMethodInContainingScopes(DllImportStubContext stub, MethodDeclarationSyntax stubMethod)
+        {
             // Stub should have at least one containing type
             Debug.Assert(stub.StubContainingTypes.Any());
 
@@ -453,6 +460,11 @@ namespace Microsoft.Interop
             MethodDeclarationSyntax originalSyntax,
             DllImportGeneratorOptions options)
         {
+            if (options.GenerateForwarders)
+            {
+                return (PrintForwarderStub(originalSyntax, dllImportStub), ImmutableArray<Diagnostic>.Empty);
+            }
+
             var diagnostics = new GeneratorDiagnostics();
 
             // Generate stub code
@@ -461,6 +473,11 @@ namespace Microsoft.Interop
                 dllImportStub.DllImportData.SetLastError && !options.GenerateForwarders,
                 (elementInfo, ex) => diagnostics.ReportMarshallingNotSupported(originalSyntax, elementInfo, ex.NotSupportedDetails),
                 dllImportStub.StubContext.GeneratorFactory);
+
+            if (stubGenerator.StubIsBasicForwarder)
+            {
+                return (PrintForwarderStub(originalSyntax, dllImportStub), ImmutableArray<Diagnostic>.Empty);
+            }
 
             ImmutableArray<AttributeSyntax> forwardedAttributes = dllImportStub.ForwardedAttributes;
 
@@ -485,6 +502,38 @@ namespace Microsoft.Interop
             return (PrintGeneratedSource(originalSyntax, dllImportStub.StubContext, code), dllImportStub.Diagnostics.AddRange(diagnostics.Diagnostics));
         }
 
+        private MemberDeclarationSyntax PrintForwarderStub(MethodDeclarationSyntax userDeclaredMethod, IncrementalStubGenerationContext stub)
+        {
+            SyntaxTokenList originalModifiers = StripTriviaFromModifiers(userDeclaredMethod.Modifiers);
+            SyntaxTokenList modifiers = TokenList();
+            foreach (var modifier in originalModifiers)
+            {
+                if (modifier.Kind() != SyntaxKind.PartialKeyword)
+                {
+                    modifiers = modifiers.Add(modifier);
+                }
+            }
+            modifiers = modifiers.Add(Token(SyntaxKind.ExternKeyword)).Add(Token(SyntaxKind.PartialKeyword));
+            // Create stub function
+            MethodDeclarationSyntax stubMethod = MethodDeclaration(stub.StubContext.StubReturnType, userDeclaredMethod.Identifier)
+                .AddAttributeLists(stub.StubContext.AdditionalAttributes.ToArray())
+                .WithModifiers(modifiers)
+                .WithParameterList(ParameterList(SeparatedList(stub.StubContext.StubParameters)))
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                .AddModifiers()
+                .AddAttributeLists(
+                    AttributeList(
+                        SingletonSeparatedList(
+                            CreateDllImportAttributeForTarget(
+                                GetTargetDllImportDataFromStubData(
+                                    stub.DllImportData,
+                                    userDeclaredMethod.Identifier.ValueText,
+                                    forwardAll: true)))));
+
+            MemberDeclarationSyntax toPrint = WrapMethodInContainingScopes(stub.StubContext, stubMethod);
+
+            return toPrint;
+        }
 
         private static LocalFunctionStatementSyntax CreateTargetFunctionAsLocalStatement(
             PInvokeStubCodeGenerator stubGenerator,

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Interop
                 .ToList();
 
             StubIsBasicForwarder = !setLastError
+                && managedRetMarshaller.TypeInfo.IsNativeReturnPosition // If the managed return has native return position, then it's the return for both.
                 && _sortedMarshallers.All(
                     m => m is { Generator: BlittableMarshaller, TypeInfo: { IsByRef: false } }
                         or { Generator: Forwarder });

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Interop
         private readonly List<BoundGenerator> _sortedMarshallers;
         private readonly bool _stubReturnsVoid;
 
+        public bool StubIsBasicForwarder { get; }
+
         public PInvokeStubCodeGenerator(
             IEnumerable<TypePositionInfo> argTypes,
             bool setLastError,
@@ -134,6 +136,11 @@ namespace Microsoft.Interop
                 static m => GetInfoIndex(m.TypeInfo),
                 static m => GetInfoDependencies(m.TypeInfo))
                 .ToList();
+
+            StubIsBasicForwarder = !setLastError
+                && _sortedMarshallers.All(
+                    m => m is { Generator: BlittableMarshaller, TypeInfo: { IsByRef: false } }
+                        or { Generator: Forwarder });
 
             if (managedRetMarshaller.Generator.UsesNativeIdentifier(managedRetMarshaller.TypeInfo, this))
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -23,7 +23,18 @@ using System.Runtime.InteropServices;
 partial class C
 {
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method();
+    public static partial S Method();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }";
             Compilation comp = await TestUtils.CreateCompilation(source);
 
@@ -32,6 +43,25 @@ partial class C
             ITypeSymbol c = newComp.GetTypeByMetadataName("C")!;
             IMethodSymbol stubMethod = c.GetMembers().OfType<IMethodSymbol>().Single(m => m.Name == "Method");
             Assert.Contains(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
+        }
+
+        [Fact]
+        public async Task SkipLocalsInitNotAddedOnForwardingStub()
+        {
+            string source = @"
+using System.Runtime.InteropServices;
+partial class C
+{
+    [GeneratedDllImportAttribute(""DoesNotExist"")]
+    public static partial void Method();
+}";
+            Compilation comp = await TestUtils.CreateCompilation(source);
+
+            Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.DllImportGenerator());
+
+            ITypeSymbol c = newComp.GetTypeByMetadataName("C")!;
+            IMethodSymbol stubMethod = c.GetMembers().OfType<IMethodSymbol>().Single(m => m.Name == "Method");
+            Assert.DoesNotContain(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
         public static IEnumerable<object[]> GetDownlevelTargetFrameworks()
@@ -54,10 +84,27 @@ namespace System.Runtime.InteropServices
     {
         public GeneratedDllImportAttribute(string a) { }
     }
-}partial class C
+
+    sealed class NativeMarshallingAttribute : System.Attribute
+    {
+        public NativeMarshallingAttribute(System.Type nativeType) { }
+    }
+}
+partial class C
 {
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method();
+    public static partial S Method();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }";
             Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, referenceAssemblies);
 
@@ -85,7 +132,18 @@ using System.Runtime.CompilerServices;
 partial class C
 {
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method();
+    public static partial S Method();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }";
             Compilation comp = await TestUtils.CreateCompilation(source);
 
@@ -106,7 +164,18 @@ using System.Runtime.CompilerServices;
 partial class C
 {
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method();
+    public static partial S Method();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }";
             Compilation comp = await TestUtils.CreateCompilation(source);
 
@@ -127,7 +196,18 @@ partial class C
 {
     [SkipLocalsInit]
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method();
+    public static partial S Method();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }";
             Compilation comp = await TestUtils.CreateCompilation(source);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AttributeForwarding.cs
@@ -25,7 +25,18 @@ partial class C
 {{
     [{attributeSourceName}]
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+    public static partial S Method1();
+}}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{{
+}}
+
+struct Native
+{{
+    public Native(S s) {{ }}
+    public S ToManaged() {{ return default; }}
 }}
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
@@ -36,7 +47,6 @@ partial class C
 
             Assert.NotNull(attributeType);
 
-            // The last syntax tree is the generated code
             IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
 
             Assert.Contains(
@@ -54,7 +64,18 @@ partial class C
 {
     [UnmanagedCallConv(CallConvs = new Type[0])]
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+    public static partial S Method1();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
@@ -65,7 +86,6 @@ partial class C
 
             Assert.NotNull(attributeType);
 
-            // The last syntax tree is the generated code
             IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
 
             Assert.Contains(
@@ -86,7 +106,18 @@ partial class C
 {
     [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall)})]
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+    public static partial S Method1();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
@@ -98,7 +129,6 @@ partial class C
 
             Assert.NotNull(attributeType);
 
-            // The last syntax tree is the generated code
             IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
 
             Assert.Contains(
@@ -122,7 +152,18 @@ partial class C
 {
     [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall), typeof(CallConvSuppressGCTransition)})]
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+    public static partial S Method1();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
@@ -135,7 +176,6 @@ partial class C
 
             Assert.NotNull(attributeType);
 
-            // The last syntax tree is the generated code
             IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
 
             Assert.Contains(
@@ -165,7 +205,18 @@ partial class C
 {
     [Other]
     [GeneratedDllImportAttribute(""DoesNotExist"")]
-    public static partial void Method1();
+    public static partial S Method1();
+}
+
+[NativeMarshalling(typeof(Native))]
+struct S
+{
+}
+
+struct Native
+{
+    public Native(S s) { }
+    public S ToManaged() { return default; }
 }
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
@@ -177,7 +228,6 @@ partial class C
 
             Assert.NotNull(attributeType);
 
-            // The last syntax tree is the generated code
             IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
 
             Assert.DoesNotContain(
@@ -187,14 +237,15 @@ partial class C
 
         private static IMethodSymbol GetGeneratedPInvokeTargetFromCompilation(Compilation newComp)
         {
+            // The last syntax tree is the generated code
             SyntaxTree generatedCode = newComp.SyntaxTrees.Last();
             SemanticModel model = newComp.GetSemanticModel(generatedCode);
 
             var localFunctions = generatedCode.GetRoot()
                 .DescendantNodes().OfType<LocalFunctionStatementSyntax>()
                 .ToList();
-            Assert.Single(localFunctions);
-            IMethodSymbol targetMethod = (IMethodSymbol)model.GetDeclaredSymbol(localFunctions[0])!;
+            LocalFunctionStatementSyntax innerDllImport = Assert.Single(localFunctions);
+            IMethodSymbol targetMethod = (IMethodSymbol)model.GetDeclaredSymbol(innerDllImport)!;
             return targetMethod;
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
@@ -388,7 +388,7 @@ namespace DllImportGenerator.UnitTests
             Assert.NotNull(method.GetDllImportData());
         }
 
-    public static IEnumerable<object[]> CodeSnippetsToCompileWithMarshalType()
+        public static IEnumerable<object[]> CodeSnippetsToCompileWithMarshalType()
         {
             yield break;
         }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -38,6 +38,7 @@ namespace DllImportGenerator.UnitTests
 
         [Theory]
         [MemberData(nameof(MarshallingRequiredTypes))]
+        [MemberData(nameof(NoMarshallingRequiredTypes))]
         public async Task TypeRequiresMarshalling_ReportsDiagnostic(Type type)
         {
             string source = DllImportWithType(type.FullName!);

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -127,14 +127,6 @@ partial class Test
                     .WithArguments("Method2"));
         }
 
-        [Theory]
-        [MemberData(nameof(NoMarshallingRequiredTypes))]
-        public async Task BlittablePrimitive_NoDiagnostic(Type type)
-        {
-            string source = DllImportWithType(type.FullName!);
-            await VerifyCS.VerifyAnalyzerAsync(source);
-        }
-
         [Fact]
         public async Task NotDllImport_NoDiagnostic()
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -96,14 +96,17 @@ partial class Test
     public static extern void {{|#0:Method1|}}();
 
     [DllImport(""DoesNotExist"", PreserveSig = true)]
-    public static extern void Method2();
+    public static extern void {{|#1:Method2|}}();
 }}
 ";
             await VerifyCS.VerifyAnalyzerAsync(
                 source,
                 VerifyCS.Diagnostic(ConvertToGeneratedDllImport)
                     .WithLocation(0)
-                    .WithArguments("Method1"));
+                    .WithArguments("Method1"),
+                VerifyCS.Diagnostic(ConvertToGeneratedDllImport)
+                    .WithLocation(1)
+                    .WithArguments("Method2"));
         }
 
         [Fact]
@@ -114,16 +117,19 @@ using System.Runtime.InteropServices;
 partial class Test
 {{
     [DllImport(""DoesNotExist"", SetLastError = false)]
-    public static extern void Method1();
+    public static extern void {{|#0:Method1|}}();
 
     [DllImport(""DoesNotExist"", SetLastError = true)]
-    public static extern void {{|#0:Method2|}}();
+    public static extern void {{|#1:Method2|}}();
 }}
 ";
             await VerifyCS.VerifyAnalyzerAsync(
                 source,
                 VerifyCS.Diagnostic(ConvertToGeneratedDllImport)
                     .WithLocation(0)
+                    .WithArguments("Method1"),
+                VerifyCS.Diagnostic(ConvertToGeneratedDllImport)
+                    .WithLocation(1)
                     .WithArguments("Method2"));
         }
 


### PR DESCRIPTION
Generate the partial function as a DllImport when a full-body generated stub would be a no-op wrapper around an inner DllImport.

Fixes #60596 