### PR TITLE
Disable additional llvmfullaot Linux_arm64 CI lane

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1106,7 +1106,8 @@ jobs:
     runtimeFlavor: mono
     platforms:
     - Linux_x64
-    - Linux_arm64
+    # Disabled pending outcome of https://github.com/dotnet/runtime/issues/60234 investigation
+    #- Linux_arm64
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:


### PR DESCRIPTION
Missed excluding this configuration in https://github.com/dotnet/runtime/pull/60576