### PR TITLE
Fix various dump generation issues for VS4Mac

### DIFF
--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -84,16 +84,15 @@ CrashReportWriter::WriteCrashReport()
     {
         OpenObject();
         bool crashed = false;
-        if (thread->ManagedExceptionObject() != 0)
+        if (thread->Tid() == m_crashInfo.CrashThread())
         {
             crashed = true;
-            exceptionType = "0x05000000";   // ManagedException
-        }
-        else
-        {
-            if (thread->Tid() == m_crashInfo.CrashThread())
+            if (thread->ManagedExceptionObject() != 0)
             {
-                crashed = true;
+                exceptionType = "0x05000000";   // ManagedException
+            }
+            else
+            {
                 switch (m_crashInfo.Signal())
                 {
                 case SIGILL:

--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -95,6 +95,9 @@ CrashReportWriter::WriteCrashReport()
             {
                 switch (m_crashInfo.Signal())
                 {
+                case 0:
+                    break;
+
                 case SIGILL:
                     exceptionType = "0x50000000";
                     break;
@@ -120,8 +123,11 @@ CrashReportWriter::WriteCrashReport()
                     break;
 
                 case SIGABRT:
-                default:
                     exceptionType = "0x30000000";
+                    break;
+
+                default:
+                    exceptionType = "0x40000000";
                     break;
                 }
             }

--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -127,7 +127,7 @@ CrashReportWriter::WriteCrashReport()
                     break;
 
                 default:
-                    exceptionType = "0x40000000";
+                    exceptionType = "0x00000000";
                     break;
                 }
             }

--- a/src/coreclr/debug/dbgutil/machoreader.cpp
+++ b/src/coreclr/debug/dbgutil/machoreader.cpp
@@ -207,11 +207,11 @@ MachOModule::ReadLoadCommands()
                 m_segments.push_back(segment);
 
                 // Calculate the load bias for the module. This is the value to add to the vmaddr of a
-                // segment to get the actual address. 
-                if (strcmp(segment->segname, SEG_TEXT) == 0)
+                // segment to get the actual address. For shared modules, this is 0 since those segments
+                // are absolute address.
+                if (segment->fileoff == 0 && segment->filesize > 0)
                 {
                     m_loadBias = m_baseAddress - segment->vmaddr;
-                    m_reader.TraceVerbose("CMD: load bias %016llx\n", m_loadBias);
                 }
 
                 m_reader.TraceVerbose("CMD: vmaddr %016llx vmsize %016llx fileoff %016llx filesize %016llx nsects %d max %c%c%c init %c%c%c %02x %s\n",
@@ -245,6 +245,7 @@ MachOModule::ReadLoadCommands()
             // Get next load command
             command = (load_command*)((char*)command + command->cmdsize);
         }
+        m_reader.TraceVerbose("CMD: load bias %016llx\n", m_loadBias);
     }
 
     return true;

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -432,13 +432,22 @@ PALAPI
 PAL_SetShutdownCallback(
     IN PSHUTDOWN_CALLBACK callback);
 
+// Must be the same as the copy in excep.h and the WriteDumpFlags enum in the diagnostics repo
+enum
+{
+    GenerateDumpFlagsNone = 0x00,
+    GenerateDumpFlagsLoggingEnabled = 0x01,
+    GenerateDumpFlagsVerboseLoggingEnabled = 0x02,
+    GenerateDumpFlagsCrashReportEnabled = 0x04
+};
+
 PALIMPORT
 BOOL
 PALAPI
 PAL_GenerateCoreDump(
     IN LPCSTR dumpName,
     IN INT dumpType,
-    IN BOOL diag);
+    IN ULONG32 flags);
 
 typedef VOID (*PPAL_STARTUP_CALLBACK)(
     char *modulePath,

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -3139,8 +3139,7 @@ PROCBuildCreateDumpCommandLine(
     char** ppidarg,
     const char* dumpName,
     INT dumpType,
-    BOOL diag,
-    BOOL crashReport)
+    ULONG32 flags)
 {
     if (g_szCoreCLRPath == nullptr)
     {
@@ -3198,12 +3197,17 @@ PROCBuildCreateDumpCommandLine(
             break;
     }
 
-    if (diag)
+    if (flags & GenerateDumpFlagsLoggingEnabled)
     {
         argv.push_back("--diag");
     }
 
-    if (crashReport)
+    if (flags & GenerateDumpFlagsVerboseLoggingEnabled)
+    {
+        argv.push_back("--verbose");
+    }
+
+    if (flags & GenerateDumpFlagsCrashReportEnabled)
     {
         argv.push_back("--crashreport");
     }
@@ -3305,17 +3309,22 @@ PROCAbortInitialize()
             }
         }
 
