### PR TITLE
Attempt to fix observed AV in mark_through_cards_for_segments

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -2711,7 +2711,7 @@ alloc_list gc_heap::poh_alloc_list [NUM_POH_ALIST-1];
 #ifdef DOUBLY_LINKED_FL
 // size we removed with no undo; only for recording purpose
 size_t gc_heap::gen2_removed_no_undo = 0;
-size_t gc_heap::saved_pinned_plug_index = 0;
+size_t gc_heap::saved_pinned_plug_index = INVALID_SAVED_PINNED_PLUG_INDEX;
 #endif //DOUBLY_LINKED_FL
 
 #ifdef FEATURE_EVENT_TRACE
@@ -14138,7 +14138,20 @@ void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen)
                         uint8_t* old_loc = generation_last_free_list_allocated (gen);
 
                         // check if old_loc happens to be in a saved plug_and_gap with a pinned plug after it
-                        uint8_t* saved_plug_and_gap = pinned_plug (pinned_plug_of (saved_pinned_plug_index)) - sizeof(plug_and_gap);
+                        uint8_t* saved_plug_and_gap = nullptr;
+                        if (saved_pinned_plug_index != INVALID_SAVED_PINNED_PLUG_INDEX)
+                        {
+                            saved_plug_and_gap = pinned_plug (pinned_plug_of (saved_pinned_plug_index)) - sizeof(plug_and_gap);
+
+                            dprintf (5555, ("[h%d] sppi: %Id mtos: %Id old_loc: %Ix pp: %Ix(%Id) offs: %Id",
+                                heap_number,
+                                saved_pinned_plug_index,
+                                mark_stack_tos,
+                                old_loc,
+                                pinned_plug (pinned_plug_of (saved_pinned_plug_index)),
+                                pinned_len (pinned_plug_of (saved_pinned_plug_index)),
+                                old_loc - saved_plug_and_gap));
+                        }
                         size_t offset = old_loc - saved_plug_and_gap;
                         if (offset < sizeof(gap_reloc_pair))
                         {
@@ -14157,7 +14170,7 @@ void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen)
                             set_free_obj_in_compact_bit (old_loc);
                         }
 
-                        dprintf (3333, ("[h%d] ac: %Ix->%Ix((%Id < %Id), Pset %Ix s->%Id", heap_number,
+                        dprintf (5555, ("[h%d] ac: %Ix->%Ix((%Id < %Id), Pset %Ix s->%Id", heap_number,
                             generation_allocation_context_start_region (gen), generation_allocation_pointer (gen),
                             allocated_size, min_free_item_no_prev, filler_free_obj_size_location, filler_free_obj_size));
                     }
@@ -27783,7 +27796,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
 #ifdef DOUBLY_LINKED_FL
     gen2_removed_no_undo = 0;
-    saved_pinned_plug_index = 0;
+    saved_pinned_plug_index = INVALID_SAVED_PINNED_PLUG_INDEX;
 #endif //DOUBLY_LINKED_FL
 
     while (1)

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -261,7 +261,7 @@ void GCLog (const char *fmt, ... );
 // wanting to inspect GC logs on unmodified builds, we can use this define here
 // to do so.
 //#define dprintf(l, x)
-#define dprintf(l,x) {if ((l == 1) || (l == 5555)) {STRESS_LOG_VA(l,x);}}
+#define dprintf(l,x) {if (l == 5555) {STRESS_LOG_VA(l,x);}}
 
 #endif //SIMPLE_DPRINTF
 
@@ -2310,6 +2310,8 @@ protected:
     PER_HEAP
     void reset_pinned_queue_bos();
     PER_HEAP
+    void save_pinned_queue();
+    PER_HEAP
     void set_allocator_next_pin (generation* gen);
     PER_HEAP
     void enque_pinned_plug (generation* gen, uint8_t* plug, size_t len);
@@ -4069,6 +4071,15 @@ protected:
 
     PER_HEAP
     mark*       mark_stack_array;
+
+    PER_HEAP
+    size_t      saved_mark_stack_array_length;
+
+    PER_HEAP
+    size_t      saved_mark_stack_tos;
+
+    PER_HEAP
+    mark*       saved_mark_stack_array;
 
 #if defined (_DEBUG) && defined (VERIFY_HEAP)
     PER_HEAP

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -137,7 +137,7 @@ inline void FATAL_GC_ERROR()
 #define MAX_LONGPATH 1024
 #endif // MAX_LONGPATH
 
-//#define TRACE_GC
+#define TRACE_GC
 //#define SIMPLE_DPRINTF
 
 //#define JOIN_STATS         //amount of time spent in the join
@@ -261,7 +261,7 @@ void GCLog (const char *fmt, ... );
 // wanting to inspect GC logs on unmodified builds, we can use this define here
 // to do so.
 //#define dprintf(l, x)
-#define dprintf(l,x) STRESS_LOG_VA(l,x);
+#define dprintf(l,x) {if ((l == 1) || (l == 5555)) {STRESS_LOG_VA(l,x);}}
 
 #endif //SIMPLE_DPRINTF
 
@@ -4527,6 +4527,8 @@ protected:
     // accounting into the alloc_list class.
     PER_HEAP
     size_t gen2_removed_no_undo;
+
+#define INVALID_SAVED_PINNED_PLUG_INDEX (~0)
 
     PER_HEAP
     size_t saved_pinned_plug_index;

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1200,6 +1200,37 @@ enum bookkeeping_element
     total_bookkeeping_elements
 };
 
