### PR TITLE
[arm64] JIT: Fix IsContainableImmed for arm64 v8.1 or higher

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -73,8 +73,8 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
         {
             case GT_ADD:
             case GT_SUB:
-                return emitter::emitIns_valid_imm_for_add(immVal, size);
 #ifdef TARGET_ARM64
+                return emitter::emitIns_valid_imm_for_add(immVal, size);
             case GT_CMPXCHG:
             case GT_LOCKADD:
             case GT_XORR:

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -73,6 +73,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
         {
             case GT_ADD:
             case GT_SUB:
+                return emitter::emitIns_valid_imm_for_add(immVal, size);
 #ifdef TARGET_ARM64
             case GT_CMPXCHG:
             case GT_LOCKADD:


### PR DESCRIPTION
```csharp
static int Test(int x) => x + 1;
```
Current codegen on Apple M1 is
```asm
        mov     w1, #1
        add     w0, w0, w1
```
As you can see, `#1` was not contained.

Codegen with this PR:
```asm
        add     w0, w0, #1
```
The issue is that we always return `false` even for normal GT_AND/GT_SUB when Atomics ISA is available (>=8.1 which is pretty much any modern arm hardware) [here](https://github.com/dotnet/runtime/blob/46a3bfeffec2fb6b33bfd152d33f33b544e401c9/src/coreclr/jit/lowerarmarch.cpp#L74-L83).

Diffs are huge 😮 
## coreclr_tests.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 167864316 (overridden on cmd)
Total bytes of diff: 165435492 (overridden on cmd)
Total bytes of delta: -2428824 (-1.45 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         496 : 231644.dasm (2.71% of base)
         288 : 184858.dasm (0.23% of base)
         240 : 231619.dasm (13.39% of base)
          20 : 42441.dasm (6.33% of base)
          12 : 147939.dasm (15.79% of base)
          12 : 147943.dasm (15.79% of base)
          12 : 147947.dasm (15.79% of base)
          12 : 147953.dasm (15.79% of base)
          12 : 147963.dasm (15.79% of base)
          12 : 147967.dasm (15.79% of base)
          12 : 147971.dasm (15.79% of base)
          12 : 147975.dasm (15.79% of base)
          12 : 83146.dasm (7.50% of base)
          12 : 243928.dasm (8.57% of base)
           8 : 161864.dasm (1.22% of base)
           8 : 141804.dasm (1.33% of base)
           8 : 156464.dasm (2.78% of base)
           8 : 162052.dasm (1.15% of base)
           8 : 162053.dasm (1.14% of base)
           8 : 85857.dasm (4.00% of base)

Top file improvements (bytes):
     -249392 : 75618.dasm (-9.09% of base)
      -49672 : 5436.dasm (-0.22% of base)
      -42064 : 5439.dasm (-0.27% of base)
      -26080 : 120853.dasm (-0.98% of base)
       -9436 : 219712.dasm (-11.93% of base)
       -8824 : 173154.dasm (-7.52% of base)
       -5360 : 24723.dasm (-0.09% of base)
       -5360 : 5441.dasm (-0.05% of base)
       -5360 : 161.dasm (-0.07% of base)
       -4236 : 245095.dasm (-27.39% of base)
       -3564 : 170741.dasm (-10.14% of base)
       -2048 : 216465.dasm (-5.93% of base)
       -2048 : 216466.dasm (-5.45% of base)
       -1916 : 216464.dasm (-7.31% of base)
       -1900 : 220756.dasm (-6.50% of base)
       -1892 : 219970.dasm (-6.48% of base)
       -1884 : 215635.dasm (-23.53% of base)
       -1884 : 220148.dasm (-23.53% of base)
       -1700 : 220147.dasm (-16.22% of base)
       -1592 : 34562.dasm (-0.09% of base)

95578 total files with Code Size differences (95450 improved, 128 regressed), 168 unchanged.

Top method regressions (bytes):
         496 ( 2.71% of base) : 231644.dasm - lclfldadd:Main():int
         288 ( 0.23% of base) : 184858.dasm - overlddiv:Main():int
         240 (13.39% of base) : 231619.dasm - mainMethod:callCheckGetTypeIntCast()
          20 ( 6.33% of base) : 42441.dasm - JIT.HardwareIntrinsics.General.VectorTernaryOpTest__ConditionalSelectInt16:ValidateResult(System.Runtime.Intrinsics.Vector128`1[Int16],System.Runtime.Intrinsics.Vector128`1[Int16],System.Runtime.Intrinsics.Vector128`1[Int16],long,System.String):this
          12 ( 8.57% of base) : 243928.dasm - BinaryPrimitivesReverseEndianness.Program:ByteSwapUnsigned_General(long,int):long
          12 (15.79% of base) : 147939.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetDouble:HasAllBitsSet(double):bool:this
          12 (15.79% of base) : 147943.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetInt16:HasAllBitsSet(short):bool:this
          12 (15.79% of base) : 147947.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetInt32:HasAllBitsSet(int):bool:this
          12 (15.79% of base) : 147953.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetInt64:HasAllBitsSet(long):bool:this
          12 (15.79% of base) : 147963.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetSingle:HasAllBitsSet(float):bool:this
          12 (15.79% of base) : 147967.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetUInt16:HasAllBitsSet(ushort):bool:this
          12 (15.79% of base) : 147971.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetUInt32:HasAllBitsSet(int):bool:this
          12 (15.79% of base) : 147975.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetUInt64:HasAllBitsSet(long):bool:this
          12 ( 7.50% of base) : 83146.dasm - Runtime_57640:Main():int
           8 ( 2.25% of base) : 225262.dasm - Functions.MathTests:AcosDoubleTest()
           8 ( 2.25% of base) : 225281.dasm - Functions.MathTests:AcosSingleTest()
           8 ( 2.25% of base) : 225263.dasm - Functions.MathTests:AsinDoubleTest()
           8 ( 2.25% of base) : 225282.dasm - Functions.MathTests:AsinSingleTest()
           8 ( 2.25% of base) : 225264.dasm - Functions.MathTests:AtanDoubleTest()
           8 ( 2.25% of base) : 225283.dasm - Functions.MathTests:AtanSingleTest()

Top method improvements (bytes):
     -249392 (-9.09% of base) : 75618.dasm - Test:HugeMethod():int:this
      -49672 (-0.22% of base) : 5436.dasm - CseTest.Test_Main:Main():int
      -42064 (-0.27% of base) : 5439.dasm - CseTest.Test_Main:Main():int
      -26080 (-0.98% of base) : 120853.dasm - NullableTest:And()
       -9436 (-11.93% of base) : 219712.dasm - InstrCnt1:Main():int
       -8824 (-7.52% of base) : 173154.dasm - testout1:Main():int
       -5360 (-0.09% of base) : 24723.dasm - CseTest.Test_Main:Main():int
       -5360 (-0.05% of base) : 5441.dasm - CseTest.Test_Main:Main():int
       -5360 (-0.07% of base) : 161.dasm - CseTest.Test_Main:Main():int
       -4236 (-27.39% of base) : 245095.dasm - SimpleArray_01.Test:Test1()
       -3564 (-10.14% of base) : 170741.dasm - Program:Main(System.String[]):int
       -2048 (-5.93% of base) : 216465.dasm - testout1:Sub_Funclet_1():int
       -2048 (-5.45% of base) : 216466.dasm - testout1:Sub_Funclet_2():int
       -1916 (-7.31% of base) : 216464.dasm - testout1:Sub_Funclet_0():int
       -1900 (-6.50% of base) : 220756.dasm - <Module>:f():int
       -1892 (-6.48% of base) : 219970.dasm - <Module>:f():int
       -1884 (-23.53% of base) : 215635.dasm - testout1:Sub_Funclet_1():int
       -1884 (-23.53% of base) : 220148.dasm - testout1:Sub_Funclet_1():int
       -1700 (-16.22% of base) : 220147.dasm - testout1:Sub_Funclet_0():int
       -1592 (-0.09% of base) : 34562.dasm - CseTest.Test_Main:Main():int

Top method regressions (percentages):
          12 (15.79% of base) : 147939.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetDouble:HasAllBitsSet(double):bool:this
          12 (15.79% of base) : 147943.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetInt16:HasAllBitsSet(short):bool:this
          12 (15.79% of base) : 147947.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetInt32:HasAllBitsSet(int):bool:this
          12 (15.79% of base) : 147953.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetInt64:HasAllBitsSet(long):bool:this
          12 (15.79% of base) : 147963.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetSingle:HasAllBitsSet(float):bool:this
          12 (15.79% of base) : 147967.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetUInt16:HasAllBitsSet(ushort):bool:this
          12 (15.79% of base) : 147971.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetUInt32:HasAllBitsSet(int):bool:this
          12 (15.79% of base) : 147975.dasm - JIT.HardwareIntrinsics.General.VectorAllBitsSet__AllBitsSetUInt64:HasAllBitsSet(long):bool:this
         240 (13.39% of base) : 231619.dasm - mainMethod:callCheckGetTypeIntCast()
          12 ( 8.57% of base) : 243928.dasm - BinaryPrimitivesReverseEndianness.Program:ByteSwapUnsigned_General(long,int):long
          12 ( 7.50% of base) : 83146.dasm - Runtime_57640:Main():int
          20 ( 6.33% of base) : 42441.dasm - JIT.HardwareIntrinsics.General.VectorTernaryOpTest__ConditionalSelectInt16:ValidateResult(System.Runtime.Intrinsics.Vector128`1[Int16],System.Runtime.Intrinsics.Vector128`1[Int16],System.Runtime.Intrinsics.Vector128`1[Int16],long,System.String):this
           4 ( 5.56% of base) : 247028.dasm - ImplicitByrefTailCalls:S(System.Span`1[Int32]):int
           8 ( 5.00% of base) : 82397.dasm - Program:foo(int):int
           8 ( 4.76% of base) : 250183.dasm - JitTest.Test:ckbuf(long,int)
           8 ( 4.55% of base) : 82149.dasm - JitInliningTest.Args3:Main():int
           4 ( 4.00% of base) : 83577.dasm - Program:Bar():int
           8 ( 4.00% of base) : 85857.dasm - Repro:Main():int
           4 ( 3.85% of base) : 5343.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseSelect(byte,byte,byte):byte
           4 ( 3.85% of base) : 5293.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseSelect(short,short,short):short

Top method improvements (percentages):
         -24 (-35.29% of base) : 216110.dasm - V8.Crypto.BigInteger:cbit(int):int
         -20 (-33.33% of base) : 243402.dasm - test:test_04():int
         -20 (-33.33% of base) : 243415.dasm - test:test_104():long
         -20 (-33.33% of base) : 243388.dasm - test:test_204():int
         -20 (-31.25% of base) : 246223.dasm - A.B:downBy1ge(int):int
         -20 (-31.25% of base) : 246227.dasm - A.B:downBy1gt(int):int
         -20 (-31.25% of base) : 246233.dasm - A.B:downBy1ne(int):int
         -20 (-31.25% of base) : 246229.dasm - A.B:downBy2ge(int):int
         -20 (-31.25% of base) : 246231.dasm - A.B:downBy2gt(int):int
         -20 (-31.25% of base) : 246224.dasm - A.B:downBy2ne(int):int
         -20 (-31.25% of base) : 246236.dasm - A.B:downBy3neWrap(int):int
         -20 (-31.25% of base) : 246225.dasm - A.B:upBy1le(int):int
         -20 (-31.25% of base) : 246226.dasm - A.B:upBy1lt(int):int
         -20 (-31.25% of base) : 246232.dasm - A.B:upBy1ne(int):int
         -20 (-31.25% of base) : 246228.dasm - A.B:upBy2le(int):int
         -20 (-31.25% of base) : 246230.dasm - A.B:upBy2lt(int):int
         -20 (-31.25% of base) : 246234.dasm - A.B:upBy2ne(int):int
         -20 (-31.25% of base) : 246235.dasm - A.B:upBy3neWrap(int):int
         -20 (-31.25% of base) : 240541.dasm - B:F1downBy1ge(int):int
         -20 (-31.25% of base) : 240545.dasm - B:F1downBy1gt(int):int

95578 total methods with Code Size differences (95450 improved, 128 regressed), 168 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 48926192 (overridden on cmd)
Total bytes of diff: 48496876 (overridden on cmd)
Total bytes of delta: -429316 (-0.88 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          20 : 177310.dasm (2.76% of base)
           4 : 75010.dasm (0.52% of base)
           4 : 27019.dasm (0.33% of base)

Top file improvements (bytes):
       -1652 : 90723.dasm (-5.46% of base)
       -1152 : 65546.dasm (-10.08% of base)
        -900 : 69842.dasm (-12.40% of base)
        -884 : 63630.dasm (-8.71% of base)
        -740 : 65326.dasm (-8.50% of base)
        -720 : 82984.dasm (-5.14% of base)
        -712 : 62962.dasm (-2.31% of base)
        -676 : 131436.dasm (-8.80% of base)
        -616 : 94655.dasm (-6.79% of base)
        -604 : 97646.dasm (-6.96% of base)
        -544 : 65200.dasm (-1.89% of base)
        -528 : 118049.dasm (-8.93% of base)
        -488 : 61694.dasm (-2.03% of base)
        -480 : 117047.dasm (-6.47% of base)
        -396 : 105398.dasm (-3.84% of base)
        -392 : 28970.dasm (-14.45% of base)
        -388 : 28972.dasm (-16.58% of base)
        -376 : 65613.dasm (-2.09% of base)
        -372 : 64064.dasm (-6.05% of base)
        -364 : 106942.dasm (-2.29% of base)

34752 total files with Code Size differences (34749 improved, 3 regressed), 20 unchanged.

Top method regressions (bytes):
          20 ( 2.76% of base) : 177310.dasm - ObserversState:NotifyObserversOfCompletion(System.Exception):this
           4 ( 0.33% of base) : 27019.dasm - HashCompare:GenericComparisonArbArrayWithComparer(Microsoft.FSharp.Core.LanguagePrimitives+HashCompare+GenericComparer,System.Array,System.Array):int
           4 ( 0.52% of base) : 75010.dasm - System.Threading.Tasks.Task:AddExceptionsFromChildren(System.Threading.Tasks.Task+ContingentProperties):this

Top method improvements (bytes):
       -1652 (-5.46% of base) : 90723.dasm - Microsoft.VisualBasic.CompilerServices.VBBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
       -1152 (-10.08% of base) : 65546.dasm - System.Text.RegularExpressions.RegexInterpreter:Go():this
        -900 (-12.40% of base) : 69842.dasm - System.Reflection.Emit.OpCodes:.cctor()
        -884 (-8.71% of base) : 63630.dasm - Microsoft.Cci.PeWriter:WriteHeaders(System.IO.Stream,Microsoft.Cci.NtHeader,Microsoft.Cci.CoffHeader,System.Collections.Generic.List`1[Microsoft.Cci.SectionHeader],byref):this
        -740 (-8.50% of base) : 65326.dasm - System.Text.RegularExpressions.RegexWriter:EmitFragment(int,System.Text.RegularExpressions.RegexNode,int):this
        -720 (-5.14% of base) : 82984.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
        -712 (-2.31% of base) : 62962.dasm - Microsoft.CodeAnalysis.DesktopAssemblyIdentityComparer:.cctor()
        -676 (-8.80% of base) : 131436.dasm - System.Reflection.PortableExecutable.PEBuilder:WritePEHeader(System.Reflection.Metadata.BlobBuilder,System.Reflection.PortableExecutable.PEDirectoriesBuilder,System.Collections.Immutable.ImmutableArray`1[System.Reflection.PortableExecutable.PEBuilder+SerializedSection]):this
        -616 (-6.79% of base) : 94655.dasm - System.Data.RBTree`1:RBInsert(int,int,int,int,bool):int:this
        -604 (-6.96% of base) : 97646.dasm - System.Data.RBTree`1:RBInsert(int,int,int,int,bool):int:this
        -544 (-1.89% of base) : 65200.dasm - System.Text.RegularExpressions.RegexCompiler:GenerateOneCode():this
        -528 (-8.93% of base) : 118049.dasm - System.Xml.Schema.XmlSchemaInference:InferSimpleType(System.String,byref):int
        -488 (-2.03% of base) : 61694.dasm - Microsoft.CodeAnalysis.AttributeDescription:.cctor()
        -480 (-6.47% of base) : 117047.dasm - System.Xml.Xsl.Xslt.XsltLoader:.ctor():this
        -396 (-3.84% of base) : 105398.dasm - System.Net.Http.Headers.QPackStaticTable:.cctor()
        -392 (-14.45% of base) : 28970.dasm - Filter:populateDstViaMask(System.__Canon[],System.UInt32[],System.__Canon[]):int
        -388 (-16.58% of base) : 28972.dasm - Filter:populateMask(Microsoft.FSharp.Core.FSharpFunc`2[System.__Canon, System.Boolean],System.__Canon[],System.UInt32[]):int
        -376 (-2.09% of base) : 65613.dasm - System.Text.RegularExpressions.RegexCharClass:.cctor()
        -372 (-6.05% of base) : 64064.dasm - Microsoft.Cci.MetadataWriter:SerializeTypeReference(Microsoft.Cci.ITypeReference,Microsoft.Cci.BlobBuilder,bool,bool):this
        -364 (-2.29% of base) : 106942.dasm - <SendAsyncCore>d__60:MoveNext():this

Top method regressions (percentages):
          20 ( 2.76% of base) : 177310.dasm - ObserversState:NotifyObserversOfCompletion(System.Exception):this
           4 ( 0.52% of base) : 75010.dasm - System.Threading.Tasks.Task:AddExceptionsFromChildren(System.Threading.Tasks.Task+ContingentProperties):this
           4 ( 0.33% of base) : 27019.dasm - HashCompare:GenericComparisonArbArrayWithComparer(Microsoft.FSharp.Core.LanguagePrimitives+HashCompare+GenericComparer,System.Array,System.Array):int

Top method improvements (percentages):
         -12 (-23.08% of base) : 122849.dasm - System.Xml.XmlTextReaderImpl:OnNewLine(int):this
          -8 (-22.22% of base) : 58147.dasm - VersionResourceSerializer:PadKeyLen(int):int
         -32 (-21.62% of base) : 193539.dasm - System.IO.Compression.Zip64ExtraField:UpdateSize():this
         -32 (-20.51% of base) : 82568.dasm - System.Guid:HexsToChars(long,int,int):int
         -68 (-20.48% of base) : 87384.dasm - System.SpanHelpers:Fill(byref,long,double)
         -68 (-20.48% of base) : 87324.dasm - System.SpanHelpers:Fill(byref,long,float)
         -68 (-20.48% of base) : 87048.dasm - System.SpanHelpers:Fill(byref,long,int)
         -68 (-20.48% of base) : 87386.dasm - System.SpanHelpers:Fill(byref,long,int)
         -68 (-20.48% of base) : 87306.dasm - System.SpanHelpers:Fill(byref,long,long)
         -68 (-20.48% of base) : 87385.dasm - System.SpanHelpers:Fill(byref,long,long)
          -8 (-20.00% of base) : 138522.dasm - Enumerator:Pop():this
         -12 (-20.00% of base) : 63806.dasm - Microsoft.Cci.MetadataSizes:GetMetadataStreamHeaderSize(System.String):int
         -12 (-20.00% of base) : 158373.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.EmbeddedSymbolManager:SealCollection():this
          -8 (-20.00% of base) : 142774.dasm - Microsoft.CodeAnalysis.VisualBasic.SyntaxTreeDiagnosticEnumerator:Pop():this
         -12 (-20.00% of base) : 129170.dasm - System.Reflection.Metadata.Ecma335.MetadataSizes:GetMetadataStreamHeaderSize(System.String):int
          -8 (-20.00% of base) : 65407.dasm - System.Text.RegularExpressions.RegexParser:PopKeepOptions():this
          -8 (-20.00% of base) : 168265.dasm - System.Transactions.TransactionStatePromotedNonMSDTCBase:CompleteAbortingClone(System.Transactions.InternalTransaction):this
          -8 (-20.00% of base) : 168263.dasm - System.Transactions.TransactionStatePromotedNonMSDTCBase:CreateAbortingClone(System.Transactions.InternalTransaction):this
          -8 (-20.00% of base) : 168264.dasm - System.Transactions.TransactionStatePromotedNonMSDTCBase:CreateBlockingClone(System.Transactions.InternalTransaction):this
         -64 (-18.82% of base) : 86683.dasm - System.SpanHelpers:Fill(byref,long,ushort)

34752 total methods with Code Size differences (34749 improved, 3 regressed), 20 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 48347476 (overridden on cmd)
Total bytes of diff: 47408036 (overridden on cmd)
Total bytes of delta: -939440 (-1.94 % of base)
    diff is an improvement.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          36 : 147756.dasm (2.97% of base)
          16 : 151528.dasm (4.26% of base)
          16 : 165356.dasm (3.12% of base)
          12 : 180989.dasm (1.39% of base)
          12 : 180992.dasm (1.40% of base)
          12 : 172320.dasm (14.29% of base)
          12 : 87490.dasm (15.79% of base)
           8 : 166711.dasm (2.02% of base)
           8 : 182463.dasm (2.25% of base)
           8 : 222361.dasm (2.13% of base)
           8 : 212379.dasm (1.72% of base)
           8 : 12734.dasm (2.33% of base)
           8 : 159013.dasm (1.72% of base)
           8 : 212136.dasm (3.23% of base)
           8 : 156385.dasm (1.85% of base)
           4 : 166710.dasm (0.99% of base)
           4 : 214453.dasm (1.69% of base)
           4 : 3811.dasm (1.82% of base)
           4 : 96067.dasm (2.13% of base)
           4 : 169080.dasm (1.69% of base)

Top file improvements (bytes):
       -1504 : 104310.dasm (-5.72% of base)
       -1288 : 140.dasm (-10.66% of base)
        -920 : 79507.dasm (-1.47% of base)
        -824 : 108.dasm (-9.83% of base)
        -672 : 77655.dasm (-14.00% of base)
        -636 : 186566.dasm (-5.99% of base)
        -632 : 73915.dasm (-7.03% of base)
        -624 : 73976.dasm (-7.30% of base)
        -584 : 782.dasm (-3.10% of base)
        -576 : 114215.dasm (-9.41% of base)
        -520 : 12868.dasm (-19.43% of base)
        -512 : 178938.dasm (-4.97% of base)
        -488 : 135258.dasm (-9.41% of base)
        -480 : 115322.dasm (-8.94% of base)
        -480 : 139625.dasm (-10.51% of base)
        -468 : 25094.dasm (-6.06% of base)
        -468 : 135935.dasm (-7.35% of base)
        -452 : 186563.dasm (-5.91% of base)
        -448 : 160177.dasm (-2.75% of base)
        -432 : 121929.dasm (-2.85% of base)

55022 total files with Code Size differences (55000 improved, 22 regressed), 76 unchanged.

Top method regressions (bytes):
          36 ( 2.97% of base) : 147756.dasm - System.Configuration.BaseConfigurationRecord:MonitorStream(System.String,System.String,System.String):System.Object:this
          16 ( 3.12% of base) : 165356.dasm - CacheEntryTokens:PropagateTokens(Microsoft.Extensions.Caching.Memory.CacheEntry):this
          16 ( 4.26% of base) : 151528.dasm - System.Xml.XmlStreamNodeWriter:UnsafeGetUTF8Chars(long,int,System.Byte[],int):int:this
          12 ( 1.39% of base) : 180989.dasm - LastQueryOperatorEnumerator`1[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:MoveNext(byref,byref):bool:this
          12 ( 1.40% of base) : 180992.dasm - LastQueryOperatorEnumerator`1[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:MoveNext(byref,byref):bool:this
          12 (15.79% of base) : 87490.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCapture.PacketFragmentArgs:IsPrintable(long,long):bool
          12 (14.29% of base) : 172320.dasm - Number:TrailingZeros(System.ReadOnlySpan`1[Char],int):bool
           8 ( 2.25% of base) : 182463.dasm - Microsoft.Extensions.Configuration.ConfigurationManager:Microsoft.Extensions.Configuration.IConfigurationRoot.Reload():this
           8 ( 2.13% of base) : 222361.dasm - Microsoft.Extensions.DependencyInjection.DependencyInjectionEventSource:OnEventCommand(System.Diagnostics.Tracing.EventCommandEventArgs):this
           8 ( 2.33% of base) : 12734.dasm - Microsoft.FSharp.Collections.ArrayModule:Create(int,System.Numerics.Vector`1[Single]):System.Numerics.Vector`1[System.Single][]
           8 ( 1.85% of base) : 156385.dasm - System.DirectoryServices.Protocols.DirectoryAttribute:AddRange(System.Object[]):this
           8 ( 1.72% of base) : 212379.dasm - System.Net.HttpEndPointListener:Close():this
           8 ( 3.23% of base) : 212136.dasm - System.Net.ServiceNameStore:Contains(System.String):bool:this
           8 ( 1.72% of base) : 159013.dasm - System.Threading.Tasks.Dataflow.Internal.JoinBlockTarget`1[Byte][System.Byte]:CompleteOncePossible():this
           8 ( 2.02% of base) : 166711.dasm - Xunit.AggregateMessageSink:OnMessageWithTypes(Xunit.Abstractions.IMessageSinkMessage,System.Collections.Generic.HashSet`1[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):bool:this
           4 ( 2.13% of base) : 96067.dasm - ProviderMetaDataKey:Equals(ProviderMetaDataKey):bool:this
           4 ( 1.82% of base) : 3811.dasm - System.Drawing.Imaging.EncoderParameter:.ctor(System.Drawing.Imaging.Encoder,System.Int64[]):this
           4 ( 3.57% of base) : 172373.dasm - System.Numerics.BigIntegerCalculator:AddDivisor(System.Span`1[UInt32],System.ReadOnlySpan`1[UInt32]):int
           4 ( 1.69% of base) : 214453.dasm - System.Security.Cryptography.KeyBlobHelpers:WriteKeyParameterInteger(System.Formats.Asn1.AsnWriter,System.ReadOnlySpan`1[Byte])
           4 ( 1.69% of base) : 169080.dasm - System.Security.Cryptography.KeyBlobHelpers:WriteKeyParameterInteger(System.Formats.Asn1.AsnWriter,System.ReadOnlySpan`1[Byte])

Top method improvements (bytes):
       -1504 (-5.72% of base) : 104310.dasm - Microsoft.VisualBasic.CompilerServices.VBBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
       -1288 (-10.66% of base) : 140.dasm - System.Text.RegularExpressions.RegexInterpreter:Go():this
        -920 (-1.47% of base) : 79507.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -824 (-9.83% of base) : 108.dasm - System.Text.RegularExpressions.RegexWriter:EmitFragment(int,System.Text.RegularExpressions.RegexNode,int):this
        -672 (-14.00% of base) : 77655.dasm - Microsoft.Diagnostics.Tracing.StartStopActivityComputer:.ctor(Microsoft.Diagnostics.Tracing.Etlx.TraceLogEventSource,Microsoft.Diagnostics.Tracing.ActivityComputer,bool):this
        -636 (-5.99% of base) : 186566.dasm - System.Formats.Asn1.AsnWriter:WriteGeneralizedTimeCore(System.Formats.Asn1.Asn1Tag,System.DateTimeOffset,bool):this
        -632 (-7.03% of base) : 73915.dasm - System.Data.RBTree`1[__Canon][System.__Canon]:RBInsert(int,int,int,int,bool):int:this
        -624 (-7.30% of base) : 73976.dasm - System.Data.RBTree`1[Byte][System.Byte]:RBInsert(int,int,int,int,bool):int:this
        -584 (-3.10% of base) : 782.dasm - System.Text.RegularExpressions.RegexCompiler:GenerateOneCode():this
        -576 (-9.41% of base) : 114215.dasm - System.Xml.Schema.XmlSchemaInference:InferSimpleType(System.String,byref):int
        -520 (-19.43% of base) : 12868.dasm - Filter:populateDstViaMask(System.Byte[],System.UInt32[],System.Byte[]):int
        -512 (-4.97% of base) : 178938.dasm - R2RTest.BuildFolderSet:WriteBuildStatistics(System.IO.StreamWriter):this
        -488 (-9.41% of base) : 135258.dasm - Microsoft.Cci.MetadataWriter:SerializeTypeReference(Microsoft.Cci.ITypeReference,Microsoft.Cci.BlobBuilder,bool,bool):this
        -480 (-10.51% of base) : 139625.dasm - Microsoft.CodeAnalysis.Emit.DeltaMetadataWriter:PopulateEncMapTableRows(System.Collections.Generic.List`1[EncMapRow],System.Collections.Immutable.ImmutableArray`1[Int32]):this
        -480 (-8.94% of base) : 115322.dasm - System.Xml.Xsl.Xslt.XsltLoader:.ctor():this
        -468 (-7.35% of base) : 135935.dasm - Microsoft.Cci.PeWriter:WriteHeaders(System.IO.Stream,Microsoft.Cci.NtHeader,Microsoft.Cci.CoffHeader,System.Collections.Generic.List`1[[Microsoft.Cci.SectionHeader, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref):this
        -468 (-6.06% of base) : 25094.dasm - Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor:VisitMethod(Microsoft.CodeAnalysis.IMethodSymbol):this
        -452 (-5.91% of base) : 186563.dasm - System.Formats.Asn1.AsnWriter:WriteUtcTimeCore(System.Formats.Asn1.Asn1Tag,System.DateTimeOffset):this
        -448 (-2.75% of base) : 160177.dasm - Sys:GetDriveType(System.String):int
        -432 (-2.85% of base) : 121929.dasm - <SendAsyncCore>d__60:MoveNext():this

Top method regressions (percentages):
          12 (15.79% of base) : 87490.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCapture.PacketFragmentArgs:IsPrintable(long,long):bool
          12 (14.29% of base) : 172320.dasm - Number:TrailingZeros(System.ReadOnlySpan`1[Char],int):bool
          16 ( 4.26% of base) : 151528.dasm - System.Xml.XmlStreamNodeWriter:UnsafeGetUTF8Chars(long,int,System.Byte[],int):int:this
           4 ( 3.57% of base) : 172373.dasm - System.Numerics.BigIntegerCalculator:AddDivisor(System.Span`1[UInt32],System.ReadOnlySpan`1[UInt32]):int
           8 ( 3.23% of base) : 212136.dasm - System.Net.ServiceNameStore:Contains(System.String):bool:this
          16 ( 3.12% of base) : 165356.dasm - CacheEntryTokens:PropagateTokens(Microsoft.Extensions.Caching.Memory.CacheEntry):this
          36 ( 2.97% of base) : 147756.dasm - System.Configuration.BaseConfigurationRecord:MonitorStream(System.String,System.String,System.String):System.Object:this
           8 ( 2.33% of base) : 12734.dasm - Microsoft.FSharp.Collections.ArrayModule:Create(int,System.Numerics.Vector`1[Single]):System.Numerics.Vector`1[System.Single][]
           8 ( 2.25% of base) : 182463.dasm - Microsoft.Extensions.Configuration.ConfigurationManager:Microsoft.Extensions.Configuration.IConfigurationRoot.Reload():this
           8 ( 2.13% of base) : 222361.dasm - Microsoft.Extensions.DependencyInjection.DependencyInjectionEventSource:OnEventCommand(System.Diagnostics.Tracing.EventCommandEventArgs):this
           4 ( 2.13% of base) : 96067.dasm - ProviderMetaDataKey:Equals(ProviderMetaDataKey):bool:this
           8 ( 2.02% of base) : 166711.dasm - Xunit.AggregateMessageSink:OnMessageWithTypes(Xunit.Abstractions.IMessageSinkMessage,System.Collections.Generic.HashSet`1[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):bool:this
           8 ( 1.85% of base) : 156385.dasm - System.DirectoryServices.Protocols.DirectoryAttribute:AddRange(System.Object[]):this
           4 ( 1.82% of base) : 3811.dasm - System.Drawing.Imaging.EncoderParameter:.ctor(System.Drawing.Imaging.Encoder,System.Int64[]):this
           8 ( 1.72% of base) : 212379.dasm - System.Net.HttpEndPointListener:Close():this
           8 ( 1.72% of base) : 159013.dasm - System.Threading.Tasks.Dataflow.Internal.JoinBlockTarget`1[Byte][System.Byte]:CompleteOncePossible():this
           4 ( 1.69% of base) : 214453.dasm - System.Security.Cryptography.KeyBlobHelpers:WriteKeyParameterInteger(System.Formats.Asn1.AsnWriter,System.ReadOnlySpan`1[Byte])
           4 ( 1.69% of base) : 169080.dasm - System.Security.Cryptography.KeyBlobHelpers:WriteKeyParameterInteger(System.Formats.Asn1.AsnWriter,System.ReadOnlySpan`1[Byte])
           4 ( 1.69% of base) : 174555.dasm - System.Security.Cryptography.KeyBlobHelpers:WriteKeyParameterInteger(System.Formats.Asn1.AsnWriter,System.ReadOnlySpan`1[Byte])
          12 ( 1.40% of base) : 180992.dasm - LastQueryOperatorEnumerator`1[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:MoveNext(byref,byref):bool:this

Top method improvements (percentages):
         -20 (-33.33% of base) : 178492.dasm - System.Linq.SingleLinkedNode`1[__Canon][System.__Canon]:GetNode(int):System.Linq.SingleLinkedNode`1[__Canon]:this
         -20 (-33.33% of base) : 178498.dasm - System.Linq.SingleLinkedNode`1[Byte][System.Byte]:GetNode(int):System.Linq.SingleLinkedNode`1[Byte]:this
         -20 (-31.25% of base) : 13125.dasm - Microsoft.FSharp.Collections.ListModule:Length(Microsoft.FSharp.Collections.FSharpList`1[Byte]):int
         -16 (-28.57% of base) : 54313.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxListBuilder:Validate(int,int):this
         -28 (-28.00% of base) : 7168.dasm - |MacroReduction|_|@991:Invoke(Microsoft.FSharp.Collections.FSharpList`1[[Microsoft.FSharp.Quotations.FSharpVar, FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.FSharp.Collections.FSharpList`1[[Microsoft.FSharp.Quotations.FSharpExpr, FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):bool:this
         -16 (-26.67% of base) : 78957.dasm - Microsoft.Diagnostics.Tracing.Stacks.CallTreeNode:Depth():int:this
         -40 (-25.00% of base) : 85688.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.IpDadFailedArgs:get_DLAddress():System.Byte[]:this
         -40 (-25.00% of base) : 85691.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.IpDadFailedArgs:get_IPv6Address():System.Byte[]:this
         -40 (-25.00% of base) : 85702.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.IpDadSuccessfulArgs:get_DLAddress():System.Byte[]:this
         -40 (-25.00% of base) : 85703.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.IpDadSuccessfulArgs:get_IPv6Address():System.Byte[]:this
         -40 (-25.00% of base) : 87091.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.TcpipWakePacketIndicated1303Args:get_SrcAddress():System.Byte[]:this
         -20 (-25.00% of base) : 155731.dasm - Microsoft.DiaSymReader.ComMemoryStream:ZeroMemory(long,int)
         -20 (-25.00% of base) : 141442.dasm - Roslyn.Utilities.ComMemoryStream:ZeroMemory(long,int)
         -16 (-25.00% of base) : 207016.dasm - SendFileOperation:DoTryComplete(System.Net.Sockets.SocketAsyncContext):bool:this
         -36 (-23.68% of base) : 86444.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.task_0Args:get_IPv6Address():System.Byte[]:this
         -36 (-23.68% of base) : 87090.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.TcpipWakePacketIndicated1303Args:get_SrcDLAddress():System.Byte[]:this
         -36 (-23.68% of base) : 87075.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.TcpipWakePacketIndicatedArgs:get_SrcDLAddress():System.Byte[]:this
         -16 (-23.53% of base) : 199590.dasm - <get_Keys>d__18[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:<>m__Finally1():this
         -16 (-23.53% of base) : 199610.dasm - <get_Values>d__22[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:<>m__Finally1():this
         -28 (-23.33% of base) : 172805.dasm - Microsoft.Diagnostics.Tracing.Extensions.ETWKernelControl:ExtensionsOffset(long,int):int

55022 total methods with Code Size differences (55000 improved, 22 regressed), 78 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 114599224 (overridden on cmd)
Total bytes of diff: 112547748 (overridden on cmd)
Total bytes of delta: -2051476 (-1.79 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          36 : 132974.dasm (0.98% of base)
          16 : 127741.dasm (1.38% of base)
          12 : 212046.dasm (1.30% of base)
          12 : 171422.dasm (3.61% of base)
          12 : 279021.dasm (1.49% of base)
          12 : 81885.dasm (1.68% of base)
          12 : 172549.dasm (1.49% of base)
          12 : 284805.dasm (0.33% of base)
           8 : 211080.dasm (1.18% of base)
           8 : 180679.dasm (1.18% of base)
           8 : 77422.dasm (1.36% of base)
           8 : 77423.dasm (2.33% of base)
           8 : 288538.dasm (2.35% of base)
           8 : 238373.dasm (0.44% of base)
           8 : 333681.dasm (2.30% of base)
           8 : 194908.dasm (1.32% of base)
           4 : 320686.dasm (0.93% of base)
           4 : 129978.dasm (1.56% of base)
           4 : 309855.dasm (1.33% of base)
           4 : 134630.dasm (0.69% of base)

Top file improvements (bytes):
       -4024 : 214197.dasm (-3.23% of base)
       -3740 : 258616.dasm (-22.66% of base)
       -2712 : 282051.dasm (-3.11% of base)
       -2148 : 6057.dasm (-3.01% of base)
       -2096 : 6042.dasm (-2.68% of base)
       -1288 : 140.dasm (-10.66% of base)
       -1212 : 214597.dasm (-3.11% of base)
       -1196 : 92753.dasm (-8.30% of base)
       -1196 : 2820.dasm (-8.30% of base)
       -1076 : 212959.dasm (-2.75% of base)
       -1036 : 6052.dasm (-6.89% of base)
        -968 : 37277.dasm (-5.81% of base)
        -880 : 6050.dasm (-5.30% of base)
        -872 : 213407.dasm (-5.54% of base)
        -852 : 2104.dasm (-7.23% of base)
        -840 : 296399.dasm (-6.29% of base)
        -840 : 234885.dasm (-4.46% of base)
        -836 : 290217.dasm (-3.42% of base)
        -824 : 108.dasm (-9.83% of base)
        -824 : 314995.dasm (-9.83% of base)

107192 total files with Code Size differences (107165 improved, 27 regressed), 80 unchanged.

Top method regressions (bytes):
          36 ( 0.98% of base) : 132974.dasm - System.Threading.Tasks.Tests.Status.TaskStatusTest:RealRun():this
          16 ( 1.38% of base) : 127741.dasm - Microsoft.Build.BackEnd.Logging.LoggingService:ShutdownComponent():this
          12 ( 0.33% of base) : 284805.dasm - <TestEcho>d__3:MoveNext():this
          12 ( 1.68% of base) : 81885.dasm - Microsoft.CodeAnalysis.Options.GlobalOptionService:UpdateRegisteredWorkspacesAndRaiseEvents(System.Collections.Generic.List`1[[Microsoft.CodeAnalysis.Options.OptionChangedEventArgs, Microsoft.CodeAnalysis.Workspaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):this
          12 ( 1.30% of base) : 212046.dasm - System.Data.SqlClient.TdsParserStateObject:ReadSniError(System.Data.SqlClient.TdsParserStateObject,int):this
          12 ( 1.49% of base) : 279021.dasm - System.IO.Tests.FileStream_Flush:SafeFileHandleCallsFlush_flushToDisk_False():this
          12 ( 1.49% of base) : 172549.dasm - System.IO.Tests.FileStream_Flush:SafeFileHandleCallsFlush_flushToDisk_False():this
          12 ( 3.61% of base) : 171422.dasm - System.Security.Cryptography.Xml.Tests.XmlDsigExcC14NTransformTest:Types():this
           8 ( 0.44% of base) : 238373.dasm - <TryCreate>d__8:MoveNext():this
           8 ( 1.36% of base) : 77422.dasm - Microsoft.CodeAnalysis.Workspace:ClearOpenDocuments():this
           8 ( 2.33% of base) : 77423.dasm - Microsoft.CodeAnalysis.Workspace:ClearOpenDocuments(Microsoft.CodeAnalysis.ProjectId):this
           8 ( 2.35% of base) : 288538.dasm - Microsoft.Test.ModuleCore.TestItem:FindChild(System.Type):Microsoft.Test.ModuleCore.TestItem:this
           8 ( 1.32% of base) : 194908.dasm - NuGet.ContentModel.Infrastructure.PatternExpression:Match(System.String,System.Collections.Generic.IReadOnlyDictionary`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[NuGet.ContentModel.ContentPropertyDefinition, NuGet.Packaging, Version=5.8.0.6930, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):NuGet.ContentModel.ContentItem:this
           8 ( 1.18% of base) : 211080.dasm - System.Data.SqlClient.SqlDependencyPerAppDomainDispatcher:InvalidateCommandID(System.Data.SqlClient.SqlNotification):this
           8 ( 1.18% of base) : 180679.dasm - System.Data.SqlClient.SqlDependencyPerAppDomainDispatcher:InvalidateCommandID(System.Data.SqlClient.SqlNotification):this
           8 ( 2.30% of base) : 333681.dasm - System.Transactions.Tests.TestEventListener:LoadSourceList():this
           4 ( 0.89% of base) : 91837.dasm - DocumentSpecificOptionSet:GetOptionCore(Microsoft.CodeAnalysis.Options.OptionKey):System.Object:this
           4 ( 1.22% of base) : 329512.dasm - Humanizer.Localisation.NumberToWords.Italian.ItalianCardinalNumberCruncher:Convert():System.String:this
           4 ( 1.33% of base) : 309855.dasm - LightInject.ServiceContainer:EmitPropertyDependencies(LightInject.ConstructionInfo,LightInject.IEmitter):this
           4 ( 0.86% of base) : 315794.dasm - NuGet.Configuration.VirtualSettingSection:TryRemoveAllMergedWith(NuGet.Configuration.SettingItem,byref):bool:this

Top method improvements (bytes):
       -4024 (-3.23% of base) : 214197.dasm - <<ValidateRegex_MemberData>g__Cases|1_0>d:MoveNext():bool:this
       -3740 (-22.66% of base) : 258616.dasm - Microsoft.Extensions.DependencyInjection.Tests.CompilationTestDataProvider:Register(Microsoft.Extensions.DependencyInjection.IServiceCollection)
       -2712 (-3.11% of base) : 282051.dasm - <TestData>d__0:MoveNext():bool:this
       -2148 (-3.01% of base) : 6057.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.freach.freach001.freach001.Test:MainMethod():int
       -2096 (-2.68% of base) : 6042.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.freach.freach007.freach007.Test:MainMethod():int
       -1288 (-10.66% of base) : 140.dasm - System.Text.RegularExpressions.RegexInterpreter:Go():this
       -1212 (-3.11% of base) : 214597.dasm - <<Match_MemberData>g__Cases|0_0>d:MoveNext():bool:this
       -1196 (-8.30% of base) : 92753.dasm - SerializationTestTypes.TypeLibraryManager:get_SampleTypeList():System.Collections.Generic.List`1[[System.Type, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]:this
       -1196 (-8.30% of base) : 2820.dasm - SerializationTestTypes.TypeLibraryManager:get_SampleTypeList():System.Collections.Generic.List`1[[System.Type, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]:this
       -1076 (-2.75% of base) : 212959.dasm - System.Numerics.Tests.Driver:RunTests()
       -1036 (-6.89% of base) : 6052.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.freach.freach003.freach003.Test:MainMethod():int
        -968 (-5.81% of base) : 37277.dasm - ConstructorTestsContext_Default:.cctor()
        -880 (-5.30% of base) : 6050.dasm - ManagedTests.DynamicCSharp.Conformance.dynamic.statements.freach.freach004.freach004.Test:MainMethod():int
        -872 (-5.54% of base) : 213407.dasm - <BinaryMinus_TestData>d__2:MoveNext():bool:this
        -852 (-7.23% of base) : 2104.dasm - DataContractSerializerTests:DCS_BasicPerSerializerRoundTripAndCompare_SampleTypes()
        -840 (-4.46% of base) : 234885.dasm - <>c__DisplayClass28_0:<Read_FullItem_ReturnsExpected>b__0(System.ServiceModel.Syndication.SyndicationFeed):this
        -840 (-6.29% of base) : 296399.dasm - System.PrivateUri.Tests.UriIsWellFormedUriStringTest:get_TestIsWellFormedUriStringData():System.Collections.Generic.IEnumerable`1[[System.Object[], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
        -836 (-3.42% of base) : 290217.dasm - System.Xml.Tests.TCMaxSettings:AddChildren():this
        -824 (-7.03% of base) : 92119.dasm - DataContractSerializerTests:DCS_BasicPerSerializerRoundTripAndCompare_SampleTypes()
        -824 (-9.83% of base) : 108.dasm - System.Text.RegularExpressions.RegexWriter:EmitFragment(int,System.Text.RegularExpressions.RegexNode,int):this

Top method regressions (percentages):
           4 ( 5.88% of base) : 132743.dasm - System.Threading.Tasks.Tests.CancelWait.TaskInfo:ZetaSequence(int):double
          12 ( 3.61% of base) : 171422.dasm - System.Security.Cryptography.Xml.Tests.XmlDsigExcC14NTransformTest:Types():this
           4 ( 3.12% of base) : 137018.dasm - System.SpanTests.ReadOnlySpanTests:TestReadOnlySpan(System.Int16[],short,int)
           8 ( 2.35% of base) : 288538.dasm - Microsoft.Test.ModuleCore.TestItem:FindChild(System.Type):Microsoft.Test.ModuleCore.TestItem:this
           8 ( 2.33% of base) : 77423.dasm - Microsoft.CodeAnalysis.Workspace:ClearOpenDocuments(Microsoft.CodeAnalysis.ProjectId):this
           8 ( 2.30% of base) : 333681.dasm - System.Transactions.Tests.TestEventListener:LoadSourceList():this
          12 ( 1.68% of base) : 81885.dasm - Microsoft.CodeAnalysis.Options.GlobalOptionService:UpdateRegisteredWorkspacesAndRaiseEvents(System.Collections.Generic.List`1[[Microsoft.CodeAnalysis.Options.OptionChangedEventArgs, Microsoft.CodeAnalysis.Workspaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):this
           4 ( 1.56% of base) : 129978.dasm - TaskItem:GetItemDefinitionMetadata(System.String):Microsoft.Build.Execution.ProjectMetadataInstance:this
          12 ( 1.49% of base) : 279021.dasm - System.IO.Tests.FileStream_Flush:SafeFileHandleCallsFlush_flushToDisk_False():this
          12 ( 1.49% of base) : 172549.dasm - System.IO.Tests.FileStream_Flush:SafeFileHandleCallsFlush_flushToDisk_False():this
          16 ( 1.38% of base) : 127741.dasm - Microsoft.Build.BackEnd.Logging.LoggingService:ShutdownComponent():this
           8 ( 1.36% of base) : 77422.dasm - Microsoft.CodeAnalysis.Workspace:ClearOpenDocuments():this
           4 ( 1.33% of base) : 309855.dasm - LightInject.ServiceContainer:EmitPropertyDependencies(LightInject.ConstructionInfo,LightInject.IEmitter):this
           4 ( 1.33% of base) : 194748.dasm - NuGet.Packaging.Rules.UpholdBuildConventionRule:EndsWithMsbuildFileExtension(System.String):bool:this
           8 ( 1.32% of base) : 194908.dasm - NuGet.ContentModel.Infrastructure.PatternExpression:Match(System.String,System.Collections.Generic.IReadOnlyDictionary`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[NuGet.ContentModel.ContentPropertyDefinition, NuGet.Packaging, Version=5.8.0.6930, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):NuGet.ContentModel.ContentItem:this
          12 ( 1.30% of base) : 212046.dasm - System.Data.SqlClient.TdsParserStateObject:ReadSniError(System.Data.SqlClient.TdsParserStateObject,int):this
           4 ( 1.22% of base) : 329512.dasm - Humanizer.Localisation.NumberToWords.Italian.ItalianCardinalNumberCruncher:Convert():System.String:this
           8 ( 1.18% of base) : 211080.dasm - System.Data.SqlClient.SqlDependencyPerAppDomainDispatcher:InvalidateCommandID(System.Data.SqlClient.SqlNotification):this
           8 ( 1.18% of base) : 180679.dasm - System.Data.SqlClient.SqlDependencyPerAppDomainDispatcher:InvalidateCommandID(System.Data.SqlClient.SqlNotification):this
          36 ( 0.98% of base) : 132974.dasm - System.Threading.Tasks.Tests.Status.TaskStatusTest:RealRun():this

Top method improvements (percentages):
         -24 (-35.29% of base) : 80575.dasm - Microsoft.CodeAnalysis.Shared.Utilities.IntegerUtilities:CountOfBitsSet(long):int
         -16 (-26.67% of base) : 79643.dasm - Microsoft.CodeAnalysis.Collections.Internal.SegmentedArrayHelper:CalculateSegmentShift(int):int
         -16 (-26.67% of base) : 80578.dasm - Microsoft.CodeAnalysis.Shared.Utilities.IntegerUtilities:LogBase2(long):int
         -16 (-26.67% of base) : 282840.dasm - SQLitePCL.utf8z:my_strlen(long):long
       -3740 (-22.66% of base) : 258616.dasm - Microsoft.Extensions.DependencyInjection.Tests.CompilationTestDataProvider:Register(Microsoft.Extensions.DependencyInjection.IServiceCollection)
         -20 (-21.74% of base) : 91847.dasm - <GetChangedOptions>d__9:<>m__Finally1():this
         -12 (-21.43% of base) : 115825.dasm - <>c__DisplayClass10_0:<MethodSignatureEncoder_Parameters>b__2():this
         -12 (-21.43% of base) : 115826.dasm - <>c__DisplayClass10_0:<MethodSignatureEncoder_Parameters>b__3():this
         -12 (-21.43% of base) : 97765.dasm - System.Tests.DelegateTests:RefValueTypeMethod(byref)
         -36 (-21.43% of base) : 66224.dasm - System.Text.Json.Serialization.Tests.NumberHandlingTests:MemberAttributeAppliesToCollection_SimpleElements()
          -8 (-20.00% of base) : 161785.dasm - ClosureInfo:PopBlock():this
         -16 (-20.00% of base) : 271838.dasm - IncrementalStubGenerationContext:.ctor(IncrementalStubGenerationContext):this
          -8 (-20.00% of base) : 314889.dasm - System.Text.RegularExpressions.RegexParser:PopKeepOptions():this
        -152 (-19.90% of base) : 125706.dasm - Microsoft.Build.Execution.BuildParameters:Microsoft.Build.BackEnd.ITranslatable.Translate(Microsoft.Build.BackEnd.ITranslator):this
         -76 (-19.39% of base) : 127543.dasm - Microsoft.Build.BackEnd.SdkResolution.SdkResolverRequest:Translate(Microsoft.Build.BackEnd.ITranslator):this
         -16 (-19.05% of base) : 170576.dasm - CXmlBase:_Child(int):CXmlBase:this
         -16 (-19.05% of base) : 178692.dasm - Microsoft.SqlServer.Server.Normalizer:FlipAllBits(System.Byte[]):this
          -8 (-18.18% of base) : 88589.dasm - <>c:<.cctor>b__21_0(Microsoft.CodeAnalysis.Formatting.Rules.SuppressOperation,Microsoft.CodeAnalysis.Formatting.Rules.SuppressOperation):int:this
         -20 (-17.86% of base) : 314950.dasm - System.Text.RegularExpressions.RegexParser:HexDigit(ushort):int
         -12 (-17.65% of base) : 331903.dasm - <>c__DisplayClass28_0:<MetricsTest>b__7():bool:this

107192 total methods with Code Size differences (107165 improved, 27 regressed), 80 unchanged.

```

</details>

--------------------------------------------------------------------------------


cc @dotnet/jit-contrib 