### PR TITLE
error C2665: 'CorSigUncompressData': none of the 3 overloads could convert all the argument types

### DIFF
--- a/src/coreclr/inc/cor.h
+++ b/src/coreclr/inc/cor.h
@@ -1942,7 +1942,7 @@ inline ULONG CorSigUncompressData(      // return number of bytes of that compre
     ULONG dwSizeOfData = 0;
 
     // We don't know how big the signature is, so we'll just say that it's big enough
-    if (FAILED(CorSigUncompressData(pData, 0xff, pDataOut, &dwSizeOfData)))
+    if (FAILED(CorSigUncompressData(pData, 0xff, reinterpret_cast<uint32_t *>(pDataOut), reinterpret_cast<uint32_t *>(&dwSizeOfData))))
     {
         *pDataOut = 0;
         return (ULONG)-1;


### PR DESCRIPTION
Fix for `cor.h(1951,8): error C2665: 'CorSigUncompressData': none of the 3 overloads could convert all the argument types` on VS2019 v16.7 with warning level 4.