### PR TITLE
JIT: Disable implicit tailcalls for throwhelpers

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7132,6 +7132,14 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         return nullptr;
     }
 
+    if (call->IsNoReturn() && !call->IsTailPrefixedCall())
+    {
+        // Such tail calls always throw an exception and we won't be able to see current
+        // Caller() in the stacktrace.
+        failTailCall("Never returns");
+        return nullptr;
+    }
+
     // Heuristic: regular calls to noreturn methods can sometimes be
     // merged, so if we have multiple such calls, we defer tail calling.
     //

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7140,18 +7140,6 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         return nullptr;
     }
 
-    // Heuristic: regular calls to noreturn methods can sometimes be
-    // merged, so if we have multiple such calls, we defer tail calling.
-    //
-    // TODO: re-examine this; now that we're merging before morph we
-    // don't need to worry about interfering with merges.
-    //
-    if (call->IsNoReturn() && (optNoReturnCallCount > 1))
-    {
-        failTailCall("Defer tail calling throw helper; anticipating merge");
-        return nullptr;
-    }
-
 #ifdef DEBUG
     if (opts.compGcChecks && (info.compRetType == TYP_REF))
     {


### PR DESCRIPTION
Problem:
```csharp
using System;

public class Prog
{
    static void Main(string[] args)
    {
        Test(-42 - args.Length);
    }

    // not inlined (too big)
    static void Test(int num)
    {
        if (num < 0)
        {
            ThrowInvalidOperation();
        }
        else
        {
            // to make method big
            Console.Write(num);
            Console.Write(num);
            Console.Write(num);
            Console.Write(num);
        }
    }

    // not inlined (throw helper)
    static void ThrowInvalidOperation() => throw new InvalidOperationException("invalid op");
}
```
This program throws `InvalidOperationException` with the following stack-trace:
```
Unhandled exception. System.InvalidOperationException: invalid op
   at Prog.ThrowInvalidOperation() in C:\Users\bogat\source\repos\ConsoleApp11\ConsoleApp11\StringBuilderBenchmarks.cs:line 30
   at Prog.Main(String[] args) in C:\Users\bogat\source\repos\ConsoleApp11\ConsoleApp11\StringBuilderBenchmarks.cs:line 7
```
As you can see, we don't see `Test` in the stack trace and no, it wasn't inlined, it's hidden because `ThrowInvalidOperation` was optimized as an implicit-fast tail-call. I think we better import it as a normal call and get better exception traces.

For my specific repro this PR is even an improvement: https://www.diffchecker.com/KwEp011q because for some reason tail-called ThrowHelper is not marked as a cold block. 
But overall, as was expected, it's a size regression - a small tradeoff between size and better diagnostics: 
jit-diff (-f --pmi):
```
Total bytes of base: 61483668
Total bytes of diff: 61484710
Total bytes of delta: 1042 (0.00 % of base)
Total relative delta: 116.76
    diff is a regression.
    relative diff is a regression.


Top file regressions (bytes):
        1246 : System.Private.CoreLib.dasm (0.02% of base)
         240 : System.Linq.dasm (0.02% of base)
          81 : System.IO.Compression.dasm (0.09% of base)
          57 : System.Text.Json.dasm (0.01% of base)
          40 : System.Collections.dasm (0.01% of base)
          36 : System.Collections.Immutable.dasm (0.00% of base)
          30 : System.Security.Cryptography.X509Certificates.dasm (0.01% of base)
          29 : System.Net.Http.dasm (0.00% of base)
          28 : System.Text.RegularExpressions.dasm (0.00% of base)
          18 : System.IO.Compression.Brotli.dasm (0.08% of base)
          18 : Microsoft.Extensions.Caching.Memory.dasm (0.09% of base)
          18 : System.IO.Pipelines.dasm (0.02% of base)
          10 : System.Security.Cryptography.Csp.dasm (0.01% of base)
           9 : Microsoft.Extensions.Primitives.dasm (0.03% of base)
           9 : System.Drawing.Primitives.dasm (0.02% of base)
           5 : System.Security.Cryptography.Primitives.dasm (0.01% of base)
           5 : System.Collections.Specialized.dasm (0.02% of base)

Top file improvements (bytes):
        -254 : FSharp.Core.dasm (-0.01% of base)
        -246 : System.Private.Xml.dasm (-0.01% of base)
         -47 : Microsoft.Win32.Registry.dasm (-0.16% of base)
         -40 : System.Net.Sockets.dasm (-0.02% of base)
         -32 : ILCompiler.TypeSystem.ReadyToRun.dasm (-0.01% of base)
         -29 : System.Speech.dasm (-0.01% of base)
         -28 : System.Net.Http.WinHttpHandler.dasm (-0.02% of base)
         -20 : System.CodeDom.dasm (-0.01% of base)
         -19 : System.Private.DataContractSerialization.dasm (-0.00% of base)
         -18 : Microsoft.CodeAnalysis.dasm (-0.00% of base)
         -11 : System.Data.Common.dasm (-0.00% of base)
         -10 : System.Net.Security.dasm (-0.01% of base)
         -10 : System.Runtime.Serialization.Formatters.dasm (-0.01% of base)
         -10 : System.Net.HttpListener.dasm (-0.00% of base)
         -10 : System.Transactions.Local.dasm (-0.01% of base)
          -7 : System.Drawing.Common.dasm (-0.00% of base)
          -6 : Microsoft.Extensions.Configuration.FileExtensions.dasm (-0.11% of base)
          -5 : System.IO.Ports.dasm (-0.01% of base)
          -5 : System.Net.Quic.dasm (-0.00% of base)
          -5 : System.ServiceModel.Syndication.dasm (-0.00% of base)

45 total files with Code Size differences (28 improved, 17 regressed), 225 unchanged.

Top method regressions (bytes):
          72 (52.94% of base) : System.Private.CoreLib.dasm - ArraySegment`1:ThrowInvalidOperationIfDefault():this (8 methods)
          72 (47.37% of base) : System.Private.CoreLib.dasm - ManualResetValueTaskSourceCore`1:ValidateToken(short):this (8 methods)
          72 (56.25% of base) : System.Private.CoreLib.dasm - RandomAccess:ValidateBuffers(IReadOnlyList`1) (8 methods)
          57 (14.77% of base) : System.Private.CoreLib.dasm - ReadOnlySpan`1:CopyTo(Span`1):this (8 methods)
          57 (14.77% of base) : System.Private.CoreLib.dasm - Span`1:CopyTo(Span`1):this (8 methods)
          40 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Clear():this (8 methods)
          40 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.RemoveAt(int):this (8 methods)
          40 (100.00% of base) : System.Linq.dasm - Grouping`2:System.Collections.Generic.ICollection<TElement>.Add(Nullable`1):this (8 methods)
          40 (100.00% of base) : System.Linq.dasm - Grouping`2:System.Collections.Generic.ICollection<TElement>.Clear():this (8 methods)
          40 (100.00% of base) : System.Linq.dasm - Grouping`2:System.Collections.Generic.IList<TElement>.Insert(int,Nullable`1):this (8 methods)
          40 (100.00% of base) : System.Linq.dasm - Grouping`2:System.Collections.Generic.IList<TElement>.RemoveAt(int):this (8 methods)
          40 (100.00% of base) : System.Linq.dasm - Grouping`2:System.Collections.Generic.IList<TElement>.set_Item(int,Nullable`1):this (8 methods)
          40 (100.00% of base) : System.Linq.dasm - Iterator`1:System.Collections.IEnumerator.Reset():this (8 methods)
          40 (50.00% of base) : System.Private.CoreLib.dasm - KeyCollection:System.Collections.Generic.ICollection<TKey>.Clear():this (8 methods)
          40 (50.00% of base) : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.Generic.ICollection<T>.Clear():this (8 methods)
          40 (50.00% of base) : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.Generic.IList<T>.RemoveAt(int):this (8 methods)
          40 (50.00% of base) : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.IList.Clear():this (8 methods)
          40 (50.00% of base) : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.IList.Insert(int,Object):this (8 methods)
          40 (50.00% of base) : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.IList.Remove(Object):this (8 methods)
          40 (50.00% of base) : System.Private.CoreLib.dasm - ReadOnlyCollection`1:System.Collections.IList.RemoveAt(int):this (8 methods)

