### PR TITLE
JIT: some enhancements to redundant branch opts

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7453,7 +7453,7 @@ public:
     //
     PhaseStatus optRedundantBranches();
     bool optRedundantBranch(BasicBlock* const block);
-    bool optJumpThread(BasicBlock* const block, BasicBlock* const domBlock);
+    bool optJumpThread(BasicBlock* const block, BasicBlock* const domBlock, bool domIsSameRelop);
     bool optReachable(BasicBlock* const fromBlock, BasicBlock* const toBlock, BasicBlock* const excludedBlock);
 
 #if ASSERTION_PROP

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -149,8 +149,10 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                 const bool domIsSameRelop = matchCmp || matchSwp;
                 const bool domIsRevRelop  = matchRev || matchSwpRev;
 
-                // Note we could also infer the tree relop's value from similar relops higher in the dom tree.
-                // For example, (x >= 0) dominating (x > 0), or (x < 0) dominating (x > 0).
+                // Note we could also infer the tree relop's value from relops higher in the dom tree
+                // that involve the same operands but are not swaps or reverses.
+                //
+                // For example, (x >= 0) dominating (x > 0).
                 //
                 // That is left as a future enhancement.
                 //

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -131,20 +131,23 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                 // We can use liberal VNs as bounds checks are not yet
                 // manifest explicitly as relops.
                 //
-                ValueNum domCmpVN = domCmpTree->GetVN(VNK_Liberal);
+                ValueNum domCmpVN    = domCmpTree->GetVN(VNK_Liberal);
+                ValueNum domCmpRevVN = vnStore->GetReversedRelopVN(domCmpVN);
 
                 // Note we could also infer the tree relop's value from similar relops higher in the dom tree.
                 // For example, (x >= 0) dominating (x > 0), or (x < 0) dominating (x > 0).
                 //
                 // That is left as a future enhancement.
                 //
