### PR TITLE
[DllImportGenerator] Don't flag methods that already have GeneratedDllImport

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportAnalyzer.cs
@@ -58,11 +58,11 @@ namespace Microsoft.Interop.Analyzers
                         }
                     }
 
-                    compilationContext.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, generatedDllImportAttrType, knownUnsupportedTypes), SymbolKind.Method);
+                    compilationContext.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, knownUnsupportedTypes), SymbolKind.Method);
                 });
         }
 
-        private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol generatedDllImportAttrType, List<ITypeSymbol> knownUnsupportedTypes)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context, List<ITypeSymbol> knownUnsupportedTypes)
         {
             var method = (IMethodSymbol)context.Symbol;
 
@@ -75,7 +75,7 @@ namespace Microsoft.Interop.Analyzers
             // This can be the case when the generator creates an extern partial function for blittable signatures.
             foreach (AttributeData attr in method.GetAttributes())
             {
-                if (SymbolEqualityComparer.Default.Equals(generatedDllImportAttrType, attr.AttributeClass))
+                if (attr.AttributeClass?.ToDisplayString() == TypeNames.GeneratedDllImportAttribute)
                 {
                     return;
                 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -4,7 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
 using Xunit;
+
 using static Microsoft.Interop.Analyzers.ConvertToGeneratedDllImportAnalyzer;
 
 using VerifyCS = DllImportGenerator.UnitTests.Verifiers.CSharpAnalyzerVerifier<Microsoft.Interop.Analyzers.ConvertToGeneratedDllImportAnalyzer>;
@@ -147,6 +150,40 @@ partial class Test
         {
             string source = DllImportWithType(type.FullName!);
             await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [ConditionalFact]
+        public async Task GeneratedDllImport_NoDiagnostic()
+        {
+            string source = @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [GeneratedDllImport(""DoesNotExist"")]
+    public static partial void Method();
+}}
+partial class Test
+{{
+    [DllImport(""DoesNotExist"")]
+    public static extern partial void Method();
+}}
+";
+            // Only this test case needs the ancillary reference, so it creates/runs the test directly
+            // instead of going through VerifyAnalyzerAsync
+            (_, MetadataReference ancillary) = TestUtils.GetReferenceAssemblies();
+            var test = new VerifyCS.Test()
+            {
+                TestCode = source
+            };
+            test.SolutionTransforms.Add((solution, projectId) =>
+            {
+                Project project = solution.GetProject(projectId)!;
+                var refs = new List<MetadataReference>(project.MetadataReferences.Count + 1);
+                refs.AddRange(project.MetadataReferences);
+                refs.Add(ancillary);
+                return solution.WithProjectMetadataReferences(projectId, refs);
+            });
+            await test.RunAsync(default);
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Now that we directly generate `DllImport` methods for blittable signatures, we have method symbols with both `DllImport` and `GeneratedDllImport` - the analyzer should not flag these for conversion.