### PR TITLE
Change OperIsBlkOp test to check for store block operators

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7303,7 +7303,7 @@ struct GenTreeCC final : public GenTree
 
 inline bool GenTree::OperIsBlkOp()
 {
-    return ((gtOper == GT_ASG) && varTypeIsStruct(AsOp()->gtOp1)) || (OperIsBlk() && (AsBlk()->Data() != nullptr));
+    return ((gtOper == GT_ASG) && varTypeIsStruct(AsOp()->gtOp1)) || OperIsStoreBlk();
 }
 
 inline bool GenTree::OperIsDynBlkOp()


### PR DESCRIPTION
This PR removes the check for a Blk operation to have `Data() != nullptr` i.e. (`gtOp2 != nullptr`).  If a `GT_LCL_VAR` is converted to a `GT_OBJ`  `gtOp2` will not be set and when dumping the tree a null reference is encountered.  This comes from this question over in the runtimelab repo: https://github.com/dotnet/runtimelab/issues/1673 where you can see the stack and context.

Instead the check on the right side of the `||` is just `OperIsStoreBlk()`