### PR TITLE
Change code generation strategy for ILEmitResolverBuilder

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CompiledServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CompiledServiceProviderEngine.cs
@@ -18,6 +18,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             ResolverBuilder = new(provider);
         }
 
-        public override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite) => ResolverBuilder.Build(callSite);
+        public override ServiceFactory RealizeService(ServiceCallSite callSite) => ResolverBuilder.Build(callSite);
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _serviceProvider = serviceProvider;
         }
 
-        public override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
+        public override ServiceFactory RealizeService(ServiceCallSite callSite)
         {
             int callCount = 0;
-            return scope =>
+            return ServiceFactory.FromFactory(scope =>
             {
                 // Resolve the result before we increment the call count, this ensures that singletons
                 // won't cause any side effects during the compilation of the resolve function.
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 }
 
                 return result;
-            };
+            });
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _expressionResolverBuilder = new ExpressionResolverBuilder(serviceProvider);
         }
 
-        public override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
+        public override ServiceFactory RealizeService(ServiceCallSite callSite)
         {
             return _expressionResolverBuilder.Build(callSite);
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -198,6 +198,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 BeginCaptureDisposable(argument);
                 VisitCallSiteMain(transientCallSite, argument);
+
+                // Pop the return type off the stack since EndCaptureDisposable pushes object into the stack
+                argument.Types.Pop();
+
                 EndCaptureDisposable(argument);
             }
             else
@@ -485,6 +489,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     BeginCaptureDisposable(context);
                     context.Generator.Emit(OpCodes.Ldloc, resultLocal);
                     EndCaptureDisposable(context);