+class saved_pinned_queue
+{
+public:
+    enum gc_phase
+    {
+        invalid,
+        start_compact,
+        end_compact,
+    };
+
+private:
+    size_t   saved_gc_index;
+    gc_phase saved_phase;
+    size_t   mark_stack_tos;
+    size_t   mark_stack_array_length;
+    mark*    mark_stack_array;
+
+public:
+
+    saved_pinned_queue() :
+        saved_gc_index(0),
+        saved_phase(invalid),
+        mark_stack_tos(0),
+        mark_stack_array_length(0),
+        mark_stack_array(nullptr)
+    {
+    }
+
+    void    save(gc_phase phase, size_t gc_index, size_t tos, size_t length, mark* array);
+};
+
 //class definition of the internal class
 class gc_heap
 {
@@ -2310,7 +2341,7 @@ protected:
     PER_HEAP
     void reset_pinned_queue_bos();
     PER_HEAP
-    void save_pinned_queue();
+    void save_pinned_queue(saved_pinned_queue::gc_phase phase);
     PER_HEAP
     void set_allocator_next_pin (generation* gen);
     PER_HEAP
@@ -4072,14 +4103,13 @@ protected:
     PER_HEAP
     mark*       mark_stack_array;
 
-    PER_HEAP
-    size_t      saved_mark_stack_array_length;
+#define MAX_SAVED_PINNED_QUEUES  8
 
     PER_HEAP
-    size_t      saved_mark_stack_tos;
+    uint32_t    saved_pinned_queue_index;
 
     PER_HEAP
-    mark*       saved_mark_stack_array;
+    saved_pinned_queue saved_pinned_queues[MAX_SAVED_PINNED_QUEUES];
 
 #if defined (_DEBUG) && defined (VERIFY_HEAP)
     PER_HEAP

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -53,7 +53,7 @@ inline void FATAL_GC_ERROR()
 // Server GC we will balance regions between heaps.
 // For now enable regions by default for only StandAlone GC builds
 #if defined (HOST_64BIT) && defined (BUILD_AS_STANDALONE)
-#define USE_REGIONS
+//#define USE_REGIONS
 #endif //HOST_64BIT && BUILD_AS_STANDALONE
 
 #ifdef USE_REGIONS


### PR DESCRIPTION
The hypothesis is that when there were *no* pinned plugs in this GC, saved_pinned_plug_index will be 0, but it's erroneous to refer to pinned_plug_of (saved_pinned_plug_index) in this case.

The fix is to initialize saved_pinned_plug_index to an invalid value instead of 0, and to only refer to pinned_plug_of (saved_pinned_plug_index) if saved_pinned_plug_index has indeed been set in this GC.

It is yet unclear whether the observed AVs are due to this issue, so add instrumentation to narrow down the issue further.