### PR TITLE
[arm64] JIT: Optimize zero-extend for byte/short to uint/ulong via & 0xFF..

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -521,7 +521,7 @@ void Lowering::LowerCast(GenTree* tree)
             DISPTREE(tree)
 
             assert(genTypeSize(tree->CastToType()) > genTypeSize(dst2Type));
-            tree->ChangeOper(GT_AND, GenTree::PRESERVE_VN);
+            tree->ChangeOper(GT_AND);
             BlockRange().Remove(cast2);
             GenTreeIntCon* castMask = nullptr;
 


### PR DESCRIPTION
This PR optimizes zero-extend for small integers (byte/short) to uint/ulong via `GT_AND(x, 0xFF/0xFFFF)`
```csharp
static ulong Test(byte b) => b;
static ulong Test(ushort s) => s;
```
Codegen diff:
```diff
; Method Prog:Test(ubyte):long
G_M55250_IG01:
            stp     fp, lr, [sp,#-16]!
            mov     fp, sp
G_M55250_IG02:
-           uxtb    w0, w0
-           mov     w0, w0
+           and     x0, x0, #0xFF
G_M55250_IG03:
            ldp     fp, lr, [sp],#16
            ret     lr
-; Total bytes of code: 24
+; Total bytes of code: 20


; Method Prog:Test(ushort):long
G_M6826_IG01:
            stp     fp, lr, [sp,#-16]!
            mov     fp, sp
G_M6826_IG02:
-           uxth    w0, w0
-           mov     w0, w0
+           and     x0, x0, #0xFFFF
G_M6826_IG03:
            ldp     fp, lr, [sp],#16
            ret     lr
-; Total bytes of code: 24
+; Total bytes of code: 20
```
## coreclr_tests.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 165435496 (overridden on cmd)
Total bytes of diff: 165434332 (overridden on cmd)
Total bytes of delta: -1164 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -96 : 239377.dasm (-0.71% of base)
         -44 : 233113.dasm (-1.71% of base)
         -24 : 88532.dasm (-5.88% of base)
         -24 : 251387.dasm (-2.27% of base)
         -20 : 5286.dasm (-18.52% of base)
         -20 : 5300.dasm (-18.52% of base)
         -16 : 88563.dasm (-4.21% of base)
         -12 : 86782.dasm (-1.26% of base)
         -12 : 4219.dasm (-13.64% of base)
         -12 : 253330.dasm (-1.38% of base)
          -8 : 86880.dasm (-1.28% of base)
          -8 : 86296.dasm (-0.82% of base)
          -8 : 87053.dasm (-1.69% of base)
          -8 : 85448.dasm (-1.27% of base)
          -4 : 102008.dasm (-12.50% of base)
          -4 : 128777.dasm (-11.11% of base)
          -4 : 145026.dasm (-4.76% of base)
          -4 : 181561.dasm (-12.50% of base)
          -4 : 186094.dasm (-11.11% of base)
          -4 : 188888.dasm (-11.11% of base)

232 total files with Code Size differences (232 improved, 0 regressed), 3 unchanged.

