### PR TITLE
Avoid bogus cred scanning hits

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -22,7 +22,7 @@ namespace System.Text.RegularExpressions.Tests
 
         public RegexExperiment(ITestOutputHelper output) => _output = output;
 
-        public static bool Enabled => false;
+        public static bool Enabled => true;
 
         /// <summary>Temporary local output directory for experiment results.</summary>
         private static readonly string s_tmpWorkingDir = Path.GetTempPath();
@@ -346,9 +346,9 @@ namespace System.Text.RegularExpressions.Tests
                 string length = "[!-~]{8,12}";
 
                 // Just to make the chance that the randomly generated part actually has a match
-                // be astronomically unlikely require 'P' and 'r' to be present also,
+                // be astronomically unlikely require 'X' and 'r' to be present also,
                 // although this constraint is really bogus from password constraints point of view
-                string contains_first_P_and_then_r = ".*P.*r.*";
+                string contains_first_P_and_then_r = ".*X.*r.*";
 
                 // Conjunction of all the above constraints
                 string all = And(twoLower, twoUpper, threeDigits, oneSpecial, Not_countUp, Not_countDown, length, contains_first_P_and_then_r);
@@ -357,13 +357,13 @@ namespace System.Text.RegularExpressions.Tests
                 Regex re = new Regex($@"\b{all}\b", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
 
                 // Does not qualify because of 123 and connot end between 2 and 3 because of \b
-                string almostPassw1 = "P@ssW0rd123";
+                string almost1 = "X@ssW0rd123";
                 // Does not have at least two uppercase
-                string almostPassw2 = "P@55w0rd";
+                string almost2 = "X@55w0rd";
 
                 // These two qualify
-                string password1 = "P@55W0rd";
-                string password2 = "Pa5$w00rD";
+                string matching1 = "X@55W0rd";
+                string matching2 = "Xa5$w00rD";
 
                 foreach (int k in new int[] { 500, 1000, 5000, 10000, 50000, 100000 })
                 {
@@ -378,13 +378,13 @@ namespace System.Text.RegularExpressions.Tests
                     string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
                     string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));
 
-                    string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
+                    string input = $"{part1} {almost1} {part2} {matching1} {part3} {matching2}, finally this {almost2} does not qualify either";
 
-                    int expextedMatch1Index = (2 * k) + almostPassw1.Length + 3;
-                    int expextedMatch1Length = password1.Length;
+                    int expextedMatch1Index = (2 * k) + almost1.Length + 3;
+                    int expextedMatch1Length = matching1.Length;
 
-                    int expextedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
-                    int expextedMatch2Length = password2.Length;
+                    int expextedMatch2Index = (3 * k) + almost1.Length + matching1.Length + 5;
+                    int expextedMatch2Length = matching2.Length;
 
                     // Random text hiding almostPassw and password
                     int t = System.Environment.TickCount;
@@ -398,12 +398,12 @@ namespace System.Text.RegularExpressions.Tests
                     Assert.True(match1.Success);
                     Assert.Equal(expextedMatch1Index, match1.Index);
                     Assert.Equal(expextedMatch1Length, match1.Length);
-                    Assert.Equal(password1, match1.Value);
+                    Assert.Equal(matching1, match1.Value);
 
                     Assert.True(match2.Success);
                     Assert.Equal(expextedMatch2Index, match2.Index);
                     Assert.Equal(expextedMatch2Length, match2.Length);
-                    Assert.Equal(password2, match2.Value);
+                    Assert.Equal(matching2, match2.Value);
 
                     Assert.False(match3.Success);
                 }
@@ -432,7 +432,7 @@ namespace System.Text.RegularExpressions.Tests
                 // Just to make the chance that the randomly generated part actually has a match
                 // be astronomically unlikely require 'P' and 'r' to be present also,
                 // although this constraint is really bogus from password constraints point of view
-                string Not_contains_first_P_and_then_r = Not(".*P.*r.*");
+                string Not_contains_first_P_and_then_r = Not(".*X.*r.*");
 
                 // Negated disjunction of all the above constraints
                 // By deMorgan's laws we know that ~(A|B|...|C) = ~A&~B&...&~C and ~~A = A
@@ -443,13 +443,13 @@ namespace System.Text.RegularExpressions.Tests
                 Regex re = new Regex($@"\b{all}\b", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
 
                 // Does not qualify because of 123 and connot end between 2 and 3 because of \b
-                string almostPassw1 = "P@ssW0rd123";
+                string almost1 = "X@ssW0rd123";
                 // Does not have at least two uppercase
-                string almostPassw2 = "P@55w0rd";
+                string almost2 = "X@55w0rd";
 
                 // These two qualify
-                string password1 = "P@55W0rd";
-                string password2 = "Pa5$w00rD";
+                string matching1 = "X@55W0rd";
+                string matching2 = "Xa5$w00rD";
 
                 foreach (int k in new int[] { 500, 1000, 5000, 10000, 50000, 100000 })
                 {
@@ -464,15 +464,15 @@ namespace System.Text.RegularExpressions.Tests
                     string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
                     string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));
 
-                    string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
+                    string input = $"{part1} {almost1} {part2} {matching1} {part3} {matching2}, finally this {almost2} does not qualify either";
 
-                    int expectedMatch1Index = (2 * k) + almostPassw1.Length + 3;
-                    int expectedMatch1Length = password1.Length;
+                    int expectedMatch1Index = (2 * k) + almost1.Length + 3;
+                    int expectedMatch1Length = matching1.Length;
 
-                    int expectedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
-                    int expectedMatch2Length = password2.Length;
+                    int expectedMatch2Index = (3 * k) + almost1.Length + matching1.Length + 5;
+                    int expectedMatch2Length = matching2.Length;
 
-                    // Random text hiding almostPassw and password
+                    // Random text hiding almost and matching strings
                     int t = System.Environment.TickCount;
                     Match match1 = re.Match(input);
                     Match match2 = match1.NextMatch();
@@ -484,12 +484,12 @@ namespace System.Text.RegularExpressions.Tests
                     Assert.True(match1.Success);
                     Assert.Equal(expectedMatch1Index, match1.Index);
                     Assert.Equal(expectedMatch1Length, match1.Length);
-                    Assert.Equal(password1, match1.Value);
+                    Assert.Equal(matching1, match1.Value);
 
                     Assert.True(match2.Success);
                     Assert.Equal(expectedMatch2Index, match2.Index);
                     Assert.Equal(expectedMatch2Length, match2.Length);
-                    Assert.Equal(password2, match2.Value);
+                    Assert.Equal(matching2, match2.Value);
 
                     Assert.False(match3.Success);
                 }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -22,7 +22,7 @@ namespace System.Text.RegularExpressions.Tests
 
         public RegexExperiment(ITestOutputHelper output) => _output = output;
 
-        public static bool Enabled => true;
+        public static bool Enabled => false;
 
         /// <summary>Temporary local output directory for experiment results.</summary>
         private static readonly string s_tmpWorkingDir = Path.GetTempPath();


### PR DESCRIPTION
These strings were triggering the fuzzy scanner for credentials. It's best to avoid the word "password" or anything similar to it in tests. 

BTW, should these tests be enabled by default?