### PR TITLE
XARCH: Remove redudant tests for GT_LT/GT_GE relops.

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2618,6 +2618,16 @@ void CodeGen::genCodeForJumpTrue(GenTreeOp* jtrue)
 
         condition = GenCondition(GenCondition::P);
     }
+
+    if (relop->MarkedForSignJumpOpt())
+    {
+        // If relop was previously marked for a signed jump check optimization because of SF flag
+        // reuse, replace jge/jl with jns/js.
+
+        assert(relop->OperGet() == GT_LT || relop->OperGet() == GT_GE);
+        condition = (relop->OperGet() == GT_LT) ? GenCondition(GenCondition::S) : GenCondition(GenCondition::NS);
+    }
+
 #endif
 
     inst_JCC(condition, compiler->compCurBB->bbJumpDest);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6227,6 +6227,8 @@ void CodeGen::genCompareInt(GenTree* treeNode)
     assert(genTypeSize(type) <= genTypeSize(TYP_I_IMPL));
     // TYP_UINT and TYP_ULONG should not appear here, only small types can be unsigned
     assert(!varTypeIsUnsigned(type) || varTypeIsSmall(type));
+    // Sign jump optimization should only be set the following check
+    assert((tree->gtFlags & GTF_RELOP_SJUMP_OPT) == 0);
 
     if (canReuseFlags && emit->AreFlagsSetToZeroCmp(op1->GetRegNum(), emitTypeSize(type), tree->OperGet()))
     {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6232,6 +6232,11 @@ void CodeGen::genCompareInt(GenTree* treeNode)
     {
         JITDUMP("Not emitting compare due to flags being already set\n");
     }
+    else if (canReuseFlags && emit->AreFlagsSetForSignJumpOpt(op1->GetRegNum(), emitTypeSize(type), tree))
+    {
+        JITDUMP("Not emitting compare due to sign being already set, follow up instr will transform jump\n");
+        tree->gtFlags |= GTF_RELOP_SJUMP_OPT;
+    }
     else
     {
         emit->emitInsBinary(ins, emitTypeSize(type), op1, op2);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -353,6 +353,11 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps tr
 {
     assert(reg != REG_NA);
 
+    if (!emitComp->opts.OptimizationEnabled())
+    {
+        return false;
+    }
+
     // Don't look back across IG boundaries (possible control flow)
     if (emitCurIGinsCnt == 0 && ((emitCurIG->igFlags & IGF_EXTEND) == 0))
     {
@@ -426,6 +431,11 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps tr
 bool emitter::AreFlagsSetForSignJumpOpt(regNumber reg, emitAttr opSize, GenTree* relop)
 {
     assert(reg != REG_NA);
+
+    if (!emitComp->opts.OptimizationEnabled())
+    {
+        return false;
+    }
 
     // Don't look back across IG boundaries (possible control flow)
     if (emitCurIGinsCnt == 0 && ((emitCurIG->igFlags & IGF_EXTEND) == 0))

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -165,6 +165,21 @@ bool emitter::DoesWriteZeroFlag(instruction ins)
 }
 
 //------------------------------------------------------------------------
+// DoesWriteSignFlag: check if the instruction writes the
+//     SF flag.
+//
+// Arguments:
+//    ins - instruction to test
+//
+// Return Value:
+//    true if instruction writes the SF flag, false otherwise.
+//
+bool emitter::DoesWriteSignFlag(instruction ins)
+{
+    return (CodeGenInterface::instInfo[ins] & Writes_SF) != 0;
+}
+
+//------------------------------------------------------------------------
 // DoesResetOverflowAndCarryFlags: check if the instruction resets the
 //     OF and CF flag to 0.
 //
@@ -385,6 +400,74 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps tr
     if ((treeOps == GT_EQ) || (treeOps == GT_NE))
     {
         if (DoesWriteZeroFlag(lastIns) && IsFlagsAlwaysModified(id))
+        {
+            return id->idOpSize() == opSize;
+        }
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------
+// AreFlagsSetToForSignJumpOpt: checks if the previous instruction set the SF if the tree
+//                              node qualifies for a jg/jle to jns/js optimization
+//
+// Arguments:
+//    reg     - register of interest
+//    opSize  - size of register
+//    relop   - relational tree node
+//
+// Return Value:
+//    true if the tree node qualifies for the jg/jle to jns/js optimization
+//    false if not, or if we can't safely determine
+//
+// Notes:
+//    Currently only looks back one instruction.
+bool emitter::AreFlagsSetForSignJumpOpt(regNumber reg, emitAttr opSize, GenTree* relop)
+{
+    assert(reg != REG_NA);
+
+    // Don't look back across IG boundaries (possible control flow)
+    if (emitCurIGinsCnt == 0 && ((emitCurIG->igFlags & IGF_EXTEND) == 0))
+    {
+        return false;
+    }
+
+    instrDesc*  id      = emitLastIns;
+    instruction lastIns = id->idIns();
+    insFormat   fmt     = id->idInsFmt();
+
+    // make sure op1 is a reg
+    switch (fmt)
+    {
+        case IF_RWR_CNS:
+        case IF_RRW_CNS:
+        case IF_RRW_SHF:
+        case IF_RWR_RRD:
+        case IF_RRW_RRD:
+        case IF_RWR_MRD:
+        case IF_RWR_SRD:
+        case IF_RRW_SRD:
+        case IF_RWR_ARD:
+        case IF_RRW_ARD:
+        case IF_RWR:
+        case IF_RRD:
+        case IF_RRW:
+            break;
+        default:
+            return false;
+    }
+
+    if (id->idReg1() != reg)
+    {
+        return false;
+    }
+
+    // If we have a GT_GE/GT_LT which generates an jge/jl, and the previous instruction
+    // sets the SF, we can omit a test instruction and check for jns/js.
+    if ((relop->OperGet() == GT_GE || relop->OperGet() == GT_LT) && !GenCondition::FromRelop(relop).IsUnsigned())
+    {
+        if (DoesWriteSignFlag(lastIns) && IsFlagsAlwaysModified(id))
         {
             return id->idOpSize() == opSize;
         }

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -116,6 +116,7 @@ static bool IsJmpInstruction(instruction ins);
 bool AreUpper32BitsZero(regNumber reg);
 
 bool AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps treeOps);
+bool AreFlagsSetForSignJumpOpt(regNumber reg, emitAttr opSize, GenTree* tree);
 
 bool hasRexPrefix(code_t code)
 {
@@ -190,6 +191,7 @@ void SetContains256bitAVX(bool value)
 bool IsDstDstSrcAVXInstruction(instruction ins);
 bool IsDstSrcSrcAVXInstruction(instruction ins);
 bool DoesWriteZeroFlag(instruction ins);
+bool DoesWriteSignFlag(instruction ins);
 bool DoesResetOverflowAndCarryFlags(instruction ins);
 bool IsFlagsAlwaysModified(instrDesc* id);
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -530,6 +530,8 @@ enum GenTreeFlags : unsigned int
     GTF_RELOP_QMARK             = 0x20000000, // GT_<relop> -- the node is the condition for ?:
     GTF_RELOP_ZTT               = 0x08000000, // GT_<relop> -- Loop test cloned for converting while-loops into do-while
                                               //               with explicit "loop test" in the header block.
+    GTF_RELOP_SJUMP_OPT         = 0x04000000, // GT_<relop> -- Swap signed jl/jge with js/jns during emitter, reuses flags 
+                                              //               from previous instruction.
 
     GTF_JCMP_EQ                 = 0x80000000, // GTF_JCMP_EQ  -- Branch on equal rather than not equal
     GTF_JCMP_TST                = 0x40000000, // GTF_JCMP_TST -- Use bit test instruction rather than compare against zero instruction
@@ -3027,6 +3029,13 @@ struct GenTreeOp : public GenTreeUnOp
     {
     }
 #endif
+
+    // True if this relop is marked for a transform during the emitter
+    // phase, e.g., jge => jns
+    bool MarkedForSignJumpOpt() const
+    {
+        return (gtFlags & GTF_RELOP_SJUMP_OPT) != 0;
+    }
 };
 
 struct GenTreeVal : public GenTree


### PR DESCRIPTION
This PR addresses https://github.com/dotnet/runtime/issues/11414 but continues on with some of the work discussed in the Background section below.

## Changes

We can now optimize cases such as `(x + y < 0)` or `for (int x = v; x >= 0; x--)`
using the flag tracking logic during the emit stage. Notably, cases that
would generate...

```
add     reg0, reg1
test    reg0, reg0
jge     LABEL
```

now transform to

```
add     reg0, reg1
jns     LABEL
```

This transform is valid for signed GE and signed LT only.

## Background

It looks like https://github.com/dotnet/coreclr/pull/14027 started some logic for reusing flags during the lowering stage, at which point some of the cases had to be restricted due to the OF https://github.com/dotnet/runtime/issues/9059.  There was some discussion about making this work for `ADD/SUB + LT/GE` but it looks like it was abandoned due to low optimization opportunity https://github.com/dotnet/runtime/issues/6794#issuecomment-334262219. 

More recently, a PR https://github.com/dotnet/runtime/pull/38586 added flag tracking during the codegen/emit stage, and addressed some remaining optimization cases, e.g., `(x ^ y) < 0`. 

I think with PR 38586, we can handle cases like `if (x - y) < 0`, or more importantly, `for (int x = v; x >= 0; x -= 2)` as we can now look at whether the previous instruction set the SF, and if we are in a GT_GE/GT_LT with a SLT,/SGE and instead emit a JS/JNS instead. 

## Results

The following is from an older run with superpmi (happy to grab an updated one if needed).

Overall, the change is an improvement. From inspecting some of the diffs, the absence of test instruction impacts some of the loop alignment. A lot of [align X bytes] were optimized out, but in some cases the change actually forced the insertion of alignment. Also, although this is an edge case, I noticed that with inlining there was a greater amount of `(x - y) < 0` cases, as I saw a lot of `Math.abs(x - y)`, which inlined to a case where we could remove a redundant check.

```

### aspnet.run.windows.x64.checked.mch:
Total bytes of base: 11830343 (overridden on cmd)
Total bytes of diff: 11829856 (overridden on cmd)
Total bytes of delta: -487 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
144 total files with Code Size differences (138 improved, 6 regressed), 7 unchanged.


### benchmarks.run.windows.x64.checked.mch:
Total bytes of base: 7188195 (overridden on cmd)
Total bytes of diff: 7187002 (overridden on cmd)
Total bytes of delta: -1193 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
266 total files with Code Size differences (260 improved, 6 regressed), 9 unchanged.


### coreclr_tests.pmi.windows.x64.checked.mch:
Total bytes of base: 124413020 (overridden on cmd)
Total bytes of diff: 124411029 (overridden on cmd)
Total bytes of delta: -1991 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
378 total files with Code Size differences (376 improved, 2 regressed), 3 unchanged.


### libraries.crossgen2.windows.x64.checked.mch:
Total bytes of base: 34153782 (overridden on cmd)
Total bytes of diff: 34151790 (overridden on cmd)
Total bytes of delta: -1992 (-0.01 % of base)
    diff is an improvement.
    relative diff is an improvement.
590 total files with Code Size differences (590 improved, 0 regressed), 0 unchanged.


### libraries.pmi.windows.x64.checked.mch:
Total bytes of base: 45212184 (overridden on cmd)
Total bytes of diff: 45209998 (overridden on cmd)
Total bytes of delta: -2186 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
688 total files with Code Size differences (681 improved, 7 regressed), 5 unchanged.


### libraries_tests.pmi.windows.x64.checked.mch:
Total bytes of base: 112874921 (overridden on cmd)
Total bytes of diff: 112872212 (overridden on cmd)
Total bytes of delta: -2709 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
670 total methods with Code Size differences (669 improved, 1 regressed), 7 unchanged.
```