### PR TITLE
Detect more XHarness exit codes, lower installation timeout

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/MobileAppHandler.cs
@@ -89,7 +89,7 @@ namespace CoreclrTestLib
 
                     if (action == "install")
                     {
-                        cmdStr += " --timeout 00:05:00";
+                        cmdStr += " --timeout 00:02:30";
                     }
 
                     using (Process process = new Process())
@@ -125,7 +125,10 @@ namespace CoreclrTestLib
                             // 81 - DEVICE_NOT_FOUND
                             // 85 - ADB_DEVICE_ENUMERATION_FAILURE
                             // 86 - PACKAGE_INSTALLATION_TIMEOUT
-                            if (action == "install" && (exitCode == 78 || exitCode == 81|| exitCode == 85|| exitCode == 86))
+                            // 88 - SIMULATOR_FAILURE
+                            // 89 - DEVICE_FAILURE
+                            var retriableCodes = new[] { 78, 81, 85, 86, 88, 89 };
+                            if (action == "install" && retriableCodes.Contains(exitCode))
                             {
                                 CreateRetryFile($"{testBinaryBase}/.retry", exitCode, category);
                                 CreateRetryFile($"{testBinaryBase}/.reboot", exitCode, category);


### PR DESCRIPTION
We should be more aggressive with the timeout, also there are new exit codes

https://github.com/dotnet/core-eng/issues/14741