### PR TITLE
Disable SetOut.SetOutReadToEnd

### DIFF
--- a/src/libraries/System.Console/tests/SetOut.cs
+++ b/src/libraries/System.Console/tests/SetOut.cs
@@ -28,6 +28,7 @@ public class SetOut
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/57935", TestPlatforms.AnyUnix)]
     public static void SetOutReadToEnd()
     {
         Helpers.SetAndReadHelper(tw => Console.SetOut(tw), () => Console.Out, sr => sr.ReadToEnd());


### PR DESCRIPTION
Disables test from this issue: https://github.com/dotnet/runtime/issues/57935

This test fails couple of times per week.
