### PR TITLE
Disable a couple of pen tests on Windows

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/PenTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/PenTests.cs
@@ -52,6 +52,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new SolidBrush(Color.Red), float.MaxValue, PenType.SolidColor };
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60731", TestPlatforms.Windows)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Brush_Width_TestData))]
         public void Ctor_Brush_Width<T>(T brush, float width, PenType expectedPenType) where T : Brush
@@ -102,6 +103,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60731", TestPlatforms.Windows)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(0)]


### PR DESCRIPTION
These started failing today on CI. I suspect this was due to a helix rollout or something that changed on the Windows machines that we run CI on (maybe GDI+?). I need to investigate more, so I'll disable them to unblock CI.