### PR TITLE
[mono][workload] Work around a msbuild bug in MatchOnMetadata

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -164,7 +164,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.100-rc.2.21474.31</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>7.0.100-alpha.1.21528.1</SdkVersionForWorkloadTesting>
     <CompilerPlatformTestingVersion>1.1.1-beta1.21467.5</CompilerPlatformTestingVersion>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20211019.1</MicrosoftPrivateIntellisenseVersion>

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -317,42 +317,42 @@ jobs:
 #
 # Build the whole product using Mono and run libraries tests, for Wasm.Build.Tests
 #
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/common/global-build-job.yml
-#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-#     buildConfig: Release
-#     runtimeFlavor: mono
-#     platforms:
-#     - Browser_wasm
-#     variables:
-#       # map dependencies variables to local variables
-#       - name: monoContainsChange
-#         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
-#       - name: installerContainsChange
-#         value: $[ dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'] ]
-#     jobParameters:
-#       testGroup: innerloop
-#       nameSuffix: AllSubsets_Mono_WasmBuildTests
-#       buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false
-#       timeoutInMinutes: 180
-#       condition: >-
-#         or(
-#           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-#           eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
-#           eq(variables['isFullMatrix'], true))
-#       # extra steps, run tests
-#       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
-#       extraStepsParameters:
-#         creator: dotnet-bot
-#         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-#         scenarios:
-#         - buildwasmapps
-#         condition: >-
-#           or(
-#           eq(variables['monoContainsChange'], true),
-#           eq(variables['installerContainsChange'], true),
-#           eq(variables['isFullMatrix'], true))
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+    buildConfig: Release
+    runtimeFlavor: mono
+    platforms:
+    - Browser_wasm
+    variables:
+      # map dependencies variables to local variables
+      - name: monoContainsChange
+        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'] ]
+      - name: installerContainsChange
+        value: $[ dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'] ]
+    jobParameters:
+      testGroup: innerloop
+      nameSuffix: AllSubsets_Mono_WasmBuildTests
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:TestWasmBuildTests=true /p:TestAssemblies=false
+      timeoutInMinutes: 180
+      condition: >-
+        or(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+          eq(variables['isFullMatrix'], true))
+      # extra steps, run tests
+      extraStepsTemplate: /eng/pipelines/libraries/helix.yml
+      extraStepsParameters:
+        creator: dotnet-bot
+        testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+        scenarios:
+        - buildwasmapps
+        condition: >-
+          or(
+          eq(variables['monoContainsChange'], true),
+          eq(variables['installerContainsChange'], true),
+          eq(variables['isFullMatrix'], true))
 
 #
 # Build for Browser/wasm, with EnableAggressiveTrimming=true

--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -90,6 +90,8 @@
 
     <ItemGroup>
       <_NuGetSourceForWorkloads Include="dotnet6" Value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+      <_NuGetSourceForWorkloads Include="dotnet7" Value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+
       <_BuiltNuGets Include="$(LibrariesShippingPackagesDir)\*.nupkg" />
     </ItemGroup>
 

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
@@ -90,7 +90,7 @@
       <_MonoWorkloadRuntimePackPackageVersion>$(RuntimePackInWorkloadVersion)</_MonoWorkloadRuntimePackPackageVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_MonoWorkloadTargetsMobile)' == 'true' and '$(TargetFramework)' == 'net7.0'">
+    <ItemGroup Condition="'$(_MonoWorkloadTargetsMobile)' == 'true' and '$(TargetFramework)' == '${NetCoreAppCurrent}'">
       <MonoRuntimePackRids Include="
         linux-x64;
         win-x64;

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
@@ -90,7 +90,7 @@
       <_MonoWorkloadRuntimePackPackageVersion>$(RuntimePackInWorkloadVersion)</_MonoWorkloadRuntimePackPackageVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_MonoWorkloadTargetsMobile)' == 'true'">
+    <ItemGroup Condition="'$(_MonoWorkloadTargetsMobile)' == 'true' and '$(TargetFramework)' == 'net7.0'">
       <MonoRuntimePackRids Include="
         linux-x64;
         win-x64;
@@ -113,12 +113,11 @@
         android-x86;
         " />
 
-      <_PackUpdates Include="Microsoft.NETCore.App" TargetFramework="${NetCoreAppCurrent}" RuntimeFrameworkName="Microsoft.NETCore.App" />
-      <KnownRuntimePack Remove="@(_PackUpdates)" MatchOnMetadata="TargetFramework;RuntimeFrameworkName"/>
+      <KnownRuntimePack Remove="Microsoft.NETCore.App" />
       <KnownRuntimePack Include="Microsoft.NETCore.App"
                         TargetFramework="${NetCoreAppCurrent}"
                         RuntimeFrameworkName="Microsoft.NETCore.App"
-                        LatestRuntimeFrameworkVersion="$(_MonoWorkloadRuntimePackPackageVersion)"
+                        LatestRuntimeFrameworkVersion="**FromWorkload**"
                         RuntimePackNamePatterns="Microsoft.NETCore.App.Runtime.Mono.**RID**"
                         RuntimePackRuntimeIdentifiers="@(MonoRuntimePackRids, '%3B')"
                         RuntimePackLabels="Mono"


### PR DESCRIPTION
We appear to be hitting https://github.com/dotnet/msbuild/issues/6985 so work around it for now.  Also reenable wasm build tests now that we have an sdk with proper baseline manifests.