### PR TITLE
[DllImportGenerator] Skip unit tests that hit exceptions due to roslyn-sdk#590

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -3,11 +3,9 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -15,7 +13,7 @@ namespace DllImportGenerator.UnitTests
 {
     public class AdditionalAttributesOnStub
     {
-        [Fact]
+        [ConditionalFact]
         public async Task SkipLocalsInitAdded()
         {
             string source = @"
@@ -45,7 +43,7 @@ struct Native
             Assert.Contains(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SkipLocalsInitNotAddedOnForwardingStub()
         {
             string source = @"
@@ -72,7 +70,7 @@ partial class C
             yield return new object[] { ReferenceAssemblies.NetFramework.Net48.Default, false };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(GetDownlevelTargetFrameworks))]
         public async Task SkipLocalsInitOnDownlevelTargetFrameworks(ReferenceAssemblies referenceAssemblies, bool expectSkipLocalsInit)
         {
@@ -122,7 +120,7 @@ struct Native
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SkipLocalsInitNotAddedWhenDefinedAtModuleLevel()
         {
             string source = @"
@@ -154,7 +152,7 @@ struct Native
             Assert.DoesNotContain(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SkipLocalsInitNotAddedWhenDefinedAtClassLevel()
         {
             string source = @"
@@ -186,7 +184,7 @@ struct Native
             Assert.DoesNotContain(stubMethod.GetAttributes(), attr => attr.AttributeClass!.ToDisplayString() == typeof(SkipLocalsInitAttribute).FullName);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SkipLocalsInitNotAddedWhenDefinedOnMethodByUser()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AttributeForwarding.cs
@@ -14,7 +14,7 @@ namespace DllImportGenerator.UnitTests
 {
     public class AttributeForwarding
     {
-        [Theory]
+        [ConditionalTheory]
         [InlineData("SuppressGCTransition", "System.Runtime.InteropServices.SuppressGCTransitionAttribute")]
         [InlineData("UnmanagedCallConv", "System.Runtime.InteropServices.UnmanagedCallConvAttribute")]
         public async Task KnownParameterlessAttribute(string attributeSourceName, string attributeMetadataName)
@@ -54,7 +54,7 @@ struct Native
                 attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UnmanagedCallConvAttribute_EmptyCallConvArray()
         {
             string source = @"
@@ -96,7 +96,7 @@ struct Native
                     && attr.NamedArguments[0].Value.Values.Length == 0);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UnmanagedCallConvAttribute_SingleCallConvType()
         {
             string source = @"
@@ -142,7 +142,7 @@ struct Native
                         callConvType));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UnmanagedCallConvAttribute_MultipleCallConvTypes()
         {
             string source = @"
@@ -192,7 +192,7 @@ struct Native
                         callConvType2));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task OtherAttributeType()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
@@ -127,7 +127,7 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.MutuallyRecursiveSizeParamIndexOnParameter, 4, 0 };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(CodeSnippetsToCompile))]
         public async Task ValidateSnippets(string source, int expectedGeneratorErrors, int expectedCompilerErrors)
         {
@@ -150,7 +150,7 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.MutuallyRecursiveImplicitlyBlittableStruct, 5, 2 };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(CodeSnippetsToCompile_InvalidCode))]
         public async Task ValidateSnippets_InvalidCodeGracefulFailure(string source, int expectedGeneratorErrors, int expectedCompilerErrors)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
@@ -269,7 +269,7 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CollectionsOfCollectionsStress };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(CodeSnippetsToCompile))]
         public async Task ValidateSnippets(string source)
         {
@@ -295,7 +295,7 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.PreprocessorIfAfterAttributeAroundFunctionAdditionalFunctionAfter("Foo"), Array.Empty<string>() };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(CodeSnippetsToCompileWithPreprocessorSymbols))]
         public async Task ValidateSnippetsWithPreprocessorDefintions(string source, IEnumerable<string> preprocessorSymbols)
         {
@@ -320,7 +320,7 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<string>() };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(CodeSnippetsToCompileWithForwarder))]
         public async Task ValidateSnippetsWithForwarder(string source)
         {
@@ -338,7 +338,7 @@ namespace DllImportGenerator.UnitTests
             var newCompDiags = newComp.GetDiagnostics();
             Assert.Empty(newCompDiags);
 
-            // Verify that the forwarder generates the method as a DllImport. 
+            // Verify that the forwarder generates the method as a DllImport.
             SyntaxTree generatedCode = newComp.SyntaxTrees.Last();
             SemanticModel model = newComp.GetSemanticModel(generatedCode);
             var methods = generatedCode.GetRoot()
@@ -357,7 +357,7 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.BasicParameterByValue("int") };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(FullyBlittableSnippetsToCompile))]
         public async Task ValidateSnippetsWithBlittableAutoForwarding(string source)
         {
@@ -374,7 +374,7 @@ namespace DllImportGenerator.UnitTests
             var newCompDiags = newComp.GetDiagnostics();
             Assert.Empty(newCompDiags);
 
-            // Verify that the forwarder generates the method as a DllImport. 
+            // Verify that the forwarder generates the method as a DllImport.
             SyntaxTree generatedCode = newComp.SyntaxTrees.Last();
             SemanticModel model = newComp.GetSemanticModel(generatedCode);
             var methods = generatedCode.GetRoot()
@@ -391,7 +391,7 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.PreserveSigFalse<int>() };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(SnippetsWithBlittableTypesButNonBlittableDataToCompile))]
         public async Task ValidateSnippetsWithBlittableTypesButNonBlittableMetadataDoNotAutoForward(string source)
         {
@@ -429,7 +429,7 @@ namespace DllImportGenerator.UnitTests
 #pragma warning disable xUnit1004 // Test methods should not be skipped.
                                   // If we have any new experimental APIs that we are implementing that have not been approved,
                                   // we will add new scenarios for this test.
-        [Theory(Skip = "No current scenarios to test.")]
+        [ConditionalTheory(Skip = "No current scenarios to test.")]
 #pragma warning restore
         [MemberData(nameof(CodeSnippetsToCompileWithMarshalType))]
         public async Task ValidateSnippetsWithMarshalType(string source)
@@ -461,7 +461,7 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { new[] { CodeSnippets.BasicParameterByValue("int[]"), CodeSnippets.BasicParameterWithByRefModifier("ref", "int") } };
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(CodeSnippetsToCompileMultipleSources))]
         public async Task ValidateSnippetsWithMultipleSources(string[] sources)
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -37,7 +37,7 @@ namespace DllImportGenerator.UnitTests
             new object[] { typeof(ConsoleKey) }, // enum
         };
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(MarshallingRequiredTypes))]
         [MemberData(nameof(NoMarshallingRequiredTypes))]
         public async Task TypeRequiresMarshalling_ReportsDiagnostic(Type type)
