### PR TITLE
Fix refcount when a composite r2r image is loaded from a bundle

### DIFF
--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -146,10 +146,13 @@ NativeImage *NativeImage::Open(
     BundleFileLocation bundleFileLocation = Bundle::ProbeAppBundle(fullPath, /*pathIsBundleRelative */ true);
     if (bundleFileLocation.IsValid())
     {
-        // No need to use cache for this PE image. It is transient.
-        // We only need it to obtain the native image, which AppDomain will keep.
+        // No need to use cache for this PE image.
+        // Composite r2r PE image is not a part of anyone's identity.
+        // We only need it to obtain the native image, which will be cached at AppDomain level.
         PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_NoCache, bundleFileLocation);
         PEImageLayout* mapped = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_MAPPED);
+        // We will let pImage instance be freed after exiting this scope, but we will keep the layout,
+        // thus the layout needs an AddRef, or it will be gone together with pImage.
         mapped->AddRef();
         peLoadedImage = mapped;
     }


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/issues/60308

Erroneous use of ref counting API introduced in recent refactoring change - `SuppressRelease` vs. `AddRef`.

Note: the test in SDK must be re-enabled after this propagates to SDK. I have tested the end-to-end scenario manually.