Top method improvements (bytes):
         -96 (-0.71% of base) : 239377.dasm - ILGEN_0x372a9ae6:Method_0xdc6ff1a4(byte,byte,int,long,ushort,double,long,long):int
         -44 (-1.71% of base) : 233113.dasm - ILGEN_0x52ea038a:Method_0xc9efd6b0(int,int,double,ushort,int,ubyte,double,ubyte,ushort,byte):ushort
         -24 (-5.88% of base) : 88532.dasm - ILGEN_0x1957992d:Method_0xc2445738(byte,double,long,long):int
         -24 (-2.27% of base) : 251387.dasm - ShiftTest.byte32Test:Main():int
         -20 (-18.52% of base) : 5286.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseSelect(ubyte,ubyte,ubyte):ubyte
         -20 (-18.52% of base) : 5300.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseSelect(ushort,ushort,ushort):ushort
         -16 (-4.21% of base) : 88563.dasm - <Module>:Main():int
         -12 (-1.26% of base) : 86782.dasm - ILGEN_0x1bd95bae:Method_0x40637edd(int,byte,short,short,double,float,ubyte,float):short
         -12 (-1.38% of base) : 253330.dasm - ILGEN_0xdea951c0:Method_0x5a7bd7a1(long,short,byte,ubyte,long,long,ushort,long,int):double
         -12 (-13.64% of base) : 4219.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ReverseElement8(ushort):ushort
          -8 (-1.28% of base) : 86880.dasm - ILGEN_0x322fc2ad:Method_0xe8e111d1():int
          -8 (-1.27% of base) : 85448.dasm - ILGEN_0x65088b5c:Method_0x5ad2583a(long,ushort,int,ubyte,byte,short,ubyte):long
          -8 (-1.69% of base) : 87053.dasm - ILGEN_0xace3f910:Method_0xf9cc7d6a(long,long,float,int,ushort,long,long,long,long):float
          -8 (-0.82% of base) : 86296.dasm - ILGEN_0xbd98be78:Method_0x40eb(ushort,ubyte,long,int,double):int
          -4 (-4.76% of base) : 82379.dasm - AA:Static3(long):bool
          -4 (-11.11% of base) : 243925.dasm - BinaryPrimitivesReverseEndianness.Program:ByteSwapUInt16_Control(ushort):ushort
          -4 (-2.63% of base) : 243928.dasm - BinaryPrimitivesReverseEndianness.Program:ByteSwapUnsigned_General(long,int):long
          -4 (-2.22% of base) : 87514.dasm - DevDiv_578217.Program:ILGEN_METHOD(ushort,float,long,ushort,ubyte,short,int):short
          -4 (-1.32% of base) : 86955.dasm - DevDiv_590772:ILGEN_METHOD(long,ushort,long,int,ushort,long):byte
          -4 (-0.92% of base) : 87341.dasm - DevDiv_605447:ILGEN_METHOD(int,int,int,ushort,float):ushort

Top method improvements (percentages):
         -20 (-18.52% of base) : 5286.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseSelect(ubyte,ubyte,ubyte):ubyte
         -20 (-18.52% of base) : 5300.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseSelect(ushort,ushort,ushort):ushort
          -4 (-14.29% of base) : 251385.dasm - ShiftTest.byte32Test:f1(long):long
          -4 (-14.29% of base) : 251386.dasm - ShiftTest.byte32Test:f2(long):long
          -4 (-14.29% of base) : 224358.dasm - TestApp:test_114(ubyte,long):long
          -4 (-14.29% of base) : 229273.dasm - TestApp:test_153(ubyte,long):long
          -4 (-14.29% of base) : 227885.dasm - TestApp:test_192(ubyte,long):long
          -4 (-14.29% of base) : 224951.dasm - TestApp:test_309(ubyte,long):long
          -4 (-14.29% of base) : 224969.dasm - TestApp:test_36(ubyte,long):long
         -12 (-13.64% of base) : 4219.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ReverseElement8(ushort):ushort
          -4 (-12.50% of base) : 181561.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 201515.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 202373.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 128567.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 181560.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 189832.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 201516.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 118848.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 185884.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long
          -4 (-12.50% of base) : 206925.dasm - JIT.HardwareIntrinsics.Arm.Helpers:ShiftLeftLogical(long,ubyte):long

232 total methods with Code Size differences (232 improved, 0 regressed), 3 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 48496876 (overridden on cmd)
Total bytes of diff: 48496544 (overridden on cmd)
Total bytes of delta: -332 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -16 : 165280.dasm (-10.81% of base)
         -16 : 165279.dasm (-10.26% of base)
         -16 : 165278.dasm (-9.52% of base)
         -16 : 75331.dasm (-2.33% of base)
         -12 : 144315.dasm (-2.83% of base)
          -8 : 50813.dasm (-1.21% of base)
          -8 : 21194.dasm (-10.00% of base)
          -8 : 21298.dasm (-10.00% of base)
          -8 : 91159.dasm (-3.85% of base)
          -4 : 124338.dasm (-3.33% of base)
          -4 : 124608.dasm (-0.69% of base)
          -4 : 75353.dasm (-3.33% of base)
          -4 : 75359.dasm (-6.25% of base)
          -4 : 82489.dasm (-6.25% of base)
          -4 : 83476.dasm (-7.69% of base)
          -4 : 85238.dasm (-6.25% of base)
          -4 : 85242.dasm (-6.25% of base)
          -4 : 103204.dasm (-3.23% of base)
          -4 : 124818.dasm (-0.63% of base)
          -4 : 21302.dasm (-8.33% of base)