+
+                    context.Types.Pop();
+
                     // Pop value returned by CaptureDisposable off the stack
                     generator.Emit(OpCodes.Pop);
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilderContext.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilderContext.cs
@@ -3,14 +3,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal sealed class ILEmitResolverBuilderContext
     {
+        public FieldInfo RuntimeContextField { get; set; }
         public ILGenerator Generator { get; set; }
         public List<object> Constants { get; set; }
         public List<Func<IServiceProvider, object>> Factories { get; set; }
+        public HashSet<Assembly> Assemblies { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilderContext.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilderContext.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal sealed class ILEmitResolverBuilderContext
     {
-        public FieldInfo RuntimeContextField { get; set; }
+        public TypeBuilder TypeBuilder { get; set; }
         public ILGenerator Generator { get; set; }
-        public List<object> Constants { get; set; }
-        public List<Func<IServiceProvider, object>> Factories { get; set; }
+        public List<KeyValuePair<string, object>> Fields { get; set; }
         public HashSet<Assembly> Assemblies { get; set; }
+        public Stack<Type> Types { get; set; } = new();
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _expressionResolverBuilder = new ILEmitResolverBuilder(serviceProvider);
         }
 
-        public override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
+        public override ServiceFactory RealizeService(ServiceCallSite callSite)
         {
             return _expressionResolverBuilder.Build(callSite);
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/RuntimeServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/RuntimeServiceProviderEngine.cs
@@ -11,12 +11,20 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private RuntimeServiceProviderEngine() { }
 
-        public override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
+        public override ServiceFactory RealizeService(ServiceCallSite callSite) =>
+            new RuntimeServiceFactory(callSite);
+
+        internal sealed class RuntimeServiceFactory : ServiceFactory
         {
-            return scope =>
+            private readonly ServiceCallSite _serviceCallSite;
+
+            public RuntimeServiceFactory(ServiceCallSite serviceCallSite)
             {
-                return CallSiteRuntimeResolver.Instance.Resolve(callSite, scope);
-            };
+                _serviceCallSite = serviceCallSite;
+            }
+
+            public override object Create(ServiceProviderEngineScope scope) =>
+                CallSiteRuntimeResolver.Instance.Resolve(_serviceCallSite, scope);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
@@ -7,6 +7,45 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal abstract class ServiceProviderEngine
     {
-        public abstract Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite);
+        public abstract ServiceFactory RealizeService(ServiceCallSite callSite);
+    }
+
+    internal abstract class ServiceFactory
+    {
+        internal static ConstantServiceFactory FromValue(object instance) => new(instance);
+
+        internal static DelegateServiceFactory FromFactory(Func<ServiceProviderEngineScope, object> factory) => new(factory);
+
+        internal static NullServiceFactory Null { get; } = new();
+
+        public abstract object Create(ServiceProviderEngineScope scope);
+
+        internal sealed class DelegateServiceFactory : ServiceFactory
+        {
+            private readonly Func<ServiceProviderEngineScope, object> _factory;
+
+            public DelegateServiceFactory(Func<ServiceProviderEngineScope, object> factory)
+            {
+                _factory = factory;
+            }
+
+            public override object Create(ServiceProviderEngineScope scope) => _factory(scope);
+        }
+
+        internal sealed class NullServiceFactory : ServiceFactory
+        {
+            public override object Create(ServiceProviderEngineScope scope) => null;
+        }
+
+        internal sealed class ConstantServiceFactory : ServiceFactory
+        {
+            private readonly object _value;
+            public ConstantServiceFactory(object value)
+            {
+                _value = value;
+            }
+
+            public override object Create(ServiceProviderEngineScope scope) => _value;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             using var scope = (ServiceProviderEngineScope)provider.CreateScope();
 
             var service1 = Invoke(callSite, scope);
-            var service2 = compiledCallSite(scope);
-            var serviceEnumerator = ((IEnumerable)compiledCollectionCallSite(scope)).GetEnumerator();
+            var service2 = compiledCallSite.Create(scope);
+            var serviceEnumerator = ((IEnumerable)compiledCollectionCallSite.Create(scope)).GetEnumerator();
 
             Assert.NotNull(service1);
             Assert.True(compare(service1, service2));
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             using var scope = (ServiceProviderEngineScope)provider.CreateScope();
 
-            var serviceC = (ServiceC)compiledCallSite(scope);
+            var serviceC = (ServiceC)compiledCallSite.Create(scope);
 
             Assert.NotNull(serviceC.ServiceB.ServiceA);
             Assert.Equal(serviceC, Invoke(callSite, scope));
@@ -136,11 +136,11 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var disposables = new List<object>();
             var provider = new ServiceProvider(descriptors, ServiceProviderOptions.Default);
-            
+
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
-            var serviceC = (DisposableServiceC)compiledCallSite(provider.Root);
+            var serviceC = (DisposableServiceC)compiledCallSite.Create(provider.Root);
 
             Assert.Equal(3, provider.Root.Disposables.Count);
         }
@@ -163,7 +163,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
-            var serviceC = (DisposableServiceC)compiledCallSite(provider.Root);
+            var serviceC = (DisposableServiceC)compiledCallSite.Create(provider.Root);
 
             Assert.Equal(3, provider.Root.Disposables.Count);
         }
@@ -185,11 +185,11 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var disposables = new List<object>();
             var provider = new ServiceProvider(descriptors, ServiceProviderOptions.Default);
-            
+
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
-            var serviceC = (ServiceC)compiledCallSite(provider.Root);
+            var serviceC = (ServiceC)compiledCallSite.Create(provider.Root);
 
             Assert.Empty(provider.Root.Disposables);
         }
@@ -211,7 +211,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceD), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
-            var serviceD = (ServiceD)compiledCallSite(provider.Root);
+            var serviceD = (ServiceD)compiledCallSite.Create(provider.Root);
 
             Assert.Empty(provider.Root.Disposables);
         }
@@ -232,10 +232,10 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var callSite2 = provider.CallSiteFactory.GetCallSite(typeof(ClassWithThrowingCtor), new CallSiteChain());
             var compiledCallSite2 = CompileCallSite(callSite2, provider);
 
-            var ex1 = Assert.Throws<Exception>(() => compiledCallSite1(provider.Root));
+            var ex1 = Assert.Throws<Exception>(() => compiledCallSite1.Create(provider.Root));
             Assert.Equal(nameof(ClassWithThrowingEmptyCtor), ex1.Message);
 
