### PR TITLE
Properly use result value for dump IPC cmd

### DIFF
--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -122,8 +122,6 @@ dump_protocol_helper_generate_core_dump (
 		ds_ipc_message_send_success (stream, ipc_result);
 	}
 
-	result = true;
-
 ep_on_exit:
 	ds_generate_core_dump_command_payload_free (payload);
 	ds_ipc_stream_free (stream);

--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -105,7 +105,7 @@ dump_protocol_helper_generate_core_dump (
 	if (!stream)
 		return false;
 
-	bool result = false;
+	ds_ipc_result_t ipc_result = DS_IPC_E_FAIL;
 	DiagnosticsGenerateCoreDumpCommandPayload *payload;
 	payload = (DiagnosticsGenerateCoreDumpCommandPayload *)ds_ipc_message_try_parse_payload (message, generate_core_dump_command_try_parse_payload);
 
@@ -114,13 +114,12 @@ dump_protocol_helper_generate_core_dump (
 		ep_raise_error ();
 	}
 
-	ds_ipc_result_t ipc_result;
 	ipc_result = ds_rt_generate_core_dump (payload);
-	if (result != DS_IPC_S_OK) {
-		ds_ipc_message_send_error (stream, result);
+	if (ipc_result != DS_IPC_S_OK) {
+		ds_ipc_message_send_error (stream, ipc_result);
 		ep_raise_error ();
 	} else {
-		ds_ipc_message_send_success (stream, result);
+		ds_ipc_message_send_success (stream, ipc_result);
 	}
 
 	result = true;
@@ -128,10 +127,10 @@ dump_protocol_helper_generate_core_dump (
 ep_on_exit:
 	ds_generate_core_dump_command_payload_free (payload);
 	ds_ipc_stream_free (stream);
-	return result;
+	return ipc_result == DS_IPC_S_OK;
 
 ep_on_error:
-	EP_ASSERT (!result);
+	EP_ASSERT (ipc_result != DS_IPC_S_OK);
 	ep_exit_error_handler ();
 }
 


### PR DESCRIPTION
@lateralusX caught a small error in the dump IPC command error handling while doing some refactoring. Pulling out the fix for that observation into a separate PR for easier backporting.

Currently, the dump IPC command will always return "false" even if the dump is successful. This change fixes up the error handling to use the actual error code from creating the dump.

CC @tommcdon 