### PR TITLE
Add configureonly option to host native build

### DIFF
--- a/docs/workflow/editing-and-debugging.md
+++ b/docs/workflow/editing-and-debugging.md
@@ -27,12 +27,14 @@ The repository has a number of Visual Studio Solutions files (`*.sln`) that are 
      * `crossgen` - This is the host program that runs the JIT compiler and produces .NET Native images (`*.ni.dll`)
      for C# code.
      * This project can be automatically generated and opened in Visual Studio by running `./build.cmd -vs CoreCLR.sln -a <Arch> -c <BuildType>` from the root of the repository.
+   * `artifacts\obj\win-<Arch>.<BuildType>\corehost\ide\corehost.sln` - this solution contains the native (C++) projects for the [host components](../design/features/host-components)
+     * This project can be automatically generated and opened in Visual Studio by running `./build.cmd -vs corehost.sln -a <Arch> -c <BuildType>` from the root of the repository.
 
-Thus opening one of these two solution files (double clicking on them in Explorer) is typically all you need
+Thus opening one of these solution files (double clicking on them in Explorer) is typically all you need
 to do most editing.
 
-Notice that the CoreCLR solution is under the `artifacts` directory.  This is because it is created as part of the build.
-Thus you can only launch this solution after you have built at least once with the `-msbuild` flag or run the `./build.cmd -vs CoreCLR.sln` command line with the specified architecture and configuration.
+Notice that the CoreCLR and corehost solutions are under the `artifacts` directory.  This is because they are created as part of the build.
+Thus you can only launch these solutions after you have built at least once with the `-msbuild` flag or run the `./build.cmd -vs CoreCLR.sln` or `./build.cmd -vs corehost.sln` command line with the specified architecture and configuration.
 
 * See [Debugging CoreCLR](debugging/coreclr/debugging.md)
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -152,7 +152,7 @@ if ($vs) {
   elseif ($vs -ieq "corehost.sln") {
     $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "artifacts\obj\" | Join-Path -ChildPath "win-$archToOpen.$((Get-Culture).TextInfo.ToTitleCase($configToOpen))" | Join-Path -ChildPath "corehost" | Join-Path -ChildPath "ide" | Join-Path -ChildPath "corehost.sln"
     if (-Not (Test-Path $vs)) {
-      Invoke-Expression "& `"$repoRoot/eng/common/msbuild.ps1`" $repoRoot/src/native/corehost/corehost.proj /clp:nosummary /restore /p:Ninja=false"
+      Invoke-Expression "& `"$repoRoot/eng/common/msbuild.ps1`" $repoRoot/src/native/corehost/corehost.proj /clp:nosummary /restore /p:Ninja=false /p:Configuration=$configToOpen /p:TargetArchitecture=$archToOpen /p:ConfigureOnly=true"
       if ($lastExitCode -ne 0) {
         Write-Error "Failed to generate the CoreHost solution file."
         exit 1

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -8,6 +8,7 @@
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and '$(CMakeArgs)' != ''" Include="-cmakeargs &quot;$(CMakeArgs)&quot;" />
       <_CoreClrBuildArg Include="-$(Configuration.ToLower())" />
       <_CoreClrBuildArg Include="$(Compiler)" />
+      <_CoreClrBuildArg Condition="'$(ConfigureOnly)' == 'true'" Include="-configureonly" />
       <_CoreClrBuildArg Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="-ci" />
       <_CoreClrBuildArg Condition="'$(CrossBuild)' == 'true'" Include="-cross" />
       <_CoreClrBuildArg Condition="'$(PortableBuild)' != 'true'" Include="-portablebuild=false" />

--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -11,11 +11,9 @@ set __engNativeDir=%__sourceDir%\..\..\..\eng\native
 set __CMakeBinDir=""
 set __IntermediatesDir=""
 set __BuildArch=x64
-set __appContainer=""
 set CMAKE_BUILD_TYPE=Debug
-set "__LinkArgs= "
-set "__LinkLibraries= "
 set __PortableBuild=0
+set __ConfigureOnly=0
 set __IncrementalNativeBuild=0
 set __Ninja=1
 
@@ -40,6 +38,7 @@ if /i [%1] == [fxrver]      (set __HostFxrVersion=%2&&shift&&shift&goto Arg_Loop
 if /i [%1] == [policyver]   (set __HostPolicyVersion=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [commit]      (set __CommitSha=%2&&shift&&shift&goto Arg_Loop)
 
+if /i [%1] == [configureonly] ( set __ConfigureOnly=1&&shift&goto Arg_Loop)
 if /i [%1] == [incremental-native-build] ( set __IncrementalNativeBuild=1&&shift&goto Arg_Loop)
 if /i [%1] == [rootDir]     ( set __rootDir=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [coreclrartifacts]  (set __CoreClrArtifacts=%2&&shift&&shift&goto Arg_Loop)
@@ -63,7 +62,7 @@ set __binDir=%__rootDir%\artifacts\bin
 set __objDir=%__rootDir%\artifacts\obj
 
 :: Setup to cmake the native components
-echo Commencing build of corehost
+echo Configuring corehost native components
 echo.
 
 if %__CMakeBinDir% == "" (
@@ -109,7 +108,12 @@ call "%__engNativeDir%\gen-buildsys.cmd" "%__sourceDir%" "%__IntermediatesDir%" 
 if NOT [%errorlevel%] == [0] goto :Failure
 popd
 
+if [%__ConfigureOnly%] == [1] goto :Exit
+
 :BuildNativeProj
+
+echo Commencing build of corehost native components
+
 :: Build the project created by Cmake
 set __generatorArgs=
 if [%__Ninja%] == [1] (
@@ -145,6 +149,8 @@ if "%__RuntimeFlavor%" NEQ "Mono" (
 )
 
 echo Done building Native components
+
+:Exit
 exit /B 0
 
 :Failure

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -24,6 +24,7 @@
 
       <BuildArgs>$(Configuration) $(TargetArchitecture) -apphostver "$(AppHostVersion)" -hostver "$(HostVersion)" -fxrver "$(HostResolverVersion)" -policyver "$(HostPolicyVersion)" -commithash "$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))" -os $(TargetOS)</BuildArgs>
       <BuildArgs>$(BuildArgs) -cmakeargs "-DVERSION_FILE_PATH=$(NativeVersionFile)"</BuildArgs>
+      <BuildArgs Condition="'$(ConfigureOnly)' == 'true'">$(BuildArgs) -configureonly</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' != 'true'">$(BuildArgs) -portablebuild=false</BuildArgs>
       <BuildArgs Condition="'$(KeepNativeSymbols)' != 'false'">$(BuildArgs) -keepnativesymbols</BuildArgs>
       <BuildArgs Condition="'$(CrossBuild)' == 'true'">$(BuildArgs) -cross</BuildArgs>
@@ -84,6 +85,7 @@
       <BuildScript>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'build.cmd'))</BuildScript>
 
       <BuildArgs>$(Configuration) $(TargetArchitecture) apphostver $(AppHostVersion) hostver $(HostVersion) fxrver $(HostResolverVersion) policyver $(HostPolicyVersion) commit $([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A')) rid $(OutputRid)</BuildArgs>
+      <BuildArgs Condition="'$(ConfigureOnly)' == 'true'">$(BuildArgs) configureonly</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' == 'true'">$(BuildArgs) portable</BuildArgs>
       <BuildArgs Condition="'$(IncrementalNativeBuild)' == 'true'">$(BuildArgs) incremental-native-build</BuildArgs>
       <BuildArgs>$(BuildArgs) rootdir $(RepoRoot)</BuildArgs>


### PR DESCRIPTION
- Add `configureonly` option to host native build script on Windows (Unix already had the support)
- Make `corehost.proj` respect a `ConfigureOnly` msbuild property
- Update the `build -vs corehost.sln` command to respect arch/config and avoid the full build

Examples:
```
dotnet build src/native/corehost/corehost.proj /p:ConfigureOnly=true

build.sh/cmd host.native /p:ConfigureOnly=true

build.cmd -vs corehost.sln
```

The build scripts under `src\native\corehost` could also be called directly, but they expect a bunch of arguments that our msbuild projects handle computing, so it would be rather cumbersome.

cc @vitek-karas 