### PR TITLE
Add analyzer assemblies to code coverage

### DIFF
--- a/eng/testing/coverage.targets
+++ b/eng/testing/coverage.targets
@@ -20,9 +20,6 @@
       <CoverageInclude Include="@(AssembliesBeingTested)" />
       <CoverageInclude Include="$(CoverageAssemblies)" Condition="'$(CoverageAssemblies)' != ''" />
       <!-- Include analyzer assemblies which are referenced via the P2P protocol. -->
-      <_a1 Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer'))" />
-      <_a2 Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer')->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
-      <_a3 Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer')->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->Metadata('Filename'))" />
       <CoverageInclude Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer')->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->Metadata('Filename'))" />
     </ItemGroup>
 

--- a/eng/testing/coverage.targets
+++ b/eng/testing/coverage.targets
@@ -1,5 +1,6 @@
 <Project>
-  <Target Name="SetupCoverageFilter">
+  <Target Name="SetupCoverageFilter"
+          DependsOnTargets="ResolveReferences">
     <!--
       We need to filter the data to only the assembly being tested. Otherwise we will gather tons of data about other assemblies.
       If the code being tested is part of the runtime itself, it requires special treatment.
@@ -18,6 +19,11 @@
       <CoverageInclude Include="System.Private.CoreLib" Condition="'$(TestRuntime)' == 'true'" />
       <CoverageInclude Include="@(AssembliesBeingTested)" />
       <CoverageInclude Include="$(CoverageAssemblies)" Condition="'$(CoverageAssemblies)' != ''" />
+      <!-- Include analyzer assemblies which are referenced via the P2P protocol. -->
+      <_a1 Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer'))" />
+      <_a2 Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer')->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+      <_a3 Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer')->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->Metadata('Filename'))" />
+      <CoverageInclude Include="@(ReferencePath->WithMetadataValue('OutputItemType', 'Analyzer')->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->Metadata('Filename'))" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Instrument analyzer assemblies as well when measuring code coverage.
Filter out the ones which aren't referenced via the P2P protocol.

Fixes https://github.com/dotnet/runtime/issues/52032