### PR TITLE
Use IndexOf(..., span) in Regex FindFirstChar

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -269,9 +269,16 @@ namespace System.Text.RegularExpressions.Generator
             {
                 EmitAnchors();
 
-                if (code.BoyerMoorePrefix is RegexBoyerMoore { NegativeUnicode: null })
+                if (code.BoyerMoorePrefix is RegexBoyerMoore { NegativeUnicode: null } rbm)
                 {
-                    EmitBoyerMoore();
+                    if (rbm.CaseInsensitive || rbm.RightToLeft)
+                    {
+                        EmitBoyerMoore(rbm);
+                    }
+                    else
+                    {
+                        EmitIndexOf(rbm.Pattern);
+                    }
                 }
                 else if (lcc is not null)
                 {
@@ -408,13 +415,8 @@ namespace System.Text.RegularExpressions.Generator
                 }
             }
 
-            void EmitBoyerMoore()
+            void EmitBoyerMoore(RegexBoyerMoore rbm)
             {
-                RegexBoyerMoore? rbm = code.BoyerMoorePrefix;
-                Debug.Assert(rbm is RegexBoyerMoore { NegativeUnicode: null });
-
-                writer.WriteLine("// Boyer-Moore prefix matching");
-
                 EmitTextInfoIfRequired(writer, ref textInfoEmitted, ref hasTextInfo, rm);
 
                 int beforefirst;
@@ -533,6 +535,16 @@ namespace System.Text.RegularExpressions.Generator
                         "base.runtextpos = test + 1;");
                     writer.WriteLine("return true;");
                 }
