### PR TITLE
Added */out/ paths that are created after the build to ignored ones.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ syntax: glob
 
 # Build results
 artifacts/
+out/
 .idea/
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
On Windows machine, after building the whole project in Debug mode following folders were not ignored:

- src/coreclr/out/
- src/libraries/Native/Unix/out/
-  src/libraries/Native/Windows/out/
- src/mono/out/
- src/native/corehost/out/
- src/native/eventpipe/out/
- src/tests/out/

Adding the pattern fixes it.