-            var ex2 = Assert.Throws<Exception>(() => compiledCallSite2(provider.Root));
+            var ex2 = Assert.Throws<Exception>(() => compiledCallSite2.Create(provider.Root));
             Assert.Equal(nameof(ClassWithThrowingCtor), ex2.Message);
         }
 
@@ -392,7 +392,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             return CallSiteRuntimeResolver.Instance.Resolve(callSite, scope);
         }
 
-        private static Func<ServiceProviderEngineScope, object> CompileCallSite(ServiceCallSite callSite, ServiceProvider provider)
+        private static ServiceFactory CompileCallSite(ServiceCallSite callSite, ServiceProvider provider)
         {
             return new ExpressionResolverBuilder(provider).Build(callSite);
         }


### PR DESCRIPTION
This PR changes the code generation to move away from DynamicMethod to an abstract base class ServiceFactory. For each service we create a derived ServiceFactory with fields using the the specific implementation types where possible. The change also moves away from the `ILEmitResolverBuilderRuntimeContext` which pays 2 sets of additional costs:
- Bounds checking when accessing the array of constants
- Boxing and unboxing value types unnecessarily

Here's the before and after codegen for a simple object graph:

```C#
class A { 
  public A(B b) { }
}
class B { }

services.AddTransient<A>();
services.AddSingleton<B>();
```

Before

```C#
// This is a dynamic method
object ResolveService(ILEmitResolverBuilderRuntimeContext context, ServiceProviderScope scope)
{
   return new A((B)context.Constants[0]);
}
```

After:

```C#
public sealed class AServiceFactory : ServiceFactory
{
    private B _constantB;
    public override object Create(ServiceProviderScope scope)
    {
        return new A(_constantB);
    }
}
```

PS: The downside to this approach is that we're making a new assembly per type, that could be a performance problem.
PS: I need to run performance tests on this change to see if there's any benefit we get (especially with dynamic PGO!)

Benchmarks without dynamic PGO look like mostly noise (maybe slightly faster):

## ServiceProvider

### Before

```
          Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
---------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
 ServiceProvider | 26.30 ns | 0.039 ns | 0.030 ns | 26.30 ns | 26.25 ns | 26.36 ns | 0.0030 |      24 B |
```

### After

```
          Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
---------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
 ServiceProvider | 25.45 ns | 0.075 ns | 0.059 ns | 25.45 ns | 25.40 ns | 25.61 ns | 0.0031 |      24 B |
```

## DynamicPGO

### Before

```
          Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
---------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
 ServiceProvider | 18.50 ns | 0.068 ns | 0.056 ns | 18.48 ns | 18.45 ns | 18.66 ns | 0.0030 |      24 B |
```

### After

```
          Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |  Gen 0 | Allocated |
---------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
 ServiceProvider | 17.90 ns | 0.043 ns | 0.036 ns | 17.90 ns | 17.84 ns | 17.97 ns | 0.0030 |      24 B |
```

## GetService

### Before

