### PR TITLE
[wasm] simplify startup configuration

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -293,7 +293,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono
-      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg)
+      buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
       timeoutInMinutes: 180
       condition: >-
         or(
@@ -306,7 +306,6 @@ jobs:
       extraStepsParameters:
         creator: dotnet-bot
         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-        extraHelixArguments: $(_runSmokeTestsOnlyArg)
         scenarios:
         - normal
         - wasmtestonbrowser

--- a/src/mono/sample/mbr/browser/runtime.js
+++ b/src/mono/sample/mbr/browser/runtime.js
@@ -4,28 +4,11 @@
 "use strict";
 var Module = {
     config: null,
-
-    preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+    configSrc: "./mono-config.json",
+    onConfigLoaded: function () {
+        MONO.config.environment_variables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
     },
-
-    // Called when the runtime is initialized and wasm is ready
-    onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
-            console.log("An error occured while loading the config file");
-            return;
-        }
-
-        MONO.config.loaded_cb = function () {
-            App.init();
-        };
-        MONO.config.environment_variables = {
-            "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
-        };
-        MONO.config.fetch_file_cb = function (asset) {
-            return fetch(asset, { credentials: 'same-origin' });
-        }
-
-        MONO.mono_load_runtime_and_bcl_args(MONO.config);
+    onDotNetReady: function () {
+        App.init();
     },
 };

--- a/src/mono/sample/wasm/browser-bench/runtime.js
+++ b/src/mono/sample/wasm/browser-bench/runtime.js
@@ -4,42 +4,25 @@
 "use strict";
 var Module = {
     config: null,
-
-    preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
-    },
-
-    // Called when the runtime is initialized and wasm is ready
-    onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
-            console.log("An error occured while loading the config file");
-            return;
-        }
-
-        MONO.config.loaded_cb = function () {
-            try {
-                App.init();
-            } catch (error) {
-                test_exit(1);
-                throw (error);
-            }
-        };
-        MONO.config.fetch_file_cb = function (asset) {
-            return fetch(asset, { credentials: 'same-origin' });
-        }
-
+    configSrc: "./mono-config.json",
+    onConfigLoaded: function () {
         if (MONO.config.enable_profiler) {
             MONO.config.aot_profiler_options = {
                 write_at: "Sample.Test::StopProfile",
                 send_to: "System.Runtime.InteropServices.JavaScript.Runtime::DumpAotProfileData"
             }
         }
-
+    },
+    onDotNetReady: function () {
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            App.init();
         } catch (error) {
             test_exit(1);
             throw (error);
         }
+    },
+    onAbort: function (err) {
+        test_exit(1);
+
     },
 };

--- a/src/mono/sample/wasm/browser/runtime.js
+++ b/src/mono/sample/wasm/browser/runtime.js
@@ -3,37 +3,18 @@
 
 "use strict";
 var Module = {
-
     config: null,
-
-    preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
-    },
-
-    // Called when the runtime is initialized and wasm is ready
-    onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
-            console.log("No config found");
-            return;
-        }
-
-        MONO.config.loaded_cb = function () {
-            try {
-                App.init();
-            } catch (error) {
-                test_exit(1);
-                throw (error);
-            }
-        };
-        MONO.config.fetch_file_cb = function (asset) {
-            return fetch(asset, { credentials: 'same-origin' });
-        }
-
+    configSrc: "./mono-config.json",
+    onDotNetReady: function () {
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            App.init();
         } catch (error) {
             test_exit(1);
             throw (error);
         }
+    },
+    onAbort: function () {
+        test_exit(1);
+
     },
 };

