### PR TITLE
Fix Equals overload logic for some methods of an array created using MLC

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoSyntheticMethod.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoSyntheticMethod.cs
@@ -72,7 +72,7 @@ namespace System.Reflection.TypeLoading
             if (!(obj is RoSyntheticMethod other))
                 return false;
 
-            if (DeclaringType != other.DeclaringType)
+            if (ReturnType != other.ReturnType)
                 return false;
 
             if (_uniquifier != other._uniquifier)

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoSyntheticMethod.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoSyntheticMethod.cs
@@ -72,6 +72,9 @@ namespace System.Reflection.TypeLoading
             if (!(obj is RoSyntheticMethod other))
                 return false;
 
+            if (DeclaringType != other.DeclaringType)
+                return false;
+
             if (ReturnType != other.ReturnType)
                 return false;
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
@@ -209,6 +209,23 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        static void TestArrayMethodsGetSetAddressAreNotEquals()
+        {
+           void test(Type type)
+            {
+                var v1 = type.GetMethod("Get");
+                var v2 = type.GetMethod("Set");
+                var v3 = type.GetMethod("Address");
+                Assert.NotEqual(v1, v2);
+                Assert.NotEqual(v1, v3);
+                Assert.NotEqual(v2, v3);
+            }
+
+            test(typeof(int[]));
+            test((typeof(int[])).Project());
+        }
+
+        [Fact]
         public static void TestArrayAddressMethod()
         {
             bool expectedDefaultValue = true;

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
@@ -213,16 +213,42 @@ namespace System.Reflection.Tests
         {
            void test(Type type)
             {
-                var v1 = type.GetMethod("Get");
-                var v2 = type.GetMethod("Set");
-                var v3 = type.GetMethod("Address");
+                MethodInfo v1 = type.GetMethod("Get");
+                MethodInfo v2 = type.GetMethod("Set");
+                MethodInfo v3 = type.GetMethod("Address");
                 Assert.NotEqual(v1, v2);
                 Assert.NotEqual(v1, v3);
                 Assert.NotEqual(v2, v3);
             }
 
             test(typeof(int[]));
-            test((typeof(int[])).Project());
+            test(typeof(int[]).Project());
+        }
+
+        [Fact]
+        static void TestArrayMethodsGetSetAddressEqualityForDifferentTypes()
+        {
+            void testNotEqual(Type type1, Type type2)
+            {
+                Assert.NotEqual(type1.GetMethod("Get"), type2.GetMethod("Get"));
+                Assert.NotEqual(type1.GetMethod("Set"), type2.GetMethod("Set"));
+                Assert.NotEqual(type1.GetMethod("Address"), type2.GetMethod("Address"));
+            }
+
+            testNotEqual(typeof(int[]), typeof(long[]));
+            testNotEqual(typeof(int[]).Project(), typeof(long[]).Project());
+            testNotEqual(typeof(int[]).Project(), typeof(int[]));
+
+            void testEqual(Type type1, Type type2)
+            {
+                Assert.Equal(type1.GetMethod("Get"), type2.GetMethod("Get"));
+                Assert.Equal(type1.GetMethod("Set"), type2.GetMethod("Set"));
+                Assert.Equal(type1.GetMethod("Address"), type2.GetMethod("Address"));
+            }
+
+            testEqual(typeof(int[]), typeof(int[]));
+            testEqual(typeof(int[]).Project(), typeof(int[]).Project());
+            testEqual(typeof(long[]).Project(), typeof(long[]).Project());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57728
Update Equals overload for RoMethods created by MetadataLoadContext to check `ReturnType` instead of `DeclaringType`