### PR TITLE
Add Maui iOS and MacCatalyst build steps

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -32,143 +32,143 @@ schedules:
 
 jobs:
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+#- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
+#  # build mono
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+#      runtimeFlavor: mono
+#      buildConfig: release
+#      platforms:
+#      - Linux_x64
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
+#  # build coreclr and libraries
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+#      buildConfig: release
+#      platforms:
+#      - Linux_x64
+#      jobParameters:
+#        testGroup: perf
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Browser Wasm Artifacts
-          artifactName: BrowserWasm
-          archiveType: zip
-          archiveExtension: .zip
+#  # build mono on wasm
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/common/global-build-job.yml
+#      buildConfig: release
+#      runtimeFlavor: mono
+#      platforms:
+#      - Browser_wasm
+#      jobParameters:
+#        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+#        nameSuffix: wasm
+#        isOfficialBuild: false
+#        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+#        extraStepsParameters:
+#          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+#          includeRootFolder: true
+#          displayName: Browser Wasm Artifacts
+#          artifactName: BrowserWasm
+#          archiveType: zip
+#          archiveExtension: .zip
 
-  #run mono wasm microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'javascriptcore'
+#  #run mono wasm microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+#      buildConfig: release
+#      runtimeFlavor: wasm
+#      platforms:
+#      - Linux_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        runtimeType: wasm
+#        codeGenType: 'wasm'
+#        projectFile: microbenchmarks.proj
+#        runKind: micro
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
+#        javascriptEngine: 'javascriptcore'
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        testgroup: perf
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        projectfile: microbenchmarks.proj
-        runkind: micro
-        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptengine: 'javascriptcore'
+#  #run mono wasm aot microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+#      buildconfig: release
+#      runtimeflavor: wasm
+#      platforms:
+#      - linux_x64
+#      jobparameters:
+#        testgroup: perf
+#        livelibrariesbuildconfig: Release
+#        runtimetype: wasm
+#        codegentype: 'aot'
+#        projectfile: microbenchmarks.proj
+#        runkind: micro
+#        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
+#        javascriptengine: 'javascriptcore'
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
+  ## build coreclr and libraries
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+  #    buildConfig: release
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    - Linux_musl_x64
+  #    jobParameters:
+  #      testGroup: perf
 
-  # build mono on wasm
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Browser_wasm
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: wasm
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Browser Wasm Artifacts
-          artifactName: BrowserWasm
-          archiveType: zip
-          archiveExtension: .zip
+  ## build mono on wasm
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Browser_wasm
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: wasm
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: Browser Wasm Artifacts
+  #        artifactName: BrowserWasm
+  #        archiveType: zip
+  #        archiveExtension: .zip
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AOT
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: AOT Mono Artifacts
-          artifactName: LinuxMonoAOTx64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono for AOT
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: AOT
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: AOT Mono Artifacts
+  #        artifactName: LinuxMonoAOTx64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
 
   # build mono Android scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -214,14 +214,14 @@ jobs:
           archiveType: tar
           tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
+  ## build mono
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+  #    runtimeFlavor: mono
+  #    buildConfig: release
+  #    platforms:
+  #    - Linux_x64
 
   # run mono and maui android scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -239,7 +239,7 @@ jobs:
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
         logicalmachine: 'perfpixel4a'
 
-  # run mono iOS scenarios
+  # run mono and maui iOS scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
@@ -272,217 +272,217 @@ jobs:
         logicalmachine: 'perfpixel4a'
         iosLlvmBuild: True
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+#  # run mono microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: mono
+#      platforms:
+#      - Linux_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        runtimeType: mono
+#        projectFile: microbenchmarks.proj
+#        runKind: micro_mono
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+#  # run mono interpreter perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: mono
+#      platforms:
+#      - Linux_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        runtimeType: mono
+#        codeGenType: 'Interpreter'
+#        projectFile: microbenchmarks.proj
+#        runKind: micro_mono
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
 
