### PR TITLE
SizeConst of MarshalAs(ByValTStr) loaded by MetadataLoadContext always returns zero

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeHelpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeHelpers.cs
@@ -191,7 +191,6 @@ namespace System.Reflection.TypeLoading.Ecma
                     break;
 
                 case UnmanagedType.ByValArray:
-                case UnmanagedType.ByValTStr:
                     if (br.RemainingBytes == 0)
                         break;
                     ma.SizeConst = br.ReadCompressedInteger();
@@ -201,7 +200,11 @@ namespace System.Reflection.TypeLoading.Ecma
                     ma.ArraySubType = (UnmanagedType)br.ReadCompressedInteger();
 
                     break;
-
+                case UnmanagedType.ByValTStr:
+                    if (br.RemainingBytes == 0)
+                        break;
+                    ma.SizeConst = br.ReadCompressedInteger();
+                    break;
                 case UnmanagedType.SafeArray:
                     if (br.RemainingBytes == 0)
                         break;

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeHelpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeHelpers.cs
@@ -191,6 +191,7 @@ namespace System.Reflection.TypeLoading.Ecma
                     break;
 
                 case UnmanagedType.ByValArray:
+                case UnmanagedType.ByValTStr:
                     if (br.RemainingBytes == 0)
                         break;
                     ma.SizeConst = br.ReadCompressedInteger();

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/SampleMetadata/SampleMetadata.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/SampleMetadata/SampleMetadata.cs
@@ -418,6 +418,9 @@ namespace SampleMetadata
 
         [MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "Blah", MarshalCookie = "YumYum")]
         public int F20;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 65)]
+        public int F21;
     }
 
     [StructLayout(LayoutKind.Explicit)]

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/CustomAttributeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/CustomAttributeTests.cs
@@ -220,24 +220,5 @@ namespace System.Reflection.Tests
                 Assert.Equal(typeof(GuidAttribute).Project(), attributeType);
             }
         }
-
-        public struct StructWithMarshalByByValTStr
-        {
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 65)]
-            public string Name = string.Empty;
-        }
-
-        [Fact]
-        public static void TestMarshalCustomAttributeSizeConst_UnmanagedTypeByValTStr()
-        {
-            Type structType = typeof(StructWithMarshalByByValTStr).Project();
-            CustomAttributeData attribute = structType
-                .GetField(nameof(StructWithMarshalByByValTStr.Name))
-                .GetCustomAttributesData().FirstOrDefault(a => a.AttributeType.FullName == typeof(MarshalAsAttribute).FullName);
-
-            Assert.NotNull(attribute);
-            object size = attribute.NamedArguments.First(x => x.MemberName == nameof(MarshalAsAttribute.SizeConst)).TypedValue.Value;
-            Assert.Equal(65, size);
-        }
     }
 }

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/CustomAttributeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/CustomAttributeTests.cs
@@ -220,5 +220,24 @@ namespace System.Reflection.Tests
                 Assert.Equal(typeof(GuidAttribute).Project(), attributeType);
             }
         }
+
+        public struct StructWithMarshalByByValTStr
+        {
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 65)]
+            public string Name = string.Empty;
+        }
+
+        [Fact]
+        public static void TestMarshalCustomAttributeSizeConst_UnmanagedTypeByValTStr()
+        {
+            Type structType = typeof(StructWithMarshalByByValTStr).Project();
+            CustomAttributeData attribute = structType
+                .GetField(nameof(StructWithMarshalByByValTStr.Name))
+                .GetCustomAttributesData().FirstOrDefault(a => a.AttributeType.FullName == typeof(MarshalAsAttribute).FullName);
+
+            Assert.NotNull(attribute);
+            object size = attribute.NamedArguments.First(x => x.MemberName == nameof(MarshalAsAttribute.SizeConst)).TypedValue.Value;
+            Assert.Equal(65, size);
+        }
     }
 }

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/DllImportTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/DllImportTests.cs
@@ -232,6 +232,14 @@ namespace System.Reflection.Tests
                         MarshalType = "Blah",
                     },
                 };
+                yield return new object[]
+                {
+                     "F21",
+                    new MarshalAsAttribute(UnmanagedType.ByValTStr)
+                    {
+                        SizeConst = 65
+                    },
+                };
             }
         }
 


### PR DESCRIPTION
Fixes #57815