### PR TITLE
Update benchmark runs for superpmi collection to use net7.0

### DIFF
--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -153,7 +153,7 @@ def build_and_run(coreclr_args, output_mch_name):
 
     run_command(
         [dotnet_exe, "build", project_file, "--configuration", "Release",
-         "--framework", "net6.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
+         "--framework", "net7.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
          "-o", artifacts_directory], _exit_on_fail=True)
 
     # Disable ReadyToRun so we always JIT R2R methods and collect them


### PR DESCRIPTION
Until now, we were building microbenchmarks needed to do superpmi collection with `net6.0`. Switch to use `net7.0`.