-  # run mono wasm interpreter (default) microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+#  # run mono wasm interpreter (default) microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+#      buildConfig: release
+#      runtimeFlavor: wasm
+#      platforms:
+#      - Linux_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        runtimeType: wasm
+#        codeGenType: 'wasm'
+#        projectFile: microbenchmarks.proj
+#        runKind: micro
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
+#        javascriptEngine: 'v8'
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        testgroup: perf
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        projectfile: microbenchmarks.proj
-        runkind: micro
-        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+#  #run mono wasm aot microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+#      buildconfig: release
+#      runtimeflavor: wasm
+#      platforms:
+#      - linux_x64
+#      jobparameters:
+#        testgroup: perf
+#        livelibrariesbuildconfig: Release
+#        runtimetype: wasm
+#        codegentype: 'aot'
+#        projectfile: microbenchmarks.proj
+#        runkind: micro
+#        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
+#        javascriptEngine: 'v8'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+#  # run mono aot microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+#      buildConfig: release
+#      runtimeFlavor: aot
+#      platforms:
+#      - Linux_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        runtimeType: mono
+#        codeGenType: 'AOT'
+#        projectFile: microbenchmarks.proj
+#        runKind: micro_mono
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+#  # run coreclr perftiger microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: coreclr
+#      platforms:
+#      - Linux_x64
+#      - windows_x64
+#      - windows_x86
+#      - Linux_musl_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        projectFile: microbenchmarks.proj
+#        runKind: micro
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
 
-# run coreclr perftiger microbenchmarks pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoPgo
+## run coreclr perftiger microbenchmarks pgo perf jobs
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: coreclr
+#      platforms:
+#      - windows_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        projectFile: microbenchmarks.proj
+#        runKind: micro
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
+#        pgoRunType: -NoPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -DynamicPgo
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: coreclr
+#      platforms:
+#      - windows_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        projectFile: microbenchmarks.proj
+#        runKind: micro
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
+#        pgoRunType: -DynamicPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -FullPgo
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: coreclr
+#      platforms:
+#      - windows_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        projectFile: microbenchmarks.proj
+#        runKind: micro
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perftiger'
+#        pgoRunType: -FullPgo
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+#  # run coreclr perfowl microbenchmarks perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: coreclr
+#      platforms:
+#      - Linux_x64
+#      - windows_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        projectFile: microbenchmarks.proj
+#        runKind: micro
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+#        logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+#  # run coreclr crossgen perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: coreclr
+#      platforms:
+#      - Linux_x64
+#      - windows_x64
+#      - windows_x86
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        projectFile: crossgen_perf.proj
+#        runKind: crossgen_scenarios
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+#        logicalmachine: 'perftiger'
 
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: blazor_perf.proj
-        runKind: blazor_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        additionalSetupParameters: '--latestdotnet'
-        logicalmachine: 'perftiger'
+#  # run mono wasm blazor perf job
+#  - template: /eng/pipelines/common/platform-matrix.yml
+#    parameters:
+#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#      buildConfig: release
+#      runtimeFlavor: wasm
+#      platforms:
+#      - Linux_x64
+#      jobParameters:
+#        testGroup: perf
+#        liveLibrariesBuildConfig: Release
+#        runtimeType: wasm
+#        projectFile: blazor_perf.proj
+#        runKind: blazor_scenarios
+#        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+#        additionalSetupParameters: '--latestdotnet'
+#        logicalmachine: 'perftiger'
 
   # build maui workload packs
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -495,6 +495,8 @@ jobs:
       - Android_x64
       - Android_arm
       - Android_arm64
+      - MacCatalyst_x64
+      - iOSSimulator_x64
       jobParameters:
         buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
         nameSuffix: Maui_Packs_Mono
@@ -502,13 +504,6 @@ jobs:
         extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
         extraStepsParameters:
           name: MonoRuntimePacks
-      # Eventual platforms to add
-      # - MacCatalyst_x64
-      # - MacCatalyst_arm64
-      # - iOS_arm
-      # - iOS_arm64
-      # - OSX_x64
-      # - OSX_arm64
   
   # build maui app
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -524,9 +519,13 @@ jobs:
           - Build_Android_arm64_release_Maui_Packs_Mono
           - Build_Android_x86_release_Maui_Packs_Mono
           - Build_Android_x64_release_Maui_Packs_Mono
+          - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+          - Build_iOSSimulator_x64_release_Maui_Packs_Mono
         buildArgs: -s mono -c $(_BuildConfig)
         nameSuffix: MACiOSAndroidMaui
         isOfficialBuild: false
+        pool:
+          vmImage: 'macos-11'
         extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
         extraStepsParameters:
           rootFolder: '$(Build.SourcesDirectory)/artifacts/'

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -32,143 +32,143 @@ schedules:
 
 jobs:
 
-#- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
   
