### PR TITLE
Make sure smoke tests aren't run on the rolling build

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -13,6 +13,8 @@ variables:
   value: ${{ and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
 - name: isFullMatrix
   value: ${{ and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
+- name: isNotFullMatrix
+  value: ${{ and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}
 
 # We only run evaluate paths on runtime, runtime-staging and runtime-community pipelines on PRs
 # keep in sync with /eng/pipelines/common/xplat-setup.yml

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -50,7 +50,7 @@ jobs:
         value: $(buildConfigUpper)
 
       - name: _runSmokeTestsOnlyArg
-        value: '/p:RunSmokeTestsOnly=$(isFullMatrix)'
+        value: '/p:RunSmokeTestsOnly=$(!isFullMatrix)'
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:
         - name: archiveExtension
           value: '.zip'

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -52,14 +52,12 @@ jobs:
       - name: _runSmokeTestsOnlyArg
         ${{ if eq(variables['isFullMatrix'], false) }}:
           value: /p:RunSmokeTestsOnly=true
-      - name: _capConditionChecker
         ${{ if eq(variables['isFullMatrix'], False) }}:
           value: /p:RunSmokeTestsOnly=TRUE
-      - name: _neconditionChecker
-        ${{ if ne(variables['isFullMatrix'], false) }}:
-          value: 'ne false!'
-        ${{ if ne(variables['isFullMatrix'], False) }}:
-          value: 'ne FALSE'
+        ${{ if eq(variables['isFullMatrix'], true) }}:
+          value: /p:RunSmokeTestsOnly=false
+        ${{ if eq(variables['isFullMatrix'], True) }}:
+          value: /p:RunSmokeTestsOnly=FALSE
 
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:
         - name: archiveExtension

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -50,10 +50,16 @@ jobs:
         value: $(buildConfigUpper)
 
       - name: _runSmokeTestsOnlyArg
-        ${{ if ne(variables['nonPRBuild'], true) }}:
+        ${{ if eq(variables['isFullMatrix'], false) }}:
           value: /p:RunSmokeTestsOnly=true
-        ${{ if eq(variables['nonPRBuild'], true) }}:
-          value: ''
+      - name: _capConditionChecker
+        ${{ if eq(variables['isFullMatrix'], False) }}:
+          value: /p:RunSmokeTestsOnly=TRUE
+      - name: _neconditionChecker
+        ${{ if ne(variables['isFullMatrix'], false) }}:
+          value: 'ne false!'
+        ${{ if ne(variables['isFullMatrix'], False) }}:
+          value: 'ne FALSE'
 
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:
         - name: archiveExtension

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -50,7 +50,7 @@ jobs:
         value: $(buildConfigUpper)
 
       - name: _runSmokeTestsOnlyArg
-        value: '/p:RunSmokeTestsOnly=$(!isFullMatrix)'
+        value: /p:RunSmokeTestsOnly=$[ not(variables.isFullMatrix) ]
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:
         - name: archiveExtension
           value: '.zip'

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -50,7 +50,7 @@ jobs:
         value: $(buildConfigUpper)
 
       - name: _runSmokeTestsOnlyArg
-        value: /p:RunSmokeTestsOnly=$[ not(variables.isFullMatrix) ]
+        value: '/p:RunSmokeTestsOnly=$(isNotFullMatrix)'
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:
         - name: archiveExtension
           value: '.zip'

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -50,15 +50,7 @@ jobs:
         value: $(buildConfigUpper)
 
       - name: _runSmokeTestsOnlyArg
-        ${{ if eq(variables['isFullMatrix'], false) }}:
-          value: /p:RunSmokeTestsOnly=true
-        ${{ if eq(variables['isFullMatrix'], False) }}:
-          value: /p:RunSmokeTestsOnly=TRUE
-        ${{ if eq(variables['isFullMatrix'], true) }}:
-          value: /p:RunSmokeTestsOnly=false
-        ${{ if eq(variables['isFullMatrix'], True) }}:
-          value: /p:RunSmokeTestsOnly=FALSE
-
+        value: '/p:RunSmokeTestsOnly=$(isFullMatrix)'
       - ${{ if or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')) }}:
         - name: archiveExtension
           value: '.zip'


### PR DESCRIPTION
The way we were trying to use `isFullMatrix` was not visible to the xplat-setup template.  This PR makes sure we grab the value at run time as opposed to compile time.