### PR TITLE
lock protect nullability cache of symbolic regex node

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
@@ -32,6 +32,9 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Creates the context of the previous and the next character kinds.</summary>
         internal static uint Context(uint prevKind, uint nextKind) => (nextKind << 3) | prevKind;
 
+        /// <summary>Number of bits used to represet a character context</summary>
+        internal const int ContextBitWidth = 6;
+
         internal static string DescribePrev(uint i) => i switch
         {
             StartStop => @"\A",

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/CharKind.cs
@@ -29,11 +29,11 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Gets the next character kind from a context</summary>
         internal static uint Next(uint context) => context >> 3;
 
-        /// <summary>Creates the context of the previous and the next character kinds.</summary>
+        /// <summary>Encodes the pair (prevKind, nextKind) using 6 bits</summary>
         internal static uint Context(uint prevKind, uint nextKind) => (nextKind << 3) | prevKind;
 
-        /// <summary>Number of bits used to represet a character context</summary>
-        internal const int ContextBitWidth = 6;
+        /// <summary>Exclusive maximum context (limit) is 64 because a context uses bit-shifting where each kind needs 3 bits.</summary>
+        internal const int ContextLimit = 64;
 
         internal static string DescribePrev(uint i) => i switch
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -359,9 +359,8 @@ namespace System.Text.RegularExpressions.Symbolic
                 Debug.Assert(builder._delta is not null);
 
                 int offset = (currentState.Id << builder._mintermsCount) | mintermId;
-                return
-                    builder._delta[offset] ??
-                    matcher.CreateNewTransition(currentState, minterm, offset);
+                DfaMatchingState<TSetType>? p = Volatile.Read(ref builder._delta[offset]);
+                return p ?? matcher.CreateNewTransition(currentState, minterm, offset);
             }
         }
 
@@ -391,7 +390,8 @@ namespace System.Text.RegularExpressions.Symbolic
                     DfaMatchingState<TSetType> nextStates = builder.MkState(oneState, currentStates.PrevCharKind);
 
                     int offset = (nextStates.Id << builder._mintermsCount) | mintermId;
-                    DfaMatchingState<TSetType> p = builder._delta[offset] ?? matcher.CreateNewTransition(nextStates, minterm, offset);
+                    DfaMatchingState<TSetType>? p_ = Volatile.Read(ref builder._delta[offset]);
+                    DfaMatchingState<TSetType> p = p_ ?? matcher.CreateNewTransition(nextStates, minterm, offset);
 
                     // Observe that if p.Node is an Or it will be flattened.
                     union = builder.MkOr2(union, p.Node);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -359,8 +359,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 Debug.Assert(builder._delta is not null);
 
                 int offset = (currentState.Id << builder._mintermsCount) | mintermId;
-                DfaMatchingState<TSetType>? p = Volatile.Read(ref builder._delta[offset]);
-                return p ?? matcher.CreateNewTransition(currentState, minterm, offset);
+                return Volatile.Read(ref builder._delta[offset]) ?? matcher.CreateNewTransition(currentState, minterm, offset);
             }
         }
 
@@ -390,8 +389,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     DfaMatchingState<TSetType> nextStates = builder.MkState(oneState, currentStates.PrevCharKind);
 
                     int offset = (nextStates.Id << builder._mintermsCount) | mintermId;
-                    DfaMatchingState<TSetType>? p_ = Volatile.Read(ref builder._delta[offset]);
-                    DfaMatchingState<TSetType> p = p_ ?? matcher.CreateNewTransition(nextStates, minterm, offset);
+                    DfaMatchingState<TSetType> p = Volatile.Read(ref builder._delta[offset]) ?? matcher.CreateNewTransition(nextStates, minterm, offset);
 
                     // Observe that if p.Node is an Or it will be flattened.
                     union = builder.MkOr2(union, p.Node);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -254,13 +254,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     break;
             }
 
-            if (is_nullable)
-            {
-                _nullabilityForContext[context] = TrueByte;
-            }
-            else
-            {
-                _nullabilityForContext[context] = FalseByte;
+            Volatile.Write(ref _nullabilityForContext[context], is_nullable ? TrueByte : FalseByte);
             }
 
             return is_nullable;

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -520,8 +520,9 @@ namespace System.Text.RegularExpressions.Tests
                 Assert.Contains("conditional", e.Message);
             }
         }
+        #endregion
 
-
+        #region Random input generation tests
         public static IEnumerable<object[]> GenerateRandomMembers_TestData()
         {
             string[] patterns = new string[] { @"pa[5\$s]{2}w[o0]rd$", @"\w\d+", @"\d{10}" };
@@ -536,7 +537,7 @@ namespace System.Text.RegularExpressions.Tests
                     {
                         foreach (string input in inputs)
                         {
-                            yield return new object[] {engine, pattern, input, !negative };
+                            yield return new object[] { engine, pattern, input, !negative };
                         }
                     }
                 }


### PR DESCRIPTION
Added lock to protect` SymbolicRegexNode._nullabilityCache` that stores conditional nullability of a node for a given context, for thread-safety. This computation is not the common case as it only applies when the node (regex) starts with an anchor and can potentially be _nullable_ (accept the empty string). Initial thought was to special case nullability for context 0 using a field but this is already covered in most common cases when the regex is neither nullable nor can be nullable  that is checked before. The cache could potentially be moved to the builder as a shared cache to avoid the caches in the nodes but would then create bigger probability of thread contention at the builder level.