-                if (domCmpVN == tree->GetVN(VNK_Liberal))
+                if ((domCmpVN == tree->GetVN(VNK_Liberal)) ||
+                    ((domCmpRevVN != ValueNumStore::NoVN) && (domCmpRevVN == tree->GetVN(VNK_Liberal))))
                 {
                     // The compare in "tree" is redundant.
                     // Is there a unique path from the dominating compare?
                     //
-                    JITDUMP("\nDominator " FMT_BB " of " FMT_BB " has relop with same liberal VN:\n", domBlock->bbNum,
-                            block->bbNum);
+                    const bool domIsSameRelop = domCmpVN == tree->GetVN(VNK_Liberal);
+                    JITDUMP("\nDominator " FMT_BB " of " FMT_BB " has relop with %s liberal VN\n", domBlock->bbNum,
+                            block->bbNum, domIsSameRelop ? "the same" : "a reverse");
                     DISPTREE(domCmpTree);
                     JITDUMP(" Redundant compare; current relop:\n");
                     DISPTREE(tree);
@@ -162,7 +165,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                         // However we may be able to update the flow from block's predecessors so they
                         // bypass block and instead transfer control to jump's successors (aka jump threading).
                         //
-                        const bool wasThreaded = optJumpThread(block, domBlock);
+                        const bool wasThreaded = optJumpThread(block, domBlock, domIsSameRelop);
 
                         if (wasThreaded)
                         {
@@ -171,20 +174,20 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                     }
                     else if (trueReaches)
                     {
-                        // Taken jump in dominator reaches, fall through doesn't; relop must be true.
+                        // Taken jump in dominator reaches, fall through doesn't; relop must be true/false.
                         //
-                        JITDUMP("Jump successor " FMT_BB " of " FMT_BB " reaches, relop must be true\n",
-                                domBlock->bbJumpDest->bbNum, domBlock->bbNum);
-                        relopValue = 1;
+                        JITDUMP("Jump successor " FMT_BB " of " FMT_BB " reaches, relop must be %s\n",
+                                domBlock->bbJumpDest->bbNum, domBlock->bbNum, domIsSameRelop ? "true" : "false");
+                        relopValue = domIsSameRelop ? 1 : 0;
                         break;
                     }
                     else if (falseReaches)
                     {
-                        // Fall through from dominator reaches, taken jump doesn't; relop must be false.
+                        // Fall through from dominator reaches, taken jump doesn't; relop must be false/true.
                         //
-                        JITDUMP("Fall through successor " FMT_BB " of " FMT_BB " reaches, relop must be false\n",
-                                domBlock->bbNext->bbNum, domBlock->bbNum);
-                        relopValue = 0;
+                        JITDUMP("Fall through successor " FMT_BB " of " FMT_BB " reaches, relop must be %s\n",
+                                domBlock->bbNext->bbNum, domBlock->bbNum, domIsSameRelop ? "false" : "true");
+                        relopValue = domIsSameRelop ? 0 : 1;
                         break;
                     }
                     else
@@ -259,6 +262,8 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
 // Arguments:
 //   block - block with branch to optimize
 //   domBlock - a dominating block that has an equivalent branch
+//   domIsSameRelop - if true, dominating block does the same compare;
+//                    if false, dominating block does a reverse compare
 //
 // Returns:
 //   True if the branch was optimized.
@@ -273,7 +278,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
 //     /     \           |     |
 //    C       D          C     D
 //
-bool Compiler::optJumpThread(BasicBlock* const block, BasicBlock* const domBlock)
+bool Compiler::optJumpThread(BasicBlock* const block, BasicBlock* const domBlock, bool domIsSameRelop)
 {
     assert(block->bbJumpKind == BBJ_COND);
     assert(domBlock->bbJumpKind == BBJ_COND);
@@ -370,8 +375,13 @@ bool Compiler::optJumpThread(BasicBlock* const block, BasicBlock* const domBlock
     // are correlated exclusively with a true value for block's relop, and which
     // are correlated exclusively with a false value (aka true preds and false preds).
     //
-    // To do this we try and follow the flow from domBlock to block; any block pred
-    // reachable from domBlock's true edge is a true pred, and vice versa.
+    // To do this we try and follow the flow from domBlock to block. When domIsSameRelop
+    // is true, any block pred reachable from domBlock's true edge is a true pred of block,
+    // and any block pred reachable from domBlock's false edge is a false pred of block.
+    //
+    // If domIsSameRelop is false, then the roles of the of the paths from domBlock swap:
+    // any block pred reachable from domBlock's true edge is a false pred of block,
+    // and any block pred reachable from domBlock's false edge is a true pred of block.
     //
     // However, there are some exceptions:
     //
@@ -400,8 +410,8 @@ bool Compiler::optJumpThread(BasicBlock* const block, BasicBlock* const domBlock
     int               numTruePreds      = 0;
     int               numFalsePreds     = 0;
     BasicBlock*       fallThroughPred   = nullptr;
-    BasicBlock* const trueSuccessor     = domBlock->bbJumpDest;
-    BasicBlock* const falseSuccessor    = domBlock->bbNext;
+    BasicBlock* const trueSuccessor     = domIsSameRelop ? domBlock->bbJumpDest : domBlock->bbNext;
+    BasicBlock* const falseSuccessor    = domIsSameRelop ? domBlock->bbNext : domBlock->bbJumpDest;
     BasicBlock* const trueTarget        = block->bbJumpDest;
     BasicBlock* const falseTarget       = block->bbNext;
     BlockSet          truePreds         = BlockSetOps::MakeEmpty(this);

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -131,6 +131,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                 // We can use liberal VNs as bounds checks are not yet
                 // manifest explicitly as relops.
                 //
+                ValueNum treeVN      = tree->GetVN(VNK_Liberal);
                 ValueNum domCmpVN    = domCmpTree->GetVN(VNK_Liberal);
                 ValueNum domCmpRevVN = vnStore->GetReversedRelopVN(domCmpVN);
 
@@ -139,13 +140,12 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                 //
                 // That is left as a future enhancement.
                 //
-                if ((domCmpVN == tree->GetVN(VNK_Liberal)) ||
-                    ((domCmpRevVN != ValueNumStore::NoVN) && (domCmpRevVN == tree->GetVN(VNK_Liberal))))
+                if ((domCmpVN == treeVN) || ((domCmpRevVN != ValueNumStore::NoVN) && (domCmpRevVN == treeVN)))
                 {
                     // The compare in "tree" is redundant.
                     // Is there a unique path from the dominating compare?
                     //
-                    const bool domIsSameRelop = domCmpVN == tree->GetVN(VNK_Liberal);
+                    const bool domIsSameRelop = (domCmpVN == treeVN);
                     JITDUMP("\nDominator " FMT_BB " of " FMT_BB " has relop with %s liberal VN\n", domBlock->bbNum,
                             block->bbNum, domIsSameRelop ? "the same" : "a reverse");
                     DISPTREE(domCmpTree);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4451,7 +4451,7 @@ bool ValueNumStore::IsVNHandle(ValueNum vn)
 }
 
 //------------------------------------------------------------------------
-// GetReversedRelopVN: return value number for reversed comparsion
+// GetReversedRelopVN: return value number for reversed comparison
 //
 // Arguments:
 //    vn - vn to reverse
@@ -4460,8 +4460,10 @@ bool ValueNumStore::IsVNHandle(ValueNum vn)
 //    vn for reversed comparsion, or NoVN.
 //
 // Note:
-//    If "vn" corresponds to (x > y) 
+//    If "vn" corresponds to (x > y)
 //    then reverse("vn") corresponds to (x <= y)
+//
+//    Will return NoVN for all float comparisons.
 //
 ValueNum ValueNumStore::GetReversedRelopVN(ValueNum vn)
 {
@@ -4485,6 +4487,13 @@ ValueNum ValueNumStore::GetReversedRelopVN(ValueNum vn)
     }
 
     if (funcAttr.m_arity != 2)
+    {
+        return NoVN;
+    }
+
+    // Don't try and model float compares.
+    //
+    if (varTypeIsFloating(TypeOfVN(funcAttr.m_args[0])))
     {
         return NoVN;
     }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4455,13 +4455,13 @@ bool ValueNumStore::IsVNHandle(ValueNum vn)
 //
 // Arguments:
 //    vn - vn to base things on
-//    vnk - whether the new vn should swap, reverse, or both
+//    vrk - whether the new vn should swap, reverse, or both
 //
 // Returns:
 //    vn for reversed/swapped comparsion, or NoVN.
 //
 // Note:
-//    If "vn" corresponds to (x > y), the resulting VN correponds to
+//    If "vn" corresponds to (x > y), the resulting VN corresponds to
 //    VRK_Swap               (y < x)
 //    VRK_Reverse            (x <= y)
 //    VRK_SwapReverse        (y >= x)

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -842,11 +842,18 @@ public:
     // Returns true iff the VN represents a handle constant.
     bool IsVNHandle(ValueNum vn);
 
-    // Given a relop VN, get the VN for the "reversed" relop, which has the opposite value
-    // eg given VN(x < y), return  VN(y <=x)
+    // Given VN(x > y), return VN(y > x), VN(x <= y) or VN(y >= x)
     //
     // If vn is not a relop, return NoVN.
-    ValueNum GetReversedRelopVN(ValueNum vn);
+    //
+    enum class VN_RELATION_KIND
+    {
+        VRK_Swap,       // (y >  x)
+        VRK_Reverse,    // (x <= y)
+        VRK_SwapReverse // (y >= x)
+    };
+
+    ValueNum GetRelatedRelop(ValueNum vn, VN_RELATION_KIND vrk);
 
     // Convert a vartype_t to the value number's storage type for that vartype_t.
     // For example, ValueNum of type TYP_LONG are stored in a map of INT64 variables.

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -842,6 +842,12 @@ public:
     // Returns true iff the VN represents a handle constant.
     bool IsVNHandle(ValueNum vn);
 
+    // Given a relop VN, get the VN for the "reversed" relop, which has the opposite value
+    // eg given VN(x < y), return  VN(y <=x)
+    //
+    // If vn is not a relop, return NoVN.
+    ValueNum GetReversedRelopVN(ValueNum vn);
+
     // Convert a vartype_t to the value number's storage type for that vartype_t.
     // For example, ValueNum of type TYP_LONG are stored in a map of INT64 variables.
     // Lang is the language (C++) type for the corresponding vartype_t.


### PR DESCRIPTION
Handle cases where the dominating compare is the reverse of the compare
we're trying to optimize. For example, if `(x > y)` dominates `(y <= x)`
we may be able to optimize the dominated compare.

Addresses aspects of #48115.