### PR TITLE
Fix intermittent failure in DllImportGenerator unit tests when resolving assemblies

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -50,6 +50,7 @@
   <ItemGroup Condition="'$(TargetOS)' == 'Windows' and '$(RuntimeFlavor)' == 'Mono' and '$(RunDisabledMonoTestsOnWindows)' != 'true'">
     <!-- Issue: https://github.com/dotnet/runtime/issues/53281 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\DllImportGenerator.UnitTests\DllImportGenerator.Unit.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Android'">


### PR DESCRIPTION
Since the tests run in parallel, we could end up clearing out the variable for redirecting the package cache while it was still needed by another test.

Fixes #60706