### PR TITLE
Use RunContinuationsAsynchronously for block completion tasks

### DIFF
--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
@@ -496,7 +496,7 @@ namespace System.Threading.Tasks.Dataflow
             /// <summary>All of the output messages queued up to be received by consumers/targets.</summary>
             private readonly Queue<TOutput> _messages = new Queue<TOutput>();
             /// <summary>A TaskCompletionSource that represents the completion of this block.</summary>
-            private readonly TaskCompletionSource<VoidResult> _completionTask = new TaskCompletionSource<VoidResult>();
+            private readonly TaskCompletionSource<VoidResult> _completionTask = new TaskCompletionSource<VoidResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             /// <summary>
             /// An action to be invoked on the owner block when an item is removed.
             /// This may be null if the owner block doesn't need to be notified.

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/WriteOnceBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Blocks/WriteOnceBlock.cs
@@ -78,7 +78,7 @@ namespace System.Threading.Tasks.Dataflow
             // we need to initialize the completion task's TCS now.
             if (dataflowBlockOptions.CancellationToken.CanBeCanceled)
             {
-                _lazyCompletionTaskSource = new TaskCompletionSource<VoidResult>();
+                _lazyCompletionTaskSource = new TaskCompletionSource<VoidResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // If we've already had cancellation requested, do as little work as we have to
                 // in order to be done.
@@ -489,7 +489,7 @@ namespace System.Threading.Tasks.Dataflow
                 // it remains the block's completion task.
                 if (_lazyCompletionTaskSource == null)
                 {
-                    Interlocked.CompareExchange(ref _lazyCompletionTaskSource, new TaskCompletionSource<VoidResult>(), null);
+                    Interlocked.CompareExchange(ref _lazyCompletionTaskSource, new TaskCompletionSource<VoidResult>(TaskCreationOptions.RunContinuationsAsynchronously), null);
                 }
 
                 return _lazyCompletionTaskSource;

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Security;
 
 namespace System.Threading.Tasks.Dataflow.Internal
 {
@@ -33,7 +32,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         // *** These fields are readonly and are initialized to new instances at construction.
 
         /// <summary>A TaskCompletionSource that represents the completion of this block.</summary>
-        private readonly TaskCompletionSource<VoidResult> _completionTask = new TaskCompletionSource<VoidResult>();
+        private readonly TaskCompletionSource<VoidResult> _completionTask = new TaskCompletionSource<VoidResult>(TaskCreationOptions.RunContinuationsAsynchronously);
         /// <summary>A registry used to store all linked targets and information about them.</summary>
         private readonly TargetRegistry<TOutput> _targetRegistry;
         /// <summary>The output messages queued up to be received by consumers/targets.</summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/60768.

See https://github.com/dotnet/runtime/issues/60768#issuecomment-958742085 for more details. In short: if user code contains `await block1.Completion` followed by `block2.Completion.Wait()` (where `block1` is linked to `block2` with `PropagateCompletion`), this leads to a deadlock. Using `RunContinuationsAsynchronously` for the `Completion` task prevents that deadlock.

I can see two potential problems with this PR:

1. It goes too far. `RunContinuationsAsynchronously` has a performance cost, but it only helps users who use discouraged patterns (combining `await` with synchronous waiting), so doing this may not be worth it.
2. It does not go far enough. This PR only considers `Completion` tasks for source blocks, but Dataflow exposes tasks in many other places. Maybe those should be reviewed to see if they should also switch to `RunContinuationsAsynchronously`?