### PR TITLE
Temporarily disable scaled index on arm64

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1588,7 +1588,6 @@ AGAIN:
 
             break;
 
-#endif // TARGET_ARMARCH
         case GT_MUL:
 
             if (op2->gtOverflow())
@@ -1624,6 +1623,7 @@ AGAIN:
                 goto FOUND_AM;
             }
             break;
+#endif // TARGET_ARMARCH
 
         case GT_NOP:
 


### PR DESCRIPTION
Addresses failures in (see https://github.com/dotnet/runtime/pull/60808#issuecomment-957308752)
cc @krwq 