```
                  Type |               Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | RatioSD |  Gen 0 | Allocated |
---------------------- |--------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|
            GetService |                 NoDI |  2.762 ns | 0.0220 ns | 0.0184 ns |  2.760 ns |  2.732 ns |  2.801 ns |  1.00 |    0.00 | 0.0031 |      24 B |
 GetServiceIEnumerable |            Transient | 87.589 ns | 0.0888 ns | 0.0787 ns | 87.580 ns | 87.487 ns | 87.751 ns | 31.71 |    0.22 | 0.0437 |     344 B |
            GetService |            Transient | 25.956 ns | 0.0339 ns | 0.0265 ns | 25.951 ns | 25.913 ns | 26.003 ns |  9.40 |    0.06 | 0.0030 |      24 B |
 GetServiceIEnumerable |               Scoped | 52.824 ns | 0.0405 ns | 0.0317 ns | 52.818 ns | 52.783 ns | 52.879 ns | 19.14 |    0.12 |      - |         - |
            GetService |               Scoped | 51.425 ns | 0.0952 ns | 0.0844 ns | 51.453 ns | 51.292 ns | 51.527 ns | 18.62 |    0.12 |      - |         - |
 GetServiceIEnumerable |            Singleton | 25.778 ns | 0.0562 ns | 0.0498 ns | 25.777 ns | 25.688 ns | 25.858 ns |  9.33 |    0.07 |      - |         - |
            GetService |            Singleton | 24.407 ns | 0.0888 ns | 0.0831 ns | 24.430 ns | 24.178 ns | 24.539 ns |  8.84 |    0.07 |      - |         - |
            GetService |         ServiceScope | 47.291 ns | 0.0406 ns | 0.0380 ns | 47.280 ns | 47.226 ns | 47.363 ns | 17.12 |    0.11 | 0.0173 |     136 B |
            GetService | ServiceScopeProvider | 25.913 ns | 0.1011 ns | 0.0946 ns | 25.936 ns | 25.768 ns | 26.046 ns |  9.38 |    0.07 |      - |         - |
            GetService |      EmptyEnumerable | 26.395 ns | 0.0723 ns | 0.0676 ns | 26.392 ns | 26.291 ns | 26.506 ns |  9.55 |    0.06 |      - |         - |
```

### After

```
                  Type |               Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | RatioSD |  Gen 0 | Allocated |
---------------------- |--------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|
            GetService |                 NoDI |  2.627 ns | 0.0088 ns | 0.0069 ns |  2.627 ns |  2.617 ns |  2.644 ns |  1.00 |    0.00 | 0.0030 |      24 B |
 GetServiceIEnumerable |            Transient | 87.057 ns | 0.0901 ns | 0.0842 ns | 87.081 ns | 86.933 ns | 87.217 ns | 33.14 |    0.09 | 0.0436 |     344 B |
            GetService |            Transient | 24.868 ns | 0.2421 ns | 0.2265 ns | 24.756 ns | 24.608 ns | 25.277 ns |  9.48 |    0.08 | 0.0030 |      24 B |
 GetServiceIEnumerable |               Scoped | 55.093 ns | 0.1189 ns | 0.1112 ns | 55.049 ns | 54.963 ns | 55.341 ns | 20.97 |    0.09 |      - |         - |
            GetService |               Scoped | 53.023 ns | 0.1426 ns | 0.1264 ns | 53.020 ns | 52.813 ns | 53.270 ns | 20.18 |    0.07 |      - |         - |
 GetServiceIEnumerable |            Singleton | 27.338 ns | 0.1363 ns | 0.1275 ns | 27.357 ns | 27.063 ns | 27.536 ns | 10.41 |    0.06 |      - |         - |
            GetService |            Singleton | 23.171 ns | 0.0497 ns | 0.0465 ns | 23.175 ns | 23.088 ns | 23.249 ns |  8.82 |    0.03 |      - |         - |
            GetService |         ServiceScope | 47.818 ns | 0.0272 ns | 0.0254 ns | 47.807 ns | 47.769 ns | 47.854 ns | 18.20 |    0.05 | 0.0162 |     128 B |
            GetService | ServiceScopeProvider | 25.496 ns | 0.0645 ns | 0.0603 ns | 25.490 ns | 25.409 ns | 25.601 ns |  9.71 |    0.05 |      - |         - |
            GetService |      EmptyEnumerable | 25.505 ns | 0.1605 ns | 0.1502 ns | 25.472 ns | 25.286 ns | 25.802 ns |  9.70 |    0.05 |      - |         - |
```

## Dynamic PGO

### Before

