### PR TITLE
Add TFM and version support query to marshaller interface.

### DIFF
--- a/docs/design/libraries/DllImportGenerator/Compatibility.md
+++ b/docs/design/libraries/DllImportGenerator/Compatibility.md
@@ -8,7 +8,7 @@ The focus of version 1 is to support `NetCoreApp`. This implies that anything no
 
 ### Fallback mechanism
 
-In the event a marshaller would generate code that has a specific TFM requirement, the generator will instead produce a normal `DllImportAttribute` declaration. This fallback mechanism enables the use of `GeneratedDllImportAttribute` in most circumstances and permits the conversion from `DllImportAttribute` to `GeneratedDllImportAttribute` to be across most code bases. There are instances where the generator will not be able to handle signatures or configuration. For example, uses of `StringBuilder` are not supported in any form and consumers should retain uses of `DllImportAttribute`. Additionally, `GeneratedDllImportAttribute` cannot represent all settings available on `DllImportAttribute`&mdash;see below for details.
+In the event a marshaller would generate code that has a specific target framework or version requirement that is not satisfied, the generator will instead produce a normal `DllImportAttribute` declaration. This fallback mechanism enables the use of `GeneratedDllImportAttribute` in most circumstances and permits the conversion from `DllImportAttribute` to `GeneratedDllImportAttribute` to be across most code bases. There are instances where the generator will not be able to handle signatures or configuration. For example, uses of `StringBuilder` are not supported in any form and consumers should retain uses of `DllImportAttribute`. Additionally, `GeneratedDllImportAttribute` cannot represent all settings available on `DllImportAttribute`&mdash;see below for details.
 
 ### Semantic changes compared to `DllImportAttribute`
 

--- a/docs/design/libraries/DllImportGenerator/Compatibility.md
+++ b/docs/design/libraries/DllImportGenerator/Compatibility.md
@@ -4,7 +4,11 @@ Documentation on compatibility guidance and the current state. The version headi
 
 ## Version 1
 
-The focus of version 1 is to support `NetCoreApp`. This implies that anything not needed by `NetCoreApp` is subject to change. Only .NET 6+ is supported.
+The focus of version 1 is to support `NetCoreApp`. This implies that anything not needed by `NetCoreApp` is subject to change.
+
+### Fallback mechanism
+
+In the event a marshaller would generate code that has a specific TFM requirement, the generator will instead produce a normal `DllImportAttribute` declaration. This fallback mechanism enables the use of `GeneratedDllImportAttribute` in most circumstances and permits the conversion from `DllImportAttribute` to `GeneratedDllImportAttribute` to be across most code bases. There are instances where the generator will not be able to handle signatures or configuration. For example, uses of `StringBuilder` are not supported in any form and consumers should retain uses of `DllImportAttribute`. Additionally, `GeneratedDllImportAttribute` cannot represent all settings available on `DllImportAttribute`&mdash;see below for details.
 
 ### Semantic changes compared to `DllImportAttribute`
 
@@ -92,4 +96,4 @@ Unlike the built-in system, the source generator does not support marshalling fo
 
 ## Version 0
 
-This version is the built-in IL Stub generation system that is triggered whenever a method marked with `DllImport` is invoked.
+This version is the built-in IL Stub generation system that is triggered whenever a method marked with `DllImportAttribute` is invoked.

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
@@ -25,12 +25,12 @@ namespace Microsoft.Interop
         /// <summary>
         /// Comparer for an individual generated stub source as a syntax tree and the generated diagnostics for the stub.
         /// </summary>
-        public static readonly IEqualityComparer<(MemberDeclarationSyntax Syntax, ImmutableArray<Diagnostic> Diagnostics)> GeneratedSyntax = new CustomValueTupleElementComparer<MemberDeclarationSyntax, ImmutableArray<Diagnostic>>(new SyntaxEquivalentComparer(), new ImmutableArraySequenceEqualComparer<Diagnostic>(EqualityComparer<Diagnostic>.Default));
+        public static readonly IEqualityComparer<(MemberDeclarationSyntax Syntax, ImmutableArray<Diagnostic> Diagnostics)> GeneratedSyntax = new CustomValueTupleElementComparer<MemberDeclarationSyntax, ImmutableArray<Diagnostic>>(SyntaxEquivalentComparer.Instance, new ImmutableArraySequenceEqualComparer<Diagnostic>(EqualityComparer<Diagnostic>.Default));
 
         /// <summary>
         /// Comparer for the context used to generate a stub and the original user-provided syntax that triggered stub creation.
         /// </summary>
-        public static readonly IEqualityComparer<(MethodDeclarationSyntax Syntax, DllImportGenerator.IncrementalStubGenerationContext StubContext)> CalculatedContextWithSyntax = new CustomValueTupleElementComparer<MethodDeclarationSyntax, DllImportGenerator.IncrementalStubGenerationContext>(new SyntaxEquivalentComparer(), EqualityComparer<DllImportGenerator.IncrementalStubGenerationContext>.Default);
+        public static readonly IEqualityComparer<(MethodDeclarationSyntax Syntax, DllImportGenerator.IncrementalStubGenerationContext StubContext)> CalculatedContextWithSyntax = new CustomValueTupleElementComparer<MethodDeclarationSyntax, DllImportGenerator.IncrementalStubGenerationContext>(SyntaxEquivalentComparer.Instance, EqualityComparer<DllImportGenerator.IncrementalStubGenerationContext>.Default);
     }
 
     /// <summary>
