### PR TITLE
[release/6.0] for non-seekable file handles, the OVERLAPPED offset must be set to 0

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
@@ -294,7 +294,7 @@ namespace System.IO.Strategies
 
         public sealed override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
         {
-            long writeOffset = CanSeek ? Interlocked.Add(ref _filePosition, source.Length) - source.Length : -1;
+            long writeOffset = CanSeek ? Interlocked.Add(ref _filePosition, source.Length) - source.Length : 0;
             return RandomAccess.WriteAtOffsetAsync(_fileHandle, source, writeOffset, cancellationToken, this);
         }
 
@@ -311,7 +311,7 @@ namespace System.IO.Strategies
         {
             if (!CanSeek)
             {
-                return RandomAccess.ReadAtOffsetAsync(_fileHandle, destination, fileOffset: -1, cancellationToken);
+                return RandomAccess.ReadAtOffsetAsync(_fileHandle, destination, fileOffset: 0, cancellationToken);
             }
 
             if (LengthCachingSupported && _length >= 0 && Volatile.Read(ref _filePosition) >= _length)


### PR DESCRIPTION
## Customer Impact

Fixes a bug reported by customer via email, where an async read operation performed on a `FileStream` opened for **non-seekable device** file was throwing an `System.IO.IOException`: "The parameter is incorrect".

It turns out that `ReadFile` [doc](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile#parameters) was wrong:

> For an hFile that does not support byte offsets, Offset and OffsetHigh are ignored.

And `OVERLAPPED` [doc](https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped#members) was right:

> This member is nonzero only when performing I/O requests on a seeking device that supports the concept of an offset (also referred to as a file pointer mechanism), such as a file. Otherwise, this member **must be zero**.


## Testing

We already had a test for that, but it's part of Outerloop and that is why the regression was missed:

```log
      System.IO.Tests.DeviceInterfaceTests.DeviceInterfaceCanBeOpenedForAsyncIO [FAIL]
        System.IO.IOException : The parameter is incorrect. : '\\?\hid#vid_0b0e&pid_24c8&mi_03&col02#b&92ae56&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}'
        Stack Trace:
          D:\projects\runtime\src\libraries\System.IO.FileSystem\tests\FileStream\FileStreamConformanceTests.Windows.cs(209,0): at System.IO.Tests.DeviceInterfaceTests.DeviceInterfaceCanBeOpenedForAsyncIO()
          --- End of stack trace from previous location ---
    Finished:    System.IO.FileSystem.Tests
```

The test was used to ensure that it's passing now.

## Risk

Very low.