### PR TITLE
Fix 60597 by using genActualType

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10922,7 +10922,7 @@ GenTree* Compiler::fgMorphCastedBitwiseOp(GenTreeOp* tree)
 
         tree->gtOp1  = op1->AsCast()->CastOp();
         tree->gtOp2  = op2->AsCast()->CastOp();
-        tree->gtType = fromType;
+        tree->gtType = genActualType(fromType);
 
         op1->gtType                 = genActualType(toType);
         op1->AsCast()->gtOp1        = tree;

--- a/src/tests/JIT/CodeGenBringUpTests/CastThenBinop.cs
+++ b/src/tests/JIT/CodeGenBringUpTests/CastThenBinop.cs
@@ -38,6 +38,18 @@ public class Test
         }
     }
 
+    // github issue 60597
+    // https://github.com/dotnet/runtime/issues/60597
+    //
+    // I can only seem to reproduce the bug when _xorLeft and _xorRight are fields
+    static sbyte _xorLeft = 0;
+    static sbyte _xorRight = -1;
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static ushort UpcastXor_SignExtension()
+    {
+        return (ushort)(_xorLeft ^ (long)_xorRight);
+    }
+
     public static int Main()
     {
         const int Pass = 100;
@@ -73,6 +85,14 @@ public class Test
         {
             var result = UpcastAnd_SideEffect(0x0FF, 0xFF0, out var out1, out var out2);
             if (result != 0xF0 || out1 != 0x0FF || out2 != 0xFF0)
+            {
+                return Fail;
+            }
+        }
+
+        {
+            var result = UpcastXor_SignExtension();
+            if (result != 65535)
             {
                 return Fail;
             }


### PR DESCRIPTION
See discussion in #60597.

cc @SingleAccretion @jakobbotsch

Fixes #60597.