### PR TITLE
[DllImportGenerator] Stop adding unnecessary variable when marshalling UTF-16 string by value

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf16.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf16.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Interop
             }
         }
 
-        public override bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
+        public override bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
+            => info.IsManagedReturnPosition || info.IsByRef || !context.SingleFrameSpansNativeContext;
 
         public override bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
 


### PR DESCRIPTION
Example:
```diff
public static partial int ReturnLength(string s)
{
    unsafe
    {
-       ushort* __s_gen_native = default;
        int __retVal = default;
        fixed (char* __s_gen_native__pinned = s)
            __retVal = __PInvoke__((ushort*)__s_gen_native__pinned);
        return __retVal;
    }

    [System.Runtime.InteropServices.DllImportAttribute("Microsoft.Interop.Tests.NativeExportsNE", EntryPoint = "return_length_ushort", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
    extern static unsafe int __PInvoke__(ushort* s);
}
```

@AaronRobinsonMSFT @jkoritzinsky 

Contributes to https://github.com/dotnet/runtime/issues/60698