+        ULONG32 flags = GenerateDumpFlagsNone;
         CLRConfigNoCache createDumpCfg = CLRConfigNoCache::Get("CreateDumpDiagnostics", /*noprefix*/ false, &getenv);
         DWORD val = 0;
-        BOOL diag = createDumpCfg.IsSet() && createDumpCfg.TryAsInteger(10, val) && val == 1;
-
+        if (createDumpCfg.IsSet() && createDumpCfg.TryAsInteger(10, val) && val == 1)
+        {
+            flags |= GenerateDumpFlagsLoggingEnabled;
+        }
         CLRConfigNoCache enabldReportCfg = CLRConfigNoCache::Get("EnableCrashReport", /*noprefix*/ false, &getenv);
         val = 0;
-        BOOL crashReport = enabldReportCfg.IsSet() && enabldReportCfg.TryAsInteger(10, val) && val == 1;
-
+        if (enabldReportCfg.IsSet() && enabldReportCfg.TryAsInteger(10, val) && val == 1)
+        {
+            flags |= GenerateDumpFlagsCrashReportEnabled;
+        }
         char* program = nullptr;
         char* pidarg = nullptr;
-        if (!PROCBuildCreateDumpCommandLine(g_argvCreateDump, &program, &pidarg, dmpNameCfg.AsString(), dumpType, diag, crashReport))
+        if (!PROCBuildCreateDumpCommandLine(g_argvCreateDump, &program, &pidarg, dmpNameCfg.AsString(), dumpType, flags))
         {
             return FALSE;
         }
@@ -3337,8 +3346,8 @@ Parameters:
         WithHeap = 2,
         Triage = 3,
         Full = 4
-    diag
-        true - log createdump diagnostics to console
+    flags
+        See enum
 
 Return:
     TRUE success
@@ -3348,7 +3357,7 @@ BOOL
 PAL_GenerateCoreDump(
     LPCSTR dumpName,
     INT dumpType,
-    BOOL diag)
+    ULONG32 flags)
 {
     std::vector<const char*> argvCreateDump;
 
@@ -3362,7 +3371,7 @@ PAL_GenerateCoreDump(
     }
     char* program = nullptr;
     char* pidarg = nullptr;
-    BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, &pidarg, dumpName, dumpType, diag, false);
+    BOOL result = PROCBuildCreateDumpCommandLine(argvCreateDump, &program, &pidarg, dumpName, dumpType, flags);
     if (result)
     {
         result = PROCCreateCrashDump(argvCreateDump);

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -195,12 +195,12 @@ ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerat
 	ds_ipc_result_t result = DS_IPC_E_FAIL;
 	EX_TRY
 	{
-		uint32_t flags = ds_generate_core_dump_command_payload_get_diagnostics (payload);
-        if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP)
-        {
-            // For the old commmand, this payload field is a bool of whether to enable logging
-            flags = flags != 0 ? GenerateDumpFlagsLoggingEnabled : 0;
-        }
+		uint32_t flags = ds_generate_core_dump_command_payload_get_flags(payload);
+ 		if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP)
+ 		{
+ 			// For the old commmand, this payload field is a bool of whether to enable logging
+ 			flags = flags != 0 ? GenerateDumpFlagsLoggingEnabled : 0;
+		}
 		if (GenerateDump (reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload)),
 			static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload)),
 			flags))

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -188,16 +188,22 @@ ds_rt_config_value_get_default_port_suspend (void)
 
 static
 ds_ipc_result_t
-ds_rt_generate_core_dump (DiagnosticsGenerateCoreDumpCommandPayload *payload)
+ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerateCoreDumpCommandPayload *payload)
 {
 	STATIC_CONTRACT_NOTHROW;
 
 	ds_ipc_result_t result = DS_IPC_E_FAIL;
 	EX_TRY
 	{
+		uint32_t flags = ds_generate_core_dump_command_payload_get_diagnostics (payload);
+        if (commandId == DS_DUMP_COMMANDID_GENERATE_CORE_DUMP)
+        {
+            // For the old commmand, this payload field is a bool of whether to enable logging
+            flags = flags != 0 ? GenerateDumpFlagsLoggingEnabled : 0;
+        }
 		if (GenerateDump (reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload)),
 			static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload)),
