### PR TITLE
Use SIMD operations in InitBlkUnroll/CopyBlkUnroll and increase unroll limit up to 128 bytes

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -2142,7 +2142,7 @@ public:
         return instrStream.CanEncodeAllStores();
     }
 
-    int InstructionCount(int regSizeBytes) const
+    unsigned InstructionCount(int regSizeBytes) const
     {
         CountingStream instrStream;
         UnrollInitBlock(instrStream, regSizeBytes);
@@ -2267,7 +2267,7 @@ public:
         dstStartOffset = dstOffset;
     }
 
-    int InstructionCount(int regSizeBytes) const
+    unsigned InstructionCount(int regSizeBytes) const
     {
         CountingStream instrStream;
         UnrollCopyBlock(instrStream, instrStream, regSizeBytes);

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1889,22 +1889,22 @@ public:
         instrCount = 0;
     }
 
-    void LoadPairRegs(int offset, int regSizeBytes)
+    void LoadPairRegs(int offset, unsigned regSizeBytes)
     {
         instrCount++;
     }
 
-    void StorePairRegs(int offset, int regSizeBytes)
+    void StorePairRegs(int offset, unsigned regSizeBytes)
     {
         instrCount++;
     }
 
-    void LoadReg(int offset, int regSizeBytes)
+    void LoadReg(int offset, unsigned regSizeBytes)
     {
         instrCount++;
     }
 
-    void StoreReg(int offset, int regSizeBytes)
+    void StoreReg(int offset, unsigned regSizeBytes)
     {
         instrCount++;
     }
@@ -1960,22 +1960,22 @@ public:
         canEncodeAllStores = true;
     }
 
-    void LoadPairRegs(int offset, int regSizeBytes)
+    void LoadPairRegs(int offset, unsigned regSizeBytes)
     {
         canEncodeAllLoads = canEncodeAllLoads && CanEncodeLoadOrStorePairRegs(offset, regSizeBytes);
     }
 
-    void StorePairRegs(int offset, int regSizeBytes)
+    void StorePairRegs(int offset, unsigned regSizeBytes)
     {
         canEncodeAllStores = canEncodeAllStores && CanEncodeLoadOrStorePairRegs(offset, regSizeBytes);
     }
 
-    void LoadReg(int offset, int regSizeBytes)
+    void LoadReg(int offset, unsigned regSizeBytes)
     {
         canEncodeAllLoads = canEncodeAllLoads && CanEncodeLoadOrStoreReg(offset, regSizeBytes);
     }
 
-    void StoreReg(int offset, int regSizeBytes)
+    void StoreReg(int offset, unsigned regSizeBytes)
     {
         canEncodeAllStores = canEncodeAllStores && CanEncodeLoadOrStoreReg(offset, regSizeBytes);
     }
@@ -1991,17 +1991,17 @@ public:
     }
 
 private:
-    static bool CanEncodeLoadOrStorePairRegs(int offset, int regSizeBytes)
+    static bool CanEncodeLoadOrStorePairRegs(int offset, unsigned regSizeBytes)
     {
         const bool canEncodeWithSignedOffset =
-            (offset % regSizeBytes == 0) && (offset >= -64 * regSizeBytes) && (offset < 64 * regSizeBytes);
+            (offset % regSizeBytes == 0) && (offset >= -64 * (int)regSizeBytes) && (offset < 64 * (int)regSizeBytes);
         return canEncodeWithSignedOffset;
     }
 