65 total files with Code Size differences (65 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-10.81% of base) : 165280.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[System.Char],ushort,ushort,ushort,ushort):bool
         -16 (-10.26% of base) : 165279.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[System.Char],ushort,ushort,ushort,ushort,ushort):bool
         -16 (-9.52% of base) : 165278.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[System.Char],ushort,ushort,ushort,ushort,ushort,ushort):bool
         -16 (-2.33% of base) : 75331.dasm - WorkerThread:MaybeAddWorkingWorker(System.Threading.PortableThreadPool)
         -12 (-2.83% of base) : 144315.dasm - Microsoft.CodeAnalysis.VisualBasic.CompileTimeCalculations:NarrowIntegralResult(long,ubyte,ubyte,byref):long
          -8 (-1.21% of base) : 50813.dasm - Microsoft.CodeAnalysis.CSharp.DiagnosticsPass:FindSurprisingSignExtensionBits(Microsoft.CodeAnalysis.CSharp.BoundExpression):long
          -8 (-3.85% of base) : 91159.dasm - Microsoft.VisualBasic.CompilerServices.Operators:MultiplyUInt16(ushort,ushort):System.Object
          -8 (-10.00% of base) : 21298.dasm - System.Text.Json.Serialization.Converters.ByteConverter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ubyte,int):this
          -8 (-10.00% of base) : 21194.dasm - System.Text.Json.Serialization.Converters.UInt16Converter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ushort,int):this
          -4 (-0.23% of base) : 75391.dasm - GateThread:GateThreadStart()
          -4 (-3.23% of base) : 103204.dasm - Internal.Cryptography.Pal.ManagedX509ExtensionProcessor:ReverseBitOrder(ubyte):ubyte
          -4 (-11.11% of base) : 90680.dasm - Microsoft.VisualBasic.Conversion:Oct(ubyte):System.String
          -4 (-11.11% of base) : 90678.dasm - Microsoft.VisualBasic.Conversion:Oct(ushort):System.String
          -4 (-3.70% of base) : 134549.dasm - Newtonsoft.Json.JsonTextWriter:WriteValueAsync(ubyte,System.Threading.CancellationToken):System.Threading.Tasks.Task:this
          -4 (-3.70% of base) : 134488.dasm - Newtonsoft.Json.JsonTextWriter:WriteValueAsync(ushort,System.Threading.CancellationToken):System.Threading.Tasks.Task:this
          -4 (-3.57% of base) : 132725.dasm - Newtonsoft.Json.Linq.JToken:op_Implicit(ubyte):Newtonsoft.Json.Linq.JToken
          -4 (-3.57% of base) : 132714.dasm - Newtonsoft.Json.Linq.JToken:op_Implicit(ushort):Newtonsoft.Json.Linq.JToken
          -4 (-0.33% of base) : 76625.dasm - System.Buffers.Text.Utf8Formatter:TryFormat(ubyte,System.Span`1[System.Byte],byref,System.Buffers.StandardFormat):bool
          -4 (-0.33% of base) : 76623.dasm - System.Buffers.Text.Utf8Formatter:TryFormat(ushort,System.Span`1[System.Byte],byref,System.Buffers.StandardFormat):bool
          -4 (-5.26% of base) : 83427.dasm - System.Convert:ToDecimal(ubyte):System.Decimal

