### PR TITLE
Use remainder operator in CalendricalCalculationsHelper

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendricalCalculationsHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendricalCalculationsHelper.cs
@@ -108,15 +108,9 @@ namespace System.Globalization
             new EphemerisCorrectionAlgorithmMap(int.MinValue, CorrectionAlgorithm.Default) // default must be last
         };
 
-        private static double Reminder(double divisor, double dividend)
-        {
-            double whole = Math.Floor(divisor / dividend);
-            return divisor - (dividend * whole);
-        }
-
         private static double NormalizeLongitude(double longitude)
         {
-            longitude = Reminder(longitude, FullCircleOfArc);
+            longitude %= FullCircleOfArc;
             if (longitude < 0)
             {
                 longitude += FullCircleOfArc;


### PR DESCRIPTION
```
The "Reminder" method mimics C# language remainder operator
except in negative values, but the code in NormalizeLongitude
exactly has the logic to deal with this,

  Reminder( 52.5, 360.0) -> 52.5
  Reminder(-52.5, 360.0) -> 307.5
   52.5 % 360.0 -> 52.5
  -52.5 % 360.0 -> -52.5

As the existing logic in NormalizeLongitude, its result is
indifferent to the use of remainder operator and returns
this before and after the change,

  NormalizeLongitude( 52.5) -> 52.5
  NormalizeLongitude(-52.5) -> 307.5
```