### PR TITLE
Use Ubuntu 18.04 and dotnet-buildtools-prereq docker images for enterprise linux pipeline

### DIFF
--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -51,7 +51,7 @@ steps:
   displayName: Test linuxclient connection to web server
 
 - bash: |
-    docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci'
+    docker exec linuxclient bash -c '/repo/build.sh -subset clr+libs -runtimeconfiguration release -ci /p:NativeOptimizationDataSupported=false'
   displayName: Build product sources
 
 - bash: |

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -19,7 +19,8 @@ pr:
       - src/libraries/System.Net.Security/*
 
 pool:
-  vmImage: 'ubuntu-16.04'
+  name: NetCore1ESPool-Public
+  demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
 variables:
   - template: ../variables.yml

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/linuxclient/Dockerfile
@@ -1,31 +1,12 @@
-# Switch to mcr.microsoft.com/dotnet-buildtools/prereqs ubuntu 18.04 images when they are fixed
-FROM ubuntu:18.04
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-20211022152710-047508b
 
 # Prevents dialog prompting when installing packages
 ARG DEBIAN_FRONTEND=noninteractive
 
-# This 'RUN' step can be removed once dotnet-buildtools/prereqs image is fixed
-#
-# Makes the image capable of building and running tests in dotnet-runtime repo.
-# Add retries to apt-get since the ubuntu package servers have had errors lately such as:
-#   "E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/publicsuffix/publicsuffix_20180223.1310-1_all.deb  Undetermined Error [IP: 91.189.88.31 80]"
-ARG APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
-RUN echo "APT::Acquire::Retries \"10\";" > /etc/apt/apt.conf.d/80-retries && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg software-properties-common wget && \
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | apt-key add - && \
-    apt-add-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main' && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends cmake llvm-9 clang-9 lldb-6.0 liblldb-6.0-dev libunwind8 libunwind-dev gettext libicu-dev liblttng-ust-dev libssl-dev libnuma-dev libkrb5-dev locales && \
-    locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8
-
 # Install Kerberos, NTLM, and diagnostic tools
 COPY ./common/krb5.conf /etc/krb5.conf
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends krb5-user gss-ntlmssp iputils-ping dnsutils nano curl
+    apt-get install -y --no-install-recommends krb5-user gss-ntlmssp iputils-ping dnsutils nano
 
 # Set environment variable to turn on enterprise tests
 ENV DOTNET_RUNTIME_ENTERPRISETESTS_ENABLED 1


### PR DESCRIPTION
Ubuntu 16.04 is no longer available on Azure Pipelines, move to 18.04 1ES pool and the Docker images from dotnet-buildtools-prereq.

Also add a workaround for https://github.com/dotnet/runtime/issues/34649 which we hit during the build.

Replaces https://github.com/dotnet/runtime/pull/60261