### PR TITLE
InstallWorkload: Use the repo's `nuget.config` as the base for installing manifests

### DIFF
--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -89,9 +89,6 @@
           WorkingDirectory="$(InstallerProjectRoot)pkg/sfx/Microsoft.NETCore.App" />
 
     <ItemGroup>
-      <_NuGetSourceForWorkloads Include="dotnet6" Value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-      <_NuGetSourceForWorkloads Include="dotnet7" Value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-
       <_BuiltNuGets Include="$(LibrariesShippingPackagesDir)\*.nupkg" />
     </ItemGroup>
 
@@ -111,7 +108,7 @@
                      WorkloadId="@(WorkloadIdForTesting)"
                      VersionBand="$(SdkBandVersion)"
                      LocalNuGetsPath="$(LibrariesShippingPackagesDir)"
-                     ExtraNuGetSources="@(_NuGetSourceForWorkloads)"
+                     TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
                      SdkDir="$(SdkWithWorkloadForTestingPath)" />
     <WriteLinesToFile File="$(SdkWithWorkload_WorkloadStampPath)" Lines="" Overwrite="true" />
   </Target>
@@ -124,7 +121,7 @@
                      WorkloadId="@(WorkloadIdForTesting)"
                      VersionBand="$(SdkBandVersion)"
                      LocalNuGetsPath="$(LibrariesShippingPackagesDir)"
-                     ExtraNuGetSources="@(_NuGetSourceForWorkloads)"
+                     TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
                      SdkDir="$(SdkWithNoWorkloadForTestingPath)"
                      OnlyUpdateManifests="true"/>
 

--- a/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
+++ b/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Common\Utils.cs" />
+    <Compile Include="..\Common\LogAsErrorException.cs" />
 
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Install workloads task: Use root nuget.config to construct the  …
.. nuget.config used for restoring the workload manifests.

An alternative fix to dotnet@1091ed9