### PR TITLE
Vectorize SpanHelpers<T>.IndexOf

### DIFF
--- a/src/libraries/System.Memory/tests/Span/Contains.T.cs
+++ b/src/libraries/System.Memory/tests/Span/Contains.T.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.SpanTests
@@ -192,6 +194,115 @@ namespace System.SpanTests
         {
             Span<string> theStrings = spanInput;
             Assert.Equal(expected, theStrings.Contains(null));
+        }
+
+        [Theory]
+        [InlineData(new int[] { 1, 2, 3, 4 }, 4, true)]
+        [InlineData(new int[] { 1, 2, 3, 4 }, 5, false)]
+        public static void Contains_Int32(int[] array, int value, bool expectedResult)
+        {
+            // Test with short Span
+            Span<int> span = new Span<int>(array);
+            bool result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+
+            // Test with long Span
+            for (int i = 0; i < 10; i++)
+                array = array.Concat(array).ToArray();
+            span = new Span<int>(array);
+            result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData(new long[] { 1, 2, 3, 4 }, 4, true)]
+        [InlineData(new long[] { 1, 2, 3, 4 }, 5, false)]
+        public static void Contains_Int64(long[] array, long value, bool expectedResult)
+        {
+            // Test with short Span
+            Span<long> span = new Span<long>(array);
+            bool result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+
+            // Test with long Span
+            for (int i = 0; i < 10; i++)
+                array = array.Concat(array).ToArray();
+            span = new Span<long>(array);
+            result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 1, 2, 3, 4 }, 4, true)]
+        [InlineData(new byte[] { 1, 2, 3, 4 }, 5, false)]
+        public static void Contains_Byte(byte[] array, byte value, bool expectedResult)
+        {
+            // Test with short Span
+            Span<byte> span = new Span<byte>(array);
+            bool result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+
+            // Test with long Span
+            for (int i = 0; i < 10; i++)
+                array = array.Concat(array).ToArray();
+            span = new Span<byte>(array);
+            result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData(new char[] { 'a', 'b', 'c', 'd' }, 'd', true)]
+        [InlineData(new char[] { 'a', 'b', 'c', 'd' }, 'e', false)]
+        public static void Contains_Char(char[] array, char value, bool expectedResult)
+        {
+            // Test with short Span
+            Span<char> span = new Span<char>(array);
+            bool result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+
+            // Test with long Span
+            for (int i = 0; i < 10; i++)
+                array = array.Concat(array).ToArray();
+            span = new Span<char>(array);
+            result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+
+        }
+
+        [Theory]
+        [InlineData(new float[] { 1, 2, 3, 4 }, 4, true)]
+        [InlineData(new float[] { 1, 2, 3, 4 }, 5, false)]
+        public static void Contains_Float(float[] array, float value, bool expectedResult)
+        {
+            // Test with short Span
+            Span<float> span = new Span<float>(array);
+            bool result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+
+            // Test with long Span
+            for (int i = 0; i < 10; i++)
+                array = array.Concat(array).ToArray();
+            span = new Span<float>(array);
+            result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData(new double[] { 1, 2, 3, 4 }, 4, true)]
+        [InlineData(new double[] { 1, 2, 3, 4 }, 5, false)]
+        public static void Contains_Double(double[] array, double value, bool expectedResult)
+        {
+            // Test with short Span
+            Span<double> span = new Span<double>(array);
+            bool result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
+
+            // Test with long Span
+            for (int i = 0; i < 10; i++)
+                array = array.Concat(array).ToArray();
+            span = new Span<double>(array);
+            result = span.Contains(value);
+            Assert.Equal(result, expectedResult);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1212,42 +1212,7 @@ namespace System
                 ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
 
-            if (SpanHelpers.CanVectorizeIndexOfForType<T>())
-            {
-                if (Unsafe.SizeOf<T>() == sizeof(byte))
-                {
-                    int result = SpanHelpers.IndexOfValueType(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<byte[]>(array)), startIndex),
-                        Unsafe.As<T, byte>(ref value),
-                        count);
-                    return (result >= 0 ? startIndex : 0) + result;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(char))
-                {
-                    int result = SpanHelpers.IndexOfValueType(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<char[]>(array)), startIndex),
-                        Unsafe.As<T, char>(ref value),
-                        count);
-                    return (result >= 0 ? startIndex : 0) + result;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(int))
-                {
-                    int result = SpanHelpers.IndexOfValueType(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<int[]>(array)), startIndex),
-                        Unsafe.As<T, int>(ref value),
-                        count);
-                    return (result >= 0 ? startIndex : 0) + result;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(long))
-                {
-                    int result = SpanHelpers.IndexOfValueType(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<long[]>(array)), startIndex),
-                        Unsafe.As<T, long>(ref value),
-                        count);
-                    return (result >= 0 ? startIndex : 0) + result;
-                }
-            }
-            else if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
@@ -1267,18 +1232,28 @@ namespace System
                 }
                 else if (Unsafe.SizeOf<T>() == sizeof(int))
                 {
-                    int result = SpanHelpers.IndexOf(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<int[]>(array)), startIndex),
-                        Unsafe.As<T, int>(ref value),
-                        count);
+                    int result = typeof(T).IsValueType && SpanHelpers.CanVectorizeIndexOfForType<T>()
+                        ? SpanHelpers.IndexOfValueType(
+                            ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<int[]>(array)), startIndex),
+                            Unsafe.As<T, int>(ref value),
+                            count)
+                        : SpanHelpers.IndexOf(
+                            ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<int[]>(array)), startIndex),
+                            Unsafe.As<T, int>(ref value),
+                            count);
                     return (result >= 0 ? startIndex : 0) + result;
                 }
                 else if (Unsafe.SizeOf<T>() == sizeof(long))
                 {
-                    int result = SpanHelpers.IndexOf(
-                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<long[]>(array)), startIndex),
-                        Unsafe.As<T, long>(ref value),
-                        count);
+                    int result = typeof(T).IsValueType && SpanHelpers.CanVectorizeIndexOfForType<T>()
+                        ? SpanHelpers.IndexOfValueType(
+                            ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<long[]>(array)), startIndex),
+                            Unsafe.As<T, long>(ref value),
+                            count)
+                        : SpanHelpers.IndexOf(
+                            ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<long[]>(array)), startIndex),
+                            Unsafe.As<T, long>(ref value),
+                            count);
                     return (result >= 0 ? startIndex : 0) + result;
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1232,7 +1232,7 @@ namespace System
                 }
                 else if (Unsafe.SizeOf<T>() == sizeof(int))
                 {
-                    int result = typeof(T).IsValueType && SpanHelpers.CanVectorizeIndexOfForType<T>()
+                    int result = typeof(T).IsValueType
                         ? SpanHelpers.IndexOfValueType(
                             ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<int[]>(array)), startIndex),
                             Unsafe.As<T, int>(ref value),
