### PR TITLE
Add AggressiveInlining attribute to multi-dimension array helpers

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -375,6 +375,7 @@ namespace System
 
         public unsafe int Rank
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 int rank = RuntimeHelpers.GetMultiDimensionalArrayRank(this);
@@ -382,6 +383,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe int GetLength(int dimension)
         {
             int rank = RuntimeHelpers.GetMultiDimensionalArrayRank(this);
@@ -394,6 +396,7 @@ namespace System
             return Unsafe.Add(ref RuntimeHelpers.GetMultiDimensionalArrayBounds(this), dimension);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe int GetUpperBound(int dimension)
         {
             int rank = RuntimeHelpers.GetMultiDimensionalArrayRank(this);
@@ -407,6 +410,7 @@ namespace System
             return Unsafe.Add(ref bounds, dimension) + Unsafe.Add(ref bounds, rank + dimension) - 1;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe int GetLowerBound(int dimension)
         {
             int rank = RuntimeHelpers.GetMultiDimensionalArrayRank(this);


### PR DESCRIPTION
Specifically,

Rank.get
GetLength
GetUpperBound
GetLowerBound

These can cause significant code growth, however, they are important
to inline for the performance of multi-dimensional array loops that use them.