### PR TITLE
[release/6.0][wasm] Change dotnet.wasm link optimization

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -72,7 +72,7 @@ MONO_LIBS = \
 	$(ICU_LIBDIR)/libicui18n.a
 
 EMCC_DEBUG_FLAGS =-g -Os -s -DDEBUG=1
-EMCC_RELEASE_FLAGS=-Oz
+EMCC_RELEASE_FLAGS=-O2
 
 ifeq ($(NOSTRIP),)
 STRIP_CMD=&& $(EMSDK_PATH)/upstream/bin/wasm-opt --strip-dwarf $(NATIVE_BIN_DIR)/dotnet.wasm -o $(NATIVE_BIN_DIR)/dotnet.wasm

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -161,6 +161,7 @@
       <_EmccOptimizationFlagDefault Condition="'$(_EmccOptimizationFlagDefault)' == ''">-Oz</_EmccOptimizationFlagDefault>
 
       <EmccCompileOptimizationFlag Condition="'$(EmccCompileOptimizationFlag)' == ''">$(_EmccOptimizationFlagDefault)</EmccCompileOptimizationFlag>
+      <EmccLinkOptimizationFlag    Condition="'$(EmccLinkOptimizationFlag)' == '' and '$(Configuration)' == 'Release'">-O2</EmccLinkOptimizationFlag>
       <EmccLinkOptimizationFlag    Condition="'$(EmccLinkOptimizationFlag)' == ''"   >$(EmccCompileOptimizationFlag)</EmccLinkOptimizationFlag>
 
       <_EmccCompileRsp>$(_WasmIntermediateOutputPath)emcc-compile.rsp</_EmccCompileRsp>

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -180,7 +180,7 @@
 
     <PropertyGroup>
       <EmccConfigurationFlags Condition="'$(Configuration)' == 'Debug'">-g -Os -s -DENABLE_NETCORE=1 -DDEBUG=1</EmccConfigurationFlags>
-      <EmccConfigurationFlags Condition="'$(Configuration)' == 'Release'">-Oz -DENABLE_NETCORE=1</EmccConfigurationFlags>
+      <EmccConfigurationFlags Condition="'$(Configuration)' == 'Release'">-O2 -DENABLE_NETCORE=1</EmccConfigurationFlags>
       <StripCmd>&quot;$(EMSDK_PATH)/upstream/bin/wasm-opt&quot; --strip-dwarf &quot;$(NativeBinDir)dotnet.wasm&quot; -o &quot;$(NativeBinDir)dotnet.wasm&quot;</StripCmd>
       <WasmObjDir>$(ArtifactsObjDir)wasm</WasmObjDir>
       <WasmVersionFile>$(WasmObjDir)\emcc-version.txt</WasmVersionFile>


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/60349

When we switched to Emscripten 2.0.21, we stopped using deprecated
`--llvm-opts 2` option. This caused unwanted performance degradation.
Switching to `-O2` get us similar performance as with `--llvm-opts`.

Blazor wasm test app `Time to first UI` benchmark times:

    branch/commit        link option    time    dotnet.wasm size  .br size
    --------------------+------------+--------+------------------+---------
    release/6.0 92ff02       -Oz       491ms    2,430,639          850,109
    release/6.0 92ff02       -O2       457ms    2,474,518          853,765
    release/6.0 92ff02       -O3       444ms    2,555,824          857,961

## Customer Impact

Fixes a startup time regression for blazorwasm between .NET 5 an .NET 6 by a reverting compiler option change that was accidentally introduced as part of other build changes.

## Testing

Manual and Automated

## Regression

Yes, startup time regression.

## Risk

Low, switch to compiler options we're using in main.