### PR TITLE
throw exception when creating an entry name that already exists in ZipArchive

### DIFF
--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -309,6 +309,6 @@
     <value>Zip 64 End of Central Directory Record not where indicated.</value>
   </data>
   <data name="EntryNameAlreadyExists" xml:space="preserve">
-    <value>The entry name '{0}' already exists in the archive.</value>
+    <value>An entry named '{0}' already exists in the archive.</value>
   </data>
 </root>

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -308,4 +308,7 @@
   <data name="Zip64EOCDNotWhereExpected" xml:space="preserve">
     <value>Zip 64 End of Central Directory Record not where indicated.</value>
   </data>
+  <data name="EntryNameAlreadyExists" xml:space="preserve">
+    <value>The entry name already exists in the archive.</value>
+  </data>
 </root>

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -309,6 +309,6 @@
     <value>Zip 64 End of Central Directory Record not where indicated.</value>
   </data>
   <data name="EntryNameAlreadyExists" xml:space="preserve">
-    <value>The entry name already exists in the archive.</value>
+    <value>The entry name '{0}' already exists in the archive.</value>
   </data>
 </root>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -426,7 +426,7 @@ namespace System.IO.Compression
         private void AddEntry(ZipArchiveEntry entry)
         {
             _entries.Add(entry);
-            _entriesDictionary.Add(entry.FullName, entry);
+            _entriesDictionary.TryAdd(entry.FullName, entry);
         }
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -390,7 +390,7 @@ namespace System.IO.Compression
 
             if (_entriesDictionary.ContainsKey(entryName))
             {
-                throw new InvalidOperationException(SR.EntryNameAlreadyExists);
+                throw new InvalidOperationException(string.Format(SR.EntryNameAlreadyExists, entryName));
             }
 
             ThrowIfDisposed();

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -388,6 +388,11 @@ namespace System.IO.Compression
             if (_mode == ZipArchiveMode.Read)
                 throw new NotSupportedException(SR.CreateInReadMode);
 
+            if (_entriesDictionary.ContainsKey(entryName))
+            {
+                throw new InvalidOperationException(SR.EntryNameAlreadyExists);
+            }
+
             ThrowIfDisposed();
 
 
@@ -421,16 +426,7 @@ namespace System.IO.Compression
         private void AddEntry(ZipArchiveEntry entry)
         {
             _entries.Add(entry);
-
-            string entryName = entry.FullName;
-            if (!_entriesDictionary.ContainsKey(entryName))
-            {
-                _entriesDictionary.Add(entryName, entry);
-            }
-            else
-            {
-                throw new InvalidOperationException(SR.EntryNameAlreadyExists);
-            }
+            _entriesDictionary.Add(entry.FullName, entry);
         }
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -427,6 +427,10 @@ namespace System.IO.Compression
             {
                 _entriesDictionary.Add(entryName, entry);
             }
+            else
+            {
+                throw new InvalidOperationException(SR.EntryNameAlreadyExists);
+            }
         }
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -188,9 +188,10 @@ namespace System.IO.Compression.Tests
             // Creation will go through the path that sets the data descriptor bit when the stream is unseekable
             using (var archive = new ZipArchive(wrappedStream, ZipArchiveMode.Create))
             {
-                CreateEntry(archive, "A", "xxx");
-                AssertExtensions.ThrowsContains<InvalidOperationException>(() => CreateEntry(archive, "A", "yyy"),
-                    "The entry name 'A' already exists in the archive.");
+                string entryName = "duplicate.txt";
+                CreateEntry(archive, entryName, "xxx");
+                AssertExtensions.ThrowsContains<InvalidOperationException>(() => CreateEntry(archive, entryName, "yyy"),
+                    entryName);
             }
         }
 

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -178,6 +178,21 @@ namespace System.IO.Compression.Tests
             AssertDataDescriptor(memoryStream, false);
         }
 