+            }
+
+            void EmitIndexOf(string prefix)
+            {
+                writer.WriteLine($"int i = global::System.MemoryExtensions.IndexOf(global::System.MemoryExtensions.AsSpan(runtext, runtextpos, runtextend - runtextpos), {Literal(prefix)});");
+                writer.WriteLine("if (i >= 0)");
+                writer.WriteLine("{");
+                writer.WriteLine("    base.runtextpos = runtextpos + i;");
+                writer.WriteLine("    return true;");
+                writer.WriteLine("}");
             }
 
             void EmitLeadingCharacter_RightToLeft()

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -271,13 +271,13 @@ namespace System.Text.RegularExpressions.Generator
 
                 if (code.BoyerMoorePrefix is RegexBoyerMoore { NegativeUnicode: null } rbm)
                 {
-                    if (rbm.CaseInsensitive || rbm.RightToLeft)
+                    if (rbm.PatternSupportsIndexOf)
                     {
-                        EmitBoyerMoore(rbm);
+                        EmitIndexOf(rbm.Pattern);
                     }
                     else
                     {
-                        EmitIndexOf(rbm.Pattern);
+                        EmitBoyerMoore(rbm);
                     }
                 }
                 else if (lcc is not null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -218,6 +218,14 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        // TODO: We should be able to avoid producing the RegexBoyerMoore instance
+        // entirely if we're going to go down the code path of using IndexOf. That will
+        // require some refactoring, though.
+
+        /// <summary>Gets whether IndexOf could be used to perform the match.</summary>
+        public bool PatternSupportsIndexOf =>
+            !RightToLeft && (!CaseInsensitive || !RegexCharClass.ParticipatesInCaseConversion(Pattern));
+
         /// <summary>
         /// When a regex is anchored, we can do a quick IsMatch test instead of a Scan
         /// </summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -874,6 +874,21 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets whether the specified string participates in case conversion.</summary>
+        /// <remarks>The string participates in case conversion if any of its characters do.</remarks>
+        public static bool ParticipatesInCaseConversion(string s)
+        {
+            foreach (char c in s)
+            {
+                if (ParticipatesInCaseConversion(c))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>Gets whether we can iterate through the set list pairs in order to completely enumerate the set's contents.</summary>
         private static bool CanEasilyEnumerateSetContents(string set) =>
             set.Length > SetStartIndex &&

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1016,13 +1016,13 @@ namespace System.Text.RegularExpressions
 
             if (_boyerMoorePrefix is RegexBoyerMoore { NegativeUnicode: null } rbm)
             {
-                if (rbm.CaseInsensitive || rbm.RightToLeft)
+                if (rbm.PatternSupportsIndexOf)
                 {
-                    GenerateBoyerMoore(rbm);
+                    GenerateIndexOf(rbm.Pattern);
                 }
                 else
                 {
-                    GenerateIndexOf(rbm.Pattern);
+                    GenerateBoyerMoore(rbm);
                 }
             }
             else if (_leadingCharClasses is not null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -58,7 +58,8 @@ namespace System.Text.RegularExpressions
         private static readonly MethodInfo s_spanGetItemMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Item", new Type[] { typeof(int) })!;
         private static readonly MethodInfo s_spanGetLengthMethod = typeof(ReadOnlySpan<char>).GetMethod("get_Length")!;
         private static readonly MethodInfo s_memoryMarshalGetReference = typeof(MemoryMarshal).GetMethod("GetReference", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
-        private static readonly MethodInfo s_spanIndexOf = typeof(MemoryExtensions).GetMethod("IndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfChar = typeof(MemoryExtensions).GetMethod("IndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanIndexOfSpan = typeof(MemoryExtensions).GetMethod("IndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanIndexOfAnyCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanIndexOfAnyCharCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanSliceIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int) })!;
@@ -1013,9 +1014,16 @@ namespace System.Text.RegularExpressions
 
             GenerateAnchorChecks();
 
-            if (_boyerMoorePrefix is RegexBoyerMoore { NegativeUnicode: null })
+            if (_boyerMoorePrefix is RegexBoyerMoore { NegativeUnicode: null } rbm)
             {
-                GenerateBoyerMoore();
+                if (rbm.CaseInsensitive || rbm.RightToLeft)
+                {
+                    GenerateBoyerMoore(rbm);
+                }
+                else
+                {
+                    GenerateIndexOf(rbm.Pattern);
+                }
             }
             else if (_leadingCharClasses is not null)
             {
@@ -1212,12 +1220,8 @@ namespace System.Text.RegularExpressions
                 }
             }
 
-            void GenerateBoyerMoore()
+            void GenerateBoyerMoore(RegexBoyerMoore rbm)
             {
-                RegexBoyerMoore? rbm = _boyerMoorePrefix;
-                Debug.Assert(rbm is RegexBoyerMoore { NegativeUnicode: null });
-
-                // Compiled Boyer-Moore string matching
                 LocalBuilder limitLocal;
                 int beforefirst;
                 int last;
@@ -1425,6 +1429,43 @@ namespace System.Text.RegularExpressions
                 }
             }
 
+            void GenerateIndexOf(string prefix)
+            {
+                using RentedLocalBuilder i = RentInt32Local();
+
+                // int i = runtext.AsSpan(runtextpos, runtextend - runtextpos).IndexOf(prefix);
+                Ldthis();
+                Ldfld(s_runtextField);
+                Ldloc(_runtextposLocal);
+                Ldloc(_runtextendLocal);
+                Ldloc(_runtextposLocal);
+                Sub();
+                Call(s_stringAsSpanIntIntMethod);
+                Ldstr(prefix);
+                Call(s_stringAsSpanMethod);
+                Call(s_spanIndexOfSpan);
+                Stloc(i);
+
+                // if (i < 0)
+                // {
+                //     base.runtextpos = runtextend;
+                //     return false;
+                // }
+                Ldloc(i);
+                Ldc(0);
+                BltFar(returnFalse);
+
+                // base.runtextpos = runtextpos + i;
+                // return true;
+                Ldthis();
+                Ldloc(_runtextposLocal);
+                Ldloc(i);
+                Add();
+                Stfld(s_runtextposField);
+                Ldc(1);
+                Ret();
+            }
+
             void GenerateLeadingCharacter_RightToLeft()
             {
                 Debug.Assert(_leadingCharClasses.Length == 1, "Only the FirstChars and not MultiFirstChars computation is supported for RightToLeft");
@@ -1585,7 +1626,7 @@ namespace System.Text.RegularExpressions
                         case 1:
                             // tmp = ...IndexOf(setChars[0]);
                             Ldc(setChars[0]);
-                            Call(s_spanIndexOf);
+                            Call(s_spanIndexOfChar);
                             break;
 
                         case 2:
@@ -2849,7 +2890,7 @@ namespace System.Text.RegularExpressions
                         Ldloc(textSpanLocal);
                     }
                     Ldc(node.Ch);
-                    Call(s_spanIndexOf);
+                    Call(s_spanIndexOfChar);
                     Stloc(iterationLocal);
 
                     // if (i >= 0) goto atomicLoopDoneLabel;
@@ -4553,7 +4594,7 @@ namespace System.Text.RegularExpressions
                             Ldloc(lenLocal);
                             Call(s_stringAsSpanIntIntMethod);
                             Ldc(Operand(0));
-                            Call(s_spanIndexOf);
+                            Call(s_spanIndexOfChar);
                             Stloc(iLocal);
 
                             Label charFound = DefineLabel();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -45,11 +45,11 @@ namespace System.Text.RegularExpressions
                     (_, true) => FindFirstCharMode.LeadingAnchor_RightToLeft_EndZ,
                 };
             }
-            else if (code.BoyerMoorePrefix is not null)
+            else if (code.BoyerMoorePrefix is RegexBoyerMoore rbm)
             {
-                _findFirstCharMode =
-                    code.BoyerMoorePrefix.CaseInsensitive || code.BoyerMoorePrefix.RightToLeft ? FindFirstCharMode.BoyerMoore :
-                    FindFirstCharMode.IndexOf;
+                _findFirstCharMode = rbm.PatternSupportsIndexOf ?
+                    FindFirstCharMode.IndexOf :
+                    FindFirstCharMode.BoyerMoore;
             }
             else if (code.LeadingCharClasses is not null)
             {


### PR DESCRIPTION
We currently use Boyer-Moore to find a multi-character prefix in FindFirstChar.  That's good, and when it was originally added it was very likely better than IndexOf(..., string), but since then the latter has been vectorized and its throughput has improved significantly (we also plan to improve it further).  While there are situations where Boyer-Moore does better, for general text searching and typical cases, IndexOf wins.  So, this commit adds the ability for FindFirstChar to use IndexOf to search for a span, and prefers that over Boyer-Moore when it's applicable, namely when we're case-sensitive and left-to-right processing.