### PR TITLE
[release/6.0] Fix stable builds for some transport packages

### DIFF
--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -20,7 +20,7 @@
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == '' and '$(PreReleaseVersionLabel)' != 'servicing'">$(PackageVersion)</StableVersion>
-    <StableVersion Condition="($(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Experimental')) or $(MSBuildProjectName.Contains('Transport'))) and ('$(MSBuildProjectExtension)' == '.pkgproj' or '$(MSBuildProjectExtension)' == '.proj')"></StableVersion>
+    <StableVersion Condition="($(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Experimental')) or $(MSBuildProjectName.Contains('Transport'))) and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">

--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -20,7 +20,7 @@
     <!-- Central place to set the versions of all nuget packages produced in the repo -->
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
     <StableVersion Condition="'$(StabilizePackageVersion)' == 'true' and '$(StableVersion)' == '' and '$(PreReleaseVersionLabel)' != 'servicing'">$(PackageVersion)</StableVersion>
-    <StableVersion Condition="($(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Experimental')) or $(MSBuildProjectName.Contains('Transport'))) and '$(MSBuildProjectExtension)' == '.pkgproj'"></StableVersion>
+    <StableVersion Condition="($(MSBuildProjectName.Contains('Private')) or $(MSBuildProjectName.Contains('Experimental')) or $(MSBuildProjectName.Contains('Transport'))) and ('$(MSBuildProjectExtension)' == '.pkgproj' or '$(MSBuildProjectExtension)' == '.proj')"></StableVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PreReleaseVersionLabel)' == 'servicing'">

--- a/src/libraries/workloads-testing.targets
+++ b/src/libraries/workloads-testing.targets
@@ -1,7 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <PackageVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</PackageVersion>
+    <_PackageVersion Condition="'$(StabilizePackageVersion)' == 'true'">$(ProductVersion)</_PackageVersion>
+    <_PackageVersion Condition="'$(_PackageVersion)' == ''">$(PackageVersion)</_PackageVersion>
   </PropertyGroup>
 
   <Target Name="ProvisionSdkForWorkloadTesting"
@@ -94,7 +95,7 @@
 
     <PropertyGroup>
       <!-- Eg. Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm.6.0.0-dev.nupkg -->
-      <_AOTCrossNuGetPath>$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Runtime.AOT.$(NETCoreSdkRuntimeIdentifier).Cross.$(RuntimeIdentifier).$(PackageVersion).nupkg</_AOTCrossNuGetPath>
+      <_AOTCrossNuGetPath>$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Runtime.AOT.$(NETCoreSdkRuntimeIdentifier).Cross.$(RuntimeIdentifier).$(_PackageVersion).nupkg</_AOTCrossNuGetPath>
     </PropertyGroup>
 
     <Error Text="Could not find cross compiler nupkg at $(_AOTCrossNuGetPath). Found packages: @(_BuiltNuGets)"


### PR DESCRIPTION
Some non-shipping transport and sources packages were getting incorrectly getting stable versions. This didn't show up in the servicing excercise, though they probably did the right thing for unrelated reasons. My guess is that a number of the .proj files that should not be stabilized used to be pkgproj files. The conditional only covered pkgproj.