### PR TITLE
Fix x86 stackwalk for UnmanagedCallersOnly

### DIFF
--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2809,12 +2809,14 @@ public:
         return GetOffsetOfDatum();
     }
 
+#ifndef FEATURE_EH_FUNCLETS
     virtual BOOL NeedsUpdateRegDisplay()
     {
         return TRUE;
     }
 
     virtual void UpdateRegDisplay(const PREGDISPLAY pRD);
+#endif // FEATURE_EH_FUNCLETS
 
 protected:
 

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2812,7 +2812,9 @@ public:
 #ifndef FEATURE_EH_FUNCLETS
     virtual BOOL NeedsUpdateRegDisplay()
     {
-        return TRUE;
+        // We need to update it only for the cases when a method marked with UnmanagedCallersOnly
+        // is called by a managed method via an unmanaged function pointer.
+        return ExecutionManager::IsManagedCode(GetReturnAddress());
     }
 
     virtual void UpdateRegDisplay(const PREGDISPLAY pRD);

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -1878,6 +1878,11 @@ public:
         LIMITED_METHOD_CONTRACT;
         return offsetof(UnmanagedToManagedFrame, m_calleeSavedRegisters);
     }
+
+    CalleeSavedRegisters*  GetCalleeSavedRegisters()
+    {
+        return &m_calleeSavedRegisters;
+    }
 #endif
 
     int GetFrameType()
@@ -2803,6 +2808,13 @@ public:
         WRAPPER_NO_CONTRACT;
         return GetOffsetOfDatum();
     }
+
+    virtual BOOL NeedsUpdateRegDisplay()
+    {
+        return TRUE;
+    }
+
+    virtual void UpdateRegDisplay(const PREGDISPLAY pRD);
 
 protected:
 

--- a/src/coreclr/vm/i386/cgenx86.cpp
+++ b/src/coreclr/vm/i386/cgenx86.cpp
@@ -198,8 +198,6 @@ void EHContext::UpdateFrame(PREGDISPLAY regs)
     *regs->pEdi = this->Edi;
     *regs->pEbp = this->Ebp;
 }
-#endif // FEATURE_EH_FUNCLETS
-
 
 void UMThkCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 {
@@ -226,6 +224,8 @@ void UMThkCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 
     RETURN;
 }
+
+#endif // FEATURE_EH_FUNCLETS
 
 void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 {

--- a/src/coreclr/vm/i386/cgenx86.cpp
+++ b/src/coreclr/vm/i386/cgenx86.cpp
@@ -200,6 +200,33 @@ void EHContext::UpdateFrame(PREGDISPLAY regs)
 }
 #endif // FEATURE_EH_FUNCLETS
 
+
+void UMThkCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
+{
+    CONTRACT_VOID
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+        HOST_NOCALLS;
+        SUPPORTS_DAC;
+    }
+    CONTRACT_END;
+
+    CalleeSavedRegisters* regs = GetCalleeSavedRegisters();
+
+    pRD->PCTAddr = GetReturnAddressPtr();
+#define CALLEE_SAVED_REGISTER(regname) pRD->p##regname = (DWORD*) &regs->regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
+    pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
+    UINT cbStackPop = GetUMEntryThunk()->GetMethod()->CbStackPop();
+    pRD->SP  = (DWORD)(pRD->PCTAddr + sizeof(TADDR) + cbStackPop);
+
+    RETURN;
+}
+
 void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 {
     CONTRACT_VOID


### PR DESCRIPTION
Yet another similar issue to the recently fixed x86 EH for methods
marked with UnmanagedCallersOnly, but called from a managed method using
a function pointer. The stack walker was asserting in
VerifyValidTransitionFromManagedCode. The REGDISPLAY values that it used
for checking the code location were not set for this case, so EIP and ESP
were both set to 0.
This change fixes it by adding UpdateRegDisplay method to
UMThkCallFrame.

Close #60648
Close https://github.com/dotnet/runtime/issues/62728