-    static bool CanEncodeLoadOrStoreReg(int offset, int regSizeBytes)
+    static bool CanEncodeLoadOrStoreReg(int offset, unsigned regSizeBytes)
     {
         const bool canEncodeWithUnsignedOffset =
-            (offset % regSizeBytes == 0) && (offset >= 0) && (offset < regSizeBytes * 4096);
+            (offset % regSizeBytes == 0) && (offset >= 0) && (offset < (int)regSizeBytes * 4096);
         const bool canEncodeWithUnscaledOffset = (offset >= -256) && (offset <= 255);
 
         return canEncodeWithUnsignedOffset || canEncodeWithUnscaledOffset;
@@ -2024,7 +2024,7 @@ public:
     {
     }
 
-    void LoadPairRegs(int offset, int regSizeBytes)
+    void LoadPairRegs(int offset, unsigned regSizeBytes)
     {
         assert((regSizeBytes == 8) || (regSizeBytes == 16));
 
@@ -2045,7 +2045,7 @@ public:
         emitter->emitIns_R_R_R_I(INS_ldp, EA_SIZE(regSizeBytes), tempReg1, tempReg2, addrReg, offset);
     }
 
-    void StorePairRegs(int offset, int regSizeBytes)
+    void StorePairRegs(int offset, unsigned regSizeBytes)
     {
         assert((regSizeBytes == 8) || (regSizeBytes == 16));
 
@@ -2066,7 +2066,7 @@ public:
         emitter->emitIns_R_R_R_I(INS_stp, EA_SIZE(regSizeBytes), tempReg1, tempReg2, addrReg, offset);
     }
 
-    void LoadReg(int offset, int regSizeBytes)
+    void LoadReg(int offset, unsigned regSizeBytes)
     {
         instruction ins     = INS_ldr;
         regNumber   tempReg = intReg1;
@@ -2087,7 +2087,7 @@ public:
         emitter->emitIns_R_R_I(ins, EA_SIZE(regSizeBytes), tempReg, addrReg, offset);
     }
 
-    void StoreReg(int offset, int regSizeBytes)
+    void StoreReg(int offset, unsigned regSizeBytes)
     {
         instruction ins     = INS_str;
         regNumber   tempReg = intReg1;

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -1909,13 +1909,13 @@ public:
         instrCount++;
     }
 
-    int InstructionCount() const
+    unsigned InstructionCount() const
     {
         return instrCount;
     }
 
 private:
-    int instrCount;
+    unsigned instrCount;
 };
 
 class StoreBlockUnrollHelper

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -2495,11 +2495,11 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 
     if (dstLclNum != BAD_VAR_NUM)
     {
-        bool      FPbased;
-        const int baseAddr = compiler->lvaFrameAddress(dstLclNum, &FPbased);
+        bool      fpBased;
+        const int baseAddr = compiler->lvaFrameAddress(dstLclNum, &fpBased);
 
-        dstReg              = FPbased ? REG_FPBASE : REG_SPBASE;
-        dstRegAddrAlignment = FPbased ? (genSPtoFPdelta() % 16) : 0;
+        dstReg              = fpBased ? REG_FPBASE : REG_SPBASE;
+        dstRegAddrAlignment = fpBased ? (genSPtoFPdelta() % 16) : 0;
 
         helper.SetDstOffset(baseAddr + dstOffset);
     }
@@ -2682,11 +2682,11 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
     if (srcLclNum != BAD_VAR_NUM)
     {
-        bool      FPbased;
-        const int baseAddr = compiler->lvaFrameAddress(srcLclNum, &FPbased);
+        bool      fpBased;
+        const int baseAddr = compiler->lvaFrameAddress(srcLclNum, &fpBased);
 
-        srcReg              = FPbased ? REG_FPBASE : REG_SPBASE;
-        srcRegAddrAlignment = FPbased ? (genSPtoFPdelta() % 16) : 0;
+        srcReg              = fpBased ? REG_FPBASE : REG_SPBASE;
+        srcRegAddrAlignment = fpBased ? (genSPtoFPdelta() % 16) : 0;
 
         helper.SetSrcOffset(baseAddr + srcOffset);
     }
@@ -2696,11 +2696,11 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
 
     if (dstLclNum != BAD_VAR_NUM)
     {
-        bool      FPbased;
-        const int baseAddr = compiler->lvaFrameAddress(dstLclNum, &FPbased);
+        bool      fpBased;
+        const int baseAddr = compiler->lvaFrameAddress(dstLclNum, &fpBased);
 
-        dstReg              = FPbased ? REG_FPBASE : REG_SPBASE;
-        dstRegAddrAlignment = FPbased ? (genSPtoFPdelta() % 16) : 0;
+        dstReg              = fpBased ? REG_FPBASE : REG_SPBASE;
+        dstRegAddrAlignment = fpBased ? (genSPtoFPdelta() % 16) : 0;
 
         helper.SetDstOffset(baseAddr + dstOffset);
     }

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -2359,6 +2359,14 @@ emitter::code_t emitter::emitInsCode(instruction ins, insFormat fmt)
     return false; // not encodable
 }
 
