### PR TITLE
Disable failing DllImportGenerator.Tests.BooleanTests.ValidateBoolIsMarshalledAsExpected test for Mono

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/BooleanTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/BooleanTests.cs
@@ -90,6 +90,7 @@ namespace DllImportGenerator.IntegrationTests
         const ushort VARIANT_FALSE = 0;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60649", TestRuntimes.Mono)]
         public void ValidateBoolIsMarshalledAsExpected()
         {
             Assert.Equal((uint)1, NativeExportsNE.ReturnByteBoolAsUInt(true));


### PR DESCRIPTION
Disables the test tracked by https://github.com/dotnet/runtime/issues/60649