### PR TITLE
Mark overflow fix for regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -23501,7 +23501,7 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                 {
                     dprintf (3,("mark stack overflow for object %Ix ", (size_t)oo));
 #ifdef USE_REGIONS
-                    heap_segment* overflow_region = region_of (oo);
+                    heap_segment* overflow_region = get_region_info_for_address (oo);
                     overflow_region->flags |= heap_segment_flags_overflow;
                     gc_heap* overflow_heap = heap_of (oo);
                     overflow_heap->background_overflow_p = TRUE;
@@ -23626,7 +23626,7 @@ void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
                 {
                     dprintf (3,("mark stack overflow for object %Ix ", (size_t)oo));
 #ifdef USE_REGIONS
-                    heap_segment* overflow_region = region_of (oo);
+                    heap_segment* overflow_region = get_region_info_for_address (oo);
                     overflow_region->flags |= heap_segment_flags_overflow;
                     gc_heap* overflow_heap = heap_of (oo);
                     overflow_heap->background_overflow_p = TRUE;

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2466,6 +2466,10 @@ protected:
     void verify_mark_bits_cleared (uint8_t* obj, size_t s);
     PER_HEAP
     void clear_all_mark_array();
+#ifdef USE_REGIONS
+    PER_HEAP
+    void set_background_overflow_p (uint8_t* oo);
+#endif
 
 #ifdef BGC_SERVO_TUNING
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4282,18 +4282,24 @@ protected:
     PER_HEAP
     size_t    background_mark_stack_array_length;
 
+    // We can't process the ephemeral range concurrently so we
+    // wait till final mark to process it.
+    PER_HEAP
+    BOOL      processed_eph_overflow_p;
+
+#ifdef USE_REGIONS
+    PER_HEAP
+    BOOL      background_overflow_p;
+
+    PER_HEAP
+    BOOL      background_eph_overflow_p;
+#else
     PER_HEAP
     uint8_t*  background_min_overflow_address;
 
     PER_HEAP
     uint8_t*  background_max_overflow_address;
 
-    // We can't process the ephemeral range concurrently so we
-    // wait till final mark to process it.
-    PER_HEAP
-    BOOL      processed_eph_overflow_p;
-
-#ifndef USE_REGIONS
     PER_HEAP
     uint8_t*  background_min_soh_overflow_address;
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4290,9 +4290,6 @@ protected:
 #ifdef USE_REGIONS
     PER_HEAP
     BOOL      background_overflow_p;
-
-    PER_HEAP
-    BOOL      background_eph_overflow_p;
 #else
     PER_HEAP
     uint8_t*  background_min_overflow_address;


### PR DESCRIPTION
The change is supposed to change the behavior for `USE_REGIONS` only.

# Overall idea
We may not have a continuous small object heap, therefore I removed the `background_min_overflow_address` and `background_max_overflow_address`. Instead, I introduced new flag named `background_overflow_p` to indicate a background mark stack overflow happened for the current heap, and the flag `heap_segment_flags_overflow` defined on a region is repurposed to mean any regions that need mark overflow processing.

# Details:
When a background mark stack overflow happens. Instead of modifying the background overflow address range, we set the `heap_segment_flags_overflow` flag on the corresponding region and the `background_overflow_p` flag on the corresponding heap.

Without a range, we have to scan the whole region.

`background_first_overflow` is changed for regions so that it starts at the beginning of the region.

The only important change in `background_process_mark_overflow_internal` is that we are ignoring the input and setting `current_min_add` and `current_max_add` to the region's range when `heap_segment_flags_overflow` flag is on and (0,0) otherwise. Other changes only affect dprintfs.

In `background_process_mark_overflow`, preprocessing for the concurrent case, we removed the logic of setting the `heap_segment_flags_overflow` for ephemeral regions. The flag is no longer used for that purpose.

In `background_process_mark_overflow`, preprocessing for the non-concurrent case, we used the `background_overflow_p` flag instead of the range to detect a background mark stack overflow happened. The setting of `background_overflow_p` flag to true unconditionally is a bit tricky. That is meant to make sure we process the ephemeral regions that we skipped earlier, there isn't a separate indicator for whether or not there was a mark overflow happened in the last on the ephemeral regions.

The last change in `background_process_mark_overflow` simply pass (0, 0) as the range into `background_process_mark_overflow_internal`, the function will simply not use them.

We skipped the logic to compute the overflow range in `background_scan_dependent_handles` and in `background_mark_phase`.

# Testing
The latest code is tested in the following configuration(s):

|Test                |OS     |Build    |Configuration                             |Duration|Status              |
|:------------------:|:-----:|:-------:|:----------------------------------------:|:------:|:------------------:|
|ReliabilityFramework|Windows|Debug    |Server GC                                 |12 hours|Passed without crash|
|ReliabilityFramework|Windows|Optimized|Server GC with induced mark stack overflow|18 hours|Passed without crash|