Top method improvements (percentages):
          -4 (-11.11% of base) : 90680.dasm - Microsoft.VisualBasic.Conversion:Oct(ubyte):System.String
          -4 (-11.11% of base) : 90678.dasm - Microsoft.VisualBasic.Conversion:Oct(ushort):System.String
         -16 (-10.81% of base) : 165280.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[System.Char],ushort,ushort,ushort,ushort):bool
         -16 (-10.26% of base) : 165279.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[System.Char],ushort,ushort,ushort,ushort,ushort):bool
          -8 (-10.00% of base) : 21298.dasm - System.Text.Json.Serialization.Converters.ByteConverter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ubyte,int):this
          -8 (-10.00% of base) : 21194.dasm - System.Text.Json.Serialization.Converters.UInt16Converter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ushort,int):this
         -16 (-9.52% of base) : 165278.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[System.Char],ushort,ushort,ushort,ushort,ushort,ushort):bool
          -4 (-9.09% of base) : 85484.dasm - System.Decimal:op_Implicit(ubyte):System.Decimal
          -4 (-9.09% of base) : 85480.dasm - System.Decimal:op_Implicit(ushort):System.Decimal
          -4 (-9.09% of base) : 85481.dasm - System.Decimal:op_Implicit(ushort):System.Decimal
          -4 (-9.09% of base) : 21198.dasm - System.Text.Json.Serialization.Converters.UInt16Converter:Write(System.Text.Json.Utf8JsonWriter,ushort,System.Text.Json.JsonSerializerOptions):this
          -4 (-8.33% of base) : 21302.dasm - System.Text.Json.Serialization.Converters.ByteConverter:Write(System.Text.Json.Utf8JsonWriter,ubyte,System.Text.Json.JsonSerializerOptions):this
          -4 (-8.33% of base) : 21300.dasm - System.Text.Json.Serialization.Converters.ByteConverter:WriteAsPropertyNameCore(System.Text.Json.Utf8JsonWriter,ubyte,System.Text.Json.JsonSerializerOptions,bool):this
          -4 (-8.33% of base) : 21196.dasm - System.Text.Json.Serialization.Converters.UInt16Converter:WriteAsPropertyNameCore(System.Text.Json.Utf8JsonWriter,ushort,System.Text.Json.JsonSerializerOptions,bool):this
          -4 (-7.69% of base) : 83493.dasm - System.Convert:ToInt64(ubyte):long
          -4 (-7.69% of base) : 83491.dasm - System.Convert:ToInt64(ushort):long
          -4 (-7.69% of base) : 83495.dasm - System.Convert:ToInt64(ushort):long
          -4 (-7.69% of base) : 83476.dasm - System.Convert:ToUInt64(ubyte):long
          -4 (-7.69% of base) : 83478.dasm - System.Convert:ToUInt64(ushort):long
          -4 (-7.69% of base) : 83474.dasm - System.Convert:ToUInt64(ushort):long

