### PR TITLE
[wasm][debugger] Fix debugging blazor app after ts changes.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -170,6 +170,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         //TODO figure out how to stich out more frames and, in particular what happens when real wasm is on the stack
                         string top_func = args?["callFrames"]?[0]?["functionName"]?.Value<string>();
                         switch (top_func) {
+                            // keep function names un-mangled via src\mono\wasm\runtime\rollup.config.js
                             case "mono_wasm_runtime_ready":
                             case "_mono_wasm_runtime_ready":
                                 {

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { Module, runtimeHelpers } from "./modules";
+import { Module, MONO, runtimeHelpers } from "./modules";
 import { toBase64StringImpl } from "./base64";
 import cwraps from "./cwraps";
 import { VoidPtr } from "./types";
@@ -113,7 +113,7 @@ export function mono_wasm_raise_debug_event(event: WasmEvent, args = {}): void {
 // Used by the debugger to enumerate loaded dlls and pdbs
 export function mono_wasm_get_loaded_files(): string[] {
     cwraps.mono_wasm_set_is_debugger_attached(true);
-    return runtimeHelpers.loaded_files;
+    return MONO.loaded_files;
 }
 
 function _create_proxy_from_object_id(objectId: string, details: any) {

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -73,7 +73,7 @@ export const MONO: MONO = <any>{
     mono_wasm_load_runtime: cwraps.mono_wasm_load_runtime,
 
     config: runtimeHelpers.config,
-    loaded_files: runtimeHelpers.loaded_files,
+    loaded_files: [],
 
     // generated bindings closure `library_mono`
     mono_wasm_new_root_buffer_from_pointer,

--- a/src/mono/wasm/runtime/modules.ts
+++ b/src/mono/wasm/runtime/modules.ts
@@ -28,7 +28,6 @@ let runtime_is_ready = false;
 export const runtimeHelpers: RuntimeHelpers = <any>{
     namespace: "System.Runtime.InteropServices.JavaScript",
     classname: "Runtime",
-    loaded_files: [],
     get mono_wasm_runtime_is_ready() {
         return runtime_is_ready;
     },

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -15,6 +15,9 @@ const terserConfig = {
         drop_debugger: false,
         defaults: false
     },
+    mangle: {
+        keep_fnames: true,
+    },
     ecma: 5,
 };
 const plugins = isDebug ? [writeOnChangePlugin()] : [terser(terserConfig), writeOnChangePlugin()];

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -9,7 +9,13 @@ import dts from "rollup-plugin-dts";
 const outputFileName = "runtime.iffe.js";
 const isDebug = process.env.Configuration !== "Release";
 const nativeBinDir = process.env.NativeBinDir ? process.env.NativeBinDir.replace(/"/g, "") : "bin";
-const plugins = isDebug ? [writeOnChangePlugin()] : [terser(), writeOnChangePlugin()];
+const terserConfig = {
+    compress: {
+        ecma: 2016,
+        unused: false,
+    },
+};
+const plugins = isDebug ? [writeOnChangePlugin()] : [terser(terserConfig), writeOnChangePlugin()];
 
 export default defineConfig([
     {

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -11,9 +11,11 @@ const isDebug = process.env.Configuration !== "Release";
 const nativeBinDir = process.env.NativeBinDir ? process.env.NativeBinDir.replace(/"/g, "") : "bin";
 const terserConfig = {
     compress: {
-        ecma: 2016,
         unused: false,
+        drop_debugger: false,
+        defaults: false
     },
+    ecma: 5,
 };
 const plugins = isDebug ? [writeOnChangePlugin()] : [terser(terserConfig), writeOnChangePlugin()];
 

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -11,13 +11,28 @@ const isDebug = process.env.Configuration !== "Release";
 const nativeBinDir = process.env.NativeBinDir ? process.env.NativeBinDir.replace(/"/g, "") : "bin";
 const terserConfig = {
     compress: {
-        unused: false,
-        drop_debugger: false,
-        defaults: false
+        defaults: false,// to agressive minification breaks subsequent emcc compilation
+        drop_debugger: false,// we invoke debugger
+        drop_console: false,// we log to console
+        unused: false,// this breaks stuff
+        // below are minification features which seems to work fine
+        collapse_vars: true,
+        conditionals: true,
+        dead_code: true,
+        if_return: true,
+        inline: true,
+        join_vars: true,
+        loops: true,
+        reduce_vars: true,
+        evaluate: true,
+        hoist_props: true,
+        sequences: true,
     },
     mangle: {
-        keep_fnames: true,
+        // because of stack walk at src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+        keep_fnames: /(mono_wasm_runtime_ready|mono_wasm_fire_debugger_agent_message)/,
     },
+    // we export ES5 because emcc parser has trouble parsing it otherwise
     ecma: 5,
 };
 const plugins = isDebug ? [writeOnChangePlugin()] : [terser(terserConfig), writeOnChangePlugin()];

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { INTERNAL, Module, runtimeHelpers } from "./modules";
+import { INTERNAL, Module, MONO, runtimeHelpers } from "./modules";
 import { AssetEntry, CharPtr, CharPtrNull, MonoConfig, TypedArray, VoidPtr, wasm_type_symbol } from "./types";
 import cwraps from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
@@ -205,7 +205,7 @@ function _get_fetch_file_cb_from_args(args: MonoConfig): (asset: string) => Prom
 }
 
 function _finalize_startup(args: MonoConfig, ctx: MonoInitContext) {
-    ctx.loaded_files.forEach(value => runtimeHelpers.loaded_files.push(value.url));
+    ctx.loaded_files.forEach(value => MONO.loaded_files.push(value.url));
     if (ctx.tracing) {
         console.log("MONO_WASM: loaded_assets: " + JSON.stringify(ctx.loaded_assets));
         console.log("MONO_WASM: loaded_files: " + JSON.stringify(ctx.loaded_files));

--- a/src/mono/wasm/runtime/tsconfig.json
+++ b/src/mono/wasm/runtime/tsconfig.json
@@ -4,7 +4,7 @@
     "noEmitOnError": true,
     "removeComments": false,
     "sourceMap": false,
-    "target": "ES2015",
+    "target": "ES5",
     "moduleResolution": "Node",
     "lib": [
       "esnext",


### PR DESCRIPTION
When running a blazor app, blazor that fills variable MONO.loaded_files. With the latest changes to typescript we were ignoring the content of variable that was set from blazor.