@@ -53,7 +53,7 @@ namespace DllImportGenerator.UnitTests
                     .WithArguments("Method_Return"));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(MarshallingRequiredTypes))]
         [MemberData(nameof(NoMarshallingRequiredTypes))]
         public async Task ByRef_ReportsDiagnostic(Type type)
@@ -86,7 +86,7 @@ unsafe partial class Test
                     .WithArguments("Method_Ref"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task PreserveSigFalse_ReportsDiagnostic()
         {
             string source = @$"
@@ -110,7 +110,7 @@ partial class Test
                     .WithArguments("Method2"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task SetLastErrorTrue_ReportsDiagnostic()
         {
             string source = @$"
@@ -134,7 +134,7 @@ partial class Test
                     .WithArguments("Method2"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NotDllImport_NoDiagnostic()
         {
             string source = @$"

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
@@ -17,7 +17,7 @@ namespace DllImportGenerator.UnitTests
     [ActiveIssue("https://github.com/dotnet/runtime/issues/60650", TestRuntimes.Mono)]
     public class ConvertToGeneratedDllImportFixerTests
     {
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Basic(bool usePreprocessorDefines)
@@ -56,7 +56,7 @@ partial class Test
                 usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Comments(bool usePreprocessorDefines)
@@ -119,7 +119,7 @@ partial class Test
                 usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task MultipleAttributes(bool usePreprocessorDefines)
@@ -180,7 +180,7 @@ partial class Test
                 usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task NamedArguments(bool usePreprocessorDefines)
@@ -232,7 +232,7 @@ partial class Test
                 usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task RemoveableNamedArguments(bool usePreprocessorDefines)
@@ -284,7 +284,7 @@ partial class Test
                 usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ReplaceableExplicitPlatformDefaultCallingConvention(bool usePreprocessorDefines)
@@ -322,7 +322,7 @@ partial class Test
                 usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(CallingConvention.Cdecl, typeof(CallConvCdecl), true)]
         [InlineData(CallingConvention.Cdecl, typeof(CallConvCdecl), false)]
         [InlineData(CallingConvention.StdCall, typeof(CallConvStdcall), true)]

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
@@ -24,7 +24,7 @@ namespace DllImportGenerator.UnitTests
             Net
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(TargetFramework.Framework)]
         [InlineData(TargetFramework.Core)]
         [InlineData(TargetFramework.Standard)]
@@ -61,7 +61,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(TargetFramework.Framework)]
         [InlineData(TargetFramework.Core)]
         [InlineData(TargetFramework.Standard)]
@@ -85,7 +85,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ParameterTypeNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -123,7 +123,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ReturnTypeNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -161,7 +161,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ParameterTypeNotSupportedWithDetails_ReportsDiagnostic()
         {
             string source = @"
@@ -189,7 +189,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ReturnTypeNotSupportedWithDetails_ReportsDiagnostic()
         {
             string source = @"
@@ -220,7 +220,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ParameterConfigurationNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -253,7 +253,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ReturnConfigurationNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -288,7 +288,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task MarshalAsUnmanagedTypeNotSupported_ReportsDiagnostic()
         {
             string source = @"
@@ -328,7 +328,7 @@ partial class Test
             Assert.Empty(newCompDiags);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task MarshalAsFieldNotSupported_ReportsDiagnostic()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/DllImportGenerator.Unit.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/DllImportGenerator.Unit.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
@@ -15,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/DllImportGenerator.Unit.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/DllImportGenerator.Unit.Tests.csproj
@@ -15,7 +15,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/GeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/GeneratedDllImportAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace DllImportGenerator.UnitTests
     [ActiveIssue("https://github.com/dotnet/runtime/issues/60650", TestRuntimes.Mono)]
     public class GeneratedDllImportAnalyzerTests
     {
-        [Fact]
+        [ConditionalFact]
         public async Task NonPartialMethod_ReportsDiagnostic()
         {
             string source = @"
@@ -48,7 +48,7 @@ partial class Test
                     .WithArguments("ExternMethod2"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonStaticMethod_ReportsDiagnostic()
         {
             string source = @"
@@ -80,7 +80,7 @@ partial class Test
                     .WithArguments("Method1"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonPartialNonStaticMethod_ReportsDiagnostic()
         {
             string source = @"
@@ -116,7 +116,7 @@ partial class Test
                     .WithArguments("ExternMethod2"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NotGeneratedDllImport_NoDiagnostic()
         {
             string source = @"
@@ -130,7 +130,7 @@ partial class Test
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task StaticPartialMethod_NoDiagnostic()
         {
             string source = @"
@@ -144,7 +144,7 @@ partial class Test
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("record")]
@@ -167,7 +167,7 @@ using System.Runtime.InteropServices;
                     .WithArguments("Test"));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("record")]

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/IncrementalGenerationTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/IncrementalGenerationTests.cs
@@ -19,7 +19,7 @@ namespace DllImportGenerator.UnitTests
         public const string RequiresIncrementalSyntaxTreeModifySupport = "The GeneratorDriver treats all SyntaxTree replace operations on a Compilation as an Add/Remove operation instead of a Modify operation"
             + ", so all cached results based on that input are thrown out. As a result, we cannot validate that unrelated changes within the same SyntaxTree do not cause regeneration.";
 
-        [Fact]
+        [ConditionalFact]
         public async Task AddingNewUnrelatedType_DoesNotRegenerateSource()
         {
             string source = CodeSnippets.BasicParametersAndModifiers<int>();
@@ -44,7 +44,7 @@ namespace DllImportGenerator.UnitTests
         }
 
 #pragma warning disable xUnit1004 // Test methods should not be skipped. These tests will be updated to use the new incremental work tracking APIs and enabled then.
-        [Fact(Skip = RequiresIncrementalSyntaxTreeModifySupport)]
+        [ConditionalFact(Skip = RequiresIncrementalSyntaxTreeModifySupport)]
 #pragma warning restore
         public async Task AppendingUnrelatedSource_DoesNotRegenerateSource()
         {
@@ -73,7 +73,7 @@ namespace DllImportGenerator.UnitTests
                 });
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task AddingFileWithNewGeneratedDllImport_DoesNotRegenerateOriginalMethod()
         {
             string source = CodeSnippets.BasicParametersAndModifiers<int>();
@@ -97,7 +97,7 @@ namespace DllImportGenerator.UnitTests
             Assert.Equal(1, generator.IncrementalTracker.ExecutedSteps.Count(s => s.Step == IncrementalityTracker.StepName.OutputSourceFile));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ReplacingFileWithNewGeneratedDllImport_DoesNotRegenerateStubsInOtherFiles()
         {
             string source = CodeSnippets.BasicParametersAndModifiers<int>();
@@ -121,7 +121,7 @@ namespace DllImportGenerator.UnitTests
             Assert.Equal(1, generator.IncrementalTracker.ExecutedSteps.Count(s => s.Step == IncrementalityTracker.StepName.OutputSourceFile));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ChangingMarshallingStrategy_RegeneratesStub()
         {
             string stubSource = CodeSnippets.BasicParametersAndModifiers("CustomType");
@@ -170,7 +170,7 @@ namespace DllImportGenerator.UnitTests
         }
 
 #pragma warning disable xUnit1004 // Test methods should not be skipped. These tests will be updated to use the new incremental work tracking APIs and enabled then.
-        [Fact(Skip = RequiresIncrementalSyntaxTreeModifySupport)]
+        [ConditionalFact(Skip = RequiresIncrementalSyntaxTreeModifySupport)]
 #pragma warning restore
         public async Task ChangingMarshallingAttributes_SameStrategy_DoesNotRegenerate()
         {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ManualTypeMarshallingAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ManualTypeMarshallingAnalyzerTests.cs
@@ -59,14 +59,14 @@ struct S
         }
 
         [MemberData(nameof(NonBlittableTypeMarkedBlittable_ReportsDiagnostic_TestData))]
-        [Theory]
+        [ConditionalTheory]
         public async Task NonBlittableTypeMarkedBlittable_ReportsDiagnostic(string source)
         {
             var diagnostic = VerifyCS.Diagnostic(BlittableTypeMustBeBlittableRule).WithLocation(0).WithArguments("S");
             await VerifyCS.VerifyAnalyzerAsync(source, diagnostic);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittablePrimitiveFields_MarkedBlittable_NoDiagnostic()
         {
 
@@ -82,7 +82,7 @@ struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableEnumFields_MarkedBlittable_NoDiagnostic()
         {
 
@@ -100,7 +100,7 @@ struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableStructFields_MarkedBlittable_NoDiagnostic()
         {
             string source = @"
@@ -121,7 +121,7 @@ struct T
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableFields_MarkedBlittable_ReportDiagnosticOnFieldTypeDefinition()
         {
             string source = @"
@@ -143,7 +143,7 @@ struct T
             await VerifyCS.VerifyAnalyzerAsync(source, diagnostic);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonUnmanagedTypeMarkedBlittable_ReportsDiagnosticOnStructType()
         {
             string source = @"
@@ -165,7 +165,7 @@ struct T
                 VerifyCS.Diagnostic(BlittableTypeMustBeBlittableRule).WithLocation(0).WithArguments("T"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableTypeWithNonBlittableStaticField_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -181,7 +181,7 @@ struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NullNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -197,7 +197,7 @@ struct S
                 VerifyCS.Diagnostic(NativeTypeMustBeNonNullRule).WithLocation(0).WithArguments("S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonNamedNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -213,7 +213,7 @@ struct S
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("int*", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -240,7 +240,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ClassNativeType_ReportsDiagnostic()
         {
             string source = @"
@@ -267,7 +267,7 @@ class {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableNativeType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -296,7 +296,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableNativeWithNonBlittableValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -328,7 +328,7 @@ struct Native
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("string", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableNativeTypeWithBlittableValueProperty_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -358,7 +358,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ClassNativeTypeWithValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -389,7 +389,7 @@ class {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableGetPinnableReferenceReturnType_ReportsDiagnostic()
         {
             string source = @"
@@ -422,7 +422,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(GetPinnableReferenceReturnTypeBlittableRule).WithLocation(0));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableGetPinnableReferenceReturnType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -454,7 +454,7 @@ unsafe struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TypeWithGetPinnableReferenceNonPointerReturnType_ReportsDiagnostic()
         {
             string source = @"
@@ -487,7 +487,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(NativeTypeMustBePointerSizedRule).WithLocation(0).WithArguments("int", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TypeWithGetPinnableReferencePointerReturnType_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -519,7 +519,7 @@ unsafe struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TypeWithGetPinnableReferenceByRefReturnType_ReportsDiagnostic()
         {
             string source = @"
@@ -550,7 +550,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(RefValuePropertyUnsupportedRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithGetPinnableReferenceByRefReturnType_ReportsDiagnostic()
         {
             string source = @"
@@ -581,7 +581,7 @@ unsafe struct Native
                 VerifyCS.Diagnostic(RefValuePropertyUnsupportedRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableValueTypeWithNoFields_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -596,7 +596,7 @@ struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithNoMarshallingMethods_ReportsDiagnostic()
         {
             string source = @"
@@ -618,7 +618,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(NativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CollectionNativeTypeWithNoMarshallingMethods_ReportsDiagnostic()
         {
             string source = @"
@@ -640,7 +640,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CollectionNativeTypeWithWrongConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -668,7 +668,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CollectionNativeTypeWithCorrectConstructor_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -695,7 +695,7 @@ ref struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CollectionNativeTypeWithIncorrectStackallocConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -725,7 +725,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CollectionNativeTypeWithOnlyStackallocConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -755,7 +755,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CollectionNativeTypeWithMissingManagedValuesProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -782,7 +782,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task CollectionNativeTypeWithMissingNativeValueStorageProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -809,7 +809,7 @@ ref struct {|#0:Native|}
                 VerifyCS.Diagnostic(CollectionNativeTypeMustHaveRequiredShapeRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithOnlyConstructor_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -831,7 +831,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithOnlyToManagedMethod_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -853,7 +853,7 @@ struct Native
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithOnlyStackallocConstructor_ReportsDiagnostic()
         {
             string source = @"
@@ -878,7 +878,7 @@ struct {|#0:Native|}
                 VerifyCS.Diagnostic(StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task TypeWithOnlyNativeStackallocConstructorAndGetPinnableReference_ReportsDiagnostics()
         {
             string source = @"
@@ -906,7 +906,7 @@ struct {|#1:Native|}
                 VerifyCS.Diagnostic(GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("S", "Native"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithConstructorAndSetOnlyValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -930,7 +930,7 @@ struct Native
                 VerifyCS.Diagnostic(ValuePropertyMustHaveGetterRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithToManagedAndGetOnlyValueProperty_ReportsDiagnostic()
         {
             string source = @"
@@ -954,7 +954,7 @@ struct Native
                 VerifyCS.Diagnostic(ValuePropertyMustHaveSetterRule).WithLocation(0).WithArguments("Native"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableNativeTypeOnMarshalUsingParameter_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -989,7 +989,7 @@ static class Test
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableNativeTypeOnMarshalUsingParameter_ReportsDiagnostic()
         {
             string source = @"
@@ -1023,7 +1023,7 @@ static class Test
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableNativeTypeOnMarshalUsingParameter_MultipleCompilations_ReportsDiagnostic_WithLocation()
         {
             string source1 = @"
@@ -1074,7 +1074,7 @@ static class Test
             await test.RunAsync();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableNativeTypeOnMarshalUsingReturn_ReportsDiagnostic()
         {
             string source = @"
@@ -1108,7 +1108,7 @@ static class Test
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableNativeTypeOnMarshalUsingField_ReportsDiagnostic()
         {
             string source = @"
@@ -1142,7 +1142,7 @@ struct Test
                 VerifyCS.Diagnostic(NativeTypeMustBeBlittableRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GenericNativeTypeWithValueTypeValueProperty_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -1169,7 +1169,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task GenericNativeTypeWithGenericMemberInstantiatedWithBlittable_DoesNotReportDiagnostic()
         {
 
@@ -1197,7 +1197,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UninstantiatedGenericNativeTypeOnNonGeneric_ReportsDiagnostic()
         {
 
@@ -1225,7 +1225,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source, VerifyCS.Diagnostic(NativeGenericTypeMustBeClosedOrMatchArityRule).WithLocation(0).WithArguments("Native<>", "S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UninstantiatedGenericNativeTypeOnGenericWithArityMismatch_ReportsDiagnostic()
         {
             string source = @"
@@ -1252,7 +1252,7 @@ struct Native<T, U>
             await VerifyCS.VerifyAnalyzerAsync(source, VerifyCS.Diagnostic(NativeGenericTypeMustBeClosedOrMatchArityRule).WithLocation(0).WithArguments("Native<,>", "S<T>"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task UninstantiatedGenericNativeTypeOnGenericWithArityMatch_DoesNotReportDiagnostic()
         {
             string source = @"
@@ -1279,7 +1279,7 @@ struct Native<T>
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ValueTypeContainingPointerBlittableType_DoesNotReportDiagnostic()
         {
             var source = @"
@@ -1293,7 +1293,7 @@ unsafe struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task ValueTypeContainingPointerToNonBlittableType_ReportsDiagnostic()
         {
             var source = @"
@@ -1308,7 +1308,7 @@ unsafe struct S
                 VerifyCS.Diagnostic(BlittableTypeMustBeBlittableRule).WithLocation(0).WithArguments("S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableValueTypeContainingPointerToSelf_DoesNotReportDiagnostic()
         {
 
@@ -1324,7 +1324,7 @@ unsafe struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableValueTypeContainingPointerToSelf_ReportsDiagnostic()
         {
             var source = @"
@@ -1340,7 +1340,7 @@ unsafe struct S
                 VerifyCS.Diagnostic(BlittableTypeMustBeBlittableRule).WithLocation(0).WithArguments("S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableTypeContainingFunctionPointer_DoesNotReportDiagnostic()
         {
             var source = @"
@@ -1354,7 +1354,7 @@ unsafe struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableGenericTypeInBlittableType_DoesNotReportDiagnostic()
         {
             var source = @"
@@ -1374,7 +1374,7 @@ unsafe struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NonBlittableGenericTypeInBlittableType_ReportsDiagnostic()
         {
             var source = @"
@@ -1395,7 +1395,7 @@ unsafe struct S
                 VerifyCS.Diagnostic(BlittableTypeMustBeBlittableRule).WithLocation(0).WithArguments("S"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableGenericTypeTypeParameterReferenceType_ReportsDiagnostic()
         {
             var source = @"
@@ -1410,7 +1410,7 @@ struct G<T> where T : class
                 VerifyCS.Diagnostic(BlittableTypeMustBeBlittableRule).WithLocation(0).WithArguments("G<T>"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableGenericTypeContainingGenericType_DoesNotReportDiagnostic()
         {
             var source = @"
@@ -1431,7 +1431,7 @@ struct F<T>
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableNestedGenericType_DoesNotReportDiagnostic()
         {
             var source = @"
@@ -1455,7 +1455,7 @@ struct S
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableNestedGenericTypeWithReferenceTypeGenericParameter_DoesNotReportDiagnostic()
         {
             var source = @"
@@ -1474,7 +1474,7 @@ struct C<T> where T : class
                 VerifyCS.Diagnostic(BlittableTypeMustBeBlittableRule).WithLocation(0).WithArguments("C<T>.G"));
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task BlittableGenericTypeWithReferenceTypeParameterNotUsedInFieldType_DoesNotReportDiagnostic()
         {
             var source = @"
@@ -1488,7 +1488,7 @@ struct G<T, U> where U : class
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task NativeTypeWithStackallocConstructorWithoutBufferSize_ReportsDiagnostic()
         {
             string source = @"

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/TestUtils.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.DotNet.XUnitExtensions;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -160,12 +161,24 @@ namespace DllImportGenerator.UnitTests
                 parseOptions: (CSharpParseOptions)c.SyntaxTrees.First().Options,
                 optionsProvider: options);
 
+        // The non-configurable test-packages folder may be incomplete/corrupt.
+        // - https://github.com/dotnet/roslyn-sdk/issues/487
+        // - https://github.com/dotnet/roslyn-sdk/issues/590
+        internal static SkipTestException GetSkipException(NuGet.Packaging.Core.PackagingException e)
+        {
+            throw new SkipTestException($"Skipping test due to issue with test-packages ({e.Message}). See https://github.com/dotnet/roslyn-sdk/issues/590.");
+        }
+
         private static async Task<ImmutableArray<MetadataReference>> ResolveReferenceAssemblies(ReferenceAssemblies referenceAssemblies)
         {
             try
             {
                 ResolveRedirect.Instance.Start();
                 return await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
+            }
+            catch (NuGet.Packaging.Core.PackagingException e)
+            {
+                throw GetSkipException(e);
             }
             finally
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/TestUtils.cs
@@ -164,9 +164,10 @@ namespace DllImportGenerator.UnitTests
         // The non-configurable test-packages folder may be incomplete/corrupt.
         // - https://github.com/dotnet/roslyn-sdk/issues/487
         // - https://github.com/dotnet/roslyn-sdk/issues/590
-        internal static SkipTestException GetSkipException(NuGet.Packaging.Core.PackagingException e)
+        internal static void ThrowSkipExceptionIfPackagingException(Exception e)
         {
-            throw new SkipTestException($"Skipping test due to issue with test-packages ({e.Message}). See https://github.com/dotnet/roslyn-sdk/issues/590.");
+            if (e.GetType().FullName == "NuGet.Packaging.Core.PackagingException")
+                throw new SkipTestException($"Skipping test due to issue with test-packages ({e.Message}). See https://github.com/dotnet/roslyn-sdk/issues/590.");
         }
 
         private static async Task<ImmutableArray<MetadataReference>> ResolveReferenceAssemblies(ReferenceAssemblies referenceAssemblies)
@@ -176,9 +177,10 @@ namespace DllImportGenerator.UnitTests
                 ResolveRedirect.Instance.Start();
                 return await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
             }
-            catch (NuGet.Packaging.Core.PackagingException e)
+            catch (Exception e)
             {
-                throw GetSkipException(e);
+                ThrowSkipExceptionIfPackagingException(e);
+                throw;
             }
             finally
             {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
@@ -116,6 +116,18 @@ namespace DllImportGenerator.UnitTests.Verifiers
 
             protected override ParseOptions CreateParseOptions()
                 => ((CSharpParseOptions)base.CreateParseOptions()).WithPreprocessorSymbols("DLLIMPORTGENERATOR_ENABLED");
+
+            protected override async Task RunImplAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    await base.RunImplAsync(cancellationToken);
+                }
+                catch(NuGet.Packaging.Core.PackagingException e)
+                {
+                    throw TestUtils.GetSkipException(e);
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
@@ -123,9 +123,10 @@ namespace DllImportGenerator.UnitTests.Verifiers
                 {
                     await base.RunImplAsync(cancellationToken);
                 }
-                catch(NuGet.Packaging.Core.PackagingException e)
+                catch (System.Exception e)
                 {
-                    throw TestUtils.GetSkipException(e);
+                    TestUtils.ThrowSkipExceptionIfPackagingException(e);
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
We are occasionally hitting a `PackagingException` when running unit tests using the Roslyn test infrastructure due to https://github.com/dotnet/roslyn-sdk/issues/590.

Treat the test as a skipped test if we hit the issue.