### PR TITLE
[mono][interp] Fix GetType called on ptr constrained to Nullable`

### DIFF
--- a/src/tests/JIT/Directed/nullabletypes/gettype.cs
+++ b/src/tests/JIT/Directed/nullabletypes/gettype.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+class C<T>
+{
+    public IEnumerable<T> Data { get; set; }
+
+    public C() { }
+
+    public bool Check()
+    {
+	return Data.ElementAt(0).GetType() == typeof(bool);
+    }
+}
+
+public class P
+{
+    public static int Main()
+    {
+        C<bool?> c = new();
+
+        // Try a nullable with value
+        c.Data = new List<bool?> { true };
+        if(!c.Check())
+            return 666;
+
+        // Try a nullable without value. Should throw NRE
+        c.Data = new List<bool?> { new Nullable<bool>() };
+
+        bool thrown = false;
+        try
+        {
+            c.Check();
+        }
+        catch(NullReferenceException)
+        {
+            thrown = true;
+        }
+        if(!thrown)
+            return 667;
+        return 100;
+    }
+}
+

--- a/src/tests/JIT/Directed/nullabletypes/gettype_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/gettype_d.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="gettype.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Directed/nullabletypes/gettype_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/gettype_do.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="gettype.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Directed/nullabletypes/gettype_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/gettype_r.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="gettype.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Directed/nullabletypes/gettype_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/gettype_ro.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="gettype.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We were statically optimizing this call to return the actual constrained class type, which is incorrect for nullables, because boxing of a nullable (as part of the constrained call) actually creates an object with the type of the nullable's value (or null if there is no value).

Fixes https://github.com/dotnet/runtime/issues/61007