### PR TITLE
Fix DGML debug tests for Regex NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
@@ -13,7 +13,15 @@ namespace System.Text.RegularExpressions
     {
         /// <summary>True if the regex has debugging enabled.</summary>
         [ExcludeFromCodeCoverage(Justification = "Debug only")]
-        internal bool IsDebug => (roptions & RegexOptions.Debug) != 0;
+        internal bool IsDebug
+        {
+            // These members aren't used from IsDebug, but we want to keep them in debug builds for now,
+            // so this is a convient place to include them rather than needing a debug-only illink file.
+            [DynamicDependency(nameof(SaveDGML))]
+            [DynamicDependency(nameof(GenerateUnicodeTables))]
+            [DynamicDependency(nameof(GenerateRandomMembers))]
+            get => (roptions & RegexOptions.Debug) != 0;
+        }
 
         /// <summary>Unwind the regex and save the resulting state graph in DGML</summary>
         /// <param name="bound">roughly the maximum number of states, 0 means no bound</param>


### PR DESCRIPTION
cc: @veanes 