### PR TITLE
Fix "fix rid processing on macOS"

### DIFF
--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -587,7 +587,7 @@ pal::string_t pal::get_current_os_rid_platform()
                 *pos = 0;
 
             }
-            else if (major == 12)
+            else if (major == 11)
             {
                 // for 11.x we publish RID as 11.0
                 // if we return anything else, it would break the RID graph processing


### PR DESCRIPTION
The `else if (major == 12)` in https://github.com/dotnet/runtime/pull/60668 was dead code, since the previous if statement `if (major > 11)` would be true for `major == 12`. Judging by the comment and code, it looks like the intention of this `else if` statement was to match `major == 11`.