### PR TITLE
Add a COMPlus variable to throw runtime exception on JIT asserts

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -294,6 +294,7 @@ CONFIG_DWORD_INFO(INTERNAL_JitDebuggable, W("JitDebuggable"), 0, "")
 #endif
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_JitEnableNoWayAssert, W("JitEnableNoWayAssert"), INTERNAL_JitEnableNoWayAssert_Default, "")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_JitFramed, W("JitFramed"), 0, "Forces EBP frames")
+CONFIG_DWORD_INFO(INTERNAL_JitThrowOnAssertionFailure, W("JitThrowOnAssertionFailure"), 0, "Throw managed exception on assertion failures during JIT instead of crashing the process")
 CONFIG_DWORD_INFO(INTERNAL_JitGCStress, W("JitGCStress"), 0, "GC stress mode for jit")
 CONFIG_DWORD_INFO(INTERNAL_JitHeartbeat, W("JitHeartbeat"), 0, "")
 CONFIG_DWORD_INFO(INTERNAL_JitHelperLogging, W("JitHelperLogging"), 0, "")

--- a/src/coreclr/scripts/azdo_pipelines_util.py
+++ b/src/coreclr/scripts/azdo_pipelines_util.py
@@ -47,9 +47,9 @@ def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _output_file=Non
                     if proc.poll() is not None:
                         break
                     if output:
-                        output_str = output.strip().decode("utf-8") + "\n"
+                        output_str = output.strip().decode("utf-8")
                         print(output_str)
-                        of.write(output_str)
+                        of.write(output_str + "\n")
         else:
             command_stdout, command_stderr = proc.communicate()
             if len(command_stdout) > 0:

--- a/src/coreclr/scripts/fuzzlyn_summarize.py
+++ b/src/coreclr/scripts/fuzzlyn_summarize.py
@@ -155,8 +155,8 @@ def main(main_args):
             continue
 
         unreduced_examples.append(example)
-        if example['Kind'] == "Crash":
-            assertion_error = extract_assertion_error(example['CrashError'])
+        if example['Kind'] == "Crash" or example['Kind'] == "HitsJitAssert":
+            assertion_error = extract_assertion_error(example['Message'])
             if assertion_error:
                 crashes_by_assert[assertion_error].append(example)
             else:
@@ -206,7 +206,7 @@ def main(main_args):
                 if len(examples) > 1:
                     f.write("Example occurence:\n")
                 f.write("```scala\n")
-                f.write(examples[0]['CrashError'].strip() + "\n")
+                f.write(examples[0]['Message'].strip() + "\n")
                 f.write("```\n")
                 f.write("Affected seeds{}:\n".format(" (10 shown)" if len(examples) > 10 else ""))
                 f.write("\n".join("* `" + str(ex['Seed']) + "`" for ex in sorted(examples[:10], key=lambda ex: ex['Seed'])))
@@ -216,9 +216,9 @@ def main(main_args):
             f.write("# {} uncategorized/unreduced examples remain\n".format(len(remaining)))
             for ex in remaining:
                 f.write("* `{}`: {}\n".format(ex['Seed'], ex['Kind']))
-                if ex['CrashError'] and len(ex['CrashError'].strip()) > 0:
+                if ex['Message'] and len(ex['Message'].strip()) > 0:
                     f.write("```scala\n")
-                    f.write(ex['CrashError'].strip() + "\n")
+                    f.write(ex['Message'].strip() + "\n")
                     f.write("```\n")
 
             f.write("\n")

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10514,6 +10514,17 @@ int CEEInfo::doAssert(const char* szFile, int iLine, const char* szExpr)
 
 #ifdef _DEBUG
     BEGIN_DEBUG_ONLY_CODE;
+    if (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitThrowOnAssertionFailure) != 0)
+    {
+        SString output;
+        output.Printf(
+            W("JIT assert failed:\n")
+            W("%hs\n")
+            W("    File: %hs Line: %d\n"),
+            szExpr, szFile, iLine);
+        COMPlusThrowNonLocalized(kInvalidProgramException, output.GetUnicode());
+    }
+
     result = _DbgBreakCheck(szFile, iLine, szExpr);
     END_DEBUG_ONLY_CODE;
 #else // !_DEBUG


### PR DESCRIPTION
Add `COMPlus_JitThrowOnAssertionFailure`: if nonzero, the runtime will
throw an InvalidProgramException with the assertion message if a JIT
assert is hit during compilation. Previously this would bring down the
process. Use this from the Fuzzlyn pipeline scripts to reduce examples
that hit JIT asserts automatically, since this can now be done much more
efficiently.