### PR TITLE
DateTimeMaskTest depends on the region configuration of the machine

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/tests/MaskedTextProviderTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/MaskedTextProviderTests.cs
@@ -553,9 +553,11 @@ namespace System.ComponentModel.Tests
         [Fact]
         public void DateTimeMaskTest()
         {
-            var maskedTextProvider = new MaskedTextProvider(TestComplexDateTimeMask, new CultureInfo("en-US"));
+            CultureInfo cultureInfo = CultureInfo.GetCultureInfo("en-US");
+            string expectedSeparator = cultureInfo.DateTimeFormat.DateSeparator;
+            var maskedTextProvider = new MaskedTextProvider(TestComplexDateTimeMask, cultureInfo);
             maskedTextProvider.Set("01012000101010");
-            Assert.Equal("01/01/2000 10:10:10", maskedTextProvider.ToString());
+            Assert.Equal($"01{expectedSeparator}01{expectedSeparator}2000 10:10:10", maskedTextProvider.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #34565