### PR TITLE
Allow for multiple copies of the same ModuleId to be found in iteration

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -243,7 +243,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         continue;
 
                     var currentInfo = new ModuleDescInfo(managedModule.ModuleID, assemblyToFullyQualifiedAssemblyName[managedModule.AssemblyID]);
-                    _modules.Add(managedModule.ModuleID, currentInfo);
+                    if (!_modules.ContainsKey(managedModule.ModuleID))
+                        _modules.Add(managedModule.ModuleID, currentInfo);
                 }
             }
         }


### PR DESCRIPTION
Sometimes we would find the same module twice and cause the dotnet-pgo tool to fail