-#  # build mono
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-#      runtimeFlavor: mono
-#      buildConfig: release
-#      platforms:
-#      - Linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - Linux_x64
 
-#  # build coreclr and libraries
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-#      buildConfig: release
-#      platforms:
-#      - Linux_x64
-#      jobParameters:
-#        testGroup: perf
+  # build coreclr and libraries
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      buildConfig: release
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
 
-#  # build mono on wasm
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/common/global-build-job.yml
-#      buildConfig: release
-#      runtimeFlavor: mono
-#      platforms:
-#      - Browser_wasm
-#      jobParameters:
-#        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-#        nameSuffix: wasm
-#        isOfficialBuild: false
-#        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-#        extraStepsParameters:
-#          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-#          includeRootFolder: true
-#          displayName: Browser Wasm Artifacts
-#          artifactName: BrowserWasm
-#          archiveType: zip
-#          archiveExtension: .zip
+  # build mono on wasm
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Browser_wasm
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: wasm
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Browser Wasm Artifacts
+          artifactName: BrowserWasm
+          archiveType: zip
+          archiveExtension: .zip
 
-#  #run mono wasm microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-#      buildConfig: release
-#      runtimeFlavor: wasm
-#      platforms:
-#      - Linux_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        runtimeType: wasm
-#        codeGenType: 'wasm'
-#        projectFile: microbenchmarks.proj
-#        runKind: micro
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
-#        javascriptEngine: 'javascriptcore'
+  #run mono wasm microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        codeGenType: 'wasm'
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'javascriptcore'
 
-#  #run mono wasm aot microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-#      buildconfig: release
-#      runtimeflavor: wasm
-#      platforms:
-#      - linux_x64
-#      jobparameters:
-#        testgroup: perf
-#        livelibrariesbuildconfig: Release
-#        runtimetype: wasm
-#        codegentype: 'aot'
-#        projectfile: microbenchmarks.proj
-#        runkind: micro
-#        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
-#        javascriptengine: 'javascriptcore'
+  #run mono wasm aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildconfig: release
+      runtimeflavor: wasm
+      platforms:
+      - linux_x64
+      jobparameters:
+        testgroup: perf
+        livelibrariesbuildconfig: Release
+        runtimetype: wasm
+        codegentype: 'aot'
+        projectfile: microbenchmarks.proj
+        runkind: micro
+        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptengine: 'javascriptcore'
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  ## build coreclr and libraries
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-  #    buildConfig: release
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    - Linux_musl_x64
-  #    jobParameters:
-  #      testGroup: perf
+  # build coreclr and libraries
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      buildConfig: release
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      - Linux_musl_x64
+      jobParameters:
+        testGroup: perf
 
-  ## build mono on wasm
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Browser_wasm
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: wasm
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: Browser Wasm Artifacts
-  #        artifactName: BrowserWasm
-  #        archiveType: zip
-  #        archiveExtension: .zip
+  # build mono on wasm
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Browser_wasm
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: wasm
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Browser Wasm Artifacts
+          artifactName: BrowserWasm
+          archiveType: zip
+          archiveExtension: .zip
 
-  ## build mono for AOT
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: AOT
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: AOT Mono Artifacts
-  #        artifactName: LinuxMonoAOTx64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono for AOT
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AOT
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: AOT Mono Artifacts
+          artifactName: LinuxMonoAOTx64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
   # build mono Android scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -214,14 +214,14 @@ jobs:
           archiveType: tar
           tarCompression: gz
 
-  ## build mono
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-  #    runtimeFlavor: mono
-  #    buildConfig: release
-  #    platforms:
-  #    - Linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - Linux_x64
 
   # run mono and maui android scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -272,217 +272,217 @@ jobs:
         logicalmachine: 'perfpixel4a'
         iosLlvmBuild: True
 
