### PR TITLE
Add a fallback RuntimeProductVersion in runtime_version.h

### DIFF
--- a/eng/native/version/runtime_version.h
+++ b/eng/native/version/runtime_version.h
@@ -7,4 +7,4 @@
 #define RuntimeProductMajorVersion 0
 #define RuntimeProductMinorVersion 0
 #define RuntimeProductPatchVersion 0
-#define RuntimeProductVersion
+#define RuntimeProductVersion 0.0.0-dev


### PR DESCRIPTION
This fixes failures encountered when building CoreCLR using the fallback files.

cc: @hoyosjs @BruceForstall 