@@ -63,6 +63,10 @@ namespace Microsoft.Interop
 
     internal class SyntaxEquivalentComparer : IEqualityComparer<SyntaxNode>
     {
+        public static readonly SyntaxEquivalentComparer Instance = new();
+
+        private SyntaxEquivalentComparer() { }
+
         public bool Equals(SyntaxNode x, SyntaxNode y)
         {
             return x.IsEquivalentTo(y);

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -24,16 +24,20 @@ namespace Microsoft.Interop
         private const string GeneratedDllImport = nameof(GeneratedDllImport);
         private const string GeneratedDllImportAttribute = nameof(GeneratedDllImportAttribute);
 
-        private static readonly Version s_minimumSupportedFrameworkVersion = new Version(5, 0);
-
-        internal sealed record IncrementalStubGenerationContext(DllImportStubContext StubContext, ImmutableArray<AttributeSyntax> ForwardedAttributes, GeneratedDllImportData DllImportData, ImmutableArray<Diagnostic> Diagnostics)
+        internal sealed record IncrementalStubGenerationContext(
+            StubEnvironment Environment,
+            DllImportStubContext StubContext,
+            ImmutableArray<AttributeSyntax> ForwardedAttributes,
+            GeneratedDllImportData DllImportData,
+            ImmutableArray<Diagnostic> Diagnostics)
         {
             public bool Equals(IncrementalStubGenerationContext? other)
             {
                 return other is not null
+                    && StubEnvironment.AreCompilationSettingsEqual(Environment, other.Environment)
                     && StubContext.Equals(other.StubContext)
                     && DllImportData.Equals(other.DllImportData)
-                    && ForwardedAttributes.SequenceEqual(other.ForwardedAttributes, (IEqualityComparer<AttributeSyntax>)new SyntaxEquivalentComparer())
+                    && ForwardedAttributes.SequenceEqual(other.ForwardedAttributes, (IEqualityComparer<AttributeSyntax>)SyntaxEquivalentComparer.Instance)
                     && Diagnostics.SequenceEqual(other.Diagnostics);
             }
 
@@ -93,11 +97,11 @@ namespace Microsoft.Interop
                 context.ReportDiagnostic(Diagnostic.Create(GeneratorDiagnostics.ReturnConfigurationNotSupported, refReturnMethod.Syntax.GetLocation(), "ref return", refReturnMethod.Symbol.ToDisplayString()));
             });
 
-            IncrementalValueProvider<(Compilation compilation, bool isSupported, Version targetFrameworkVersion)> compilationAndTargetFramework = context.CompilationProvider
+            IncrementalValueProvider<(Compilation compilation, TargetFramework targetFramework, Version targetFrameworkVersion)> compilationAndTargetFramework = context.CompilationProvider
                 .Select(static (compilation, ct) =>
                 {
-                    bool isSupported = IsSupportedTargetFramework(compilation, out Version targetFrameworkVersion);
-                    return (compilation, isSupported, targetFrameworkVersion);
+                    TargetFramework fmk = DetermineTargetFramework(compilation, out Version targetFrameworkVersion);
+                    return (compilation, fmk, targetFrameworkVersion);
                 });
 
             context.RegisterSourceOutput(
@@ -105,16 +109,16 @@ namespace Microsoft.Interop
                     .Combine(methodsToGenerate.Collect()),
                 static (context, data) =>
                 {
-                    if (!data.Left.isSupported && data.Right.Any())
+                    if (data.Left.targetFramework is TargetFramework.Unknown && data.Right.Any())
                     {
-                        // We don't block source generation when the TFM is unsupported.
+                        // We don't block source generation when the TFM is unknown.
                         // This allows a user to copy generated source and use it as a starting point
                         // for manual marshalling if desired.
                         context.ReportDiagnostic(
                             Diagnostic.Create(
                                 GeneratorDiagnostics.TargetFrameworkNotSupported,
                                 Location.None,
-                                s_minimumSupportedFrameworkVersion.ToString(2)));
+                                data.Left.targetFrameworkVersion));
                     }
                 });
 
@@ -127,7 +131,7 @@ namespace Microsoft.Interop
                     static (data, ct) =>
                         new StubEnvironment(
                             data.Left.compilation,
-                            data.Left.isSupported,
+                            data.Left.targetFramework,
                             data.Left.targetFrameworkVersion,
                             data.Left.compilation.SourceModule.GetAttributes().Any(attr => attr.AttributeClass?.ToDisplayString() == TypeNames.System_Runtime_CompilerServices_SkipLocalsInitAttribute),
                             data.Right)
@@ -312,7 +316,7 @@ namespace Microsoft.Interop
             return toPrint;
         }
 
-        private static bool IsSupportedTargetFramework(Compilation compilation, out Version version)
+        private static TargetFramework DetermineTargetFramework(Compilation compilation, out Version version)
         {
             IAssemblySymbol systemAssembly = compilation.GetSpecialType(SpecialType.System_Object).ContainingAssembly;
             version = systemAssembly.Identity.Version;
@@ -320,12 +324,13 @@ namespace Microsoft.Interop
             return systemAssembly.Identity.Name switch
             {
                 // .NET Framework
-                "mscorlib" => false,
+                "mscorlib" => TargetFramework.Framework,
                 // .NET Standard
-                "netstandard" => false,
+                "netstandard" => TargetFramework.Standard,
                 // .NET Core (when version < 5.0) or .NET
-                "System.Runtime" or "System.Private.CoreLib" => version >= s_minimumSupportedFrameworkVersion,
-                _ => false,
+                "System.Runtime" or "System.Private.CoreLib" =>
+                    (version.Major < 5) ? TargetFramework.Core : TargetFramework.Net,
+                _ => TargetFramework.Unknown,
             };
         }
 