@@ -1245,7 +1245,7 @@ namespace System
                 }
                 else if (Unsafe.SizeOf<T>() == sizeof(long))
                 {
-                    int result = typeof(T).IsValueType && SpanHelpers.CanVectorizeIndexOfForType<T>()
+                    int result = typeof(T).IsValueType
                         ? SpanHelpers.IndexOfValueType(
                             ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<long[]>(array)), startIndex),
                             Unsafe.As<T, long>(ref value),

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1212,7 +1212,42 @@ namespace System
                 ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count();
             }
 
-            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            if (SpanHelpers.CanVectorizeIndexOfForType<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(byte))
+                {
+                    int result = SpanHelpers.IndexOfValueType(
+                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<byte[]>(array)), startIndex),
+                        Unsafe.As<T, byte>(ref value),
+                        count);
+                    return (result >= 0 ? startIndex : 0) + result;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(char))
+                {
+                    int result = SpanHelpers.IndexOfValueType(
+                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<char[]>(array)), startIndex),
+                        Unsafe.As<T, char>(ref value),
+                        count);
+                    return (result >= 0 ? startIndex : 0) + result;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    int result = SpanHelpers.IndexOfValueType(
+                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<int[]>(array)), startIndex),
+                        Unsafe.As<T, int>(ref value),
+                        count);
+                    return (result >= 0 ? startIndex : 0) + result;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                {
+                    int result = SpanHelpers.IndexOfValueType(
+                        ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(Unsafe.As<long[]>(array)), startIndex),
+                        Unsafe.As<T, long>(ref value),
+                        count);
+                    return (result >= 0 ? startIndex : 0) + result;
+                }
+            }
+            else if (RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -279,6 +279,18 @@ namespace System
                         ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, char>(ref value),
                         span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(int))
+                    return -1 != SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, int>(ref value),
+                        span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(long))
+                    return -1 != SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, long>(ref value),
+                        span.Length);
             }
 
             return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