Top method improvements (bytes):
         -89 (-5.82% of base) : FSharp.Core.dasm - List:splitAtFreshConsTail(FSharpList`1,int,FSharpList`1):FSharpList`1 (8 methods)
         -85 (-2.68% of base) : FSharp.Core.dasm - List:take(int,FSharpList`1):FSharpList`1 (8 methods)
         -75 (-1.08% of base) : FSharp.Core.dasm - List:splitAt(int,FSharpList`1):Tuple`2 (8 methods)
         -24 (-9.38% of base) : System.Private.CoreLib.dasm - TaskCompletionSource`1:SetException(Exception):this (8 methods)
         -24 (-9.38% of base) : System.Private.CoreLib.dasm - TaskCompletionSource`1:SetException(IEnumerable`1):this (8 methods)
         -23 (-3.38% of base) : Microsoft.CodeAnalysis.dasm - <>c__DisplayClass10_0:<EnqueueCore>b__0():this (8 methods)
         -21 (-4.01% of base) : System.Private.CoreLib.dasm - AsyncValueTaskMethodBuilder`1:SetResult(Vector`1):this
         -20 (-4.71% of base) : System.CodeDom.dasm - CSharpCodeGenerator:FromFile(CompilerParameters,String):CompilerResults:this
         -18 (-5.31% of base) : Microsoft.Win32.Registry.dasm - RegistryKey:DeleteSubKeyTreeInternal(String):this
         -17 (-3.62% of base) : Microsoft.Win32.Registry.dasm - RegistryKey:DeleteSubKeyTree(String,bool):this
         -17 (-2.09% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:PushExternalEntityOrSubset(String,String,Uri,String):this
         -15 (-3.33% of base) : System.Net.HttpListener.dasm - HttpResponseStream:EndWriteCore(IAsyncResult):this
         -15 (-2.33% of base) : System.Net.Sockets.dasm - Socket:SetSocketOption(int,int,ref):this
         -15 (-5.98% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:Throw(String,int,int):this
         -14 (-8.59% of base) : System.Private.DataContractSerialization.dasm - XmlExceptionHelper:ThrowDuplicateAttribute(XmlDictionaryReader,String,String,String,String)
         -13 (-3.94% of base) : System.Net.Sockets.dasm - Socket:SetIPv6MulticastOption(int,IPv6MulticastOption):this
         -13 (-3.67% of base) : System.Net.Sockets.dasm - Socket:SetLingerOption(LingerOption):this
         -13 (-3.67% of base) : System.Net.Sockets.dasm - Socket:SetMulticastOption(int,MulticastOption):this
         -13 (-6.67% of base) : System.Transactions.Local.dasm - TransactionStatePromotedP0Aborting:EnterState(InternalTransaction):this
         -13 (-4.48% of base) : System.Private.Xml.dasm - XmlTextReaderImpl:ReThrow(Exception,int,int):this

Top method regressions (percentages):
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(__Canon):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(double):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(int):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(long):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(Nullable`1):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(short):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(ubyte):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Add(Vector`1):this
          40 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.ICollection<T>.Clear():this (8 methods)
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,__Canon):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,double):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,int):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,long):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,Nullable`1):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,short):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,ubyte):this
           5 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.Insert(int,Vector`1):this
          40 (100.00% of base) : System.Private.CoreLib.dasm - ArraySegment`1:System.Collections.Generic.IList<T>.RemoveAt(int):this (8 methods)
           5 (100.00% of base) : System.Transactions.Local.dasm - EnterpriseServices:LeaveServiceDomain()
           5 (100.00% of base) : System.Transactions.Local.dasm - EnterpriseServices:PushServiceDomain(Transaction)

Top method improvements (percentages):
          -3 (-13.04% of base) : System.Private.CoreLib.dasm - ExceptionDispatchInfo:Throw(Exception)
          -3 (-13.04% of base) : xunit.core.dasm - ExceptionExtensions:RethrowWithNoStackTraceLoss(Exception)
          -3 (-13.04% of base) : xunit.execution.dotnet.dasm - ExceptionExtensions:RethrowWithNoStackTraceLoss(Exception)
          -3 (-13.04% of base) : xunit.runner.utility.netcoreapp10.dasm - ExceptionExtensions:RethrowWithNoStackTraceLoss(Exception)
          -4 (-12.90% of base) : System.Private.DataContractSerialization.dasm - EncodingStreamWrapper:ThrowEncodingMismatch(String,int)
          -4 (-11.76% of base) : ILCompiler.TypeSystem.ReadyToRun.dasm - ThrowHelper:ThrowTypeLoadException(String,ModuleDesc)
          -3 (-11.11% of base) : System.Linq.Expressions.dasm - ExceptionHelpers:UnwrapAndRethrow(TargetInvocationException)
          -4 (-10.26% of base) : System.IO.Ports.dasm - SerialStream:CheckReadWriteArguments(ref,int,int):this
          -3 (-9.68% of base) : System.Private.CoreLib.dasm - TranscodingStream:ThrowObjectDisposedException():this
          -4 (-9.52% of base) : System.Private.CoreLib.dasm - UmAlQuraCalendar:CheckYearMonthRange(int,int,int)
          -3 (-9.38% of base) : System.Private.CoreLib.dasm - MemoryStream:EnsureWriteable():this
          -3 (-9.38% of base) : System.Private.CoreLib.dasm - TaskCompletionSource:SetException(Exception):this
          -3 (-9.38% of base) : System.Private.CoreLib.dasm - TaskCompletionSource:SetException(IEnumerable`1):this
          -3 (-9.38% of base) : System.Private.CoreLib.dasm - TaskCompletionSource:SetResult():this
         -24 (-9.38% of base) : System.Private.CoreLib.dasm - TaskCompletionSource`1:SetException(Exception):this (8 methods)
         -24 (-9.38% of base) : System.Private.CoreLib.dasm - TaskCompletionSource`1:SetException(IEnumerable`1):this (8 methods)
          -3 (-9.38% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryStream:EnsureReadable():this
          -3 (-9.38% of base) : System.Private.CoreLib.dasm - UnmanagedMemoryStream:EnsureWriteable():this
          -5 (-8.62% of base) : System.ServiceModel.Syndication.dasm - XmlExceptionHelper:ThrowStartElementExpected(XmlDictionaryReader)
         -14 (-8.59% of base) : System.Private.DataContractSerialization.dasm - XmlExceptionHelper:ThrowDuplicateAttribute(XmlDictionaryReader,String,String,String,String)

348 total methods with Code Size differences (150 improved, 198 regressed), 277094 unchanged.
```
/cc @dotnet/jit-contrib @jakobbotsch 