### PR TITLE
[release/6.0] [HTTP/3] Fixed stress

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -50,7 +50,7 @@ jobs:
 
   - bash: |
       cd '$(httpStressProject)'
-      export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0 -xops 10"
+      export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0"
       export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 3.0

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -10,9 +10,9 @@ COPY . .
 # Pulling the msquic Debian package from msquic-ci public pipeline and from a hardcoded build.
 # Note that this is a temporary solution until we have properly published Linux packages.
 # Also note that in order to update to a newer msquic build, you have update this link.
-ARG MSQUIC_PACKAGE=libmsquic_1.6.0_amd64.deb
-ARG PACKAGES_DIR=LinuxPackages
-RUN wget 'https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/1266893/artifacts?artifactName=LinuxPackages&api-version=6.0&%24format=zip' -O "$PACKAGES_DIR".zip
+ARG MSQUIC_PACKAGE=libmsquic_1.9.0_amd64.deb
+ARG PACKAGES_DIR=UnsignedUnixPackages
+RUN wget 'https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/1426627/artifacts?artifactName=UnsignedUnixPackages&api-version=6.0&%24format=zip' -O "$PACKAGES_DIR".zip
 RUN apt-get update
 RUN apt-get install unzip
 RUN unzip $PACKAGES_DIR.zip


### PR DESCRIPTION
Manual backport of #60364 to release/6.0

This is a test-only change updating msquic for HttpStress  so we can run linux tests again on `release/6.0`.

/cc @ManickaP 

## Customer Impact

We need stress tests to assure the quality of the HTTP stack in .NET 6.0.

## Testing

CI run should show if the build error is gone.

## Risk

None.