-#  # run mono microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: mono
-#      platforms:
-#      - Linux_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        runtimeType: mono
-#        projectFile: microbenchmarks.proj
-#        runKind: micro_mono
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-#  # run mono interpreter perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: mono
-#      platforms:
-#      - Linux_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        runtimeType: mono
-#        codeGenType: 'Interpreter'
-#        projectFile: microbenchmarks.proj
-#        runKind: micro_mono
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-#  # run mono wasm interpreter (default) microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-#      buildConfig: release
-#      runtimeFlavor: wasm
-#      platforms:
-#      - Linux_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        runtimeType: wasm
-#        codeGenType: 'wasm'
-#        projectFile: microbenchmarks.proj
-#        runKind: micro
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
-#        javascriptEngine: 'v8'
+  # run mono wasm interpreter (default) microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        codeGenType: 'wasm'
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-#  #run mono wasm aot microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-#      buildconfig: release
-#      runtimeflavor: wasm
-#      platforms:
-#      - linux_x64
-#      jobparameters:
-#        testgroup: perf
-#        livelibrariesbuildconfig: Release
-#        runtimetype: wasm
-#        codegentype: 'aot'
-#        projectfile: microbenchmarks.proj
-#        runkind: micro
-#        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
-#        javascriptEngine: 'v8'
+  #run mono wasm aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildconfig: release
+      runtimeflavor: wasm
+      platforms:
+      - linux_x64
+      jobparameters:
+        testgroup: perf
+        livelibrariesbuildconfig: Release
+        runtimetype: wasm
+        codegentype: 'aot'
+        projectfile: microbenchmarks.proj
+        runkind: micro
+        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-#  # run mono aot microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-#      buildConfig: release
-#      runtimeFlavor: aot
-#      platforms:
-#      - Linux_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        runtimeType: mono
-#        codeGenType: 'AOT'
-#        projectFile: microbenchmarks.proj
-#        runKind: micro_mono
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-#  # run coreclr perftiger microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: coreclr
-#      platforms:
-#      - Linux_x64
-#      - windows_x64
-#      - windows_x86
-#      - Linux_musl_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        projectFile: microbenchmarks.proj
-#        runKind: micro
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      - Linux_musl_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-## run coreclr perftiger microbenchmarks pgo perf jobs
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: coreclr
-#      platforms:
-#      - windows_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        projectFile: microbenchmarks.proj
-#        runKind: micro
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
-#        pgoRunType: -NoPgo
+# run coreclr perftiger microbenchmarks pgo perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -NoPgo
 
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: coreclr
-#      platforms:
-#      - windows_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        projectFile: microbenchmarks.proj
-#        runKind: micro
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
-#        pgoRunType: -DynamicPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -DynamicPgo
 
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: coreclr
-#      platforms:
-#      - windows_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        projectFile: microbenchmarks.proj
-#        runKind: micro
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perftiger'
-#        pgoRunType: -FullPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -FullPgo
 
-#  # run coreclr perfowl microbenchmarks perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: coreclr
-#      platforms:
-#      - Linux_x64
-#      - windows_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        projectFile: microbenchmarks.proj
-#        runKind: micro
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-#        logicalmachine: 'perfowl'
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perfowl'
 
-#  # run coreclr crossgen perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: coreclr
-#      platforms:
-#      - Linux_x64
-#      - windows_x64
-#      - windows_x86
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        projectFile: crossgen_perf.proj
-#        runKind: crossgen_scenarios
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-#        logicalmachine: 'perftiger'
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: crossgen_perf.proj
+        runKind: crossgen_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perftiger'
 
-#  # run mono wasm blazor perf job
-#  - template: /eng/pipelines/common/platform-matrix.yml
-#    parameters:
-#      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-#      buildConfig: release
-#      runtimeFlavor: wasm
-#      platforms:
-#      - Linux_x64
-#      jobParameters:
-#        testGroup: perf
-#        liveLibrariesBuildConfig: Release
-#        runtimeType: wasm
-#        projectFile: blazor_perf.proj
-#        runKind: blazor_scenarios
-#        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-#        additionalSetupParameters: '--latestdotnet'
-#        logicalmachine: 'perftiger'
+  # run mono wasm blazor perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        projectFile: blazor_perf.proj
+        runKind: blazor_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        additionalSetupParameters: '--latestdotnet'
+        logicalmachine: 'perftiger'
 
   # build maui workload packs
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -120,15 +120,15 @@ steps:
   - script: |
       chmod -R a+r .
       ../dotnet.sh publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
-      ls -lR ./bin/Release/net6.0-ios
-    displayName: Build MAUI Android
+      mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiTestingiOS.app
+    displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
   - script: |
       chmod -R a+r .
       ../dotnet.sh publish -bl:MauiMacCatalyst.binlog -f net6.0-maccatalyst -c Release
       ls -lR ./bin/Release/net6.0-maccatalyst
-    displayName: Build MAUI Android
+    displayName: Build MAUI MacCatalyst
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
   - task: PublishBuildArtifacts@1
