### PR TITLE
support loading versioned libmsquic

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -135,7 +135,8 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 return;
             }
 
-            if (NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle))
+            if (NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle) ||
+                NativeLibrary.TryLoad($"{Interop.Libraries.MsQuic}.{MsQuicVersion}", typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out msQuicHandle))
             {
                 try
                 {


### PR DESCRIPTION
This allows to consume out libmsquic.so as well as binary produced directly by MsQuic with major version. 

At some point we may drop our or switch the order but for not this should allow us to handle the transition (and hopefully retire dotnet/msquic)

cc: @ThadHouse @nibanks