### PR TITLE
Disable CounterSample_Calculate_CalculateCounterSample on Win10 ARM64

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleTests.cs
@@ -48,6 +48,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60403", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows))]
         public static void CounterSample_Calculate_CalculateCounterSampleCounterSample()
         {
             CounterSample counterSample1 = new CounterSample(5, 0, 0, 1, 0, 0, PerformanceCounterType.CounterDelta32);


### PR DESCRIPTION
Disables another test case related to https://github.com/dotnet/runtime/issues/60403
Seems I missed that there were two different test cases showing this failure in https://github.com/dotnet/runtime/pull/60553 and previously disabled just one of two.

cc: @danmoseley 