```
                  Type |               Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | RatioSD |  Gen 0 | Allocated |
---------------------- |--------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|
            GetService |                 NoDI |  2.715 ns | 0.0455 ns | 0.0426 ns |  2.695 ns |  2.672 ns |  2.800 ns |  1.00 |    0.00 | 0.0030 |      24 B |
 GetServiceIEnumerable |            Transient | 81.416 ns | 0.0368 ns | 0.0307 ns | 81.411 ns | 81.360 ns | 81.478 ns | 30.03 |    0.46 | 0.0437 |     344 B |
            GetService |            Transient | 19.946 ns | 0.4808 ns | 0.5144 ns | 20.106 ns | 18.484 ns | 20.213 ns |  7.34 |    0.28 | 0.0031 |      24 B |
 GetServiceIEnumerable |               Scoped | 45.484 ns | 0.0294 ns | 0.0245 ns | 45.481 ns | 45.450 ns | 45.536 ns | 16.78 |    0.25 |      - |         - |
            GetService |               Scoped | 41.268 ns | 0.0650 ns | 0.0608 ns | 41.259 ns | 41.195 ns | 41.362 ns | 15.20 |    0.23 |      - |         - |
 GetServiceIEnumerable |            Singleton | 20.963 ns | 0.0098 ns | 0.0092 ns | 20.962 ns | 20.952 ns | 20.980 ns |  7.72 |    0.12 |      - |         - |
            GetService |            Singleton | 14.179 ns | 0.0575 ns | 0.0480 ns | 14.155 ns | 14.146 ns | 14.285 ns |  5.23 |    0.09 |      - |         - |
            GetService |         ServiceScope | 34.820 ns | 0.0199 ns | 0.0156 ns | 34.821 ns | 34.799 ns | 34.857 ns | 12.85 |    0.21 | 0.0173 |     136 B |
            GetService | ServiceScopeProvider | 16.974 ns | 0.0100 ns | 0.0088 ns | 16.972 ns | 16.959 ns | 16.990 ns |  6.26 |    0.09 |      - |         - |
            GetService |      EmptyEnumerable | 19.040 ns | 0.0103 ns | 0.0096 ns | 19.036 ns | 19.030 ns | 19.062 ns |  7.01 |    0.11 |      - |         - |
```

### After

```
DynamicPGO


                  Type |               Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Ratio | RatioSD |  Gen 0 | Allocated |
---------------------- |--------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|
            GetService |                 NoDI |  2.723 ns | 0.0178 ns | 0.0148 ns |  2.721 ns |  2.706 ns |  2.761 ns |  1.00 |    0.00 | 0.0030 |      24 B |
 GetServiceIEnumerable |            Transient | 81.078 ns | 0.0356 ns | 0.0297 ns | 81.083 ns | 81.038 ns | 81.127 ns | 29.77 |    0.16 | 0.0437 |     344 B |
            GetService |            Transient | 17.551 ns | 0.0765 ns | 0.0639 ns | 17.533 ns | 17.498 ns | 17.720 ns |  6.45 |    0.04 | 0.0030 |      24 B |
 GetServiceIEnumerable |               Scoped | 44.052 ns | 0.0291 ns | 0.0258 ns | 44.047 ns | 44.008 ns | 44.110 ns | 16.18 |    0.09 |      - |         - |
            GetService |               Scoped | 42.828 ns | 0.0740 ns | 0.0692 ns | 42.809 ns | 42.755 ns | 42.993 ns | 15.73 |    0.10 |      - |         - |
 GetServiceIEnumerable |            Singleton | 20.501 ns | 0.0327 ns | 0.0306 ns | 20.504 ns | 20.447 ns | 20.548 ns |  7.53 |    0.04 |      - |         - |
            GetService |            Singleton | 14.285 ns | 0.0106 ns | 0.0088 ns | 14.284 ns | 14.267 ns | 14.298 ns |  5.25 |    0.03 |      - |         - |
            GetService |         ServiceScope | 36.626 ns | 0.0330 ns | 0.0309 ns | 36.622 ns | 36.553 ns | 36.668 ns | 13.45 |    0.07 | 0.0163 |     128 B |
            GetService | ServiceScopeProvider | 16.707 ns | 0.0134 ns | 0.0126 ns | 16.703 ns | 16.685 ns | 16.726 ns |  6.14 |    0.04 |      - |         - |
            GetService |      EmptyEnumerable | 16.930 ns | 0.0271 ns | 0.0253 ns | 16.923 ns | 16.902 ns | 16.969 ns |  6.22 |    0.04 |      - |         - |
```
