### PR TITLE
Fix to run all the tests for the scheduled builds, as intended

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -22,6 +22,7 @@ jobs:
     shouldContinueOnError: ${{ and(endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest')) }}
 
     # keep in sync with /eng/pipelines/common/variables.yml
+    isFullMatrix: ${{ and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
     dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community')) }}
 
     variables:
@@ -47,11 +48,11 @@ jobs:
 
       - name: _BuildConfig
         value: $(buildConfigUpper)
-      
+
       - name: _runSmokeTestsOnlyArg
-        ${{ if ne(parameters.variables['isFullMatrix'], true) }}:
+        ${{ if ne(variables['isFullMatrix'], true) }}:
           value: /p:RunSmokeTestsOnly=true
-        ${{ if eq(parameters.variables['isFullMatrix'], true) }}:
+        ${{ if eq(variables['isFullMatrix'], true) }}:
           value: ''
 
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -22,7 +22,7 @@ jobs:
     shouldContinueOnError: ${{ and(endsWith(variables['Build.DefinitionName'], 'staging'), eq(variables['Build.Reason'], 'PullRequest')) }}
 
     # keep in sync with /eng/pipelines/common/variables.yml
-    isFullMatrix: ${{ and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
+    nonPRBuild: ${{ and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
     dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-staging', 'runtime-community')) }}
 
     variables:
@@ -50,9 +50,9 @@ jobs:
         value: $(buildConfigUpper)
 
       - name: _runSmokeTestsOnlyArg
-        ${{ if ne(variables['isFullMatrix'], true) }}:
+        ${{ if ne(variables['nonPRBuild'], true) }}:
           value: /p:RunSmokeTestsOnly=true
-        ${{ if eq(variables['isFullMatrix'], true) }}:
+        ${{ if eq(variables['nonPRBuild'], true) }}:
           value: ''
 
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:


### PR DESCRIPTION
`parameters.variables['isFullMatrix']` doesn't seem to surface the variable, so set it explicitly, similar to `dependOnEvaluatePaths` being done in the next line.
Using the same name causes `eng/pipelines/common/xplat-setup.yml (Line: 152, Col: 22): 'isFullMatrix' is already defined`, so instead use a different one.

This caused the scheduled builds to run only the smoke tests.