### PR TITLE
Several tweaks to RegexGenerator (the tool, not the emitted code)

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Generators.Tests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Generators.Tests/RegexGeneratorParserTests.cs
@@ -55,7 +55,7 @@ namespace System.Text.RegularExpressions.Generator.Tests
         }
 
         [Theory]
-        [InlineData(128)]
+        [InlineData(0x800)]
         public async Task Diagnostic_InvalidRegexOptions(int options)
         {
             IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@$"


### PR DESCRIPTION
- Fixed a bunch of nullable reference types warnings (they're suppressed as a netstandard2.0 project, but I temporarily and locally compiled it for netcoreapp current to get clean)
- Fixed the comparer used to aid in avoiding recomputing regexes when typing
- Added a hook to start exploring code gen for NonBacktracking