65 total methods with Code Size differences (65 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 47408036 (overridden on cmd)
Total bytes of diff: 47407724 (overridden on cmd)
Total bytes of delta: -312 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -16 : 171091.dasm (-15.38% of base)
         -16 : 171090.dasm (-16.00% of base)
         -16 : 171092.dasm (-13.33% of base)
         -12 : 63759.dasm (-3.45% of base)
          -8 : 156095.dasm (-0.85% of base)
          -8 : 99873.dasm (-14.29% of base)
          -8 : 99766.dasm (-14.29% of base)
          -8 : 156096.dasm (-1.44% of base)
          -8 : 103806.dasm (-4.08% of base)
          -4 : 107402.dasm (-0.75% of base)
          -4 : 107980.dasm (-8.33% of base)
          -4 : 124246.dasm (-16.67% of base)
          -4 : 144122.dasm (-0.79% of base)
          -4 : 205891.dasm (-0.41% of base)
          -4 : 107834.dasm (-8.33% of base)
          -4 : 124220.dasm (-16.67% of base)
          -4 : 125123.dasm (-12.50% of base)
          -4 : 99869.dasm (-12.50% of base)
          -4 : 103350.dasm (-3.33% of base)
          -4 : 107855.dasm (-10.00% of base)

62 total files with Code Size differences (62 improved, 0 regressed), 1 unchanged.

Top method improvements (bytes):
         -16 (-16.00% of base) : 171090.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort):bool
         -16 (-15.38% of base) : 171091.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort):bool
         -16 (-13.33% of base) : 171092.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort,ushort):bool
         -12 (-3.45% of base) : 63759.dasm - Microsoft.CodeAnalysis.VisualBasic.CompileTimeCalculations:NarrowIntegralResult(long,ubyte,ubyte,byref):long
          -8 (-4.08% of base) : 103806.dasm - Microsoft.VisualBasic.CompilerServices.Operators:MultiplyUInt16(ushort,ushort):System.Object
          -8 (-14.29% of base) : 99766.dasm - System.Text.Json.Serialization.Converters.ByteConverter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ubyte,int):this
          -8 (-14.29% of base) : 99873.dasm - System.Text.Json.Serialization.Converters.UInt16Converter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ushort,int):this
          -8 (-1.44% of base) : 156096.dasm - System.UriHelper:EscapeString(System.ReadOnlySpan`1[Char],byref,bool,ushort,ushort)
          -8 (-0.85% of base) : 156095.dasm - System.UriHelper:EscapeString(System.String,bool,System.ReadOnlySpan`1[Boolean],ushort,ushort):System.String
          -4 (-3.57% of base) : 174393.dasm - Internal.Cryptography.Pal.ManagedX509ExtensionProcessor:ReverseBitOrder(ubyte):ubyte
          -4 (-0.75% of base) : 170285.dasm - Internal.TypeSystem.Ecma.EcmaGenericParameter:get_TypeConstraints():System.Collections.Generic.IEnumerable`1[[Internal.TypeSystem.TypeDesc, ILCompiler.TypeSystem.ReadyToRun, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null]]:this
          -4 (-0.79% of base) : 137594.dasm - Microsoft.CodeAnalysis.PEModule:GetGenericParamConstraintsOrThrow(System.Reflection.Metadata.GenericParameterHandle):System.Reflection.Metadata.EntityHandle[]:this
          -4 (-3.33% of base) : 103350.dasm - Microsoft.VisualBasic.CompilerServices.Conversions:CastByteEnum(ubyte,System.Type):System.Object
          -4 (-3.33% of base) : 103352.dasm - Microsoft.VisualBasic.CompilerServices.Conversions:CastUInt16Enum(ushort,System.Type):System.Object
          -4 (-16.67% of base) : 104371.dasm - Microsoft.VisualBasic.Conversion:Oct(ubyte):System.String
          -4 (-16.67% of base) : 104373.dasm - Microsoft.VisualBasic.Conversion:Oct(ushort):System.String
          -4 (-0.52% of base) : 144195.dasm - Newtonsoft.Json.JsonTextWriter:WriteValueAsync(System.Nullable`1[Byte],System.Threading.CancellationToken):System.Threading.Tasks.Task:this
          -4 (-0.52% of base) : 144123.dasm - Newtonsoft.Json.JsonTextWriter:WriteValueAsync(System.Nullable`1[UInt16],System.Threading.CancellationToken):System.Threading.Tasks.Task:this
          -4 (-0.79% of base) : 144194.dasm - Newtonsoft.Json.JsonTextWriter:WriteValueAsync(ubyte,System.Threading.CancellationToken):System.Threading.Tasks.Task:this
          -4 (-0.79% of base) : 144122.dasm - Newtonsoft.Json.JsonTextWriter:WriteValueAsync(ushort,System.Threading.CancellationToken):System.Threading.Tasks.Task:this

Top method improvements (percentages):
          -4 (-16.67% of base) : 104371.dasm - Microsoft.VisualBasic.Conversion:Oct(ubyte):System.String
          -4 (-16.67% of base) : 104373.dasm - Microsoft.VisualBasic.Conversion:Oct(ushort):System.String
          -4 (-16.67% of base) : 124210.dasm - System.Int64:System.INumber<System.Int64>.Create(ubyte):long
          -4 (-16.67% of base) : 124215.dasm - System.Int64:System.INumber<System.Int64>.CreateSaturating(ubyte):long
          -4 (-16.67% of base) : 124220.dasm - System.Int64:System.INumber<System.Int64>.CreateTruncating(ubyte):long
          -4 (-16.67% of base) : 124236.dasm - System.IntPtr:System.INumber<nint>.Create(ubyte):long
          -4 (-16.67% of base) : 124241.dasm - System.IntPtr:System.INumber<nint>.CreateSaturating(ubyte):long
          -4 (-16.67% of base) : 124246.dasm - System.IntPtr:System.INumber<nint>.CreateTruncating(ubyte):long
          -4 (-16.67% of base) : 125102.dasm - System.UInt64:System.INumber<System.UInt64>.Create(ubyte):long
          -4 (-16.67% of base) : 125107.dasm - System.UInt64:System.INumber<System.UInt64>.CreateSaturating(ubyte):long
          -4 (-16.67% of base) : 125112.dasm - System.UInt64:System.INumber<System.UInt64>.CreateTruncating(ubyte):long
          -4 (-16.67% of base) : 125128.dasm - System.UIntPtr:System.INumber<nuint>.Create(ubyte):long
          -4 (-16.67% of base) : 125133.dasm - System.UIntPtr:System.INumber<nuint>.CreateSaturating(ubyte):long
          -4 (-16.67% of base) : 125138.dasm - System.UIntPtr:System.INumber<nuint>.CreateTruncating(ubyte):long
         -16 (-16.00% of base) : 171090.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort):bool
         -16 (-15.38% of base) : 171091.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort):bool
          -8 (-14.29% of base) : 99766.dasm - System.Text.Json.Serialization.Converters.ByteConverter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ubyte,int):this
          -8 (-14.29% of base) : 99873.dasm - System.Text.Json.Serialization.Converters.UInt16Converter:WriteNumberWithCustomHandling(System.Text.Json.Utf8JsonWriter,ushort,int):this
         -16 (-13.33% of base) : 171092.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort,ushort):bool
          -4 (-12.50% of base) : 124225.dasm - System.Int64:System.INumber<System.Int64>.TryCreate(ubyte,byref):bool

62 total methods with Code Size differences (62 improved, 0 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.Linux.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 112547716 (overridden on cmd)
Total bytes of diff: 112547260 (overridden on cmd)
Total bytes of delta: -456 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -24 : 215681.dasm (-4.00% of base)
         -16 : 94462.dasm (-13.33% of base)
         -16 : 94460.dasm (-16.00% of base)
         -16 : 94461.dasm (-15.38% of base)
         -12 : 136601.dasm (-1.76% of base)
         -12 : 137179.dasm (-1.54% of base)
          -8 : 290013.dasm (-1.42% of base)
          -8 : 80579.dasm (-6.67% of base)
          -8 : 290012.dasm (-0.83% of base)
          -4 : 293490.dasm (-16.67% of base)
          -4 : 49749.dasm (-0.68% of base)
          -4 : 50203.dasm (-1.00% of base)
          -4 : 50238.dasm (-1.18% of base)
          -4 : 51797.dasm (-1.00% of base)
          -4 : 51825.dasm (-1.10% of base)
          -4 : 196342.dasm (-16.67% of base)
          -4 : 49507.dasm (-1.00% of base)
          -4 : 49565.dasm (-0.74% of base)
          -4 : 50189.dasm (-1.01% of base)
          -4 : 51087.dasm (-1.01% of base)

93 total files with Code Size differences (93 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -24 (-4.00% of base) : 215681.dasm - Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers.CastSimplifier:FindSurprisingSignExtensionBits(Microsoft.CodeAnalysis.IOperation,bool):long
         -16 (-16.00% of base) : 94460.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort):bool
         -16 (-15.38% of base) : 94461.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort):bool
         -16 (-13.33% of base) : 94462.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort,ushort):bool
         -12 (-1.76% of base) : 136601.dasm - System.SpanTests.ReadOnlySpanTests:SequenceEqualNoMatch_Long()
         -12 (-1.54% of base) : 137179.dasm - System.SpanTests.SpanTests:SequenceEqualNoMatch_Long()
          -8 (-6.67% of base) : 80579.dasm - Microsoft.CodeAnalysis.Shared.Utilities.IntegerUtilities:Convert(long,byte):long
          -8 (-1.42% of base) : 290013.dasm - System.UriHelper:EscapeString(System.ReadOnlySpan`1[Char],byref,bool,ushort,ushort)
          -8 (-0.83% of base) : 290012.dasm - System.UriHelper:EscapeString(System.String,bool,System.ReadOnlySpan`1[Boolean],ushort,ushort):System.String
          -4 (-1.89% of base) : 309265.dasm - <>c:<Int64EnumSelfSubtraction>b__55_1(long,long):System.Object[]:this
          -4 (-16.67% of base) : 293490.dasm - <>c:<SpanMethodsUsed_NotOverridden_ArrayMethodsInvoked>b__0_1(ubyte):long:this
          -4 (-1.89% of base) : 309272.dasm - <>c:<UInt64EnumSelfSubtraction>b__63_1(long,long):System.Object[]:this
          -4 (-2.78% of base) : 329087.dasm - Humanizer.ByteSizeExtensions:Bits(ubyte):Humanizer.Bytes.ByteSize
          -4 (-2.78% of base) : 329090.dasm - Humanizer.ByteSizeExtensions:Bits(ushort):Humanizer.Bytes.ByteSize
          -4 (-6.67% of base) : 116799.dasm - Microsoft.VisualBasic.Tests.ConversionTests:Oct_Byte(ubyte,System.String):this
          -4 (-6.67% of base) : 116801.dasm - Microsoft.VisualBasic.Tests.ConversionTests:Oct_Ushort(ushort,System.String):this
          -4 (-0.41% of base) : 110363.dasm - System.Buffers.Text.Tests.FormatterTests:TryFormatUtf8(ubyte,System.Span`1[Byte],byref,System.Buffers.StandardFormat):bool
          -4 (-16.67% of base) : 299536.dasm - System.Diagnostics.Metrics.Tests.MetricsTests:ConvertValue(ubyte):long:this
          -4 (-1.01% of base) : 50226.dasm - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedByteToDecimal(ubyte,bool)
          -4 (-1.18% of base) : 50232.dasm - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedByteToEnumLong(ubyte,bool)

