### PR TITLE
Disable a couple of pen tests on Windows on release/6.0

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/PenTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/PenTests.cs
@@ -46,6 +46,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new SolidBrush(Color.Red), float.MaxValue, PenType.SolidColor };
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60731", TestPlatforms.Windows)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Brush_Width_TestData))]
         public void Ctor_Brush_Width<T>(T brush, float width, PenType expectedPenType) where T : Brush
@@ -96,6 +97,7 @@ namespace System.Drawing.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60731", TestPlatforms.Windows)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(0)]


### PR DESCRIPTION
I'm still investigating these failures which seem to have been caused by windows updates on the CI vms, but still confirming.