@@ -155,6 +155,16 @@ steps:
         includeRootFolder: true
         displayName: Maui Android App
         artifactName: MauiAndroidApp
+        archiveExtension: '.tar.gz'
+        archiveType: tar
+        tarCompression: gz
+
+  - template: /eng/pipelines/common/upload-artifact-step.yml
+    parameters:
+        rootFolder: $(Build.SourcesDirectory)/MauiTesting/MauiTestingiOS.app
+        includeRootFolder: true
+        displayName: Maui iOS App
+        artifactName: MauiiOSApp
         archiveExtension: '.tar.gz'
         archiveType: tar
         tarCompression: gz

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -26,10 +26,10 @@ steps:
       path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
       patterns: |
         IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
         
       # Other artifacts to include once they are being built
-      # IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
-      # IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
       # IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
 
   - task: CopyFiles@2
@@ -79,6 +79,20 @@ steps:
         destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.android-x64
         overwriteExistingFiles: true
         cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract maccatalyst-x64 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
+  - task: ExtractFiles@1
+    displayName: Extract iossimulator-x64 runtime
+    inputs:
+        archiveFilePatterns: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64.*.zip
+        destinationFolder: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64
+        overwriteExistingFiles: true
+        cleanDestinationFolder: false
 
   - script: |
       curl -o ./rollback.json 'maui.blob.core.windows.net/metadata/rollbacks/main.json'
@@ -102,10 +116,36 @@ steps:
     displayName: Build MAUI Android
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
+  - script: |
+      chmod -R a+r .
+      ../dotnet.sh publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
+      ls -lR ./bin/Release/net6.0-ios
+    displayName: Build MAUI Android
+    workingDirectory: $(Build.SourcesDirectory)/MauiTesting
+
+  - script: |
+      chmod -R a+r .
+      ../dotnet.sh publish -bl:MauiMacCatalyst.binlog -f net6.0-maccatalyst -c Release
+      ls -lR ./bin/Release/net6.0-maccatalyst
+    displayName: Build MAUI Android
+    workingDirectory: $(Build.SourcesDirectory)/MauiTesting
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish MauiAndroid binlog'
     inputs:
       pathtoPublish: $(Build.SourcesDirectory)/MauiTesting/MauiAndroid.binlog
+      artifactName:  ${{ parameters.artifactName }}
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish MauiiOS binlog'
+    inputs:
+      pathtoPublish: $(Build.SourcesDirectory)/MauiTesting/MauiiOS.binlog
+      artifactName:  ${{ parameters.artifactName }}
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish MauiMacCatalyst binlog'
+    inputs:
+      pathtoPublish: $(Build.SourcesDirectory)/MauiTesting/MauiMacCatalyst.binlog
       artifactName:  ${{ parameters.artifactName }}
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
@@ -142,4 +182,3 @@ steps:
       archiveExtension:  ${{ parameters.archiveExtension }}
       archiveType:  ${{ parameters.archiveType }}
       tarCompression:  ${{ parameters.tarCompression }}
-  

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -120,14 +120,14 @@ steps:
   - script: |
       chmod -R a+r .
       ../dotnet.sh publish -bl:MauiiOS.binlog -f net6.0-ios -c Release
-      mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiTestingiOS.app
+      mv ./bin/Release/net6.0-ios/iossimulator-x64/MauiTesting.app ./MauiiOSDefault.app
     displayName: Build MAUI iOS
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
   - script: |
       chmod -R a+r .
       ../dotnet.sh publish -bl:MauiMacCatalyst.binlog -f net6.0-maccatalyst -c Release
-      ls -lR ./bin/Release/net6.0-maccatalyst
+      mv ./bin/Release/net6.0-maccatalyst/maccatalyst-x64/MauiTesting.app ./MauiMacCatalystDefault.app
     displayName: Build MAUI MacCatalyst
     workingDirectory: $(Build.SourcesDirectory)/MauiTesting
 
@@ -161,10 +161,20 @@ steps:
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
     parameters:
-        rootFolder: $(Build.SourcesDirectory)/MauiTesting/MauiTestingiOS.app
+        rootFolder: $(Build.SourcesDirectory)/MauiTesting/MauiiOSDefault.app
         includeRootFolder: true
         displayName: Maui iOS App
