### PR TITLE
Fix common workflow issues

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -48,7 +48,9 @@ check_prereqs()
 
 build_native()
 {
-    eval "$__RepoRootDir/eng/native/version/copy_version_files.sh"
+    if [[ ! -e "$__RepoRootDir/artifacts/obj/_version.c" ]]; then
+        eval "$__RepoRootDir/eng/native/version/copy_version_files.sh"
+    fi
 
     targetOS="$1"
     platformArch="$2"
@@ -257,7 +259,7 @@ while :; do
         break
     fi
 
-    lowerI="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
+    lowerI="$(echo "${1/--/-}" | tr "[:upper:]" "[:lower:]")"
     case "$lowerI" in
         -\?|-h|--help)
             usage


### PR DESCRIPTION
Port of https://github.com/dotnet/diagnostics/pull/2720.

In the context of runtime, it allows us to pass double hyphen args to internal scripts: `src/coreclr/build-runtime.sh`, `src/libraries/Native/build-native.sh`, `src/native/corehost/build.sh`, when they are invoked directly (e.g. for native-only builds).