@@ -338,7 +343,6 @@ namespace Microsoft.Interop
                 // [TODO] Report GeneratedDllImport has an error - corrupt metadata?
                 throw new InvalidProgramException();
             }
-
 
             // Default values for these properties are based on the
             // documented semanatics of DllImportAttribute:
@@ -473,7 +477,7 @@ namespace Microsoft.Interop
             // Create the stub.
             var dllImportStub = DllImportStubContext.Create(symbol, stubDllImportData, environment, generatorDiagnostics, ct);
 
-            return new IncrementalStubGenerationContext(dllImportStub, additionalAttributes.ToImmutableArray(), stubDllImportData, generatorDiagnostics.Diagnostics.ToImmutableArray());
+            return new IncrementalStubGenerationContext(environment, dllImportStub, additionalAttributes.ToImmutableArray(), stubDllImportData, generatorDiagnostics.Diagnostics.ToImmutableArray());
         }
 
         private (MemberDeclarationSyntax, ImmutableArray<Diagnostic>) GenerateSource(
@@ -490,12 +494,16 @@ namespace Microsoft.Interop
 
             // Generate stub code
             var stubGenerator = new PInvokeStubCodeGenerator(
+                dllImportStub.Environment,
                 dllImportStub.StubContext.ElementTypeInformation,
                 dllImportStub.DllImportData.SetLastError && !options.GenerateForwarders,
                 (elementInfo, ex) => diagnostics.ReportMarshallingNotSupported(originalSyntax, elementInfo, ex.NotSupportedDetails),
                 dllImportStub.StubContext.GeneratorFactory);
 
-            if (stubGenerator.StubIsBasicForwarder)
+            // Check if the generator should produce a forwarder stub - regular DllImport.
+            // This is done if the signature is blittable or the target framework is not supported.
+            if (stubGenerator.StubIsBasicForwarder
+                || !stubGenerator.SupportsTargetFramework)
             {
                 return (PrintForwarderStub(originalSyntax, dllImportStub), dllImportStub.Diagnostics.AddRange(diagnostics.Diagnostics));
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
@@ -18,10 +18,27 @@ namespace Microsoft.Interop
 {
     internal record StubEnvironment(
         Compilation Compilation,
-        bool SupportedTargetFramework,
+        TargetFramework TargetFramework,
         Version TargetFrameworkVersion,
         bool ModuleSkipLocalsInit,
-        DllImportGeneratorOptions Options);
+        DllImportGeneratorOptions Options)
+    {
+        /// <summary>
+        /// Override for determining if two StubEnvironment instances are
+        /// equal. This intentionally excludes the Compilation instance
+        /// since that represents the actual compilation and not just the settings.
+        /// </summary>
+        /// <param name="env1">The first StubEnvironment</param>
+        /// <param name="env2">The second StubEnvironment</param>
+        /// <returns>True if the settings are equal, otherwise false.</returns>
+        public static bool AreCompilationSettingsEqual(StubEnvironment env1, StubEnvironment env2)
+        {
+            return env1.TargetFramework == env2.TargetFramework
+                && env1.TargetFrameworkVersion == env2.TargetFrameworkVersion
+                && env1.ModuleSkipLocalsInit == env2.ModuleSkipLocalsInit
+                && env1.Options.Equals(env2.Options);
+        }
+    }
 
     internal sealed class DllImportStubContext : IEquatable<DllImportStubContext>
     {
@@ -164,7 +181,6 @@ namespace Microsoft.Interop
                     NativeIndex = typeInfos.Count
                 };
                 typeInfos.Add(typeInfo);
-
             }
 
             TypePositionInfo retTypeInfo = new(ManagedTypeInfo.CreateTypeInfoForTypeSymbol(method.ReturnType), marshallingAttributeParser.ParseMarshallingInfo(method.ReturnType, method.GetReturnTypeAttributes()));
@@ -234,9 +250,9 @@ namespace Microsoft.Interop
             return other is not null
                 && StubTypeNamespace == other.StubTypeNamespace
                 && ElementTypeInformation.SequenceEqual(other.ElementTypeInformation)
-                && StubContainingTypes.SequenceEqual(other.StubContainingTypes, (IEqualityComparer<TypeDeclarationSyntax>)new SyntaxEquivalentComparer())
+                && StubContainingTypes.SequenceEqual(other.StubContainingTypes, (IEqualityComparer<TypeDeclarationSyntax>)SyntaxEquivalentComparer.Instance)
                 && StubReturnType.IsEquivalentTo(other.StubReturnType)
-                && AdditionalAttributes.SequenceEqual(other.AdditionalAttributes, (IEqualityComparer<AttributeListSyntax>)new SyntaxEquivalentComparer())
+                && AdditionalAttributes.SequenceEqual(other.AdditionalAttributes, (IEqualityComparer<AttributeListSyntax>)SyntaxEquivalentComparer.Instance)
                 && Options.Equals(other.Options);
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
@@ -34,6 +34,10 @@ namespace Microsoft.Interop
 
         public override bool AdditionalTemporaryStateLivesAcrossStages => true;
 
+        public bool SupportsTargetFramework { get; init; }
+
+        public bool StubIsBasicForwarder { get; init; }
+
         /// <summary>
         /// Identifier for managed return value
         /// </summary>
@@ -58,9 +62,8 @@ namespace Microsoft.Interop
         private readonly List<BoundGenerator> _sortedMarshallers;
         private readonly bool _stubReturnsVoid;
 
-        public bool StubIsBasicForwarder { get; }
-
         public PInvokeStubCodeGenerator(
+            StubEnvironment environment,
             IEnumerable<TypePositionInfo> argTypes,
             bool setLastError,
             Action<TypePositionInfo, MarshallingNotSupportedException> marshallingNotSupportedCallback,
@@ -68,6 +71,19 @@ namespace Microsoft.Interop
         {
             _setLastError = setLastError;
 
+            // Support for SetLastError logic requires .NET 6+. Initialize the
+            // supports target framework value with this value.
+            if (_setLastError)
+            {
+                SupportsTargetFramework = environment.TargetFramework == TargetFramework.Net
+                    && environment.TargetFrameworkVersion.Major >= 6;
+            }
+            else
+            {
+                SupportsTargetFramework = true;
+            }
+
+            bool noMarshallingNeeded = true;
             List<BoundGenerator> allMarshallers = new();
             List<BoundGenerator> paramMarshallers = new();
             bool foundNativeRetMarshaller = false;
@@ -78,6 +94,14 @@ namespace Microsoft.Interop
             foreach (TypePositionInfo argType in argTypes)
             {
                 BoundGenerator generator = CreateGenerator(argType);
+
+                // Check each marshaler if the current target framework is supported or not.
+                SupportsTargetFramework &= generator.Generator.IsSupported(environment.TargetFramework, environment.TargetFrameworkVersion);
+
+                // Check if generator is either blittable or just a forwarder.
+                noMarshallingNeeded &= generator is { Generator: BlittableMarshaller, TypeInfo: { IsByRef: false } }
+                        or { Generator: Forwarder };
+
                 allMarshallers.Add(generator);
                 if (argType.IsManagedReturnPosition)
                 {
@@ -139,9 +163,7 @@ namespace Microsoft.Interop
 
             StubIsBasicForwarder = !setLastError
                 && managedRetMarshaller.TypeInfo.IsNativeReturnPosition // If the managed return has native return position, then it's the return for both.
-                && _sortedMarshallers.All(
-                    m => m is { Generator: BlittableMarshaller, TypeInfo: { IsByRef: false } }
-                        or { Generator: Forwarder });
+                && noMarshallingNeeded;
 
             if (managedRetMarshaller.Generator.UsesNativeIdentifier(managedRetMarshaller.TypeInfo, this))
             {

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.Designer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.Designer.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to P/Invoke source generation is only supported on .NET {0} or above. The generated source will not be compatible with other frameworks..
+        ///   Looks up a localized string similar to P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks..
         /// </summary>
         internal static string TargetFrameworkNotSupportedDescription {
             get {
@@ -520,7 +520,7 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;GeneratedDllImportAttribute&apos; cannot be used for source-generated P/Invokes on the current target framework. Source-generated P/Invokes require .NET {0} or above..
+        ///   Looks up a localized string similar to &apos;GeneratedDllImportAttribute&apos; cannot be used for source-generated P/Invokes on an unknown target framework v{0}..
         /// </summary>
         internal static string TargetFrameworkNotSupportedMessage {
             get {

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
@@ -269,11 +269,11 @@
     <value>Native type '{0}' has a stack-allocating constructor does not support marshalling in scenarios where stack allocation is impossible</value>
   </data>
   <data name="TargetFrameworkNotSupportedDescription" xml:space="preserve">
-    <value>P/Invoke source generation is only supported on .NET {0} or above. The generated source will not be compatible with other frameworks.</value>
+    <value>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</value>
     <comment>{0} is a version number</comment>
   </data>
   <data name="TargetFrameworkNotSupportedMessage" xml:space="preserve">
-    <value>'GeneratedDllImportAttribute' cannot be used for source-generated P/Invokes on the current target framework. Source-generated P/Invokes require .NET {0} or above.</value>
+    <value>'GeneratedDllImportAttribute' cannot be used for source-generated P/Invokes on an unknown target framework v{0}.</value>
     <comment>{0} is a version number</comment>
   </data>
   <data name="TargetFrameworkNotSupportedTitle" xml:space="preserve">

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -21,6 +22,11 @@ namespace Microsoft.Interop
             _elementType = elementType;
             _enablePinning = enablePinning;
             _options = options;
+        }
+
+        public bool IsSupported(TargetFramework target, Version version)
+        {
+            return target is TargetFramework.Net && version.Major >= 6;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
@@ -12,6 +13,8 @@ namespace Microsoft.Interop
 {
     public sealed class BlittableMarshaller : IMarshallingGenerator
     {
+        public bool IsSupported(TargetFramework target, Version version) => true;
+
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             return info.ManagedType.Syntax;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -25,6 +26,8 @@ namespace Microsoft.Interop
             _falseValue = falseValue;
             _compareToTrue = compareToTrue;
         }
+
+        public bool IsSupported(TargetFramework target, Version version) => true;
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Interop
         {
         }
 
+        public bool IsSupported(TargetFramework target, Version version) => true;
+
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
             (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ConditionalStackallocMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ConditionalStackallocMarshallingGenerator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -225,6 +226,12 @@ namespace Microsoft.Interop
                     SyntaxKind.NotEqualsExpression,
                     IdentifierName(context.GetIdentifiers(info).managed),
                     LiteralExpression(SyntaxKind.NullLiteralExpression));
+        }
+
+        /// <inheritdoc/>
+        public virtual bool IsSupported(TargetFramework target, Version version)
+        {
+            return target is TargetFramework.Net && version.Major >= 6;
         }
 
         /// <inheritdoc/>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Interop
             _enableByValueContentsMarshalling = enableByValueContentsMarshalling;
         }
 
+        public bool IsSupported(TargetFramework target, Version version)
+        {
+            return target is TargetFramework.Net && version.Major >= 6;
+        }
+
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
             return _nativeTypeMarshaller.AsArgument(info, context);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -11,6 +12,8 @@ namespace Microsoft.Interop
 {
     public sealed class DelegateMarshaller : IMarshallingGenerator
     {
+        public bool IsSupported(TargetFramework target, Version version) => true;
+
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             return MarshallerHelpers.SystemIntPtrType;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Interop
 {
     public sealed class Forwarder : IMarshallingGenerator, IAttributedReturnTypeMarshallingGenerator
     {
+        public bool IsSupported(TargetFramework target, Version version) => true;
+
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             return info.ManagedType.Syntax;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/HResultExceptionMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/HResultExceptionMarshaller.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Interop
     {
         private static readonly TypeSyntax s_nativeType = PredefinedType(Token(SyntaxKind.IntKeyword));
 
+        public bool IsSupported(TargetFramework target, Version version) => true;
+
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             Debug.Assert(info.ManagedType is SpecialTypeInfo(_, _, SpecialType.System_Int32));

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -9,10 +9,30 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.Interop
 {
     /// <summary>
+    /// Target framework identifier
+    /// </summary>
+    public enum TargetFramework
+    {
+        Unknown,
+        Framework,
+        Core,
+        Standard,
+        Net
+    }
+
+    /// <summary>
     /// Interface for generation of marshalling code for P/Invoke stubs
     /// </summary>
     public interface IMarshallingGenerator
     {
+        /// <summary>
+        /// Determine if the generator is supported for the supplied version of the framework.
+        /// </summary>
+        /// <param name="target">The framework to target.</param>
+        /// <param name="version">The version of the framework.</param>
+        /// <returns>True if the marshaller is supported, otherwise false.</returns>
+        bool IsSupported(TargetFramework target, Version version);
+
         /// <summary>
         /// Get the native type syntax for <paramref name="info"/>
         /// </summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PinnableManagedValueMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PinnableManagedValueMarshaller.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -16,6 +17,9 @@ namespace Microsoft.Interop
         {
             _manualMarshallingGenerator = manualMarshallingGenerator;
         }
+
+        public bool IsSupported(TargetFramework target, Version version)
+            => _manualMarshallingGenerator.IsSupported(target, version);
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
@@ -12,6 +13,11 @@ namespace Microsoft.Interop
 {
     public sealed class SafeHandleMarshaller : IMarshallingGenerator
     {
+        public bool IsSupported(TargetFramework target, Version version)
+        {
+            return target is TargetFramework.Net && version.Major >= 6;
+        }
+
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             return MarshallerHelpers.SystemIntPtrType;

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -64,48 +64,45 @@ partial class C
 
         public static IEnumerable<object[]> GetDownlevelTargetFrameworks()
         {
-            yield return new object[] { ReferenceAssemblies.Net.Net60, true };
-            yield return new object[] { ReferenceAssemblies.Net.Net50, false };
-            yield return new object[] { ReferenceAssemblies.NetCore.NetCoreApp31, false };
-            yield return new object[] { ReferenceAssemblies.NetStandard.NetStandard20, false };
-            yield return new object[] { ReferenceAssemblies.NetFramework.Net48.Default, false };
+            yield return new object[] { TestTargetFramework.Net, true };
+            yield return new object[] { TestTargetFramework.Net6, true };
+            yield return new object[] { TestTargetFramework.Net5, false };
+            yield return new object[] { TestTargetFramework.Core, false };
+            yield return new object[] { TestTargetFramework.Standard, false };
+            yield return new object[] { TestTargetFramework.Framework, false };
         }
 
         [ConditionalTheory]
         [MemberData(nameof(GetDownlevelTargetFrameworks))]
-        public async Task SkipLocalsInitOnDownlevelTargetFrameworks(ReferenceAssemblies referenceAssemblies, bool expectSkipLocalsInit)
+        public async Task SkipLocalsInitOnDownlevelTargetFrameworks(TestTargetFramework targetFramework, bool expectSkipLocalsInit)
         {
-            string source = @"
+            string source = $@"
 using System.Runtime.InteropServices;
+{CodeSnippets.GeneratedDllImportAttributeDeclaration}
 namespace System.Runtime.InteropServices
-{
-    sealed class GeneratedDllImportAttribute : System.Attribute
-    {
-        public GeneratedDllImportAttribute(string a) { }
-    }
-
+{{
     sealed class NativeMarshallingAttribute : System.Attribute
-    {
-        public NativeMarshallingAttribute(System.Type nativeType) { }
-    }
-}
+    {{
+        public NativeMarshallingAttribute(System.Type nativeType) {{ }}
+    }}
+}}
 partial class C
-{
+{{
     [GeneratedDllImportAttribute(""DoesNotExist"")]
     public static partial S Method();
-}
+}}
 
 [NativeMarshalling(typeof(Native))]
 struct S
-{
-}
+{{
+}}
 
 struct Native
-{
-    public Native(S s) { }
-    public S ToManaged() { return default; }
-}";
-            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, referenceAssemblies);
+{{
+    public Native(S s) {{ }}
+    public S ToManaged() {{ return default; }}
+}}";
+            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.DllImportGenerator());
 

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -64,7 +64,8 @@ partial class C
 
         public static IEnumerable<object[]> GetDownlevelTargetFrameworks()
         {
-            yield return new object[] { ReferenceAssemblies.Net.Net50, true };
+            yield return new object[] { ReferenceAssemblies.Net.Net60, true };
+            yield return new object[] { ReferenceAssemblies.Net.Net50, false };
             yield return new object[] { ReferenceAssemblies.NetCore.NetCoreApp31, false };
             yield return new object[] { ReferenceAssemblies.NetStandard.NetStandard20, false };
             yield return new object[] { ReferenceAssemblies.NetFramework.Net48.Default, false };

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/AdditionalAttributesOnStub.cs
@@ -102,7 +102,7 @@ struct Native
     public Native(S s) {{ }}
     public S ToManaged() {{ return default; }}
 }}";
-            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
+            Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);
 
             Compilation newComp = TestUtils.RunGenerators(comp, out _, new Microsoft.Interop.DllImportGenerator());
 

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -8,6 +8,20 @@ namespace DllImportGenerator.UnitTests
     internal static class CodeSnippets
     {
         /// <summary>
+        /// Partially define attribute for pre-.NET 6.0
+        /// </summary>
+        public static readonly string GeneratedDllImportAttributeDeclaration = @"
+namespace System.Runtime.InteropServices
+{
+    sealed class GeneratedDllImportAttribute : System.Attribute
+    {
+        public GeneratedDllImportAttribute(string a) { }
+        public CharSet CharSet { get; set; }
+    }
+}
+";
+
+        /// <summary>
         /// Trivial declaration of GeneratedDllImport usage
         /// </summary>
         public static readonly string TrivialClassDeclarations = @"
@@ -336,8 +350,9 @@ partial class Test
         /// <summary>
         /// Declaration with parameters with <see cref="CharSet"/> set.
         /// </summary>
-        public static string BasicParametersAndModifiersWithCharSet(string typename, CharSet value) => @$"
+        public static string BasicParametersAndModifiersWithCharSet(string typename, CharSet value, string preDeclaration = "") => @$"
 using System.Runtime.InteropServices;
+{preDeclaration}
 partial class Test
 {{
     [GeneratedDllImport(""DoesNotExist"", CharSet = CharSet.{value})]
@@ -349,14 +364,15 @@ partial class Test
 }}
 ";
 
-        public static string BasicParametersAndModifiersWithCharSet<T>(CharSet value) =>
-            BasicParametersAndModifiersWithCharSet(typeof(T).ToString(), value);
+        public static string BasicParametersAndModifiersWithCharSet<T>(CharSet value, string preDeclaration = "") =>
+            BasicParametersAndModifiersWithCharSet(typeof(T).ToString(), value, preDeclaration);
 
         /// <summary>
         /// Declaration with parameters.
         /// </summary>
-        public static string BasicParametersAndModifiers(string typeName) => @$"
+        public static string BasicParametersAndModifiers(string typeName, string preDeclaration = "") => @$"
 using System.Runtime.InteropServices;
+{preDeclaration}
 partial class Test
 {{
     [GeneratedDllImport(""DoesNotExist"")]
@@ -396,7 +412,7 @@ partial class Test
         out {typeName} pOut);
 }}";
 
-        public static string BasicParametersAndModifiers<T>() => BasicParametersAndModifiers(typeof(T).ToString());
+        public static string BasicParametersAndModifiers<T>(string preDeclaration = "") => BasicParametersAndModifiers(typeof(T).ToString(), preDeclaration);
 
         /// <summary>
         /// Declaration with [In, Out] style attributes on a by-value parameter.

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
@@ -337,7 +337,7 @@ namespace DllImportGenerator.UnitTests
         [MemberData(nameof(CodeSnippetsToValidateFallbackForwarder))]
         public async Task ValidateSnippetsFallbackForwarder(string source, TestTargetFramework targetFramework, bool expectFallbackForwarder)
         {
-            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
+            Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
             var newComp = TestUtils.RunGenerators(

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
@@ -310,27 +310,38 @@ namespace DllImportGenerator.UnitTests
             Assert.Empty(newCompDiags);
         }
 
-        public static IEnumerable<object[]> CodeSnippetsToCompileWithForwarder()
+        public static IEnumerable<object[]> CodeSnippetsToValidateFallbackForwarder()
         {
-            yield return new[] { CodeSnippets.UserDefinedEntryPoint };
-            yield return new[] { CodeSnippets.AllSupportedDllImportNamedArguments };
+            yield return new object[] { CodeSnippets.UserDefinedEntryPoint, TestTargetFramework.Net, true };
 
-            // Parameter / return types (supported in DllImportGenerator)
-            yield return new[] { CodeSnippets.BasicParametersAndModifiers<byte>() };
-            // Parameter / return types (not supported in DllImportGenerator)
-            yield return new[] { CodeSnippets.BasicParametersAndModifiers<string>() };
+            // Confirm that all unsupported target frameworks can be generated.
+            {
+                string code = CodeSnippets.BasicParametersAndModifiers<byte>(CodeSnippets.GeneratedDllImportAttributeDeclaration);
+                yield return new object[] { code, TestTargetFramework.Net5, false };
+                yield return new object[] { code, TestTargetFramework.Core, false };
+                yield return new object[] { code, TestTargetFramework.Standard, false };
+                yield return new object[] { code, TestTargetFramework.Framework, false };
+            }
+
+            // Confirm that all unsupported target frameworks fallback to a forwarder.
+            {
+                string code = CodeSnippets.BasicParametersAndModifiersWithCharSet<string>(CharSet.Unicode, CodeSnippets.GeneratedDllImportAttributeDeclaration);
+                yield return new object[] { code, TestTargetFramework.Net5, true };
+                yield return new object[] { code, TestTargetFramework.Core, true };
+                yield return new object[] { code, TestTargetFramework.Standard, true };
+                yield return new object[] { code, TestTargetFramework.Framework, true };
+            }
         }
 
         [ConditionalTheory]
-        [MemberData(nameof(CodeSnippetsToCompileWithForwarder))]
-        public async Task ValidateSnippetsWithForwarder(string source)
+        [MemberData(nameof(CodeSnippetsToValidateFallbackForwarder))]
+        public async Task ValidateSnippetsFallbackForwarder(string source, TestTargetFramework targetFramework, bool expectFallbackForwarder)
         {
-            Compilation comp = await TestUtils.CreateCompilation(source);
+            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
             var newComp = TestUtils.RunGenerators(
                 comp,
-                new DllImportGeneratorOptionsProvider(useMarshalType: false, generateForwarders: true),
                 out var generatorDiags,
                 new Microsoft.Interop.DllImportGenerator());
 
@@ -349,7 +360,8 @@ namespace DllImportGenerator.UnitTests
 
             IMethodSymbol method = model.GetDeclaredSymbol(generatedMethod)!;
 
-            Assert.NotNull(method.GetDllImportData());
+            // If we expect fallback forwarder, then the DllImportData will not be null.
+            Assert.Equal(expectFallbackForwarder, method.GetDllImportData() is not null);
         }
 
         public static IEnumerable<object[]> FullyBlittableSnippetsToCompile()

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
@@ -28,7 +28,7 @@ namespace DllImportGenerator.UnitTests
         [InlineData(TargetFramework.Framework)]
         [InlineData(TargetFramework.Core)]
         [InlineData(TargetFramework.Standard)]
-        public async Task TargetFrameworkNotSupported_ReportsDiagnostic(TargetFramework targetFramework)
+        public async Task TargetFrameworkNotSupported_NoDiagnostic(TargetFramework targetFramework)
         {
             string source = @"
 using System.Runtime.InteropServices;
@@ -50,12 +50,7 @@ partial class Test
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
             var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.DllImportGenerator());
-            DiagnosticResult[] expectedDiags = new DiagnosticResult[]
-            {
-                new DiagnosticResult(GeneratorDiagnostics.TargetFrameworkNotSupported)
-                    .WithArguments("5.0")
-            };
-            VerifyDiagnostics(expectedDiags, GetSortedDiagnostics(generatorDiags));
+            Assert.Empty(generatorDiags);
 
             var newCompDiags = newComp.GetDiagnostics();
             Assert.Empty(newCompDiags);

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
@@ -32,7 +32,7 @@ partial class Test
     public static partial void Method();
 }}
 ";
-            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
+            Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
             var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.DllImportGenerator());
@@ -57,7 +57,7 @@ partial class Test
     public static extern void Method();
 }
 ";
-            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
+            Compilation comp = await TestUtils.CreateCompilation(source, targetFramework);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
             var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.DllImportGenerator());

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Diagnostics.cs
@@ -16,37 +16,23 @@ namespace DllImportGenerator.UnitTests
 {
     public class Diagnostics
     {
-        public enum TargetFramework
-        {
-            Framework,
-            Core,
-            Standard,
-            Net
-        }
-
         [ConditionalTheory]
-        [InlineData(TargetFramework.Framework)]
-        [InlineData(TargetFramework.Core)]
-        [InlineData(TargetFramework.Standard)]
-        public async Task TargetFrameworkNotSupported_NoDiagnostic(TargetFramework targetFramework)
+        [InlineData(TestTargetFramework.Framework)]
+        [InlineData(TestTargetFramework.Core)]
+        [InlineData(TestTargetFramework.Standard)]
+        [InlineData(TestTargetFramework.Net5)]
+        public async Task TargetFrameworkNotSupported_NoDiagnostic(TestTargetFramework targetFramework)
         {
-            string source = @"
+            string source = $@"
 using System.Runtime.InteropServices;
-namespace System.Runtime.InteropServices
-{
-    // Define attribute for pre-.NET 5.0
-    sealed class GeneratedDllImportAttribute : System.Attribute
-    {
-        public GeneratedDllImportAttribute(string a) { }
-    }
-}
+{CodeSnippets.GeneratedDllImportAttributeDeclaration}
 partial class Test
-{
+{{
     [GeneratedDllImport(""DoesNotExist"")]
     public static partial void Method();
-}
+}}
 ";
-            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, GetReferenceAssemblies(targetFramework));
+            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
             var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.DllImportGenerator());
@@ -57,10 +43,11 @@ partial class Test
         }
 
         [ConditionalTheory]
-        [InlineData(TargetFramework.Framework)]
-        [InlineData(TargetFramework.Core)]
-        [InlineData(TargetFramework.Standard)]
-        public async Task TargetFrameworkNotSupported_NoGeneratedDllImport_NoDiagnostic(TargetFramework targetFramework)
+        [InlineData(TestTargetFramework.Framework)]
+        [InlineData(TestTargetFramework.Core)]
+        [InlineData(TestTargetFramework.Standard)]
+        [InlineData(TestTargetFramework.Net5)]
+        public async Task TargetFrameworkNotSupported_NoGeneratedDllImport_NoDiagnostic(TestTargetFramework targetFramework)
         {
             string source = @"
 using System.Runtime.InteropServices;
@@ -70,7 +57,7 @@ partial class Test
     public static extern void Method();
 }
 ";
-            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, GetReferenceAssemblies(targetFramework));
+            Compilation comp = await TestUtils.CreateCompilationWithReferenceAssemblies(source, targetFramework);
             TestUtils.AssertPreSourceGeneratorCompilation(comp);
 
             var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.DllImportGenerator());
@@ -392,18 +379,6 @@ partial class Test
                 .ThenBy(d => d.Location.SourceSpan.End)
                 .ThenBy(d => d.Id)
                 .ToArray();
-        }
-
-        private static ReferenceAssemblies GetReferenceAssemblies(TargetFramework targetFramework)
-        {
-            return targetFramework switch
-            {
-                TargetFramework.Framework => ReferenceAssemblies.NetFramework.Net48.Default,
-                TargetFramework.Standard => ReferenceAssemblies.NetStandard.NetStandard21,
-                TargetFramework.Core => ReferenceAssemblies.NetCore.NetCoreApp31,
-                TargetFramework.Net => ReferenceAssemblies.Net.Net50,
-                _ => ReferenceAssemblies.Default
-            };
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/TestUtils.cs
@@ -83,9 +83,9 @@ namespace DllImportGenerator.UnitTests
         /// <param name="outputKind">Output type</param>
         /// <param name="allowUnsafe">Whether or not use of the unsafe keyword should be allowed</param>
         /// <returns>The resulting compilation</returns>
-        public static Task<Compilation> CreateCompilation(string source, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
+        public static Task<Compilation> CreateCompilation(string source, TestTargetFramework targetFramework = TestTargetFramework.Net, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
         {
-            return CreateCompilation(new[] { source }, outputKind, allowUnsafe, preprocessorSymbols);
+            return CreateCompilation(new[] { source }, targetFramework, outputKind, allowUnsafe, preprocessorSymbols);
         }
 
         /// <summary>
@@ -95,11 +95,12 @@ namespace DllImportGenerator.UnitTests
         /// <param name="outputKind">Output type</param>
         /// <param name="allowUnsafe">Whether or not use of the unsafe keyword should be allowed</param>
         /// <returns>The resulting compilation</returns>
-        public static Task<Compilation> CreateCompilation(string[] sources, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
+        public static Task<Compilation> CreateCompilation(string[] sources, TestTargetFramework targetFramework = TestTargetFramework.Net, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
         {
             return CreateCompilation(
                 sources.Select(source =>
                     CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview, preprocessorSymbols: preprocessorSymbols))).ToArray(),
+                targetFramework,
                 outputKind,
                 allowUnsafe,
                 preprocessorSymbols);
@@ -112,25 +113,7 @@ namespace DllImportGenerator.UnitTests
         /// <param name="outputKind">Output type</param>
         /// <param name="allowUnsafe">Whether or not use of the unsafe keyword should be allowed</param>
         /// <returns>The resulting compilation</returns>
-        public static async Task<Compilation> CreateCompilation(SyntaxTree[] sources, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
-        {
-            var (mdRefs, ancillary) = GetReferenceAssemblies();
-
-            return CSharpCompilation.Create("compilation",
-                sources,
-                (await ResolveReferenceAssemblies(mdRefs)).Add(ancillary),
-                new CSharpCompilationOptions(outputKind, allowUnsafe: allowUnsafe));
-        }
-
-        /// <summary>
-        /// Create a compilation given source and a target framework
-        /// </summary>
-        /// <param name="source">Source to compile</param>
-        /// <param name="targetFramework">Target framework</param>
-        /// <param name="outputKind">Output type</param>
-        /// <param name="allowUnsafe">Whether or not use of the unsafe keyword should be allowed</param>
-        /// <returns>The resulting compilation</returns>
-        public static async Task<Compilation> CreateCompilationWithReferenceAssemblies(string source, TestTargetFramework targetFramework, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true)
+        public static async Task<Compilation> CreateCompilation(SyntaxTree[] sources, TestTargetFramework targetFramework = TestTargetFramework.Net, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
         {
             var (mdRefs, ancillary) = GetReferenceAssemblies(targetFramework);
 
@@ -141,8 +124,6 @@ namespace DllImportGenerator.UnitTests
             {
                 referenceAssemblies = referenceAssemblies.Add(ancillary);
             }
-
-            var sources = new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview)) };
 
             return CSharpCompilation.Create("compilation",
                 sources,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/60662

If any marshaller fails to support the current tfm version, fallback to using the built-in `DllImport` attribute.

This logic permits using the source generator for any .NET TFM and will gracefully "fallback" to only support platforms that can consume the generated source.

/cc @jkoritzinsky @elinor-fung @stephentoub @eerhardt 