+        [Fact]
+        public static void CreateNormal_With2SameEntries_ThrowException()
+        {
+            using var memoryStream = new MemoryStream();
+            // We need an non-seekable stream so the data descriptor bit is turned on when saving
+            var wrappedStream = new WrappedStream(memoryStream);
+
+            // Creation will go through the path that sets the data descriptor bit when the stream is unseekable
+            using (var archive = new ZipArchive(wrappedStream, ZipArchiveMode.Create))
+            {
+                CreateEntry(archive, "A", "xxx");
+                Assert.Throws<InvalidOperationException>(() => CreateEntry(archive, "A", "yyy"));
+            }
+        }
+
         private static string ReadStringFromSpan(Span<byte> input)
         {
             return Text.Encoding.UTF8.GetString(input.ToArray());

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -189,7 +189,8 @@ namespace System.IO.Compression.Tests
             using (var archive = new ZipArchive(wrappedStream, ZipArchiveMode.Create))
             {
                 CreateEntry(archive, "A", "xxx");
-                Assert.Throws<InvalidOperationException>(() => CreateEntry(archive, "A", "yyy"));
+                AssertExtensions.ThrowsContains<InvalidOperationException>(() => CreateEntry(archive, "A", "yyy"),
+                    "The entry name 'A' already exists in the archive.");
             }
         }
 

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -102,8 +102,9 @@ namespace System.IO.Compression.Tests
                 }
                 else
                 {
-                    ZipArchiveEntry e = archive.GetEntry("data2.txt");
-                    e.Delete();
+                    Assert.Throws<InvalidOperationException>(() => AddEntry(archive, "data1.txt", data1, lastWrite));
+
+                    Assert.Throws<InvalidOperationException>(() => archive.CreateEntry("empty.txt"));
                 }
             }
 
@@ -119,8 +120,9 @@ namespace System.IO.Compression.Tests
                 }
                 else
                 {
-                    ZipArchiveEntry e = archive.GetEntry("data2.txt");
-                    e.Delete();
+                    Assert.Throws<InvalidOperationException>(() => AddEntry(archive, "data1.txt", data1, lastWrite));
+
+                    Assert.Throws<InvalidOperationException>(() => archive.CreateEntry("empty.txt"));
                 }
             }
             //compare

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -92,20 +92,36 @@ namespace System.IO.Compression.Tests
             baseline = baseline.Clone();
             using (ZipArchive archive = new ZipArchive(baseline, mode))
             {
-                AddEntry(archive, "data1.txt", data1, lastWrite);
+                if (mode == ZipArchiveMode.Create)
+                {
+                    AddEntry(archive, "data1.txt", data1, lastWrite);
 
-                ZipArchiveEntry e = archive.CreateEntry("empty.txt");
-                e.LastWriteTime = lastWrite;
-                using (Stream s = e.Open()) { }
+                    ZipArchiveEntry e = archive.CreateEntry("empty.txt");
+                    e.LastWriteTime = lastWrite;
+                    using (Stream s = e.Open()) { }
+                }
+                else
+                {
+                    ZipArchiveEntry e = archive.GetEntry("data2.txt");
+                    e.Delete();
+                }
             }
 
             test = test.Clone();
             using (ZipArchive archive = new ZipArchive(test, mode))
             {
-                AddEntry(archive, "data1.txt", data1, lastWrite);
+                if (mode == ZipArchiveMode.Create)
+                {
+                    AddEntry(archive, "data1.txt", data1, lastWrite);
 
-                ZipArchiveEntry e = archive.CreateEntry("empty.txt");
-                e.LastWriteTime = lastWrite;
+                    ZipArchiveEntry e = archive.CreateEntry("empty.txt");
+                    e.LastWriteTime = lastWrite;
+                }
+                else
+                {
+                    ZipArchiveEntry e = archive.GetEntry("data2.txt");
+                    e.Delete();
+                }
             }
             //compare
             Assert.True(ArraysEqual(baseline.ToArray(), test.ToArray()), "Arrays didn't match after update");


### PR DESCRIPTION
Fixes #51051