-			(ds_generate_core_dump_command_payload_get_diagnostics (payload) != 0) ? true : false))
+			flags))
 			result = DS_IPC_S_OK;
 	}
 	EX_CATCH {}

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4175,8 +4175,8 @@ InitializeCrashDump()
 
 bool GenerateDump(
     LPCWSTR dumpName,
-    int dumpType,
-    bool diag)
+    INT dumpType,
+    ULONG32 flags)
 {
 #ifdef TARGET_UNIX
     MAKE_UTF8PTR_FROMWIDE_NOTHROW (dumpNameUtf8, dumpName);
@@ -4186,10 +4186,10 @@ bool GenerateDump(
     }
     else
     {
-        return PAL_GenerateCoreDump(dumpNameUtf8, dumpType, diag);
+        return PAL_GenerateCoreDump(dumpNameUtf8, dumpType, flags);
     }
 #else // TARGET_UNIX
-    return GenerateCrashDump(dumpName, dumpType, diag);
+    return GenerateCrashDump(dumpName, dumpType, flags & GenerateDumpFlagsLoggingEnabled);
 #endif // TARGET_UNIX
 }
 

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -195,10 +195,20 @@ enum UnhandledExceptionLocation
 };
 
 #ifdef HOST_WINDOWS
+
+// Must be the same as the copy in pal.h and the WriteDumpFlags enum in the diagnostics repo
+enum
+{
+    GenerateDumpFlagsNone = 0x00,
+    GenerateDumpFlagsLoggingEnabled = 0x01,
+    GenerateDumpFlagsVerboseLoggingEnabled = 0x02,
+    GenerateDumpFlagsCrashReportEnabled = 0x04
+};
+
 void InitializeCrashDump();
 void CreateCrashDumpIfEnabled(bool stackoverflow = false);
 #endif
