### PR TITLE
[mono] Add mono_class_get_special_jit_flags and MONO_SPECIAL_JIT_DEFER_CLASS_INIT_TO_CTOR

### DIFF
--- a/src/mono/mono/metadata/class-accessors.c
+++ b/src/mono/mono/metadata/class-accessors.c
@@ -25,7 +25,8 @@ typedef enum {
 	PROP_FIELD_DEF_VALUES = 7, /* MonoFieldDefaultValue* */
 	PROP_DECLSEC_FLAGS = 8, /* guint32 */
 	PROP_WEAK_BITMAP = 9,
-	PROP_DIM_CONFLICTS = 10 /* GSList of MonoMethod* */
+	PROP_DIM_CONFLICTS = 10, /* GSList of MonoMethod* */
+	PROP_SPECIAL_JIT_FLAGS = 11, /* guint32 */
 }  InfrequentDataKind;
 
 /* Accessors based on class kind*/
@@ -402,6 +403,24 @@ mono_class_set_declsec_flags (MonoClass *klass, guint32 value)
 	prop->head.tag = PROP_DECLSEC_FLAGS;
 	prop->value = value;
 	mono_property_bag_add (m_class_get_infrequent_data (klass), prop);
+}
+
+void
+mono_class_set_special_jit_flags (MonoClass *klass, guint32 value)
+{
+	Uint32Property *prop = (Uint32Property*)mono_class_alloc (klass, sizeof (Uint32Property));
+	prop->head.tag = PROP_SPECIAL_JIT_FLAGS;
+	prop->value = value;
+	mono_property_bag_add (m_class_get_infrequent_data (klass), prop);
+}
+
+guint32
+mono_class_get_special_jit_flags (MonoClass *klass)
+{
+	if (!m_class_has_special_jit_flags (klass))
+		return 0;
+	Uint32Property *prop = (Uint32Property*)mono_property_bag_get (m_class_get_infrequent_data (klass), PROP_SPECIAL_JIT_FLAGS);
+	return prop ? prop->value : 0;
 }
 
 void