@@ -306,6 +318,18 @@ namespace System
                         ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, char>(ref value),
                         span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(int))
+                    return -1 != SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, int>(ref value),
+                        span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(long))
+                    return -1 != SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, long>(ref value),
+                        span.Length);
             }
 
             return SpanHelpers.Contains(ref MemoryMarshal.GetReference(span), value, span.Length);
@@ -331,6 +355,18 @@ namespace System
                     return SpanHelpers.IndexOf(
                         ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, char>(ref value),
+                        span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(int))
+                    return SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, int>(ref value),
+                        span.Length);
+
+                if (Unsafe.SizeOf<T>() == sizeof(long))
+                    return SpanHelpers.IndexOfValueType(
+                        ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
+                        Unsafe.As<T, long>(ref value),
                         span.Length);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -315,8 +315,6 @@ namespace System
             }
             while (length >= 8)
             {
-                length -= 8;
-
                 if (value.Equals(Unsafe.Add(ref searchSpace, index)))
                     goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
@@ -334,13 +332,12 @@ namespace System
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 7)))
                     goto Found7;
 
+                length -= 8;
                 index += 8;
             }
 
-            if (length >= 4)
+            while (length >= 4)
             {
-                length -= 4;
-
                 if (value.Equals(Unsafe.Add(ref searchSpace, index)))
                     goto Found;
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 1)))
@@ -350,6 +347,7 @@ namespace System
                 if (value.Equals(Unsafe.Add(ref searchSpace, index + 3)))
                     goto Found3;
 