-bool GenerateDump(LPCWSTR dumpName, int dumpType, bool diag);
+bool GenerateDump(LPCWSTR dumpName, INT dumpType, ULONG32 flags);
 
 // Generates crash dumps if enabled for both Windows and Linux
 void CrashDumpAndTerminateProcess(UINT exitCode);

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1695,7 +1695,7 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGene
             {
                 EX_TRY
                 {
-                    GenerateDump (GENAWARE_DUMP_FILE_NAME, 2, false);
+                    GenerateDump (GENAWARE_DUMP_FILE_NAME, 2, GenerateDumpFlagsNone);
                 }
                 EX_CATCH {}
                 EX_END_CATCH(SwallowAllExceptions);

--- a/src/mono/mono/eventpipe/ds-rt-mono.h
+++ b/src/mono/mono/eventpipe/ds-rt-mono.h
@@ -172,7 +172,7 @@ ds_rt_config_value_get_default_port_suspend (void)
 static
 inline
 ds_ipc_result_t
-ds_rt_generate_core_dump (DiagnosticsGenerateCoreDumpCommandPayload *payload)
+ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerateCoreDumpCommandPayload *payload)
 {
 	// TODO: Implement.
 	return DS_IPC_E_NOTSUPPORTED;

--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -51,7 +51,7 @@ generate_core_dump_command_try_parse_payload (
 
 	if (!ds_ipc_message_try_parse_string_utf16_t (&buffer_cursor, &buffer_cursor_len, &instance->dump_name ) ||
 		!ds_ipc_message_try_parse_uint32_t (&buffer_cursor, &buffer_cursor_len, &instance->dump_type) ||
-		!ds_ipc_message_try_parse_uint32_t (&buffer_cursor, &buffer_cursor_len, &instance->diagnostics))
+		!ds_ipc_message_try_parse_uint32_t (&buffer_cursor, &buffer_cursor_len, &instance->flags))
 		ep_raise_error ();
 
 ep_on_exit:

--- a/src/native/eventpipe/ds-dump-protocol.c
+++ b/src/native/eventpipe/ds-dump-protocol.c
@@ -106,6 +106,7 @@ dump_protocol_helper_generate_core_dump (
 		return false;
 
 	ds_ipc_result_t ipc_result = DS_IPC_E_FAIL;
+	DiagnosticsDumpCommandId commandId = (DiagnosticsDumpCommandId)ds_ipc_header_get_commandid (ds_ipc_message_get_header_ref (message));
 	DiagnosticsGenerateCoreDumpCommandPayload *payload;
 	payload = (DiagnosticsGenerateCoreDumpCommandPayload *)ds_ipc_message_try_parse_payload (message, generate_core_dump_command_try_parse_payload);
 
@@ -114,7 +115,7 @@ dump_protocol_helper_generate_core_dump (
 		ep_raise_error ();
 	}
 
-	ipc_result = ds_rt_generate_core_dump (payload);
+	ipc_result = ds_rt_generate_core_dump (commandId, payload);
 	if (ipc_result != DS_IPC_S_OK) {
 		ds_ipc_message_send_error (stream, ipc_result);
 		ep_raise_error ();
@@ -144,6 +145,7 @@ ds_dump_protocol_helper_handle_ipc_message (
 
 	switch ((DiagnosticsDumpCommandId)ds_ipc_header_get_commandid (ds_ipc_message_get_header_ref (message))) {
 	case DS_DUMP_COMMANDID_GENERATE_CORE_DUMP:
+	case DS_DUMP_COMMANDID_GENERATE_CORE_DUMP2:
 		result = dump_protocol_helper_generate_core_dump (message, stream);
 		break;
 	default:

--- a/src/native/eventpipe/ds-dump-protocol.h
+++ b/src/native/eventpipe/ds-dump-protocol.h
@@ -44,7 +44,7 @@ struct _DiagnosticsGenerateCoreDumpCommandPayload {
 
 DS_DEFINE_GETTER(DiagnosticsGenerateCoreDumpCommandPayload *, generate_core_dump_command_payload, const ep_char16_t *, dump_name)
 DS_DEFINE_GETTER(DiagnosticsGenerateCoreDumpCommandPayload *, generate_core_dump_command_payload, uint32_t, dump_type)
-DS_DEFINE_GETTER(DiagnosticsGenerateCoreDumpCommandPayload *, generate_core_dump_command_payload, uint32_t, diagnostics)
+DS_DEFINE_GETTER(DiagnosticsGenerateCoreDumpCommandPayload *, generate_core_dump_command_payload, uint32_t, flags)
 
 DiagnosticsGenerateCoreDumpCommandPayload *
 ds_generate_core_dump_command_payload_alloc (void);

--- a/src/native/eventpipe/ds-dump-protocol.h
+++ b/src/native/eventpipe/ds-dump-protocol.h
@@ -27,13 +27,13 @@ struct _DiagnosticsGenerateCoreDumpCommandPayload_Internal {
 	// The protocol buffer is defined as:
 	//   string - dumpName (UTF16)
 	//   int - dumpType
-	//   int - diagnostics
+	//   uint32 - flags
 	// returns
 	//   ulong - status
 
 	const ep_char16_t *dump_name;
 	uint32_t dump_type;
-	uint32_t diagnostics;
+	uint32_t flags;
 };
 
 #if !defined(DS_INLINE_GETTER_SETTER) && !defined(DS_IMPL_DUMP_PROTOCOL_GETTER_SETTER)

--- a/src/native/eventpipe/ds-rt.h
+++ b/src/native/eventpipe/ds-rt.h
@@ -87,7 +87,7 @@ ds_rt_config_value_get_default_port_suspend (void);
 
 static
 ds_ipc_result_t
-ds_rt_generate_core_dump (DiagnosticsGenerateCoreDumpCommandPayload *payload);
+ds_rt_generate_core_dump (DiagnosticsDumpCommandId commandId, DiagnosticsGenerateCoreDumpCommandPayload *payload);
 
 /*
  * DiagnosticsIpc.

--- a/src/native/eventpipe/ds-types.h
+++ b/src/native/eventpipe/ds-types.h
@@ -44,6 +44,7 @@ typedef struct _EventPipeStopTracingCommandPayload EventPipeStopTracingCommandPa
 typedef enum {
 	DS_DUMP_COMMANDID_RESERVED = 0x00,
 	DS_DUMP_COMMANDID_GENERATE_CORE_DUMP = 0x01,
+	DS_DUMP_COMMANDID_GENERATE_CORE_DUMP2 = 0x02,
 	// future
 } DiagnosticsDumpCommandId;
 


### PR DESCRIPTION
The createdump crash report can have multiple threads indicated as crashed. Fixes issue: https://github.com/dotnet/runtime/issues/60932

Add new generate core dump IPC command that allows the generate crash report flag to be passed through to createdump for VS4Mac. Issue: https://github.com/dotnet/runtime/issues/60775

VS4Mac needs to distinguish between WriteDump/no signal and unknown signal ExceptionType.

Fix how the load bias is calculate for shared modules.