-        artifactName: MauiiOSApp
+        artifactName: MauiiOSDefault
+        archiveExtension: '.tar.gz'
+        archiveType: tar
+        tarCompression: gz
+
+  - template: /eng/pipelines/common/upload-artifact-step.yml
+    parameters:
+        rootFolder: $(Build.SourcesDirectory)/MauiTesting/MauiMacCatalystDefault.app
+        includeRootFolder: true
+        displayName: Maui MacCatalyst App
+        artifactName: MauiMacCatalystDefault
         archiveExtension: '.tar.gz'
         archiveType: tar
         tarCompression: gz

--- a/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+++ b/eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
@@ -26,8 +26,9 @@ steps:
       path: $(Build.SourcesDirectory)/MauiTesting/ArtifactPacks
       patterns: |
         IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-!(*.symbols).nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
-        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-!(*.symbols).nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-!(*.symbols).nupkg
+        IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-!(*.symbols).nupkg
         
       # Other artifacts to include once they are being built
       # IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -65,6 +65,7 @@ jobs:
       - ${{ 'Build_iOS_arm64_release_MACiOSAndroidMaui' }}
     - ${{ if eq(parameters.runtimeType, 'iOSMono')}}:
       - ${{ 'build_iOS_arm64_release_iOSMono' }}
+      - ${{ 'Build_iOS_arm64_release_MACiOSAndroidMaui' }}
 
     ${{ if and(eq(parameters.osGroup, 'windows'), not(in(parameters.runtimeType, 'AndroidMono', 'iOSMono'))) }}:
       ${{ if eq(parameters.runtimeType, 'mono') }}:

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -168,7 +168,7 @@ jobs:
           displayName: 'Maui Android App'
       
     
-    # Download iOSMono tests and MauiiOS
+    # Download iOSMono tests and MauiiOS/MacCatalyst
     - ${{ if eq(parameters.runtimeType, 'iOSMono') }}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
@@ -186,11 +186,18 @@ jobs:
           displayName: 'iOS Sample App LLVM'
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
-          unpackFolder: $(Build.SourcesDirectory)
+          unpackFolder: $(Build.SourcesDirectory)/MauiiOSDefault
           cleanUnpackFolder: false
-          artifactFileName: 'MauiTestingiOS.tar.gz'
-          artifactName: 'MauiTestingiOS'
+          artifactFileName: 'MauiiOSDefault.tar.gz'
+          artifactName: 'MauiiOSDefault'
           displayName: 'Maui iOS App'
+      - template: /eng/pipelines/common/download-artifact-step.yml
+        parameters:
+          unpackFolder: $(Build.SourcesDirectory)/MauiMacCatalystDefault
+          cleanUnpackFolder: false
+          artifactFileName: 'MauiMacCatalystDefault.tar.gz'
+          artifactName: 'MauiMacCatalystDefault'
+          displayName: 'Maui MacCatalyst App'
 
     # Create Core_Root
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(buildConfig) $(archType) generatelayoutonly $(librariesOverrideArg)

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -150,7 +150,7 @@ jobs:
       - script: "mkdir -p $(librariesDownloadDir)/bin/aot/sgen;mkdir -p $(librariesDownloadDir)/bin/aot/pack;cp -r $(librariesDownloadDir)/LinuxMonoAOT/artifacts/obj/mono/Linux.${{ parameters.archType }}.Release/mono/* $(librariesDownloadDir)/bin/aot/sgen;cp -r $(librariesDownloadDir)/LinuxMonoAOT/artifacts/bin/microsoft.netcore.app.runtime.linux-${{ parameters.archType }}/Release/* $(librariesDownloadDir)/bin/aot/pack"
         displayName: "Create aot directory (Linux)"
 
-    # Download AndroidMono
+    # Download AndroidMono and MauiAndroid
     - ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:
@@ -168,7 +168,7 @@ jobs:
           displayName: 'Maui Android App'
       
     
-    # Download iOSMono tests
+    # Download iOSMono tests and MauiiOS
     - ${{ if eq(parameters.runtimeType, 'iOSMono') }}:
       - template: /eng/pipelines/common/download-artifact-step.yml
         parameters:

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -184,6 +184,13 @@ jobs:
           artifactFileName: 'iOSSampleAppLLVM.tar.gz'
           artifactName: 'iOSSampleAppLLVM'
           displayName: 'iOS Sample App LLVM'
