### PR TITLE
Fix the antigen summarize bug

### DIFF
--- a/src/coreclr/scripts/antigen_summarize.py
+++ b/src/coreclr/scripts/antigen_summarize.py
@@ -152,7 +152,7 @@ def print_unique_issues_summary(issues_directory, platform, arch, build_config):
                 f.write("```\n\n")
 
         if len(remaining_issues) > 0:
-            f.write("# {} uncategorized issues found\n", len(remaining_issues))
+            f.write("# {} uncategorized issues found\n".format(len(remaining_issues)))
 # Turned off since the output does not seem particularly useful
 #            for issue, occurences in sorted(remaining_issues.items(), key=lambda p: p[1], reverse=True):
 #                f.write("## {} occurences\n".format(occurences))


### PR DESCRIPTION
`.format()` was missing while printing the summary.