### PR TITLE
Move NoInt32OverflowInTheBufferingLogic to OuterLoop

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -16,6 +16,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
         public void NoInt32OverflowInTheBufferingLogic()
         {
@@ -30,24 +31,13 @@ namespace System.IO.Tests
             using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
             {
                 stream.Seek(position1, SeekOrigin.Begin);
-                stream.Write(data1, 0, data1.Length);
+                stream.Write(data1);
 
                 stream.Seek(position2, SeekOrigin.Begin);
-                stream.Write(data2, 0, data2.Length);
+                stream.Write(data2);
             }
 
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-            {
-                stream.Seek(position1, SeekOrigin.Begin);
-                Assert.Equal(buffer.Length, stream.Read(buffer));
-                Assert.Equal(data1, buffer);
-
-                stream.Seek(position2, SeekOrigin.Begin);
-                Assert.Equal(buffer.Length, stream.Read(buffer));
-                Assert.Equal(data2, buffer);
-            }
-
-            using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0)))
             {
                 stream.Seek(position1, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));

--- a/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -323,6 +323,40 @@ namespace System.IO.Tests
             Array.Copy(data, 1, expected, 0, expected.Length);
             Assert.Equal(expected, dst.ToArray());
         }
+
+        [Fact]
+        [OuterLoop]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
+        public void NoInt32OverflowInTheBufferingLogic()
+        {
+            const long position1 = 10;
+            const long position2 = (1L << 32) + position1;
+
+            string filePath = Path.GetTempFileName();
+            byte[] data1 = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] data2 = new byte[] { 6, 7, 8, 9, 10 };
+            byte[] buffer = new byte[5];
+
+            using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
+            {
+                stream.Seek(position1, SeekOrigin.Begin);
+                stream.Write(data1);
+
+                stream.Seek(position2, SeekOrigin.Begin);
+                stream.Write(data2);
+            }
+
+            using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0)))
+            {
+                stream.Seek(position1, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data1, buffer);
+
+                stream.Seek(position2, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data2, buffer);
+            }
+        }
     }
 
     public class BufferedStream_TestLeaveOpen : TestLeaveOpen


### PR DESCRIPTION
It appears to be a long running test in CI: https://dev.azure.com/dnceng/public/_build/results?buildId=1424571&view=ms.vss-test-web.build-test-results-tab&runId=41213488&resultId=193806&paneView=dotnet-dnceng.dnceng-build-release-tasks.helix-test-information-tab

In addition, this PR addresses some suggestions left in https://github.com/dotnet/runtime/pull/60459.