### PR TITLE
Enable sourcelink in source-build to produce `.version` file in shared fx

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -23,14 +23,6 @@
     <LogVerbosity Condition="'$(LogVerbosity)' == ''">minimal</LogVerbosity>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Work around issue where local clone may cause failure using non-origin remote fallback: https://github.com/dotnet/sourcelink/issues/629 -->
-    <InnerBuildEnv Include="EnableSourceControlManagerQueries=false" />
-    <InnerBuildEnv Include="EnableSourceLink=false" />
-    <InnerBuildEnv Include="DisableSourceLink=true" />
-    <InnerBuildEnv Include="DeterministicSourcePaths=false" />
-  </ItemGroup>
-
   <Target Name="GetRuntimeSourceBuildCommandConfiguration"
           BeforeTargets="GetSourceBuildCommandConfiguration">
     <PropertyGroup>


### PR DESCRIPTION
* For https://github.com/dotnet/source-build/issues/2569
* For https://github.com/dotnet/source-build/issues/1693

In 6.0.100, the source-build team noticed the `.version` file in the source-built shared framework was missing. The file should contain the commit hash and version number. Enabling sourcelink is the clear way to get that infrastructure back online.

---

Enabling sourcelink regresses a dev scenario for Arcade-powered source-build local builds: due to a sourcelink bug, you must use `origin` as a remote name:

* https://github.com/dotnet/sourcelink/issues/629

This probably doesn't affect many people and it's not impossible to adapt to it, so it seems worth going ahead with it anyway.