### PR TITLE
Disable DllImportGenerator.UnitTests.ConvertToGeneratedDllImportAnalyzerTests.TypeRequiresMarshalling_ReportsDiagnostic

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -47,6 +47,7 @@ namespace DllImportGenerator.UnitTests
         [ConditionalTheory]
         [MemberData(nameof(MarshallingRequiredTypes))]
         [MemberData(nameof(NoMarshallingRequiredTypes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/60909", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows))]
         public async Task TypeRequiresMarshalling_ReportsDiagnostic(Type type)
         {
             string source = DllImportWithType(type.FullName!);


### PR DESCRIPTION
Disables test from https://github.com/dotnet/runtime/issues/60909 which failed on the rolling build: https://dev.azure.com/dnceng/public/_build/results?buildId=1442365&view=results