--- a/src/mono/mono/metadata/class-getters.h
+++ b/src/mono/mono/metadata/class-getters.h
@@ -48,6 +48,7 @@ MONO_CLASS_GETTER(m_class_is_fields_inited, gboolean, , MonoClass, fields_inited
 MONO_CLASS_GETTER(m_class_has_failure, gboolean, , MonoClass, has_failure)
 MONO_CLASS_GETTER(m_class_has_weak_fields, gboolean, , MonoClass, has_weak_fields)
 MONO_CLASS_GETTER(m_class_has_dim_conflicts, gboolean, , MonoClass, has_dim_conflicts)
+MONO_CLASS_GETTER(m_class_has_special_jit_flags, gboolean, , MonoClass, has_special_jit_flags)
 MONO_CLASS_GETTER(m_class_get_parent, MonoClass *, , MonoClass, parent)
 MONO_CLASS_GETTER(m_class_get_nested_in, MonoClass *, ,  MonoClass, nested_in)
 MONO_CLASS_GETTER(m_class_get_image, MonoImage *, , MonoClass, image)

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -417,7 +417,7 @@ struct MonoSpecialJitHandlingClass {
  * FIXME: use the MVID or an assembly version range, too?
  */
 static struct MonoSpecialJitHandlingClass special_jit_handling_classes[] = {
-	{ "xunit.console.dll", "Xunit.ConsoleClient", "ConsoleRunner", MONO_SPECIAL_JIT_USE_ICALL_NEWOBJ },
+	{ "xunit.console.dll", "Xunit.ConsoleClient", "ConsoleRunner", MONO_SPECIAL_JIT_DEFER_CLASS_INIT_TO_CTOR },
 };
 
 static guint32

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -578,6 +578,16 @@ typedef struct {
 	MonoMethod *wrapper_method;
 } MonoJitICallInfo;
 
+/* Flags on classes that require some different handling by the JIT.  See
+ * m_class_has_special_jit_flags() and mono_class_get_special_jit_flags()
+ */
+enum MonoSpecialJitClassFlags {
+	/* The MONO_CEE_NEWONJ opcode should avoid initializing the class at JIT time; delegate
+	 * class initialization and instance creation to an icall at runtime.
+	 */
+	MONO_SPECIAL_JIT_USE_ICALL_NEWOBJ = 0x01,
+};
+
 MONO_COMPONENT_API void
 mono_class_setup_supertypes (MonoClass *klass);
 
@@ -1414,6 +1424,12 @@ mono_class_get_declsec_flags (MonoClass *klass);
 
 void
 mono_class_set_declsec_flags (MonoClass *klass, guint32 value);
+
+guint32
+mono_class_get_special_jit_flags (MonoClass *klass);
+
+void
+mono_class_set_special_jit_flags (MonoClass *klass, guint32 value);
 
 void
 mono_class_set_is_com_object (MonoClass *klass);

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -582,10 +582,10 @@ typedef struct {
  * m_class_has_special_jit_flags() and mono_class_get_special_jit_flags()
  */
 enum MonoSpecialJitClassFlags {
-	/* The MONO_CEE_NEWONJ opcode should avoid initializing the class at JIT time; delegate
-	 * class initialization and instance creation to an icall at runtime.
+	/* The MONO_CEE_NEWOBJ and MONO_CEE_CALL opcodes should avoid initializing the class at JIT time; delegate
+	 * class initialization until the first instance is created, by using an icall for instance construction.
 	 */
-	MONO_SPECIAL_JIT_USE_ICALL_NEWOBJ = 0x01,
+	MONO_SPECIAL_JIT_DEFER_CLASS_INIT_TO_CTOR = 0x01,
 };
 
 MONO_COMPONENT_API void

--- a/src/mono/mono/metadata/class-private-definition.h
+++ b/src/mono/mono/metadata/class-private-definition.h
@@ -80,6 +80,7 @@ struct _MonoClass {
 	guint has_failure : 1; /* See mono_class_get_exception_data () for a MonoErrorBoxed with the details */
 	guint has_weak_fields : 1; /* class has weak reference fields */
 	guint has_dim_conflicts : 1; /* Class has conflicting default interface methods */
+	guint has_special_jit_flags : 1; /* Class has PROP_SPECIAL_JIT_FLAGS property */
 
 	MonoClass  *parent;
 	MonoClass  *nested_in;

--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -206,6 +206,7 @@ MONO_JIT_ICALL (mono_helper_compile_generic_method) \
 MONO_JIT_ICALL (mono_helper_ldstr) \
 MONO_JIT_ICALL (mono_helper_ldstr_mscorlib) \
 MONO_JIT_ICALL (mono_helper_newobj_mscorlib) \
+MONO_JIT_ICALL (mono_helper_newobj_from_token) \
 MONO_JIT_ICALL (mono_helper_stelem_ref_check) \
 MONO_JIT_ICALL (mono_init_vtable_slot) \
 MONO_JIT_ICALL (mono_interp_entry_from_trampoline) \

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1151,6 +1151,23 @@ mono_helper_newobj_mscorlib (guint32 idx)
 	return obj;
 }
 
+MonoObject*
+mono_helper_newobj_from_token (MonoImage *image, guint32 ctor_token)
+{
+	ERROR_DECL (error);
+	MonoMethod *ctor = mono_get_method_checked (image, ctor_token, NULL, NULL/*context*/, error);
+	if (!is_ok (error)) {
+		mono_error_set_pending_exception (error);
+		return NULL;
+	}
+	MonoClass *klass = ctor->klass;
+	MonoObject *obj = mono_object_new_checked (klass, error);
+	if (!is_ok (error))
+		mono_error_set_pending_exception (error);
+	return obj;
+}
+	
+
 /*
  * On some architectures, gdb doesn't like encountering the cpu breakpoint instructions
  * in generated code. So instead we emit a call to this function and place a gdb

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -114,6 +114,8 @@ ICALL_EXPORT MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
 
 ICALL_EXPORT MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
 
+ICALL_EXPORT MonoObject *mono_helper_newobj_from_token (MonoImage *image, guint32 ctor_token);
+
 ICALL_EXPORT double mono_fsub (double a, double b);
 
 ICALL_EXPORT double mono_fadd (double a, double b);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7344,7 +7344,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (!m_class_is_inited (cmethod->klass))
 			{
 				gboolean special = !cfg->compile_aot && m_class_has_special_jit_flags (cmethod->klass) &&
-					((mono_class_get_special_jit_flags (cmethod->klass) & MONO_SPECIAL_JIT_USE_ICALL_NEWOBJ) != 0);
+					((mono_class_get_special_jit_flags (cmethod->klass) & MONO_SPECIAL_JIT_DEFER_CLASS_INIT_TO_CTOR) != 0);
 
 				if (!special && !mono_class_init_internal (cmethod->klass))
 					TYPE_LOAD_ERROR (cmethod->klass);
@@ -8797,7 +8797,7 @@ calli_end:
 			mono_save_token_info (cfg, image, token, cmethod);
 
 			use_icall_for_alloc = !cfg->compile_aot && m_class_has_special_jit_flags (cmethod->klass) &&
-				((mono_class_get_special_jit_flags (cmethod->klass) & MONO_SPECIAL_JIT_USE_ICALL_NEWOBJ) != 0);
+				((mono_class_get_special_jit_flags (cmethod->klass) & MONO_SPECIAL_JIT_DEFER_CLASS_INIT_TO_CTOR) != 0);
 
 			if (G_LIKELY (!use_icall_for_alloc))
 				if (!mono_class_init_internal (cmethod->klass))

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7342,9 +7342,13 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			}
 
 			if (!m_class_is_inited (cmethod->klass))
-				if (!mono_class_init_internal (cmethod->klass))
-					TYPE_LOAD_ERROR (cmethod->klass);
+			{
+				gboolean special = !cfg->compile_aot && m_class_has_special_jit_flags (cmethod->klass) &&
+					((mono_class_get_special_jit_flags (cmethod->klass) & MONO_SPECIAL_JIT_USE_ICALL_NEWOBJ) != 0);
 
+				if (!special && !mono_class_init_internal (cmethod->klass))
+					TYPE_LOAD_ERROR (cmethod->klass);
+			}
 			fsig = mono_method_signature_internal (cmethod);
 			if (!fsig)
 				LOAD_ERROR;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4861,6 +4861,7 @@ register_icalls (void)
 	register_icall (mono_helper_ldstr, mono_icall_sig_object_ptr_int, FALSE);
 	register_icall (mono_helper_ldstr_mscorlib, mono_icall_sig_object_int, FALSE);
 	register_icall (mono_helper_newobj_mscorlib, mono_icall_sig_object_int, FALSE);
+	register_icall (mono_helper_newobj_from_token, mono_icall_sig_object_ptr_int, FALSE);
 	register_icall (mono_value_copy_internal, mono_icall_sig_void_ptr_ptr_ptr, FALSE);
 	register_icall (mono_object_castclass_unbox, mono_icall_sig_object_object_ptr, FALSE);
 	register_icall (mono_break, NULL, TRUE);

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -186,8 +186,12 @@ install_assembly_loader_hooks (void)
 static gboolean
 check_tpa_has_exe (MonoCoreTrustedPlatformAssemblies *tpa)
 {
+	const char *ext = ".exe";
+	const size_t ext_len = strlen (ext);
 	for (int i = 0; i < tpa->assembly_count; ++i) {
-		if (strcasestr (tpa->basenames[i], ".exe") != NULL)
+		/* Does the basename end with .exe ? */
+		const char* endp = tpa->basenames[i] + tpa->basename_lens[i] - ext_len;
+		if (!g_strcasecmp (endp, ext))
 			return TRUE;
 	}
 	return FALSE;


### PR DESCRIPTION
This is a hack to address https://github.com/dotnet/runtime/issues/60550 and #60976 

Add a flag that the loader can set on a type to tell the JIT to delay initialization of a class mentioned in a `newobj` instruction until runtime.

Set the flag when we load `Xunit.ConsoleClient.ConsoleRunner` from xunit.console.dll
becuase it essentially has this in its Main:
```csharp
  AssemblyLoadContext.Default.Resolving += SomeResolvingHelper();
  new ConsoleRunner().EntryPoint (args);
```

So the call to `new ConsoleRunner` triggers class loading at JIT time to initialize the fields of `ConsoleRunner` before the resolving helper has been installed.

---

Also update the interpreter to respect the defer flag.

---

Also stop looking in `ApplicationBase` for assemblies.  (That's the #60976 part)