+      - template: /eng/pipelines/common/download-artifact-step.yml
+        parameters:
+          unpackFolder: $(Build.SourcesDirectory)
+          cleanUnpackFolder: false
+          artifactFileName: 'MauiTestingiOS.tar.gz'
+          artifactName: 'MauiTestingiOS'
+          displayName: 'Maui iOS App'
 
     # Create Core_Root
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(buildConfig) $(archType) generatelayoutonly $(librariesOverrideArg)

--- a/eng/testing/performance/ios_scenarios.proj
+++ b/eng/testing/performance/ios_scenarios.proj
@@ -30,5 +30,17 @@
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
+    <HelixWorkItem Include="SOD - Maui iOS .app Size" Condition="'$(iOSLlvmBuild)' == 'False'">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands>cd $(ScenarioDirectory)mauiios;xcopy %HELIX_CORRELATION_PAYLOAD%\MauiiOSDefault .\app\/e;$(Python) pre.py</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <PostCommands>$(Python) post.py</PostCommands>
+    </HelixWorkItem>
+    <HelixWorkItem Include="SOD - Maui MacCatalyst .app Size" Condition="'$(iOSLlvmBuild)' == 'False'">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <PreCommands>cd $(ScenarioDirectory)mauiios;xcopy %HELIX_CORRELATION_PAYLOAD%\MauiMacCatalystDefault .\app\/e;$(Python) pre.py</PreCommands>
+      <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <PostCommands>$(Python) post.py</PostCommands>
+    </HelixWorkItem>
   </ItemGroup>
 </Project>

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -124,7 +124,7 @@ if ($RunFromPerformanceRepo) {
     robocopy $SourceDirectory $PerformanceDirectory /E /XD $PayloadDirectory $SourceDirectory\artifacts $SourceDirectory\.git
 }
 else {
-    git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance/ $PerformanceDirectory
+    git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance $PerformanceDirectory
 }
 
 if($MonoDotnet -ne "")

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -124,7 +124,7 @@ if ($RunFromPerformanceRepo) {
     robocopy $SourceDirectory $PerformanceDirectory /E /XD $PayloadDirectory $SourceDirectory\artifacts $SourceDirectory\.git
 }
 else {
-    git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance $PerformanceDirectory
+    git clone --branch MauiiOSPerf --depth 1 --quiet https://github.com/LoopedBard3/performance/ $PerformanceDirectory
 }
 
 if($MonoDotnet -ne "")
@@ -162,6 +162,8 @@ if ($iOSMono) {
         Copy-Item -path "$SourceDirectory\iosHelloWorld\llvm" $PayloadDirectory\iosHelloWorld\llvm -Recurse
     } else {
         Copy-Item -path "$SourceDirectory\iosHelloWorld\nollvm" $PayloadDirectory\iosHelloWorld\nollvm -Recurse
+        Copy-Item -path "$SourceDirectory\MauiiOSDefault" $PayloadDirectory\MauiiOSDefault -Recurse
+        Copy-Item -path "$SourceDirectory\MauiMacCatalystDefault" $PayloadDirectory\MauiMacCatalystDefault -Recurse
     }
 
     $SetupArguments = $SetupArguments -replace $Architecture, 'arm64'

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -124,7 +124,7 @@ if ($RunFromPerformanceRepo) {
     robocopy $SourceDirectory $PerformanceDirectory /E /XD $PayloadDirectory $SourceDirectory\artifacts $SourceDirectory\.git
 }
 else {
-    git clone --branch MauiiOSPerf --depth 1 --quiet https://github.com/LoopedBard3/performance/ $PerformanceDirectory
+    git clone --branch main --depth 1 --quiet https://github.com/dotnet/performance/ $PerformanceDirectory
 }
 
 if($MonoDotnet -ne "")

--- a/src/tests/Common/maui/MauiScenario.targets
+++ b/src/tests/Common/maui/MauiScenario.targets
@@ -18,6 +18,10 @@
                              Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'android-x86'" />
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.android-x64"
                              Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'android-x64'" />
+      <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
+                             Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'maccatalyst-x64'" />
+      <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)/Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64"
+                             Condition="'%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App' and '%(ResolvedRuntimePack.RuntimeIdentifier)' == 'iossimulator-x64'" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Added the Maui iOS and MacCatalyst build steps for the SOD performance testing (per dotnet/performance#2075). Includes addition of runtime replacement during build, building of necessary runtime files, building of iOS and MacCatalyst, piping of the built apps through the pipeline, and the helix items for the tests.  