### PR TITLE
More stack overflow avoidance in regex NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/MintermGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/MintermGenerator.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
@@ -114,6 +116,12 @@ namespace System.Text.RegularExpressions.Symbolic
 
             internal void Refine(TPredicate other)
             {
+                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                {
+                    StackHelper.CallOnEmptyStack(Refine, other);
+                    return;
+                }
+
                 if (_left is null && _right is null)
                 {
                     // If this is a leaf node create left and/or right children for the new predicate
@@ -187,6 +195,12 @@ namespace System.Text.RegularExpressions.Symbolic
             /// </summary>
             private void ExtendLeft()
             {
+                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                {
+                    StackHelper.CallOnEmptyStack(ExtendLeft);
+                    return;
+                }
+
                 if (_left is null && _right is null)
                 {
                     _left = new PartitionTree(_solver, _pred, null, null);
@@ -204,6 +218,12 @@ namespace System.Text.RegularExpressions.Symbolic
             /// </summary>
             private void ExtendRight()
             {
+                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                {
+                    StackHelper.CallOnEmptyStack(ExtendRight);
+                    return;
+                }
+
                 if (_left is null && _right is null)
                 {
                     _right = new PartitionTree(_solver, _pred, null, null);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/MintermGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/MintermGenerator.cs
@@ -116,7 +116,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
             internal void Refine(TPredicate other)
             {
-                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                if (!StackHelper.TryEnsureSufficientExecutionStack())
                 {
                     StackHelper.CallOnEmptyStack(Refine, other);
                     return;
@@ -195,7 +195,7 @@ namespace System.Text.RegularExpressions.Symbolic
             /// </summary>
             private void ExtendLeft()
             {
-                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                if (!StackHelper.TryEnsureSufficientExecutionStack())
                 {
                     StackHelper.CallOnEmptyStack(ExtendLeft);
                     return;
@@ -218,7 +218,7 @@ namespace System.Text.RegularExpressions.Symbolic
             /// </summary>
             private void ExtendRight()
             {
-                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                if (!StackHelper.TryEnsureSufficientExecutionStack())
                 {
                     StackHelper.CallOnEmptyStack(ExtendRight);
                     return;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -31,6 +31,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
         private BDD CreateConditionFromSet(bool ignoreCase, string set)
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(CreateConditionFromSet, ignoreCase, set);
+            }
+
             (bool ignoreCase, string set) key = (ignoreCase, set);
             if (!_createConditionFromSet_Cache.TryGetValue(key, out BDD? result))
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -31,7 +31,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         private BDD CreateConditionFromSet(bool ignoreCase, string set)
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(CreateConditionFromSet, ignoreCase, set);
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
@@ -295,6 +297,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal SymbolicRegexNode<T> Transform<T>(SymbolicRegexNode<TElement> sr, SymbolicRegexBuilder<T> builderT, Func<TElement, T> predicateTransformer) where T : notnull
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(Transform, sr, builderT, predicateTransformer);
+            }
+
             switch (sr._kind)
             {
                 case SymbolicRegexKind.StartAnchor:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -297,7 +297,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal SymbolicRegexNode<T> Transform<T>(SymbolicRegexNode<TElement> sr, SymbolicRegexBuilder<T> builderT, Func<TElement, T> predicateTransformer) where T : notnull
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(Transform, sr, builderT, predicateTransformer);
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -130,7 +130,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
             static void AppendToList(SymbolicRegexNode<S> concat, List<SymbolicRegexNode<S>> list)
             {
-                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                if (!StackHelper.TryEnsureSufficientExecutionStack())
                 {
                     StackHelper.CallOnEmptyStack(AppendToList, concat, list);
                     return;
@@ -168,7 +168,7 @@ namespace System.Text.RegularExpressions.Symbolic
             if (!_info.CanBeNullable)
                 return false;
 
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(IsNullableFor, context);
             }
@@ -805,7 +805,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 return _transitionRegex;
             }
 
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(MkDerivative);
             }
@@ -911,7 +911,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 return _builder._nothing;
             }
 
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(ExtractNullabilityTest);
             }
@@ -1025,7 +1025,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 // Check equality of the sets of regexes
                 Debug.Assert(_alts is not null && that._alts is not null);
-                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                if (!StackHelper.TryEnsureSufficientExecutionStack())
                 {
                     return StackHelper.CallOnEmptyStack(_alts.Equals, that._alts);
                 }
@@ -1215,7 +1215,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         private void CollectPredicates_helper(HashSet<S> predicates)
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 StackHelper.CallOnEmptyStack(CollectPredicates_helper, predicates);
                 return;
@@ -1312,7 +1312,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         public SymbolicRegexNode<S> Reverse()
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(Reverse);
             }
@@ -1391,7 +1391,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal bool StartsWithLoop(int upperBoundLowestValue = 1)
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(StartsWithLoop, upperBoundLowestValue);
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -130,6 +130,12 @@ namespace System.Text.RegularExpressions.Symbolic
 
             static void AppendToList(SymbolicRegexNode<S> concat, List<SymbolicRegexNode<S>> list)
             {
+                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                {
+                    StackHelper.CallOnEmptyStack(AppendToList, concat, list);
+                    return;
+                }
+
                 SymbolicRegexNode<S> node = concat;
                 while (node._kind == SymbolicRegexKind.Concat)
                 {
@@ -161,6 +167,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
             if (!_info.CanBeNullable)
                 return false;
+
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(IsNullableFor, context);
+            }
 
             // Initialize the nullability cache for this node.
             _nullabilityCache ??= new Dictionary<uint, bool>();
@@ -550,71 +561,6 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         /// <summary>
-        /// Transform the symbolic regex so that all singletons have been intersected with the given predicate pred.
-        /// </summary>
-        public SymbolicRegexNode<S> Restrict(S pred)
-        {
-            switch (_kind)
-            {
-                case SymbolicRegexKind.StartAnchor:
-                case SymbolicRegexKind.EndAnchor:
-                case SymbolicRegexKind.BOLAnchor:
-                case SymbolicRegexKind.EOLAnchor:
-                case SymbolicRegexKind.Epsilon:
-                case SymbolicRegexKind.WatchDog:
-                case SymbolicRegexKind.WBAnchor:
-                case SymbolicRegexKind.NWBAnchor:
-                case SymbolicRegexKind.EndAnchorZ:
-                case SymbolicRegexKind.EndAnchorZRev:
-                    return this;
-
-                case SymbolicRegexKind.Singleton:
-                    {
-                        Debug.Assert(_set is not null);
-                        S newset = _builder._solver.And(_set, pred);
-                        return _set.Equals(newset) ? this : _builder.MkSingleton(newset);
-                    }
-
-                case SymbolicRegexKind.Loop:
-                    {
-                        Debug.Assert(_left is not null);
-                        SymbolicRegexNode<S> body = _left.Restrict(pred);
-                        return body == _left ? this : _builder.MkLoop(body, IsLazy, _lower, _upper);
-                    }
-
-                case SymbolicRegexKind.Concat:
-                    {
-                        Debug.Assert(_left is not null && _right is not null);
-                        SymbolicRegexNode<S> first = _left.Restrict(pred);
-                        SymbolicRegexNode<S> second = _right.Restrict(pred);
-                        return first == _left && second == _right ? this : _builder.MkConcat(first, second);
-                    }
-
-                case SymbolicRegexKind.Or:
-                    {
-                        Debug.Assert(_alts is not null);
-                        SymbolicRegexSet<S> choices = _alts.Restrict(pred);
-                        return _builder.MkOr(choices);
-                    }
-
-                case SymbolicRegexKind.And:
-                    {
-                        Debug.Assert(_alts is not null);
-                        SymbolicRegexSet<S> conjuncts = _alts.Restrict(pred);
-                        return _builder.MkAnd(conjuncts);
-                    }
-
-                default:
-                    {
-                        Debug.Assert(_kind == SymbolicRegexKind.Not, $"{nameof(Restrict)}:{_kind}");
-                        Debug.Assert(_left is not null);
-                        SymbolicRegexNode<S> restricted = _left.Restrict(pred);
-                        return _builder.MkNot(restricted);
-                    }
-            }
-        }
-
-        /// <summary>
         /// Returns the fixed matching length of the regex or -1 if the regex does not have a fixed matching length.
         /// </summary>
         public int GetFixedLength()
@@ -680,6 +626,7 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         private Dictionary<(S, uint), SymbolicRegexNode<S>>? _MkDerivative_Cache;
+
         /// <summary>
         /// Takes the derivative of the symbolic regex wrt elem.
         /// Assumes that elem is either a minterm wrt the predicates of the whole regex or a singleton set.
@@ -858,6 +805,11 @@ namespace System.Text.RegularExpressions.Symbolic
                 return _transitionRegex;
             }
 
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(MkDerivative);
+            }
+
             switch (_kind)
             {
                 case SymbolicRegexKind.Singleton:
@@ -957,6 +909,11 @@ namespace System.Text.RegularExpressions.Symbolic
             if (!CanBeNullable)
             {
                 return _builder._nothing;
+            }
+
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(ExtractNullabilityTest);
             }
 
             switch (_kind)
@@ -1068,6 +1025,10 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 // Check equality of the sets of regexes
                 Debug.Assert(_alts is not null && that._alts is not null);
+                if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+                {
+                    return StackHelper.CallOnEmptyStack(_alts.Equals, that._alts);
+                }
                 return _alts.Equals(that._alts);
             }
 
@@ -1254,6 +1215,12 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         private void CollectPredicates_helper(HashSet<S> predicates)
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                StackHelper.CallOnEmptyStack(CollectPredicates_helper, predicates);
+                return;
+            }
+
             switch (_kind)
             {
                 case SymbolicRegexKind.BOLAnchor:
@@ -1345,6 +1312,11 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         public SymbolicRegexNode<S> Reverse()
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(Reverse);
+            }
+
             switch (_kind)
             {
                 case SymbolicRegexKind.Loop:
@@ -1419,6 +1391,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal bool StartsWithLoop(int upperBoundLowestValue = 1)
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(StartsWithLoop, upperBoundLowestValue);
+            }
+
             switch (_kind)
             {
                 case SymbolicRegexKind.Loop:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -273,19 +273,6 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 
-        public SymbolicRegexSet<S> Restrict(S pred)
-        {
-            return CreateMulti(_builder, RestrictElements(pred), _kind);
-
-            IEnumerable<SymbolicRegexNode<S>> RestrictElements(S pred)
-            {
-                foreach (SymbolicRegexNode<S> elem in this)
-                {
-                    yield return elem.Restrict(pred);
-                }
-            }
-        }
-
         internal bool IsNullableFor(uint context)
         {
             Enumerator e = GetEnumerator();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -336,6 +336,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
+            // This function is mutually recursive with the one in SymbolicRegexNode, which has stack overflow avoidance
             if (obj is not SymbolicRegexSet<S> that ||
                 _kind != that._kind ||
                 _singleton is null && that._singleton is not null ||
@@ -360,6 +361,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public void ToString(StringBuilder sb)
         {
+            // This function is mutually recursive with the one in SymbolicRegexNode, which has stack overflow avoidance
             if (IsNothing)
             {
                 sb.Append(SymbolicRegexNode<S>.EmptyCharClass);
@@ -402,6 +404,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal SymbolicRegexSet<S> CreateDerivative(S elem, uint context)
         {
+            // This function is mutually recursive with the one in SymbolicRegexNode, which has stack overflow avoidance
             return CreateMulti(_builder, MkDerivativesOfElems(elem, context), _kind);
 
             IEnumerable<SymbolicRegexNode<S>> MkDerivativesOfElems(S elem, uint context)
@@ -415,6 +418,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal SymbolicRegexSet<T> Transform<T>(SymbolicRegexBuilder<T> builderT, Func<S, T> predicateTransformer) where T : notnull
         {
+            // This function is mutually recursive with the one in SymbolicRegexBuilder, which has stack overflow avoidance
             return SymbolicRegexSet<T>.CreateMulti(builderT, TransformElements(builderT, predicateTransformer), _kind);
 
             IEnumerable<SymbolicRegexNode<T>> TransformElements(SymbolicRegexBuilder<T> builderT, Func<S, T> predicateTransformer)
@@ -438,6 +442,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal SymbolicRegexSet<S> Reverse()
         {
+            // This function is mutually recursive with the one in SymbolicRegexNode, which has stack overflow avoidance
             return CreateMulti(_builder, ReverseElements(), _kind);
 
             IEnumerable<SymbolicRegexNode<S>> ReverseElements()
@@ -451,6 +456,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal bool StartsWithLoop(int upperBoundLowestValue)
         {
+            // This function is mutually recursive with the one in SymbolicRegexNode, which has stack overflow avoidance
             foreach (SymbolicRegexNode<S> n in this)
             {
                 if (n.StartsWithLoop(upperBoundLowestValue))
@@ -470,6 +476,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal int GetFixedLength()
         {
+            // This function is mutually recursive with the one in SymbolicRegexNode, which has stack overflow avoidance
             if (_loops.Count > 0)
             {
                 return -1;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
@@ -4,6 +4,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
@@ -77,6 +79,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public TransitionRegex<S> Complement()
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(Complement);
+            }
+
             switch (_kind)
             {
                 case TransitionRegexKind.Leaf:
@@ -100,6 +107,11 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Concatenate a node at the end of this transition regex</summary>
         public TransitionRegex<S> Concat(SymbolicRegexNode<S> node)
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(Concat, node);
+            }
+
             switch (_kind)
             {
                 case TransitionRegexKind.Leaf:
@@ -132,6 +144,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
         private TransitionRegex<S> IntersectWith(TransitionRegex<S> that, S pathIn)
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(IntersectWith, that, pathIn);
+            }
+
             Debug.Assert(_builder._solver.IsSatisfiable(pathIn));
 
             #region Conditional
@@ -205,6 +222,11 @@ namespace System.Text.RegularExpressions.Symbolic
 
         private static TransitionRegex<S> Union(TransitionRegex<S> one, TransitionRegex<S> two)
         {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return StackHelper.CallOnEmptyStack(Union, one, two);
+            }
+
             // Apply common simplifications, always trying to push the operations into the leaves or to eliminate redundant branches
             if (one.IsNothing || two.IsAnyStar || one == two)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
@@ -79,7 +79,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public TransitionRegex<S> Complement()
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(Complement);
             }
@@ -107,7 +107,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Concatenate a node at the end of this transition regex</summary>
         public TransitionRegex<S> Concat(SymbolicRegexNode<S> node)
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(Concat, node);
             }
@@ -144,7 +144,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         private TransitionRegex<S> IntersectWith(TransitionRegex<S> that, S pathIn)
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(IntersectWith, that, pathIn);
             }
@@ -222,7 +222,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         private static TransitionRegex<S> Union(TransitionRegex<S> one, TransitionRegex<S> two)
         {
-            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
             {
                 return StackHelper.CallOnEmptyStack(Union, one, two);
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
@@ -43,6 +43,17 @@ namespace System.Threading
         /// <summary>Calls the provided action on the stack of a different thread pool thread.</summary>
         /// <typeparam name="TArg1">The type of the first argument to pass to the function.</typeparam>
         /// <typeparam name="TArg2">The type of the second argument to pass to the function.</typeparam>
+        /// <param name="action">The action to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the action.</param>
+        /// <param name="arg2">The second argument to pass to the action.</param>
+        public static void CallOnEmptyStack<TArg1, TArg2>(Action<TArg1, TArg2> action, TArg1 arg1, TArg2 arg2) =>
+            Task.Run(() => action(arg1, arg2))
+                .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                .GetAwaiter().GetResult();
+
+        /// <summary>Calls the provided action on the stack of a different thread pool thread.</summary>
+        /// <typeparam name="TArg1">The type of the first argument to pass to the function.</typeparam>
+        /// <typeparam name="TArg2">The type of the second argument to pass to the function.</typeparam>
         /// <typeparam name="TArg3">The type of the third argument to pass to the function.</typeparam>
         /// <param name="action">The action to invoke.</param>
         /// <param name="arg1">The first argument to pass to the action.</param>
@@ -50,6 +61,24 @@ namespace System.Threading
         /// <param name="arg3">The second argument to pass to the action.</param>
         public static void CallOnEmptyStack<TArg1, TArg2, TArg3>(Action<TArg1, TArg2, TArg3> action, TArg1 arg1, TArg2 arg2, TArg3 arg3) =>
             Task.Run(() => action(arg1, arg2, arg3))
+                .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                .GetAwaiter().GetResult();
+
+        /// <summary>Calls the provided function on the stack of a different thread pool thread.</summary>
+        /// <typeparam name="TResult">The return type of the function.</typeparam>
+        /// <param name="func">The function to invoke.</param>
+        public static TResult CallOnEmptyStack<TResult>(Func<TResult> func) =>
+            Task.Run(() => func())
+                .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                .GetAwaiter().GetResult();
+
+        /// <summary>Calls the provided function on the stack of a different thread pool thread.</summary>
+        /// <typeparam name="TArg1">The type of the first argument to pass to the function.</typeparam>
+        /// <typeparam name="TResult">The return type of the function.</typeparam>
+        /// <param name="func">The function to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the function.</param>
+        public static TResult CallOnEmptyStack<TArg1, TResult>(Func<TArg1, TResult> func, TArg1 arg1) =>
+            Task.Run(() => func(arg1))
                 .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
                 .GetAwaiter().GetResult();
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
@@ -32,6 +32,13 @@ namespace System.Threading
         // also plays nicely with the thread pool's sync-over-async aggressive thread injection policies.
 
         /// <summary>Calls the provided action on the stack of a different thread pool thread.</summary>
+        /// <param name="action">The action to invoke.</param>
+        public static void CallOnEmptyStack(Action action) =>
+            Task.Run(() => action())
+                .ContinueWith(t => t.GetAwaiter().GetResult(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default)
+                .GetAwaiter().GetResult();
+
+        /// <summary>Calls the provided action on the stack of a different thread pool thread.</summary>
         /// <typeparam name="TArg1">The type of the first argument to pass to the function.</typeparam>
         /// <param name="action">The action to invoke.</param>
         /// <param name="arg1">The first argument to pass to the action.</param>


### PR DESCRIPTION
This adds more stack overflow avoidance to regex NonBacktracking's recursive algorithms. This includes all the fixes from https://github.com/dotnet/runtimelab/pull/1662 plus additional ones found in a full audit we did with @veanes.

`Restrict` in SymbolicRegexNode and SymbolicRegexSet would've required it too, but they turned out to be dead code, so were removed.