### PR TITLE
[wasm] preparation for module encapsulation

### DIFF
--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -17,35 +17,10 @@ if (typeof (console) === "undefined") {
         clear: function () { }
     };
 }
-globalThis.testConsole = console;
-
-//define arguments for later
-let allRuntimeArguments = null;
-try {
-    if (is_browser) {
-        // We expect to be run by tests/runtime/run.js which passes in the arguments using http parameters
-        const url = new URL(decodeURI(window.location));
-        allRuntimeArguments = [];
-        for (let param of url.searchParams) {
-            if (param[0] == "arg") {
-                allRuntimeArguments.push(param[1]);
-            }
-        }
-
-    } else if (typeof arguments !== "undefined" && typeof arguments !== "null") {
-        allRuntimeArguments = arguments;
-    } else if (typeof process !== 'undefined' && typeof process.argv !== "undefined") {
-        allRuntimeArguments = process.argv.slice(2);
-    } else if (typeof scriptArgs !== "undefined") {
-        allRuntimeArguments = scriptArgs;
-    } else if (typeof WScript !== "undefined" && WScript.Arguments) {
-        allRuntimeArguments = WScript.Arguments;
-    } else {
-        allRuntimeArguments = [];
-    }
-} catch (e) {
-    console.log(e);
-}
+const originalConsole = {
+    log: console.log,
+    error: console.error
+};
 
 function proxyMethod(prefix, func, asJson) {
     return function () {
@@ -76,7 +51,7 @@ function proxyMethod(prefix, func, asJson) {
 
 const methods = ["debug", "trace", "warn", "info", "error"];
 for (let m of methods) {
-    if (typeof (console[m]) != "function") {
+    if (typeof (console[m]) !== "function") {
         console[m] = proxyMethod(`console.${m}: `, console.log, false);
     }
 }
@@ -91,20 +66,17 @@ if (is_browser) {
 
     let consoleWebSocket = new WebSocket(consoleUrl);
     consoleWebSocket.onopen = function (event) {
-        proxyJson(function (msg) { consoleWebSocket.send(msg); });
-        globalThis.testConsole.log("browser: Console websocket connected.");
+        proxyJson(function (msg) {
+            consoleWebSocket.send(msg);
+        });
+        console.log("browser: Console websocket connected.");
     };
     consoleWebSocket.onerror = function (event) {
-        console.log(`websocket error: ${event}`);
+        console.error(`websocket error: ${event}`);
     };
 }
-//proxyJson(console.log);
 
-
-let print = globalThis.testConsole.log;
-let printErr = globalThis.testConsole.error;
-
-if (typeof crypto === 'undefined') {
+if (typeof globalThis.crypto === 'undefined') {
     // **NOTE** this is a simple insecure polyfill for testing purposes only
     // /dev/random doesn't work on js shells, so define our own
     // See library_fs.js:createDefaultDevices ()
@@ -116,255 +88,149 @@ if (typeof crypto === 'undefined') {
     }
 }
 
-if (typeof performance == 'undefined') {
-    // performance.now() is used by emscripten and doesn't work in JSC
-    globalThis.performance = {
-        now: function () {
-            return Date.now();
+if (typeof globalThis.performance === 'undefined') {
+    if (is_node) {
+        const { performance } = require("perf_hooks");
+        globalThis.performance = performance;
+    } else {
+        // performance.now() is used by emscripten and doesn't work in JSC
+        globalThis.performance = {
+            now: function () {
+                return Date.now();
+            }
         }
-    }
-}
-
-//end of all the nice shell glue code.
-
-function test_exit(exit_code) {
-    if (is_browser) {
-        // Notify the selenium script
-        Module.exit_code = exit_code;
-        Module.print("WASM EXIT " + exit_code);
-        const tests_done_elem = document.createElement("label");
-        tests_done_elem.id = "tests_done";
-        tests_done_elem.innerHTML = exit_code.toString();
-        document.body.appendChild(tests_done_elem);
-    } else {
-        INTERNAL.mono_wasm_exit(exit_code);
-    }
-}
-
-function fail_exec(reason) {
-    Module.print(reason);
-    test_exit(1);
-}
-
-function inspect_object(o) {
-    const r = "";
-    for (let p in o) {
-        const t = typeof o[p];
-        r += "'" + p + "' => '" + t + "', ";
-    }
-    return r;
-}
-
-// Preprocess arguments
-console.info("Arguments: " + allRuntimeArguments);
-const profilers = [];
-const setenv = {};
-const runtime_args = [];
-let enable_gc = true;
-let working_dir = '/';
-while (allRuntimeArguments !== undefined && allRuntimeArguments.length > 0) {
-    if (allRuntimeArguments[0].startsWith("--profile=")) {
-        const arg = allRuntimeArguments[0].substring("--profile=".length);
-
-        profilers.push(arg);
-
-        allRuntimeArguments = allRuntimeArguments.slice(1);
-    } else if (allRuntimeArguments[0].startsWith("--setenv=")) {
-        const arg = allRuntimeArguments[0].substring("--setenv=".length);
-        const parts = arg.split('=');
-        if (parts.length != 2)
-            fail_exec("Error: malformed argument: '" + allRuntimeArguments[0]);
-        setenv[parts[0]] = parts[1];
-        allRuntimeArguments = allRuntimeArguments.slice(1);
-    } else if (allRuntimeArguments[0].startsWith("--runtime-arg=")) {
-        const arg = allRuntimeArguments[0].substring("--runtime-arg=".length);
-        runtime_args.push(arg);
-        allRuntimeArguments = allRuntimeArguments.slice(1);
-    } else if (allRuntimeArguments[0] == "--disable-on-demand-gc") {
-        enable_gc = false;
-        allRuntimeArguments = allRuntimeArguments.slice(1);
-    } else if (allRuntimeArguments[0].startsWith("--working-dir=")) {
-        const arg = allRuntimeArguments[0].substring("--working-dir=".length);
-        working_dir = arg;
-        allRuntimeArguments = allRuntimeArguments.slice(1);
-    } else {
-        break;
-    }
-}
-
-// cheap way to let the testing infrastructure know we're running in a browser context (or not)
-setenv["IsBrowserDomSupported"] = is_browser.toString().toLowerCase();
-
-function writeContentToFile(content, path) {
-    const stream = FS.open(path, 'w+');
-    FS.write(stream, content, 0, content.length, 0);
-    FS.close(stream);
-}
-
-function loadScript(url) {
-    if (is_browser) {
-        const script = document.createElement("script");
-        script.src = url;
-        document.head.appendChild(script);
-    } else {
-        load(url);
     }
 }
 
 var Module = {
+    no_global_exports: true,
     mainScriptUrlOrBlob: "dotnet.js",
     config: null,
-    print,
-    printErr,
-
+    print: console.log,
+    printErr: console.error,
+    /** Called before the runtime is loaded and before it is run
+     * @type {() => Promise<void>}
+     */
     preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
     },
 
+    /** Called after an exception occurs during execution
+     * @type {(x: string|number=) => void}
+     * @param {string|number} x error message
+     */
     onAbort: function (x) {
-        print("ABORT: " + x);
+        console.log("ABORT: " + x);
         const err = new Error();
-        print("Stacktrace: \n");
-        print(err.stack);
-        test_exit(1);
+        console.log("Stacktrace: \n");
+        console.error(err.stack);
+        fail_exec(1);
     },
 
+    /** Called after the runtime is loaded but before it is run mostly prepares runtime and config for the tests
+     * @type {() => void}
+     */
     onRuntimeInitialized: function () {
+        if (!Module.config) {
+            console.error("Could not find ./mono-config.json. Cancelling run");
+            fail_exec(1);
+        }
         // Have to set env vars here to enable setting MONO_LOG_LEVEL etc.
-        for (let variable in setenv) {
-            MONO.mono_wasm_setenv(variable, setenv[variable]);
+        for (let variable in processedArguments.setenv) {
+            MONO.mono_wasm_setenv(variable, processedArguments.setenv[variable]);
         }
 
-        if (!enable_gc) {
+        if (!processedArguments.enable_gc) {
             INTERNAL.mono_wasm_enable_on_demand_gc(0);
         }
 
-        MONO.config.loaded_cb = function () {
-            let wds = FS.stat(working_dir);
-            if (wds === undefined || !FS.isDir(wds.mode)) {
-                fail_exec(`Could not find working directory ${working_dir}`);
+        Module.config.loaded_cb = function () {
+            let wds = Module.FS.stat(processedArguments.working_dir);
+            if (wds === undefined || !Module.FS.isDir(wds.mode)) {
+                fail_exec(1, `Could not find working directory ${processedArguments.working_dir}`);
                 return;
             }
 
-            FS.chdir(working_dir);
+            Module.FS.chdir(processedArguments.working_dir);
             App.init();
         };
-        MONO.config.fetch_file_cb = function (asset) {
-            // console.log("fetch_file_cb('" + asset + "')");
-            // for testing purposes add BCL assets to VFS until we special case File.Open
-            // to identify when an assembly from the BCL is being open and resolve it correctly.
-            /*
-            const content = new Uint8Array (read (asset, 'binary'));
-            const path = asset.substr(MONO.config.deploy_prefix.length);
-            writeContentToFile(content, path);
-            */
 
-            if (typeof window != 'undefined') {
-                return fetch(asset, { credentials: 'same-origin' });
-            } else {
-                // The default mono_load_runtime_and_bcl defaults to using
-                // fetch to load the assets.  It also provides a way to set a
-                // fetch promise callback.
-                // Here we wrap the file read in a promise and fake a fetch response
-                // structure.
-                return new Promise((resolve, reject) => {
-                    let bytes = null, error = null;
-                    try {
-                        bytes = read(asset, 'binary');
-                    } catch (exc) {
-                        console.log('v8 file read failed ' + asset + ' ' + exc)
-                        error = exc;
-                    }
-                    const response = {
-                        ok: (bytes && !error), url: asset,
-                        arrayBuffer: function () {
-                            return new Promise((resolve2, reject2) => {
-                                if (error)
-                                    reject2(error);
-                                else
-                                    resolve2(new Uint8Array(bytes));
-                            }
-                            )
-                        }
-                    }
-                    resolve(response);
-                })
-            }
-        };
-
-        MONO.mono_load_runtime_and_bcl_args(MONO.config);
+        MONO.mono_load_runtime_and_bcl_args(Module.config);
     },
 };
-loadScript("dotnet.js");
-
-const IGNORE_PARAM_COUNT = -1;
 
 const App = {
     init: function () {
         console.info("Initializing.....");
 
-        for (let i = 0; i < profilers.length; ++i) {
-            const init = Module.cwrap('mono_wasm_load_profiler_' + profilers[i], 'void', ['string'])
-
+        for (let i = 0; i < processedArguments.profilers.length; ++i) {
+            const init = Module.cwrap('mono_wasm_load_profiler_' + processedArguments.profilers[i], 'void', ['string']);
             init("");
         }
 
-        if (allRuntimeArguments.length == 0) {
-            fail_exec("Missing required --run argument");
+        if (processedArguments.applicationArgs.length == 0) {
+            fail_exec(1, "Missing required --run argument");
             return;
         }
 
-        if (allRuntimeArguments[0] == "--regression") {
+        if (processedArguments.applicationArgs[0] == "--regression") {
+            const exec_regression = Module.cwrap('mono_wasm_exec_regression', 'number', ['number', 'string']);
+
             let res = 0;
             try {
-                res = INTERNAL.mono_wasm_exec_regression(10, allRuntimeArguments[1]);
-                Module.print("REGRESSION RESULT: " + res);
+                res = exec_regression(10, processedArguments.applicationArgs[1]);
+                console.log("REGRESSION RESULT: " + res);
             } catch (e) {
-                Module.print("ABORT: " + e);
-                print(e.stack);
+                console.error("ABORT: " + e);
+                console.error(e.stack);
                 res = 1;
             }
 
             if (res)
-                fail_exec("REGRESSION TEST FAILED");
+                fail_exec(1, "REGRESSION TEST FAILED");
 
             return;
         }
 
-        if (runtime_args.length > 0)
-            INTERNAL.mono_wasm_set_runtime_options(runtime_args);
+        if (processedArguments.runtime_args.length > 0)
+            INTERNAL.mono_wasm_set_runtime_options(processedArguments.runtime_args);
 
-        if (allRuntimeArguments[0] == "--run") {
+        if (processedArguments.applicationArgs[0] == "--run") {
             // Run an exe
-            if (allRuntimeArguments.length == 1) {
-                fail_exec("Error: Missing main executable argument.");
+            if (processedArguments.applicationArgs.length == 1) {
+                fail_exec(1, "Error: Missing main executable argument.");
                 return;
             }
 
-            const main_assembly_name = allRuntimeArguments[1];
-            const app_args = allRuntimeArguments.slice(2);
-            INTERNAL.mono_wasm_set_main_args(allRuntimeArguments[1], app_args);
+            const main_assembly_name = processedArguments.applicationArgs[1];
+            const app_args = processedArguments.applicationArgs.slice(2);
+            INTERNAL.mono_wasm_set_main_args(processedArguments.applicationArgs[1], app_args);
 
             // Automatic signature isn't working correctly
-            let result = BINDING.call_assembly_entry_point(main_assembly_name, [app_args], "m");
-            let onError = function (error) {
+            const result = BINDING.call_assembly_entry_point(main_assembly_name, [app_args], "m");
+            const onError = function (error) {
                 console.error(error);
                 if (error.stack)
                     console.error(error.stack);
 
-                test_exit(1);
+                fail_exec(1);
             }
             try {
-                result.then(test_exit).catch(onError);
+                result.then(fail_exec).catch(onError);
             } catch (error) {
                 onError(error);
             }
 
         } else {
-            fail_exec("Unhandled argument: " + allRuntimeArguments[0]);
+            fail_exec(1, "Unhandled argument: " + processedArguments.applicationArgs[0]);
         }
     },
+
+    /** Runs a particular test
+     * @type {(method_name: string, args: any[]=, signature: any=) => return number}
+     */
     call_test_method: function (method_name, args, signature) {
+        // note: arguments here is the array of arguments passsed to this function
         if ((arguments.length > 2) && (typeof (signature) !== "string"))
             throw new Error("Invalid number of arguments for call_test_method");
 
@@ -377,3 +243,130 @@ const App = {
         }
     }
 };
+globalThis.App = App; // Necessary as System.Runtime.InteropServices.JavaScript.Tests.MarshalTests (among others) call the App.call_test_method directly
+
+function fail_exec(exit_code, reason) {
+    if (reason) {
+        console.error(reason);
+    }
+    if (is_browser) {
+        // Notify the selenium script
+        Module.exit_code = exit_code;
+        originalConsole.log("WASM EXIT " + exit_code);
+        const tests_done_elem = document.createElement("label");
+        tests_done_elem.id = "tests_done";
+        tests_done_elem.innerHTML = exit_code.toString();
+        document.body.appendChild(tests_done_elem);
+    } else { // shell or node
+        INTERNAL.mono_wasm_exit(exit_code);
+    }
+}
+
+function processArguments(incomingArguments) {
+    console.log("Incoming arguments: " + incomingArguments.join(' '));
+    let profilers = [];
+    let setenv = {};
+    let runtime_args = [];
+    let enable_gc = true;
+    let working_dir = '/';
+    while (incomingArguments && incomingArguments.length > 0) {
+        const currentArg = incomingArguments[0];
+        if (currentArg.startsWith("--profile=")) {
+            const arg = currentArg.substring("--profile=".length);
+            profilers.push(arg);
+        } else if (currentArg.startsWith("--setenv=")) {
+            const arg = currentArg.substring("--setenv=".length);
+            const parts = arg.split('=');
+            if (parts.length != 2)
+                fail_exec(1, "Error: malformed argument: '" + currentArg);
+            setenv[parts[0]] = parts[1];
+        } else if (currentArg.startsWith("--runtime-arg=")) {
+            const arg = currentArg.substring("--runtime-arg=".length);
+            runtime_args.push(arg);
+        } else if (currentArg == "--disable-on-demand-gc") {
+            enable_gc = false;
+        } else if (currentArg.startsWith("--working-dir=")) {
+            const arg = currentArg.substring("--working-dir=".length);
+            working_dir = arg;
+        } else {
+            break;
+        }
+        incomingArguments = incomingArguments.slice(1);
+    }
+
+    // cheap way to let the testing infrastructure know we're running in a browser context (or not)
+    setenv["IsBrowserDomSupported"] = is_browser.toString().toLowerCase();
+
+    console.log("Application arguments: " + incomingArguments.join(' '));
+
+    return {
+        applicationArgs: incomingArguments,
+        profilers,
+        setenv,
+        runtime_args,
+        enable_gc,
+        working_dir,
+    }
+}
+
+let processedArguments = null;
+// this can't be function because of `arguments` scope
+try {
+    if (is_node) {
+        processedArguments = processArguments(process.argv.slice(2));
+    } else if (is_browser) {
+        // We expect to be run by tests/runtime/run.js which passes in the arguments using http parameters
+        const url = new URL(decodeURI(window.location));
+        let urlArguments = []
+        for (let param of url.searchParams) {
+            if (param[0] == "arg") {
+                urlArguments.push(param[1]);
+            }
+        }
+        processedArguments = processArguments(urlArguments);
+    } else if (typeof arguments !== "undefined") {
+        processedArguments = processArguments(Array.from(arguments));
+    } else if (typeof scriptArgs !== "undefined") {
+        processedArguments = processArguments(Array.from(scriptArgs));
+    } else if (typeof WScript !== "undefined" && WScript.Arguments) {
+        processedArguments = processArguments(Array.from(WScript.Arguments));
+    }
+} catch (e) {
+    console.error(e);
+}
+
+async function loadDotnet(file) {
+    let loadScript = undefined;
+    if (typeof WScript !== "undefined") { // Chakra
+        loadScript = WScript.LoadScriptFile;
+        return globalThis.Module;
+    } else if (is_node) { // NodeJS
+        loadScript = async function (file) {
+            return require(file);
+        };
+    } else if (is_browser) { // vanila JS in browser
+        loadScript = async function (file) {
+            const script = document.createElement("script");
+            script.src = file;
+            document.head.appendChild(script);
+            return globalThis.Module;
+        }
+    }
+    else if (typeof globalThis.load !== 'undefined') {
+        loadScript = async function (file) {
+            globalThis.load(file)
+            return globalThis.Module;
+        }
+    }
+    else {
+        throw new Error("Unknown environment, can't load config");
+    }
+
+    return loadScript(file);
+}
+
+loadDotnet("./dotnet.js").catch(function (err) {
+    console.error(err);
+    fail_exec(1, "failed to load the dotnet.js file");
+    throw err;
+});

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -30,47 +30,7 @@ extern MonoObject* mono_wasm_web_socket_send (int webSocket_js_handle, void* buf
 extern MonoObject* mono_wasm_web_socket_receive (int webSocket_js_handle, void* buffer_ptr, int offset, int length, void* response_ptr, int *thenable_js_handle, int *is_exception);
 extern MonoObject* mono_wasm_web_socket_close (int webSocket_js_handle, int code, MonoString * reason, int wait_for_close_received, int *thenable_js_handle, int *is_exception);
 extern MonoString* mono_wasm_web_socket_abort (int webSocket_js_handle, int *is_exception);
-
-// Compiles a JavaScript function from the function data passed.
-// Note: code snippet is not a function definition. Instead it must create and return a function instance.
-EM_JS(MonoObject*, compile_function, (int snippet_ptr, int len, int *is_exception), {
-	try {
-		var data = INTERNAL.string_decoder.decode (snippet_ptr, snippet_ptr + len);
-		var wrapper = '(function () { ' + data + ' })';
-		var funcFactory = eval(wrapper);
-		var func = funcFactory();
-		if (typeof func !== 'function') {
-			throw new Error('Code must return an instance of a JavaScript function. '
-				+ 'Please use `return` statement to return a function.');
-		}
-		setValue (is_exception, 0, "i32");
-		return BINDING.js_to_mono_obj (func, true);	
-	}
-	catch (e)
-	{
-		res = e.toString ();
-		setValue (is_exception, 1, "i32");
-		if (res === null || res === undefined)
-			res = "unknown exception";
-		return BINDING.js_to_mono_obj (res, true);
-	}
-});
-
-static MonoObject*
-mono_wasm_compile_function (MonoString *str, int *is_exception)
-{
-	if (str == NULL)
-	 	return NULL;
-	//char *native_val = mono_string_to_utf8 (str);
-	mono_unichar2 *native_val = mono_string_chars (str);
-	int native_len = mono_string_length (str) * 2;
-
-	MonoObject* native_res =  compile_function((int)native_val, native_len, is_exception);
-	mono_free (native_val);
-	if (native_res == NULL)
-	 	return NULL;
-	return native_res;
-}
+extern MonoObject* mono_wasm_compile_function (MonoString *str, int *is_exception);
 
 void core_initialize_internals ()
 {

--- a/src/mono/wasm/runtime/cs-to-js.ts
+++ b/src/mono/wasm/runtime/cs-to-js.ts
@@ -3,9 +3,9 @@
 
 import { mono_wasm_new_root, WasmRoot } from "./roots";
 import {
-    GCHandle, Int32Ptr, JSHandle, JSHandleDisposed, MonoArray,
-    MonoArrayNull, MonoObject, MonoObjectNull, MonoString, MonoClass,
-    MonoClassNull, MonoType, MonoTypeNull
+    GCHandle, Int32Ptr, JSHandleDisposed, MonoArray,
+    MonoArrayNull, MonoObject, MonoObjectNull, MonoString,
+    MonoType, MonoTypeNull
 } from "./types";
 import { Module, runtimeHelpers } from "./modules";
 import { conv_string } from "./strings";
@@ -82,7 +82,8 @@ function _unbox_cs_owned_root_as_js_object(root: WasmRoot<any>) {
     return js_obj;
 }
 
-function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<any>, type: MarshalType, typePtr: MonoType, unbox_buffer: VoidPtr) : any {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<any>, type: MarshalType, typePtr: MonoType, unbox_buffer: VoidPtr): any {
     //See MARSHAL_TYPE_ defines in driver.c
     switch (type) {
         case MarshalType.INT64:
@@ -121,25 +122,25 @@ function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<a
         case MarshalType.VOID:
             return undefined;
         default:
-            throw new Error(`no idea on how to unbox object of MarshalType ${type} at offset ${root.value} (root address is ${root.get_address()})`);            
+            throw new Error(`no idea on how to unbox object of MarshalType ${type} at offset ${root.value} (root address is ${root.get_address()})`);
     }
 }
 
-export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot<any>, type: MarshalType, unbox_buffer: VoidPtr) : any {
+export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot<any>, type: MarshalType, unbox_buffer: VoidPtr): any {
     if (type >= MarshalError.FIRST)
         throw new Error(`Got marshaling error ${type} when attempting to unbox object at address ${root.value} (root located at ${root.get_address()})`);
-    
+
     let typePtr = MonoTypeNull;
     if ((type === MarshalType.VT) || (type == MarshalType.OBJECT)) {
         typePtr = <MonoType><any>Module.HEAPU32[<any>unbox_buffer >>> 2];
         if (<number><any>typePtr < 1024)
             throw new Error(`Got invalid MonoType ${typePtr} for object at address ${root.value} (root located at ${root.get_address()})`);
     }
-    
+
     return _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root, type, typePtr, unbox_buffer);
 }
 
-export function _unbox_mono_obj_root(root: WasmRoot<any>) : any {
+export function _unbox_mono_obj_root(root: WasmRoot<any>): any {
     if (root.value === 0)
         return undefined;
 
@@ -350,7 +351,7 @@ function _unbox_task_root_as_promise(root: WasmRoot<MonoObject>) {
     return result;
 }
 
-export function _unbox_ref_type_root_as_js_object(root: WasmRoot<MonoObject>) {
+export function _unbox_ref_type_root_as_js_object(root: WasmRoot<MonoObject>): any {
 
     if (root.value === MonoObjectNull)
         return null;

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { 
-    CharPtr, CharPtrPtr, Int32Ptr, 
-    MonoArray, MonoAssembly, MonoClass, 
-    MonoMethod, MonoObject, MonoString, 
-    MonoType, VoidPtr 
+import {
+    CharPtr, CharPtrPtr, Int32Ptr,
+    MonoArray, MonoAssembly, MonoClass,
+    MonoMethod, MonoObject, MonoString,
+    MonoType, VoidPtr
 } from "./types";
 import { Module } from "./modules";
 
@@ -55,8 +55,8 @@ const fn_signatures: [ident: string, returnType: string | null, argTypes?: strin
     ["mono_wasm_typed_array_new", "number", ["number", "number", "number", "number"]],
     ["mono_wasm_class_get_type", "number", ["number"]],
     ["mono_wasm_type_get_class", "number", ["number"]],
-    ["mono_wasm_get_type_name", 'string', ['number']],
-    ["mono_wasm_get_type_aqn", 'string', ['number']],
+    ["mono_wasm_get_type_name", "string", ["number"]],
+    ["mono_wasm_get_type_aqn", "string", ["number"]],
     ["mono_wasm_unbox_rooted", "number", ["number"]],
 
     //DOTNET
@@ -121,7 +121,7 @@ export interface t_Cwraps {
 
     //DOTNET
     mono_wasm_string_from_js(str: string): MonoString;
-    
+
     //INTERNAL
     mono_wasm_exit(exit_code: number): number;
     mono_wasm_enable_on_demand_gc(enable: number): void;

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -130,6 +130,10 @@ function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: an
     if (!module.no_global_exports) {
         (<any>globalThis).Module = module;
         const warnWrap = (name: string, value: any) => {
+            if (typeof ((<any>globalThis)[name]) !== "undefined") {
+                // it already exists in the global namespace
+                return;
+            }
             let warnOnce = true;
             Object.defineProperty(globalThis, name, {
                 get: () => {

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -26,7 +26,7 @@ import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
     mono_wasm_load_data_archive, mono_wasm_asm_loaded,
-    mono_wasm_invoke_js_blazor, mono_wasm_invoke_js_marshalled, mono_wasm_invoke_js_unmarshalled, mono_wasm_set_main_args
+    mono_wasm_set_main_args
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
@@ -39,7 +39,10 @@ import {
 import {
     call_static_method, mono_bind_static_method, mono_call_assembly_entry_point,
     mono_method_resolve,
+    mono_wasm_compile_function,
     mono_wasm_get_by_index, mono_wasm_get_global_object, mono_wasm_get_object_property,
+    mono_wasm_invoke_js,
+    mono_wasm_invoke_js_blazor,
     mono_wasm_invoke_js_with_args, mono_wasm_set_by_index, mono_wasm_set_object_property,
     _get_args_root_buffer_for_method_call, _get_buffer_for_method_call,
     _handle_exception_for_call, _teardown_after_call
@@ -64,6 +67,10 @@ export const MONO: MONO = <any>{
     mono_wasm_new_root_buffer,
     mono_wasm_new_root,
     mono_wasm_release_roots,
+
+    // for Blazor's future!
+    mono_wasm_add_assembly: cwraps.mono_wasm_add_assembly,
+    mono_wasm_load_runtime: cwraps.mono_wasm_load_runtime,
 
     config: runtimeHelpers.config,
     loaded_files: runtimeHelpers.loaded_files,
@@ -121,11 +128,28 @@ function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: an
 
     // here we expose objects used in tests to global namespace
     if (!module.no_global_exports) {
-        (<any>globalThis).DOTNET = dotnet;
-        (<any>globalThis).MONO = mono;
-        (<any>globalThis).BINDING = binding;
-        (<any>globalThis).INTERNAL = internal;
         (<any>globalThis).Module = module;
+        const warnWrap = (name: string, value: any) => {
+            let warnOnce = true;
+            Object.defineProperty(globalThis, name, {
+                get: () => {
+                    if (warnOnce) {
+                        const stack = (new Error()).stack;
+                        const nextLine = stack ? stack.substr(stack.indexOf("\n", 8) + 1) : "";
+                        console.warn(`global ${name} is obsolete, please use Module.${name} instead ${nextLine}`);
+                        warnOnce = false;
+                    }
+                    return value;
+                }
+            });
+        };
+        warnWrap("MONO", mono);
+        warnWrap("BINDING", binding);
+
+        // Blazor back compat
+        warnWrap("cwrap", Module.cwrap);
+        warnWrap("addRunDependency", Module.addRunDependency);
+        warnWrap("removeRunDependency", Module.removeRunDependency);
     }
 }
 
@@ -143,9 +167,8 @@ const linker_exports = {
     schedule_background_exec,
 
     // also keep in sync with driver.c
+    mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
-    mono_wasm_invoke_js_marshalled,
-    mono_wasm_invoke_js_unmarshalled,
 
     // also keep in sync with corebindings.c
     mono_wasm_invoke_js_with_args,
@@ -168,6 +191,7 @@ const linker_exports = {
     mono_wasm_web_socket_receive,
     mono_wasm_web_socket_close,
     mono_wasm_web_socket_abort,
+    mono_wasm_compile_function,
 
     //  also keep in sync with pal_icushim_static.c
     mono_wasm_load_icu_data,
@@ -231,6 +255,10 @@ export interface MONO {
     mono_wasm_new_root_buffer: typeof mono_wasm_new_root_buffer;
     mono_wasm_new_root: typeof mono_wasm_new_root;
     mono_wasm_release_roots: typeof mono_wasm_release_roots;
+
+    // for Blazor's future!
+    mono_wasm_add_assembly: typeof cwraps.mono_wasm_add_assembly,
+    mono_wasm_load_runtime: typeof cwraps.mono_wasm_load_runtime,
 
     loaded_files: string[];
     config: MonoConfig | MonoConfigError,

--- a/src/mono/wasm/runtime/library-dotnet.js
+++ b/src/mono/wasm/runtime/library-dotnet.js
@@ -5,13 +5,9 @@
 "use strict";
 
 const DotNetSupportLib = {
-    // this will become globalThis.DOTNET
     $DOTNET: {},
-    // this will become globalThis.MONO
     $MONO: {},
-    // this will become globalThis.BINDING
     $BINDING: {},
-    // this will become globalThis.INTERNAL
     $INTERNAL: {},
     // this line will be executed on runtime, populating the objects with methods
     $DOTNET__postset: "__dotnet_runtime.INTERNAL.export_to_emscripten (DOTNET, MONO, BINDING, INTERNAL, Module);",
@@ -31,9 +27,8 @@ const linked_functions = [
     "schedule_background_exec",
 
     // driver.c
+    "mono_wasm_invoke_js",
     "mono_wasm_invoke_js_blazor",
-    "mono_wasm_invoke_js_marshalled",
-    "mono_wasm_invoke_js_unmarshalled",
 
     // corebindings.c
     "mono_wasm_invoke_js_with_args",
@@ -56,6 +51,7 @@ const linked_functions = [
     "mono_wasm_web_socket_receive",
     "mono_wasm_web_socket_close",
     "mono_wasm_web_socket_abort",
+    "mono_wasm_compile_function",
 
     // pal_icushim_static.c
     "mono_wasm_load_icu_data",

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -1,11 +1,11 @@
-import { Module, MONO } from './modules'
+import { Module } from "./modules";
 
-let _temp_mallocs : Array<Array<VoidPtr> | null> = [];
+const _temp_mallocs: Array<Array<VoidPtr> | null> = [];
 
-export function temp_malloc (size : number) : VoidPtr {
+export function temp_malloc(size: number): VoidPtr {
     if (!_temp_mallocs || !_temp_mallocs.length)
         throw new Error("No temp frames have been created at this point");
-        
+
     const frame = _temp_mallocs[_temp_mallocs.length - 1] || [];
     const result = Module._malloc(size);
     frame.push(result);
@@ -13,18 +13,18 @@ export function temp_malloc (size : number) : VoidPtr {
     return result;
 }
 
-export function _create_temp_frame () {
+export function _create_temp_frame(): void {
     _temp_mallocs.push(null);
 }
 
-export function _release_temp_frame () {
+export function _release_temp_frame(): void {
     if (!_temp_mallocs.length)
         throw new Error("No temp frames have been created at this point");
 
     const frame = _temp_mallocs.pop();
     if (!frame)
         return;
-    
+
     for (let i = 0, l = frame.length; i < l; i++)
         Module._free(frame[i]);
 }

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -2,20 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { mono_wasm_new_root, mono_wasm_new_root_buffer, WasmRoot, WasmRootBuffer } from "./roots";
-import { 
-    JSHandle, MonoArray, MonoMethod, MonoObject, 
-    MonoObjectNull, MonoString, coerceNull as coerceNull, 
-    VoidPtr, VoidPtrNull, Int32Ptr
+import {
+    JSHandle, MonoArray, MonoMethod, MonoObject,
+    MonoObjectNull, MonoString, coerceNull as coerceNull,
+    VoidPtr, VoidPtrNull, Int32Ptr, MonoStringNull
 } from "./types";
-import { Module, runtimeHelpers } from "./modules";
+import { BINDING, INTERNAL, Module, MONO, runtimeHelpers } from "./modules";
 import { _mono_array_root_to_js_array, _unbox_mono_obj_root } from "./cs-to-js";
 import { get_js_obj, mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
 import { js_array_to_mono_array, _box_js_bool, _js_to_mono_obj } from "./js-to-cs";
-import { 
-    ArgsMarshalString, mono_bind_method, 
-    Converter, _compile_converter_for_marshal_string, 
-    _decide_if_result_is_marshaled, find_method, 
-    BoundMethodToken 
+import {
+    ArgsMarshalString, mono_bind_method,
+    Converter, _compile_converter_for_marshal_string,
+    _decide_if_result_is_marshaled, find_method,
+    BoundMethodToken
 } from "./method-binding";
 import { conv_string, js_string_to_mono_string } from "./strings";
 import cwraps from "./cwraps";
@@ -36,12 +36,12 @@ function _verify_args_for_method_call(args_marshal: ArgsMarshalString, args: any
     return has_args_marshal && has_args;
 }
 
-export function _get_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null) : VoidPtr | undefined {
+export function _get_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null): VoidPtr | undefined {
     if (!converter)
         return VoidPtrNull;
 
     let result = VoidPtrNull;
-    if (token !== null)	{
+    if (token !== null) {
         result = token.scratchBuffer || VoidPtrNull;
         token.scratchBuffer = VoidPtrNull;
     } else {
@@ -51,7 +51,7 @@ export function _get_buffer_for_method_call(converter: Converter, token: BoundMe
     return result;
 }
 
-export function _get_args_root_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null) : WasmRootBuffer | undefined {
+export function _get_args_root_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null): WasmRootBuffer | undefined {
     if (!converter)
         return undefined;
 
@@ -72,7 +72,7 @@ export function _get_args_root_buffer_for_method_call(converter: Converter, toke
         //  mono_wasm_new_root_buffer_from_pointer instead. Not that important
         //  at present because the scratch buffer will be reused unless we are
         //  recursing through a re-entrant call
-        result = mono_wasm_new_root_buffer (converter.steps.length);
+        result = mono_wasm_new_root_buffer(converter.steps.length);
         // FIXME
         (<any>result).converter = converter;
     }
@@ -88,7 +88,7 @@ function _release_args_root_buffer_from_method_call(
 
     // Store the arguments root buffer for re-use in later calls
     if (token && (token.scratchRootBuffer === null)) {
-        argsRootBuffer.clear ();
+        argsRootBuffer.clear();
         token.scratchRootBuffer = argsRootBuffer;
     } else if (!converter.scratchRootBuffer) {
         argsRootBuffer.clear();
@@ -175,9 +175,9 @@ export function call_method(method: MonoMethod, this_arg: MonoObject | undefined
 
 export function _handle_exception_for_call(
     converter: Converter | undefined, token: BoundMethodToken | null,
-    buffer: VoidPtr, resultRoot: WasmRoot<MonoString>, 
+    buffer: VoidPtr, resultRoot: WasmRoot<MonoString>,
     exceptionRoot: WasmRoot<MonoObject>, argsRootBuffer?: WasmRootBuffer
-) : void {
+): void {
     const exc = _convert_exception_for_method_call(resultRoot.value, exceptionRoot.value);
     if (!exc)
         return;
@@ -188,10 +188,10 @@ export function _handle_exception_for_call(
 
 function _handle_exception_and_produce_result_for_call(
     converter: Converter | undefined, token: BoundMethodToken | null,
-    buffer: VoidPtr, resultRoot: WasmRoot<MonoString>, 
-    exceptionRoot: WasmRoot<MonoObject>, argsRootBuffer: WasmRootBuffer | undefined, 
+    buffer: VoidPtr, resultRoot: WasmRoot<MonoString>,
+    exceptionRoot: WasmRoot<MonoObject>, argsRootBuffer: WasmRootBuffer | undefined,
     is_result_marshaled: boolean
-) : any {
+): any {
     _handle_exception_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
 
     let result: any = resultRoot.value;
@@ -205,9 +205,9 @@ function _handle_exception_and_produce_result_for_call(
 
 export function _teardown_after_call(
     converter: Converter | undefined, token: BoundMethodToken | null,
-    buffer: VoidPtr, resultRoot: WasmRoot<any>, 
+    buffer: VoidPtr, resultRoot: WasmRoot<any>,
     exceptionRoot: WasmRoot<any>, argsRootBuffer?: WasmRootBuffer
-) : void {
+): void {
     _release_temp_frame();
     _release_args_root_buffer_from_method_call(converter, token, argsRootBuffer);
     _release_buffer_from_method_call(converter, token, buffer);
@@ -217,22 +217,22 @@ export function _teardown_after_call(
         if ((token !== null) && (token.scratchResultRoot === null))
             token.scratchResultRoot = resultRoot;
         else
-            resultRoot.release ();
+            resultRoot.release();
     }
     if (exceptionRoot) {
         exceptionRoot.value = 0;
         if ((token !== null) && (token.scratchExceptionRoot === null))
             token.scratchExceptionRoot = exceptionRoot;
         else
-            exceptionRoot.release ();
+            exceptionRoot.release();
     }
 }
 
 function _call_method_with_converted_args(
-    method: MonoMethod, this_arg: MonoObject, converter: Converter | undefined, 
-    token: BoundMethodToken | null, buffer: VoidPtr, 
+    method: MonoMethod, this_arg: MonoObject, converter: Converter | undefined,
+    token: BoundMethodToken | null, buffer: VoidPtr,
     is_result_marshaled: boolean, argsRootBuffer?: WasmRootBuffer
-) : any {
+): any {
     const resultRoot = mono_wasm_new_root<MonoString>(), exceptionRoot = mono_wasm_new_root<MonoObject>();
     resultRoot.value = <any>cwraps.mono_wasm_invoke_method(method, this_arg, buffer, <any>exceptionRoot.get_address());
     return _handle_exception_and_produce_result_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer, is_result_marshaled);
@@ -457,6 +457,15 @@ export function wrap_error(is_exception: Int32Ptr | null, ex: any): MonoString {
     let res = "unknown exception";
     if (ex) {
         res = ex.toString();
+        const stack = ex.stack;
+        if (stack) {
+            // Some JS runtimes insert the error message at the top of the stack, some don't,
+            //  so normalize it by using the stack as the result if it already contains the error
+            if (stack.startsWith(res))
+                res = stack;
+            else
+                res += "\n" + stack;
+        }
     }
     if (is_exception) {
         Module.setValue(is_exception, 1, "i32");
@@ -507,4 +516,73 @@ export function mono_method_resolve(fqn: string): MonoMethod {
     if (!method)
         throw new Error("Could not find method: " + methodname);
     return method;
+}
+
+// Blazor specific custom routine
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function mono_wasm_invoke_js_blazor(exceptionMessage: Int32Ptr, callInfo: any, arg0: any, arg1: any, arg2: any): void | number {
+    try {
+        const blazorExports = (<any>globalThis).Blazor;
+        if (!blazorExports) {
+            throw new Error("The blazor.webassembly.js library is not loaded.");
+        }
+
+        return blazorExports._internal.invokeJSFromDotNet(callInfo, arg0, arg1, arg2);
+    } catch (ex: any) {
+        const exceptionJsString = ex.message + "\n" + ex.stack;
+        const exceptionSystemString = cwraps.mono_wasm_string_from_js(exceptionJsString);
+        Module.setValue(exceptionMessage, <any>exceptionSystemString, "i32"); // *exceptionMessage = exceptionSystemString;
+        return 0;
+    }
+}
+
+// code like `App.call_test_method();`
+export function mono_wasm_invoke_js(code: MonoString, is_exception: Int32Ptr): MonoString | null {
+    if (code === MonoStringNull)
+        return MonoStringNull;
+
+    const js_code = conv_string(code);
+
+    try {
+        const closure = {
+            Module, MONO, BINDING, INTERNAL
+        };
+        const fn_body_template = `const {Module, MONO, BINDING, INTERNAL} = __closure; const __fn = function(){ ${js_code} }; return __fn.call(__closure);`;
+        const fn_defn = new Function("__closure", fn_body_template);
+        const res = fn_defn(closure);
+        Module.setValue(is_exception, 0, "i32");
+        if (typeof res === "undefined" || res === null)
+            return MonoStringNull;
+        if (typeof res !== "string")
+            return wrap_error(is_exception, `Return type of InvokeJS is string. Can't marshal response of type ${typeof res}.`);
+        return js_string_to_mono_string(res);
+    } catch (ex) {
+        return wrap_error(is_exception, ex);
+    }
+}
+
+// TODO is this unused code ?
+// Compiles a JavaScript function from the function data passed.
+// Note: code snippet is not a function definition. Instead it must create and return a function instance.
+// code like `return function() { App.call_test_method(); };`
+export function mono_wasm_compile_function(code: MonoString, is_exception: Int32Ptr): MonoObject {
+    if (code === MonoStringNull)
+        return MonoStringNull;
+
+    const js_code = conv_string(code);
+
+    try {
+        const closure = {
+            Module, MONO, BINDING, INTERNAL
+        };
+        const fn_body_template = `const {Module, MONO, BINDING, INTERNAL} = __closure; ${js_code} ;`;
+        const fn_defn = new Function("__closure", fn_body_template);
+        const res = fn_defn(closure);
+        if (!res || typeof res !== "function")
+            return wrap_error(is_exception, "Code must return an instance of a JavaScript function. Please use `return` statement to return a function.");
+        Module.setValue(is_exception, 0, "i32");
+        return _js_to_mono_obj(true, res);
+    } catch (ex) {
+        return wrap_error(is_exception, ex);
+    }
 }

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { INTERNAL, Module, runtimeHelpers } from "./modules";
-import { AssetEntry, CharPtr, CharPtrNull, Int32Ptr, MonoConfig, MonoString, MonoStringNull, TypedArray, VoidPtr, wasm_type_symbol } from "./types";
+import { AssetEntry, CharPtr, CharPtrNull, MonoConfig, TypedArray, VoidPtr, wasm_type_symbol } from "./types";
 import cwraps from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
 import { mono_wasm_globalization_init, mono_wasm_load_icu_data } from "./icu";
@@ -10,83 +10,7 @@ import { toBase64StringImpl } from "./base64";
 import { mono_wasm_init_aot_profiler, mono_wasm_init_coverage_profiler } from "./profiler";
 import { mono_wasm_load_bytes_into_heap } from "./buffers";
 import { bind_runtime_method, get_method, _create_primitive_converters } from "./method-binding";
-import { conv_string } from "./strings";
 import { find_corlib_class } from "./class-loader";
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function mono_wasm_invoke_js_blazor(exceptionMessage: Int32Ptr, callInfo: any, arg0: any, arg1: any, arg2: any): void | number {
-    try {
-        const blazorExports = (<any>globalThis).Blazor;
-        if (!blazorExports) {
-            throw new Error("The blazor.webassembly.js library is not loaded.");
-        }
-
-        return blazorExports._internal.invokeJSFromDotNet(callInfo, arg0, arg1, arg2);
-    } catch (ex: any) {
-        const exceptionJsString = ex.message + "\n" + ex.stack;
-        const exceptionSystemString = cwraps.mono_wasm_string_from_js(exceptionJsString);
-        Module.setValue(exceptionMessage, <any>exceptionSystemString, "i32"); // *exceptionMessage = exceptionSystemString;
-        return 0;
-    }
-}
-
-// This is for back-compat only and will eventually be removed
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function mono_wasm_invoke_js_marshalled(exceptionMessage: Int32Ptr, asyncHandleLongPtr: number, functionName: MonoString, argsJson: MonoString, treatResultAsVoid: boolean): MonoString {
-    try {
-        // Passing a .NET long into JS via Emscripten is tricky. The method here is to pass
-        // as pointer to the long, then combine two reads from the HEAPU32 array.
-        // Even though JS numbers can't represent the full range of a .NET long, it's OK
-        // because we'll never exceed Number.MAX_SAFE_INTEGER (2^53 - 1) in this case.
-        //var u32Index = $1 >> 2;
-        const u32Index = asyncHandleLongPtr >> 2;
-        const asyncHandleJsNumber = Module.HEAPU32[u32Index + 1] * 4294967296 + Module.HEAPU32[u32Index];
-
-        // var funcNameJsString = UTF8ToString (functionName);
-        // var argsJsonJsString = argsJson && UTF8ToString (argsJson);
-        const funcNameJsString = conv_string(functionName);
-        const argsJsonJsString = argsJson && conv_string(argsJson);
-
-        const dotNetExports = (<any>globalThis).DotNet;
-        if (!dotNetExports) {
-            throw new Error("The Microsoft.JSInterop.js library is not loaded.");
-        }
-
-        if (asyncHandleJsNumber) {
-            dotNetExports.jsCallDispatcher.beginInvokeJSFromDotNet(asyncHandleJsNumber, funcNameJsString, argsJsonJsString, treatResultAsVoid);
-            return MonoStringNull;
-        } else {
-            const resultJson = dotNetExports.jsCallDispatcher.invokeJSFromDotNet(funcNameJsString, argsJsonJsString, treatResultAsVoid);
-            return resultJson === null ? MonoStringNull : cwraps.mono_wasm_string_from_js(resultJson);
-        }
-    } catch (ex: any) {
-        const exceptionJsString = ex.message + "\n" + ex.stack;
-        const exceptionSystemString = cwraps.mono_wasm_string_from_js(exceptionJsString);
-        Module.setValue(exceptionMessage, <any>exceptionSystemString, "i32"); // *exceptionMessage = exceptionSystemString;
-        return MonoStringNull;
-    }
-}
-
-// This is for back-compat only and will eventually be removed
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function mono_wasm_invoke_js_unmarshalled(exceptionMessage: Int32Ptr, funcName: MonoString, arg0: any, arg1: any, arg2: any): void | number {
-    try {
-        // Get the function you're trying to invoke
-        const funcNameJsString = conv_string(funcName);
-        const dotNetExports = (<any>globalThis).DotNet;
-        if (!dotNetExports) {
-            throw new Error("The Microsoft.JSInterop.js library is not loaded.");
-        }
-        const funcInstance = dotNetExports.jsCallDispatcher.findJSFunction(funcNameJsString);
-
-        return funcInstance.call(null, arg0, arg1, arg2);
-    } catch (ex: any) {
-        const exceptionJsString = ex.message + "\n" + ex.stack;
-        const exceptionSystemString = cwraps.mono_wasm_string_from_js(exceptionJsString);
-        Module.setValue(exceptionMessage, <any>exceptionSystemString, "i32"); // *exceptionMessage = exceptionSystemString;
-        return 0;
-    }
-}
 
 // Set environment variable NAME to VALUE
 // Should be called before mono_load_runtime_and_bcl () in most cases
@@ -243,34 +167,37 @@ function _get_fetch_file_cb_from_args(args: MonoConfig): (asset: string) => Prom
     if (typeof (args.fetch_file_cb) === "function")
         return args.fetch_file_cb;
 
-    if (ENVIRONMENT_IS_NODE) {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const fs = require("fs");
-        return function (asset) {
-            console.debug("MONO_WASM: Loading... " + asset);
-            const binary = fs.readFileSync(asset);
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const resolve_func2 = function (resolve: Function, reject: Function) {
-                resolve(new Uint8Array(binary));
-            };
-
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const resolve_func1 = function (resolve: Function, reject: Function) {
-                const response = {
-                    ok: true,
-                    url: asset,
-                    arrayBuffer: function () {
-                        return new Promise(resolve_func2);
-                    }
-                };
-                resolve(response);
-            };
-
-            return new Promise(resolve_func1);
-        };
-    } else if (typeof (fetch) === "function") {
+    if (typeof (fetch) === "function") {
         return function (asset) {
             return fetch(asset, { credentials: "same-origin" });
+        };
+    } else if (ENVIRONMENT_IS_NODE || typeof (read) === "function") {
+        return async function (asset) {
+            let data: any = null;
+            let err: any = null;
+            try {
+                if (ENVIRONMENT_IS_NODE) {
+                    // eslint-disable-next-line @typescript-eslint/no-var-requires
+                    const fs = require("fs");
+                    data = await fs.promises.readFile(asset);
+                }
+                else {
+                    data = read(asset, "binary");
+                }
+            }
+            catch (exc) {
+                data = null;
+                err = exc;
+            }
+            const res: any = {
+                ok: !!data,
+                url: asset,
+                arrayBuffer: async function () {
+                    if (err) throw err;
+                    return new Uint8Array(data);
+                }
+            };
+            return <Response>res;
         };
     } else {
         throw new Error("No fetch_file_cb was provided and this environment does not expose 'fetch'.");
@@ -420,7 +347,7 @@ function _load_assets_and_runtime(args: MonoConfig) {
         if (ctx.pending_count === 0) {
             try {
                 _finalize_startup(args, ctx);
-            } catch (exc : any) {
+            } catch (exc: any) {
                 console.error("Unhandled exception in _finalize_startup", exc);
                 console.error(exc.stack);
                 throw exc;
@@ -593,15 +520,19 @@ export async function mono_wasm_load_config(configFilePath: string): Promise<voi
             const configRaw = await fetch(configFilePath);
             config = await configRaw.json();
         } else if (ENVIRONMENT_IS_NODE) {
-            config = require(configFilePath);
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const fs = require("fs");
+            const json = await fs.promises.readFile(configFilePath);
+            config = JSON.parse(json);
         } else { // shell or worker
-            config = JSON.parse(read(configFilePath)); // read is a v8 debugger command
+            const json = read(configFilePath);// read is a v8 debugger command
+            config = JSON.parse(json);
         }
         runtimeHelpers.config = config;
-    } catch (e) {
+    } catch (exc) {
         const errMessage = "failed to load config file " + configFilePath;
-        console.error(errMessage);
-        runtimeHelpers.config = { message: errMessage, error: e };
+        console.error(errMessage, exc);
+        runtimeHelpers.config = { message: errMessage, error: exc };
     } finally {
         Module.removeRunDependency(configFilePath);
     }

--- a/src/mono/wasm/runtime/types/v8.d.ts
+++ b/src/mono/wasm/runtime/types/v8.d.ts
@@ -2,4 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // read is a v8 debugger command
-declare function read(name: string): string;
+declare function read(name: string, mode?: string): any;

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -66,7 +66,7 @@
       <_EmccCommonFlags Include="-s ALLOW_MEMORY_GROWTH=1" />
       <_EmccCommonFlags Include="-s NO_EXIT_RUNTIME=1" />
       <_EmccCommonFlags Include="-s FORCE_FILESYSTEM=1" />
-      <_EmccCommonFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency']&quot;" />
+      <_EmccCommonFlags Include="-s EXPORTED_RUNTIME_METHODS=&quot;['DOTNET','MONO','BINDING','INTERNAL','FS','print','ccall','cwrap','setValue','getValue','UTF8ToString','UTF8ArrayToString','FS_createPath','FS_createDataFile','removeRunDependency','addRunDependency']&quot;" />
       <_EmccCommonFlags Include="-s EXPORTED_FUNCTIONS=&quot;['_free','_malloc']&quot;" />
       <_EmccCommonFlags Include="--source-map-base http://example.com" />
 
@@ -173,7 +173,7 @@
     <RunWithEmSdkEnv Condition="'$(ContinuousIntegrationBuild)' != 'true'" Command="npm install" EmSdkPath="$(EMSDK_PATH)" IgnoreStandardErrorWarningFormat="true" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>
 
     <!-- code style check -->
-    <RunWithEmSdkEnv Condition="'$(ContinuousIntegrationBuild)' != 'true'" Command="npm run lint" StandardOutputImportance="High" EmSdkPath="$(EMSDK_PATH)" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>
+    <RunWithEmSdkEnv Command="npm run lint" StandardOutputImportance="High" EmSdkPath="$(EMSDK_PATH)" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>
 
     <!-- compile typescript -->
     <RunWithEmSdkEnv Command="npm run rollup -- --environment Configuration:$(Configuration),NativeBinDir:$(NativeBinDir)" EmSdkPath="$(EMSDK_PATH)" IgnoreStandardErrorWarningFormat="true" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>


### PR DESCRIPTION
- simplified fetch and script loading logic/polyfil
- clarified `runtime-test.js` based on Daniel's draft.
- extracted `mono_wasm_invoke_js` and `mono_wasm_compile_function` out of C macro into proper .ts function
- wrapped access to API via `globalThis` with warning on first use
- added `cwraps.mono_wasm_add_assembly` and `cwraps.mono_wasm_load_runtime` which Blazor uses
- fixed closures for generated functions, so that they don't use global `Module` reference
- `mono_wasm_invoke_js` now uses `new Function` instead of `eval()`
- removed deprecated Blazor functions
