### PR TITLE
[release/6.0] Disable package validation in source-build for reliability

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -1,14 +1,13 @@
 <Project>
 
   <PropertyGroup>
-    <EnablePackageValidation>true</EnablePackageValidation>
     <!--
       Package validation causes flaky errors during the build. Validation isn't useful during
       source-build (it is only a guardrail for devs), so disable it during source-build to avoid the
       impact on build reliability. https://github.com/dotnet/runtime/issues/60883 tracks fixing the
-      flakiness and removing this.
+      flakiness and removing this condition.
     -->
-    <EnablePackageValidation Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnablePackageValidation>
+    <EnablePackageValidation Condition="'$(DotNetBuildFromSource)' != 'true'">true</EnablePackageValidation>
     <!-- Don't restore prebuilt packages during sourcebuild. -->
     <DisablePackageBaselineValidation Condition="'$(DotNetBuildFromSource)' == 'true'">true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">$([MSBuild]::Subtract($(MajorVersion), 1)).0.0</PackageValidationBaselineVersion>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <!--
+      Package validation causes flaky errors during the build. Validation isn't useful during
+      source-build (it is only a guardrail for devs), so disable it during source-build to avoid the
+      impact on build reliability.
+    -->
+    <EnablePackageValidation Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnablePackageValidation>
     <!-- Don't restore prebuilt packages during sourcebuild. -->
     <DisablePackageBaselineValidation Condition="'$(DotNetBuildFromSource)' == 'true'">true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">$([MSBuild]::Subtract($(MajorVersion), 1)).0.0</PackageValidationBaselineVersion>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -5,7 +5,8 @@
     <!--
       Package validation causes flaky errors during the build. Validation isn't useful during
       source-build (it is only a guardrail for devs), so disable it during source-build to avoid the
-      impact on build reliability.
+      impact on build reliability. https://github.com/dotnet/runtime/issues/60883 tracks fixing the
+      flakiness and removing this.
     -->
     <EnablePackageValidation Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnablePackageValidation>
     <!-- Don't restore prebuilt packages during sourcebuild. -->


### PR DESCRIPTION
      Package validation causes flaky errors during the build. Validation isn't useful during
      source-build (it is only a guardrail for devs), so disable it during source-build to avoid the
      impact on build reliability.

* For https://github.com/dotnet/source-build/issues/2501

This has been fixed in `main`, but not `release/6.0`. I'm submitting this PR to fix 6.0 source-build reliability in the short term while waiting for the real fixes to be ported to 6.0:

* https://github.com/dotnet/runtime/pull/60847
* https://github.com/dotnet/sdk/pull/22277

For followup removal:
* https://github.com/dotnet/runtime/issues/60883

@safern 