--- a/src/mono/wasm/debugger/tests/debugger-test/runtime-debugger.js
+++ b/src/mono/wasm/debugger/tests/debugger-test/runtime-debugger.js
@@ -5,34 +5,20 @@
 
 var Module = {
 	config: null,
-
-	preInit: async function () {
-		await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
-	},
-
-	// Called when the runtime is initialized and wasm is ready
-	onRuntimeInitialized: function () {
-		if (!MONO.config || MONO.config.error) {
-			console.log("An error occured while loading the config file");
-			return;
-		}
-
-		MONO.config.loaded_cb = function () {
-			App.init();
-		};
+	configSrc: "./mono-config.json",
+	onConfigLoaded: function () {
+		MONO.config.environment_variables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
 		// For custom logging patch the functions below
 		/*
+		MONO.config.environment_variables["MONO_LOG_LEVEL"] = "debug";
+		MONO.config.environment_variables["MONO_LOG_MASK"] = "all";
 		INTERNAL.logging = {
-			trace: function (domain, log_level, message, isFatal, dataPtr) {},
-			debugger: function (level, message) {}
+			trace: function (domain, log_level, message, isFatal, dataPtr) { },
+			debugger: function (level, message) { }
 		};
-		MONO.mono_wasm_setenv ("MONO_LOG_LEVEL", "debug");
-		MONO.mono_wasm_setenv ("MONO_LOG_MASK", "all");
 		*/
-
-		MONO.config.environment_variables = {
-			"DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
-		};
-		MONO.mono_load_runtime_and_bcl_args(MONO.config)
+	},
+	onDotNetReady: function () {
+		App.init();
 	},
 };

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -21,12 +21,14 @@ import {
     mono_wasm_fire_debugger_agent_message,
 } from "./debug";
 import { runtimeHelpers, setLegacyModules } from "./modules";
-import { MonoArray, MonoConfig, MonoConfigError, MonoObject } from "./types";
+import { EmscriptenModuleMono, MonoArray, MonoConfig, MonoConfigError, MonoObject } from "./types";
 import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
     mono_wasm_load_data_archive, mono_wasm_asm_loaded,
-    mono_wasm_set_main_args
+    mono_wasm_set_main_args,
+    mono_wasm_pre_init,
+    mono_wasm_on_runtime_initialized
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
@@ -108,6 +110,8 @@ export const BINDING: BINDING = <any>{
 // it exports methods to global objects MONO, BINDING and Module in backward compatible way
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: any, module: any): void {
+    const moduleExt = module as EmscriptenModuleMono;
+
     // we want to have same instance of MONO, BINDING and Module in dotnet iffe
     setLegacyModules(dotnet, mono, binding, internal, module);
 
@@ -117,17 +121,20 @@ function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: an
     Object.assign(binding, BINDING);
     Object.assign(internal, INTERNAL);
 
-    // backward compatibility, sync with EmscriptenModuleMono
-    Object.assign(module, {
-        // https://github.com/search?q=mono_bind_static_method&type=Code
-        mono_bind_static_method: (fqn: string, signature: ArgsMarshalString): Function => {
+    // this could be overriden on Module
+    moduleExt.preInit = mono_wasm_pre_init;
+    moduleExt.onRuntimeInitialized = mono_wasm_on_runtime_initialized;
+
+    if (!moduleExt.disableDotNet6Compatibility) {
+        // backward compatibility
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        moduleExt.mono_bind_static_method = (fqn: string, signature: ArgsMarshalString): Function => {
             console.warn("Module.mono_bind_static_method is obsolete, please use BINDING.bind_static_method instead");
             return mono_bind_static_method(fqn, signature);
-        },
-    });
+        };
 
-    // here we expose objects used in tests to global namespace
-    if (!module.no_global_exports) {
+        // here we expose objects used in tests to global namespace
         (<any>globalThis).Module = module;
         const warnWrap = (name: string, value: any) => {
             if (typeof ((<any>globalThis)[name]) !== "undefined") {

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { INTERNAL, Module, MONO, runtimeHelpers } from "./modules";
-import { AssetEntry, CharPtr, CharPtrNull, MonoConfig, TypedArray, VoidPtr, wasm_type_symbol } from "./types";
+import { AssetEntry, CharPtr, CharPtrNull, EmscriptenModuleMono, GlobalizationMode, MonoConfig, TypedArray, VoidPtr, wasm_type_symbol } from "./types";
 import cwraps from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
 import { mono_wasm_globalization_init, mono_wasm_load_icu_data } from "./icu";
@@ -11,6 +11,34 @@ import { mono_wasm_init_aot_profiler, mono_wasm_init_coverage_profiler } from ".
 import { mono_wasm_load_bytes_into_heap } from "./buffers";
 import { bind_runtime_method, get_method, _create_primitive_converters } from "./method-binding";
 import { find_corlib_class } from "./class-loader";
+
+export async function mono_wasm_pre_init(): Promise<void> {
+    const moduleExt = Module as EmscriptenModuleMono;
+    if (moduleExt.configSrc) {
+        // sets MONO.config implicitly
+        await mono_wasm_load_config(moduleExt.configSrc);
+
+        if (moduleExt.onConfigLoaded) {
+            try {
+                moduleExt.onConfigLoaded();
+            }
+            catch (err: any) {
+                Module.printErr("MONO_WASM: onConfigLoaded () failed: " + err);
+                Module.printErr("MONO_WASM: Stacktrace: \n");
+                Module.printErr(err.stack);
+                throw err;
+            }
+        }
+    }
+}
+
+export function mono_wasm_on_runtime_initialized(): void {
+    const moduleExt = Module as EmscriptenModuleMono;
+    if (!moduleExt.config || moduleExt.config.isError) {
+        return;
+    }
+    mono_load_runtime_and_bcl_args(moduleExt.config);
+}
 
 // Set environment variable NAME to VALUE
 // Should be called before mono_load_runtime_and_bcl () in most cases
@@ -94,7 +122,7 @@ function _handle_loaded_asset(ctx: MonoInitContext, asset: AssetEntry, url: stri
     }
     else if (asset.behavior === "icu") {
         if (!mono_wasm_load_icu_data(offset!))
-            console.error(`Error loading ICU asset ${asset.name}`);
+            console.error(`MONO_WASM: Error loading ICU asset ${asset.name}`);
     }
     else if (asset.behavior === "resource") {
         cwraps.mono_wasm_add_satellite_assembly(virtualName, asset.culture!, offset!, bytes.length);
@@ -102,49 +130,11 @@ function _handle_loaded_asset(ctx: MonoInitContext, asset: AssetEntry, url: stri
 }
 
 // Initializes the runtime and loads assemblies, debug information, and other files.
-// @args is a dictionary-style Object with the following properties:
-//    assembly_root: (required) the subfolder containing managed assemblies and pdbs
-//    debug_level or enable_debugging: (required)
-//    assets: (required) a list of assets to load along with the runtime. each asset
-//     is a dictionary-style Object with the following properties:
-//        name: (required) the name of the asset, including extension.
-//        behavior: (required) determines how the asset will be handled once loaded:
-//          "heap": store asset into the native heap
-//          "assembly": load asset as a managed assembly (or debugging information)
-//          "resource": load asset as a managed resource assembly
-//          "icu": load asset as an ICU data archive
-//          "vfs": load asset into the virtual filesystem (for fopen, File.Open, etc)
-//        load_remote: (optional) if true, an attempt will be made to load the asset
-//          from each location in @args.remote_sources.
-//        virtual_path: (optional) if specified, overrides the path of the asset in
-//          the virtual filesystem and similar data structures once loaded.
-//        is_optional: (optional) if true, any failure to load this asset will be ignored.
-//    loaded_cb: (required) a function () invoked when loading has completed.
-//    fetch_file_cb: (optional) a function (string) invoked to fetch a given file.
-//      If no callback is provided a default implementation appropriate for the current
-//      environment will be selected (readFileSync in node, fetch elsewhere).
-//      If no default implementation is available this call will fail.
-//    remote_sources: (optional) additional search locations for assets.
-//      sources will be checked in sequential order until the asset is found.
-//      the string "./" indicates to load from the application directory (as with the
-//      files in assembly_list), and a fully-qualified URL like "https://example.com/" indicates
-//      that asset loads can be attempted from a remote server. Sources must end with a "/".
-//    environment_variables: (optional) dictionary-style Object containing environment variables
-//    runtime_options: (optional) array of runtime options as strings
-//    aot_profiler_options: (optional) dictionary-style Object. see the comments for
-//      mono_wasm_init_aot_profiler. If omitted, aot profiler will not be initialized.
-//    coverage_profiler_options: (optional) dictionary-style Object. see the comments for
-//      mono_wasm_init_coverage_profiler. If omitted, coverage profiler will not be initialized.
-//    globalization_mode: (optional) configures the runtime's globalization mode:
-//      "icu": load ICU globalization data from any runtime assets with behavior "icu".
-//      "invariant": operate in invariant globalization mode.
-//      "auto" (default): if "icu" behavior assets are present, use ICU, otherwise invariant.
-//    diagnostic_tracing: (optional) enables diagnostic log messages during startup
 export function mono_load_runtime_and_bcl_args(args: MonoConfig): void {
     try {
         return _load_assets_and_runtime(args);
     } catch (exc: any) {
-        console.error("error in mono_load_runtime_and_bcl_args:", exc);
+        console.error("MONO_WASM: Error in mono_load_runtime_and_bcl_args:", exc);
         throw exc;
     }
 }
@@ -205,6 +195,8 @@ function _get_fetch_file_cb_from_args(args: MonoConfig): (asset: string) => Prom
 }
 
 function _finalize_startup(args: MonoConfig, ctx: MonoInitContext) {
+    const moduleExt = Module as EmscriptenModuleMono;
+
     ctx.loaded_files.forEach(value => MONO.loaded_files.push(value.url));
     if (ctx.tracing) {
         console.log("MONO_WASM: loaded_assets: " + JSON.stringify(ctx.loaded_assets));
@@ -219,9 +211,9 @@ function _finalize_startup(args: MonoConfig, ctx: MonoInitContext) {
         try {
             cwraps.mono_wasm_load_runtime("unused", args.debug_level || 0);
         } catch (ex: any) {
-            Module.print("MONO_WASM: load_runtime () failed: " + ex);
-            Module.print("MONO_WASM: Stacktrace: \n");
-            Module.print(ex.stack);
+            Module.printErr("MONO_WASM: mono_wasm_load_runtime () failed: " + ex);
+            Module.printErr("MONO_WASM: Stacktrace: \n");
+            Module.printErr(ex.stack);
 
             const wasm_exit = cwraps.mono_wasm_exit;
             wasm_exit(1);
@@ -240,15 +232,18 @@ function _finalize_startup(args: MonoConfig, ctx: MonoInitContext) {
     }
     mono_wasm_setenv("TZ", tz || "UTC");
     mono_wasm_runtime_ready();
-    args.loaded_cb();
-}
 
-
-export function mono_bindings_init(binding_asm?: string): void {
-    if (binding_asm) {
-        INTERNAL.BINDING_ASM = binding_asm;
+    if (moduleExt.onDotNetReady) {
+        try {
+            moduleExt.onDotNetReady();
+        }
+        catch (err: any) {
+            Module.printErr("MONO_WASM: onDotNetReady () failed: " + err);
+            Module.printErr("MONO_WASM: Stacktrace: \n");
+            Module.printErr(err.stack);
+            throw err;
+        }
     }
-
 }
 
 export function bindings_lazy_init(): void {
@@ -315,14 +310,6 @@ export function bindings_lazy_init(): void {
 function _load_assets_and_runtime(args: MonoConfig) {
     if (args.enable_debugging)
         args.debug_level = args.enable_debugging;
-    if (args.assembly_list)
-        throw new Error("Invalid args (assembly_list was replaced by assets)");
-    if (args.runtime_assets)
-        throw new Error("Invalid args (runtime_assets was replaced by assets)");
-    if (args.runtime_asset_sources)
-        throw new Error("Invalid args (runtime_asset_sources was replaced by remote_sources)");
-    if (!args.loaded_cb)
-        throw new Error("loaded_cb not provided");
 
     const ctx: MonoInitContext = {
         tracing: args.diagnostic_tracing || false,
@@ -335,7 +322,7 @@ function _load_assets_and_runtime(args: MonoConfig) {
     };
 
     if (ctx.tracing)
-        console.log("mono_wasm_load_runtime_with_args", JSON.stringify(args));
+        console.log("MONO_WASM: mono_wasm_load_runtime_with_args", JSON.stringify(args));
 
     _apply_configuration_from_args(args);
 
@@ -348,7 +335,7 @@ function _load_assets_and_runtime(args: MonoConfig) {
             try {
                 _finalize_startup(args, ctx);
             } catch (exc: any) {
-                console.error("Unhandled exception in _finalize_startup", exc);
+                console.error("MONO_WASM: Unhandled exception in _finalize_startup", exc);
                 console.error(exc.stack);
                 throw exc;
             }
@@ -359,7 +346,7 @@ function _load_assets_and_runtime(args: MonoConfig) {
         try {
             _handle_loaded_asset(ctx, asset, url, buffer);
         } catch (exc) {
-            console.error(`Unhandled exception in processFetchResponseBuffer ${url}`, exc);
+            console.error(`MONO_WASM: Unhandled exception in processFetchResponseBuffer ${url} ${exc}`);
             throw exc;
         } finally {
             onPendingRequestComplete();
@@ -376,7 +363,7 @@ function _load_assets_and_runtime(args: MonoConfig) {
                     attemptNextSource();
                     return;
                 } catch (exc) {
-                    console.error(`MONO_WASM: Unhandled exception in handleFetchResponse attemptNextSource for asset ${asset.name}`, exc);
+                    console.error(`MONO_WASM: Unhandled exception in handleFetchResponse attemptNextSource for asset ${asset.name} ${exc}`);
                     throw exc;
                 }
             }
@@ -385,7 +372,7 @@ function _load_assets_and_runtime(args: MonoConfig) {
                 const bufferPromise = response.arrayBuffer();
                 bufferPromise.then((data) => processFetchResponseBuffer(asset, response.url, data));
             } catch (exc) {
-                console.error(`MONO_WASM: Unhandled exception in handleFetchResponse for asset ${asset.name}`, exc);
+                console.error(`MONO_WASM: Unhandled exception in handleFetchResponse for asset ${asset.name} ${exc}`);
                 attemptNextSource();
             }
         };
@@ -432,15 +419,15 @@ function _load_assets_and_runtime(args: MonoConfig) {
             try {
                 if (asset.name === attemptUrl) {
                     if (ctx.tracing)
-                        console.log(`Attempting to fetch '${attemptUrl}'`);
+                        console.log(`MONO_WASM: Attempting to fetch '${attemptUrl}'`);
                 } else {
                     if (ctx.tracing)
-                        console.log(`Attempting to fetch '${attemptUrl}' for ${asset.name}`);
+                        console.log(`MONO_WASM: Attempting to fetch '${attemptUrl}' for ${asset.name}`);
                 }
                 const fetch_promise = fetch_file_cb(attemptUrl);
                 fetch_promise.then(handleFetchResponse);
             } catch (exc) {
-                console.error(`MONO_WASM: Error fetching ${attemptUrl}`, exc);
+                console.error(`MONO_WASM: Error fetching ${attemptUrl} ${exc}`);
                 attemptNextSource();
             }
         };
@@ -529,10 +516,16 @@ export async function mono_wasm_load_config(configFilePath: string): Promise<voi
             config = JSON.parse(json);
         }
         runtimeHelpers.config = config;
+        config.environment_variables = config.environment_variables || {};
+        config.assets = config.assets || [];
+        config.runtime_options = config.runtime_options || [];
+        config.globalization_mode = config.globalization_mode || GlobalizationMode.AUTO;
+
     } catch (exc) {
-        const errMessage = "failed to load config file " + configFilePath;
-        console.error(errMessage, exc);
-        runtimeHelpers.config = { message: errMessage, error: exc };
+        const errMessage = `Failed to load config file ${configFilePath} ${exc}`;
+        console.error(errMessage);
+        runtimeHelpers.config = { message: errMessage, error: exc, isError: true };
+        throw exc;
     } finally {
         Module.removeRunDependency(configFilePath);
     }

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -44,10 +44,10 @@ export interface MonoString extends MonoObject {
 export interface MonoClass extends MonoObject {
     __brand: "MonoClass"
 }
-export interface MonoType extends ManagedPointer{
+export interface MonoType extends ManagedPointer {
     __brand: "MonoType"
 }
-export interface MonoMethod extends ManagedPointer{
+export interface MonoMethod extends ManagedPointer {
     __brand: "MonoMethod"
 }
 export interface MonoArray extends MonoObject {
@@ -73,16 +73,13 @@ export function coerceNull<T extends ManagedPointer | NativePointer>(ptr: T | nu
 }
 
 export type MonoConfig = {
+    isError: false,
     assembly_root: string, // the subfolder containing managed assemblies and pdbs
     assets: (AssetEntry | AssemblyEntry | SatelliteAssemblyEntry | VfsEntry | IcuData)[], // a list of assets to load along with the runtime. each asset is a dictionary-style Object with the following properties:
-    loaded_cb: Function, // a function invoked when loading has completed
     debug_level?: number, // Either this or the next one needs to be set
     enable_debugging?: number, // Either this or the previous one needs to be set
     fetch_file_cb?: Request, // a function (string) invoked to fetch a given file. If no callback is provided a default implementation appropriate for the current environment will be selected (readFileSync in node, fetch elsewhere). If no default implementation is available this call will fail.
     globalization_mode: GlobalizationMode, // configures the runtime's globalization mode
-    assembly_list?: any, // obsolete but necessary for the check
-    runtime_assets?: any, // obsolete but necessary for the check
-    runtime_asset_sources?: any, // obsolete but necessary for the check
     diagnostic_tracing?: boolean // enables diagnostic log messages during startup
     remote_sources?: string[], // additional search locations for assets. Sources will be checked in sequential order until the asset is found. The string "./" indicates to load from the application directory (as with the files in assembly_list), and a fully-qualified URL like "https://example.com/" indicates that asset loads can be attempted from a remote server. Sources must end with a "/".
     environment_variables?: {
@@ -94,7 +91,11 @@ export type MonoConfig = {
     ignore_pdb_load_errors?: boolean
 };
 
-export type MonoConfigError = { message: string, error: any }
+export type MonoConfigError = {
+    isError: true,
+    message: string,
+    error: any
+}
 
 // Types of assets that can be in the mono-config.js/mono-config.json file (taken from /src/tasks/WasmAppBuilder/WasmAppBuilder.cs)
 export type AssetEntry = {
@@ -177,10 +178,16 @@ export type CoverageProfilerOptions = {
 
 // how we extended emscripten Module
 export type EmscriptenModuleMono = EmscriptenModule & {
-    no_global_exports?: boolean,
+    disableDotNet6Compatibility?: boolean,
 
     // backward compatibility
     config?: MonoConfig | MonoConfigError,
-    // backward compatibility https://github.com/search?q=mono_bind_static_method&type=Code
+    configSrc?: string,
+    onConfigLoaded?: () => void;
+    onDotNetReady?: () => void;
+
+    /**
+     * @deprecated DEPRECATED! backward compatibility https://github.com/search?q=mono_bind_static_method&type=Code
+     */
     mono_bind_static_method: (fqn: string, signature: string) => Function,
 }

--- a/src/mono/wasm/runtime/types/emscripten.d.ts
+++ b/src/mono/wasm/runtime/types/emscripten.d.ts
@@ -52,6 +52,7 @@ declare interface EmscriptenModule {
 
     // this should match emcc -s EXPORTED_RUNTIME_METHODS
     print(message: string): void;
+    printErr(message: string): void;
     ccall<T>(ident: string, returnType?: string | null, argTypes?: string[], args?: any[], opts?: any): T;
     cwrap<T extends Function>(ident: string, returnType: string, argTypes?: string[], opts?: any): T;
     cwrap<T extends Function>(ident: string, ...args: any[]): T;
@@ -64,6 +65,9 @@ declare interface EmscriptenModule {
     FS_createDataFile(parent: string, name: string, data: TypedArray, canRead: boolean, canWrite: boolean, canOwn?: boolean): string;
     removeRunDependency(id: string): void;
     addRunDependency(id: string): void;
+
+    preInit?: () => Promise<void>;
+    onRuntimeInitialized?: () => void;
 }
 
 declare type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/runtime.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/runtime.js
@@ -1,46 +1,23 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+"use strict";
+
 var Module = {
-
     config: null,
-
-    preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+    configSrc: "./mono-config.json",
+    onConfigLoaded: function () {
+        MONO.config.environment_variables["DOTNET_MODIFIABLE_ASSEMBLIES"] = "debug";
     },
-
-    onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
-            console.log("No config found");
-            test_exit(1);
-            throw (MONO.config.error);
-        }
-
-        MONO.config.loaded_cb = function () {
-            try {
-                App.init();
-            } catch (error) {
-                test_exit(1);
-                throw (error);
-            }
-        };
-        MONO.config.fetch_file_cb = function (asset) {
-            return fetch(asset, { credentials: 'same-origin' });
-        }
-
-        if (MONO.config.environment_variables !== undefined) {
-            console.log("expected environment variables to be undefined, but they're: ", MONO.config.environment_variables);
-            test_exit(1);
-        }
-        MONO.config.environment_variables = {
-            "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
-        };
-
+    onDotNetReady: function () {
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            App.init();
         } catch (error) {
             test_exit(1);
             throw (error);
         }
+    },
+    onAbort: function () {
+        test_exit(1);
     },
 };

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/runtime.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/runtime.js
@@ -1,38 +1,20 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+"use strict";
+
 var Module = {
-
     config: null,
-
-    preInit: async function () {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
-    },
-
-    onRuntimeInitialized: function () {
-        if (!MONO.config || MONO.config.error) {
-            console.log("No config found");
-            test_exit(1);
-            throw (MONO.config.error);
-        }
-
-        MONO.config.loaded_cb = function () {
-            try {
-                App.init();
-            } catch (error) {
-                test_exit(1);
-                throw (error);
-            }
-        };
-        MONO.config.fetch_file_cb = function (asset) {
-            return fetch(asset, { credentials: 'same-origin' });
-        }
-
+    configSrc: "./mono-config.json",
+    onDotNetReady: function () {
         try {
-            MONO.mono_load_runtime_and_bcl_args(MONO.config);
+            App.init();
         } catch (error) {
             test_exit(1);
             throw (error);
         }
+    },
+    onAbort: function () {
+        test_exit(1);
     },
 };


### PR DESCRIPTION
* added `Module.configSrc` - to configure path to `MonoConfig` json file
* added `Module.onConfigLoaded` callback
* added `Module.onDotNetReady` replacing `MonoConfig.loaded_cb`
* removed `loaded_cb`, `assembly_list`, `runtime_assets`, `runtime_asset_sources` from `MonoConfig`
* simplified all sample and test projects
* renamed `Module.no_global_exports` to `Module.disableDotNet6Compatibility`
* implement default `Module.preInit` and `Module.onRuntimeInitialized` which could be overridden by user code (like Blazor)