Top method improvements (percentages):
          -4 (-16.67% of base) : 293490.dasm - <>c:<SpanMethodsUsed_NotOverridden_ArrayMethodsInvoked>b__0_1(ubyte):long:this
          -4 (-16.67% of base) : 299536.dasm - System.Diagnostics.Metrics.Tests.MetricsTests:ConvertValue(ubyte):long:this
          -4 (-16.67% of base) : 196342.dasm - System.Tests.NumberHelper`1[Int64][System.Int64]:Create(ubyte):long
          -4 (-16.67% of base) : 196347.dasm - System.Tests.NumberHelper`1[Int64][System.Int64]:CreateSaturating(ubyte):long
          -4 (-16.67% of base) : 196352.dasm - System.Tests.NumberHelper`1[Int64][System.Int64]:CreateTruncating(ubyte):long
         -16 (-16.00% of base) : 94460.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort):bool
         -16 (-15.38% of base) : 94461.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort):bool
         -16 (-13.33% of base) : 94462.dasm - System.Text.Encodings.Web.SpanUtility:TryWriteChars(System.Span`1[Char],ushort,ushort,ushort,ushort,ushort,ushort):bool
          -4 (-8.33% of base) : 146469.dasm - XmlEncodedString@973-3:Invoke(ushort):bool:this
          -8 (-6.67% of base) : 80579.dasm - Microsoft.CodeAnalysis.Shared.Utilities.IntegerUtilities:Convert(long,byte):long
          -4 (-6.67% of base) : 116799.dasm - Microsoft.VisualBasic.Tests.ConversionTests:Oct_Byte(ubyte,System.String):this
          -4 (-6.67% of base) : 116801.dasm - Microsoft.VisualBasic.Tests.ConversionTests:Oct_Ushort(ushort,System.String):this
         -24 (-4.00% of base) : 215681.dasm - Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers.CastSimplifier:FindSurprisingSignExtensionBits(Microsoft.CodeAnalysis.IOperation,bool):long
          -4 (-2.78% of base) : 329087.dasm - Humanizer.ByteSizeExtensions:Bits(ubyte):Humanizer.Bytes.ByteSize
          -4 (-2.78% of base) : 329090.dasm - Humanizer.ByteSizeExtensions:Bits(ushort):Humanizer.Bytes.ByteSize
          -4 (-1.89% of base) : 309265.dasm - <>c:<Int64EnumSelfSubtraction>b__55_1(long,long):System.Object[]:this
          -4 (-1.89% of base) : 309272.dasm - <>c:<UInt64EnumSelfSubtraction>b__63_1(long,long):System.Object[]:this
         -12 (-1.76% of base) : 136601.dasm - System.SpanTests.ReadOnlySpanTests:SequenceEqualNoMatch_Long()
         -12 (-1.54% of base) : 137179.dasm - System.SpanTests.SpanTests:SequenceEqualNoMatch_Long()
          -8 (-1.42% of base) : 290013.dasm - System.UriHelper:EscapeString(System.ReadOnlySpan`1[Char],byref,bool,ushort,ushort)

93 total methods with Code Size differences (93 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

