### PR TITLE
Turn off reloc generation for handles

### DIFF
--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -238,7 +238,9 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
 
             emitAttr attr = emitActualTypeSize(targetType);
 
-            if (con->IsIconHandle())
+            // TODO-CQ: Currently we cannot do this for all handles because of
+            // https://github.com/dotnet/runtime/issues/60712
+            if (con->ImmedValNeedsReloc(compiler))
             {
                 attr = EA_SET_FLG(attr, EA_CNS_RELOC_FLG);
             }

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1692,13 +1692,13 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
     {
         case GT_CNS_INT:
         {
-            // relocatable values tend to come down as a CNS_INT of native int type
-            // so the line between these two opcodes is kind of blurry
             GenTreeIntConCommon* con    = tree->AsIntConCommon();
             ssize_t              cnsVal = con->IconValue();
 
             emitAttr attr = emitActualTypeSize(targetType);
-            if (con->IsIconHandle())
+            // TODO-CQ: Currently we cannot do this for all handles because of
+            // https://github.com/dotnet/runtime/issues/60712
+            if (con->ImmedValNeedsReloc(compiler))
             {
                 attr = EA_SET_FLG(attr, EA_CNS_RELOC_FLG);
             }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -466,7 +466,13 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
             ssize_t              cnsVal = con->IconValue();
 
             emitAttr attr = emitActualTypeSize(targetType);
-            if (con->IsIconHandle())
+            // Currently this cannot be done for all handles due to
+            // https://github.com/dotnet/runtime/issues/60712. However, it is
+            // also unclear whether we unconditionally want to use rip-relative
+            // lea instructions when not necessary. While a mov is larger, on
+            // many Intel CPUs rip-relative lea instructions have higher
+            // latency.
+            if (con->ImmedValNeedsReloc(compiler))
             {
                 attr = EA_SET_FLG(attr, EA_CNS_RELOC_FLG);
             }


### PR DESCRIPTION
Due to #60712 we cannot unconditionally generate lea for handles, since
the runtime does not expect us to ask for reloc hints for
arbitrary constants. In addition, for many Intel CPUs it looks like
rip-relative lea has greater latency than mov with an 8-byte immediate.

Instead of reverting the change I'm just turning it off here, since the
change also unified a couple of functions to simplify the handling.

Fix #60626
Fix #60627
Fix #60629