### PR TITLE
Do not force create new IG for align instruction

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1385,6 +1385,7 @@ protected:
         insGroup*       idaIG;   // containing group
     };
 
+    void emitCheckAlignFitInCurIG(unsigned short nAlignInstr);
     void emitLoopAlign(unsigned short paddingBytes);
     void emitLongLoopAlign(unsigned short alignmentBoundary);
 


### PR DESCRIPTION
For multiple `align` instructions (arm64 or x64 non-adaptive mode), we check in advance if all `align` instructions will fit in given IG and if not, we force to create new IG so the `align` instructions are not spread out but are all contained in same IG. Other part of alignment logic depends on this assumption. In stress mode, we might force every instruction to be present in their own IG. Disable this from happening for `align` instructions. In order to do that, make sure that we mark the `emitCurIG` with `IGF_LOOP_ALIGN` in advance so `emitAllocAnyInstr()` can see it and skip inserting new IG. 

Fixes: https://github.com/dotnet/runtime/issues/60820