+// true if 'imm' can be encoded as an offset in a ldp/stp instruction
+/*static*/ bool emitter::canEncodeLoadOrStorePairOffset(INT64 imm, emitAttr attr)
+{
+    assert((attr == EA_4BYTE) || (attr == EA_8BYTE) || (attr == EA_16BYTE));
+    const int size = EA_SIZE_IN_BYTES(attr);
+    return (imm % size == 0) && (imm >= -64 * size) && (imm < 64 * size);
+}
+
 /************************************************************************
  *
  *   A helper method to return the natural scale for an EA 'size'

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -485,6 +485,9 @@ static bool emitIns_valid_imm_for_alu(INT64 imm, emitAttr size);
 // true if this 'imm' can be encoded as the offset in a ldr/str instruction
 static bool emitIns_valid_imm_for_ldst_offset(INT64 imm, emitAttr size);
 
+// true if 'imm' can be encoded as an offset in a ldp/stp instruction
+static bool canEncodeLoadOrStorePairOffset(INT64 imm, emitAttr size);
+
 // true if 'imm' can use the left shifted by 12 bits encoding
 static bool canEncodeWithShiftImmBy12(INT64 imm);
 

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -321,7 +321,6 @@ enum emitAttr : unsigned
 #define EA_ATTR(x)                  ((emitAttr)(x))
 #define EA_SIZE(x)                  ((emitAttr)(((unsigned)(x)) &  EA_SIZE_MASK))
 #define EA_SIZE_IN_BYTES(x)         ((UNATIVE_OFFSET)(EA_SIZE(x)))
-#define EA_SET_SIZE(x, sz)          ((emitAttr)((((unsigned)(x)) & ~EA_SIZE_MASK) | (sz)))
 #define EA_SET_FLG(x, flg)          ((emitAttr)(((unsigned)(x)) | (flg)))
 #define EA_REMOVE_FLG(x, flg)       ((emitAttr)(((unsigned)(x)) & ~(flg)))
 #define EA_4BYTE_DSP_RELOC          (EA_SET_FLG(EA_4BYTE, EA_DSP_RELOC_FLG))
@@ -335,8 +334,6 @@ enum emitAttr : unsigned
 #define EA_IS_CNS_RELOC(x)          ((((unsigned)(x)) & ((unsigned)EA_CNS_RELOC_FLG)) != 0)
 #define EA_IS_RELOC(x)              (EA_IS_DSP_RELOC(x) || EA_IS_CNS_RELOC(x))
 #define EA_TYPE(x)                  ((emitAttr)(((unsigned)(x)) & ~(EA_OFFSET_FLG | EA_DSP_RELOC_FLG | EA_CNS_RELOC_FLG)))
-
-#define EmitSize(x)                 (EA_ATTR(genTypeSize(TypeGet(x))))
 
 // clang-format on
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -442,24 +442,14 @@ void Lowering::ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenT
     GenTreeIntCon* offsetNode = addr->AsOp()->gtGetOp2()->AsIntCon();
     ssize_t        offset     = offsetNode->IconValue();
 
-    // All integer load/store instructions on both ARM32 and ARM64 support
-    // offsets in range -255..255. Of course, this is a rather conservative
-    // check. For example, if the offset and size are a multiple of 8 we
-    // could allow a combined offset of up to 32760 on ARM64.
+#ifdef TARGET_ARM
+    // All integer load/store instructions on Arm support offsets in range -255..255.
+    // Of course, this is a rather conservative check.
     if ((offset < -255) || (offset > 255) || (offset + static_cast<int>(size) > 256))
     {
         return;
     }
-
-#ifdef TARGET_ARM64
-    // If we're going to use LDP/STP we need to ensure that the offset is
-    // a multiple of 8 since these instructions do not have an unscaled
-    // offset variant.
-    if ((size >= 2 * REGSIZE_BYTES) && (offset % REGSIZE_BYTES != 0))
-    {
-        return;
-    }
-#endif
+#endif // TARGET_ARM
 
     if (!IsSafeToContainMem(blkNode, addr))
     {

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -619,6 +619,12 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         switch (blkNode->gtBlkOpKind)
         {
             case GenTreeBlk::BlkOpKindUnroll:
+#ifdef TARGET_ARM64
+                if (size > 2 * FP_REGSIZE_BYTES)
+                {
+                    buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
+                }
+#endif // TARGET_ARM64
                 break;
 
             case GenTreeBlk::BlkOpKindHelper:

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -681,11 +681,14 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                 case GenTreeBlk::BlkOpKindUnroll:
                     buildInternalIntRegisterDefForNode(blkNode);
 #ifdef TARGET_ARM64
+                    buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
+
                     if (size >= 2 * REGSIZE_BYTES)
                     {
                         // We will use ldp/stp to reduce code size and improve performance
                         // so we need to reserve an extra internal register
                         buildInternalIntRegisterDefForNode(blkNode);
+                        buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
                     }
 #endif
                     break;


### PR DESCRIPTION
Currently, `CodeGen::genCodeForInitBlkUnroll()` and `CodeGen::genCodeForCpBlkUnroll()` do not use SIMD instructions when generating code for `InitBlock`/`CopyBlock` operations on Arm and Arm64.

This PR adds support for that on Arm64.

In order to accurately estimate whether the use of SIMD instructions is needed and/or whether the base address of a block needs to computed and stored to a integer register the algorithm does multiple passes - (one that verifies whether all offsets can be encoded and another that counts how many instructions will be emitted).

The following are justifications why such approach was chosen:

1. In a case when one of the instruction offsets can not be encoded the new implementation would "spill" the address of the beginning of the block to an integer register in order to avoid doing this multiple times as it is now. 
In fact, that issue was already pointed out by a TODO comment (that is removed by the PR)
```
// TODO-ARM-CQ: If the local frame offset is too large to be encoded, the emitter automatically
// loads the offset into a reserved register (see CodeGen::rsGetRsvdReg()). If we generate
// multiple store instructions we'll also generate multiple offset loading instructions.
// We could try to detect such cases, compute the base destination address in this reserved
// and use it in all store instructions we generate. This would effectively undo the effect
// of local address containment done by lowering.
 ```
In other words it transforms a problem of code-generating of `InitBlock(largeOffset, byteCount)` to `InitBlock(0, byteCount)`. In order to do figure out that such transformation is required, the algorithm needs a pass to verify whether all the offsets are encodable.

For example, the following snippet shows such case
```diff
             add     xip1, fp, #0xd1ffab1e
-            stp     xzr, xzr, [xip1]   // [V49 tmp34]
-            add     xip1, fp, #0xd1ffab1e
-            stp     xzr, xzr, [xip1]   // [V49 tmp34+0x10]
-            add     xip1, fp, #0xd1ffab1e
-            stp     xzr, xzr, [xip1]   // [V49 tmp34+0x20]
-            str     xzr, [fp,#0xd1ffab1e]      // [V49 tmp34+0x30]
+            stp     xzr, xzr, [xip1]
+            stp     xzr, xzr, [xip1,#16]
+            stp     xzr, xzr, [xip1,#32]
+            str     xzr, [xip1,#48]
```

2. In some cases using SIMD instructions would result in a longer instruction sequence(e.g. in `InitBlockAllZeros(startOffset=8, byteCount=16)`) since the JIT would need to initialize a SIMD register while it could just use a `str xzr, xzr, [dstReg, #dstOffset]` instead (assuming `dstOffset` is encodable). In order to figure out such cases I've chose to use the same mechanism of multiple passes instead of trying to *"encode"* all corner cases.

As an example, the following demonstrates a case where it is beneficial to *"spill"* that the base of address of destination in `CopyBlock` and use SIMD instructions than use integer instructions without spilling.

```diff
-            ldp     x1, x2, [fp,#80]   // [V17 tmp13]
-            stp     x1, x2, [fp,#24]   // [V32 tmp28]
-            ldp     x1, x2, [fp,#96]   // [V17 tmp13+0x10]
-            stp     x1, x2, [fp,#40]   // [V32 tmp28+0x10]
-            ldp     x1, x2, [fp,#112]  // [V17 tmp13+0x20]
-            stp     x1, x2, [fp,#56]   // [V32 tmp28+0x20]
-            ldr     x1, [fp,#128]      // [V17 tmp13+0x30]
-            str     x1, [fp,#72]       // [V32 tmp28+0x30]
-                                               ;; bbWeight=0.50 PerfScore 7.50
+            add     xip1, fp, #56
+            ldr     x1, [xip1,#24]
+            str     x1, [fp,#24]
+            ldp     q16, q17, [xip1,#32]
+            stp     q16, q17, [fp,#32]
+            ldr     q16, [xip1,#64]
+            str     q16, [fp,#64]
```

In addition to that, the instruction selection strategy that the current implementation uses can be characterized as greedy *"best fit"* and it doesn't always produce the optimal result (for example, `InitBlock` sequence for 7 bytes is `str rInitValue, [rAddr]; strh rInitValue, [rAddr+4]; strb rInitValue, [rAddr+6]`). I changed the strategy slightly and added support to allow overlapping stores (so that sequence would become `str rInitValue, [rAddr]; stur rInitValue, [rAddr+3]`.

The following is an example where using overlapping loads/stores result in shorter instruction sequence
```diff
             ldp     x1, x3, [x0]
             stp     x1, x3, [x2,#16]
-            ldr     w1, [x0,#16]
-            str     w1, [x2,#32]
-            ldrh    w1, [x0,#20]
-            strh    w1, [x2,#36]
+            ldr     x1, [x0,#14]
+            str     x1, [x2,#30]
```