+                length -= 4;
                 index += 4;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -322,7 +322,7 @@ namespace System
                 {
                     // Number of elements is not a multiple of Vector<T>.Count, so do one
                     // check and shift only enough for the remaining set to be a multiple
-                    // of Vecotr<T>.Count.
+                    // of Vector<T>.Count.
                     compareVector = Unsafe.As<T, Vector<T>>(ref Unsafe.Add(ref searchSpace, index));
                     matchVector = Vector.Equals(valueVector, compareVector);
                     if (matchVector != Vector<T>.Zero)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -313,7 +313,7 @@ namespace System
             Debug.Assert(length >= 0);
 
             nint index = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
-            if (Vector.IsHardwareAccelerated && CanVectorizeIndexOfForType<T>() && (Vector<T>.Count * 2) <= length)
+            if (Vector.IsHardwareAccelerated && Vector<T>.IsTypeSupported && (Vector<T>.Count * 2) <= length)
             {
                 Vector<T> valueVector = new Vector<T>(value);
                 Vector<T> compareVector = default;
@@ -349,7 +349,7 @@ namespace System
                     if (compareVector[i].Equals(value))
                         return (int)(index + i);
             }
-            
+
             while (length >= 8)
             {
                 if (value.Equals(Unsafe.Add(ref searchSpace, index)))
@@ -1267,22 +1267,6 @@ namespace System
                     return result;
             }
             return firstLength.CompareTo(secondLength);
-        }
-
-        internal static bool CanVectorizeIndexOfForType<T>()
-        {
-            return (typeof(T) == typeof(byte)) ||
-                   (typeof(T) == typeof(double)) ||
-                   (typeof(T) == typeof(short)) ||
-                   (typeof(T) == typeof(int)) ||
-                   (typeof(T) == typeof(long)) ||
-                   (typeof(T) == typeof(nint)) ||
-                   (typeof(T) == typeof(nuint)) ||
-                   (typeof(T) == typeof(sbyte)) ||
-                   (typeof(T) == typeof(float)) ||
-                   (typeof(T) == typeof(ushort)) ||
-                   (typeof(T) == typeof(uint)) ||
-                   (typeof(T) == typeof(ulong));
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -226,22 +226,6 @@ namespace System
         {
             Debug.Assert(length >= 0);
 
-            if (typeof(T).IsValueType && RuntimeHelpers.IsBitwiseEquatable<T>())
-            {
-                // bool and char will already have been checked before, just do checks for types
-                // that are equal to sizeof(int) or sizeof(long)
-                if (Unsafe.SizeOf<T>() == sizeof(int))
-                {
-                    int result = IndexOfValueType(ref Unsafe.As<T, int>(ref searchSpace), Unsafe.As<T, int>(ref value), length);
-                    return result != -1;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(long))
-                {
-                    int result = IndexOfValueType(ref Unsafe.As<T, long>(ref searchSpace), Unsafe.As<T, long>(ref value), length);
-                    return result != -1;
-                }
-            }
-
             nint index = 0; // Use nint for arithmetic to avoid unnecessary 64->32->64 truncations
 
             if (default(T) != null || (object)value != null)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -318,7 +318,7 @@ namespace System
                 Vector<T> valueVector = new Vector<T>(value);
                 Vector<T> compareVector = default;
                 Vector<T> matchVector = default;
-                if (length % Vector<T>.Count != 0)
+                if ((uint)length % (uint)Vector<T>.Count != 0)
                 {
                     // Number of elements is not a multiple of Vector<T>.Count, so do one
                     // check and shift only enough for the remaining set to be a multiple
@@ -349,6 +349,7 @@ namespace System
                     if (compareVector[i].Equals(value))
                         return (int)(index + i);
             }
+            
             while (length >= 8)
             {
                 if (value.Equals(Unsafe.Add(ref searchSpace, index)))

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -226,7 +226,7 @@ namespace System
         {
             Debug.Assert(length >= 0);
 
-            if (typeof(T).IsValueType)
+            if (typeof(T).IsValueType && RuntimeHelpers.IsBitwiseEquatable<T>())
             {
                 // bool and char will already have been checked before, just do checks for types
                 // that are equal to sizeof(int) or sizeof(long)


### PR DESCRIPTION
Add a vectorized path in `SpanHelpers.T.cs` for value types that performs the same logic as `SpanHelpers.IndexOf<T>` but will vectorize the operations where possible.

Baseline is commit 31c38ef019883f3042119.

Benchmark results:

```
PS C:\Users\acovingt\source\repos\performance> py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter System.Collections.Contains*Int32* System.Memory.Span*Int32*IndexOf* System.Tests.Perf_Array.IndexOf* --corerun C:\Users\acovingt\source\repos\runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe --bdn-artifacts C:\Users\acovingt\Documents\micro-compare-final\runtime\ --bdn-arguments "--launchCount 5"
PS C:\Users\acovingt\source\repos\performance> py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter System.Collections.Contains*Int32* System.Memory.Span*Int32*IndexOf* System.Tests.Perf_Array.IndexOf* --corerun C:\Users\acovingt\source\repos\runtime-master\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe --bdn-artifacts C:\Users\acovingt\Documents\micro-compare-final\runtime-master\ --bdn-arguments "--launchCount 5"
PS C:\Users\acovingt\source\repos\performance\src\tools\ResultsComparer> dotnet run -- --base C:\Users\acovingt\Documents\micro-compare-final\runtime-master\results\ --diff C:\Users\acovingt\Documents\micro-compare-final\runtime\results\ --threshold 3% --noise 5ns
summary:
better: 11, geomean: 1.979
total diff: 11

No Slower results for the provided threshold = 3% and noise filter = 5ns.

| Faster                                                            | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ----------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Collections.ContainsFalse<Int32>.ICollection(Size: 512)    |      2.97 |         49319.68 |         16603.82 |         |
| System.Collections.ContainsFalse<Int32>.ImmutableArray(Size: 512) |      2.77 |         50947.90 |         18381.32 |         |
| System.Collections.ContainsFalse<Int32>.Queue(Size: 512)          |      2.23 |         46246.47 |         20723.50 |         |
| System.Collections.ContainsFalse<Int32>.Array(Size: 512)          |      2.06 |         49333.88 |         23935.60 |         |
| System.Collections.ContainsTrue<Int32>.Array(Size: 512)           |      1.95 |         34437.90 |         17660.55 |         |
| System.Collections.ContainsFalse<Int32>.List(Size: 512)           |      1.89 |         44184.18 |         23359.91 |         |
| System.Collections.ContainsTrue<Int32>.ImmutableArray(Size: 512)  |      1.87 |         35886.60 |         19165.18 |         |
| System.Collections.ContainsTrue<Int32>.List(Size: 512)            |      1.78 |         33536.09 |         18847.10 |         |
| System.Collections.ContainsTrue<Int32>.ICollection(Size: 512)     |      1.76 |         34361.86 |         19510.32 |         |
| System.Collections.ContainsTrue<Int32>.Queue(Size: 512)           |      1.74 |         34743.45 |         19957.12 |         |
| System.Memory.Span<Int32>.LastIndexOfAnyValues(Size: 512)         |      1.28 |           103.35 |            80.87 |         |
```