### PR TITLE
[HTTP/3] MultiplexedConnection mockup

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -400,6 +400,7 @@ namespace System.Net.Http
         protected internal override System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> SendAsync(System.Net.Http.HttpRequestMessage request, System.Threading.CancellationToken cancellationToken) { throw null; }
         public bool EnableMultipleHttp2Connections { get { throw null; } set { } }
         public Func<SocketsHttpConnectionContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.IO.Stream>>? ConnectCallback { get { throw null; } set { } }
+        public Func<SocketsHttpConnectionContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.MultiplexedConnection>>? MultiplexedConnectCallback { get { throw null; } set { } }
         public Func<SocketsHttpPlaintextStreamFilterContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.IO.Stream>>? PlaintextStreamFilter { get { throw null; } set { } }
         [System.CLSCompliantAttribute(false)]
         public System.Diagnostics.DistributedContextPropagator? ActivityHeadersPropagator { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -194,6 +194,12 @@ namespace System.Net.Http
             set => throw new PlatformNotSupportedException();
         }
 
+        public Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<MultiplexedConnection>>? MultiplexedConnectCallback
+        {
+            get => throw new PlatformNotSupportedException();
+            set => throw new PlatformNotSupportedException();
+        }
+
         public Func<SocketsHttpPlaintextStreamFilterContext, CancellationToken, ValueTask<Stream>>? PlaintextStreamFilter
         {
             get => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -105,11 +105,11 @@ namespace System.Net.Http
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
-        public static async ValueTask<QuicConnection> ConnectQuicAsync(HttpRequestMessage request, QuicImplementationProvider quicImplementationProvider, DnsEndPoint endPoint, SslClientAuthenticationOptions clientAuthenticationOptions, CancellationToken cancellationToken)
+        public static async ValueTask<MultiplexedConnection> ConnectQuicAsync(HttpRequestMessage request, QuicImplementationProvider quicImplementationProvider, DnsEndPoint endPoint, SslClientAuthenticationOptions clientAuthenticationOptions, CancellationToken cancellationToken)
         {
             clientAuthenticationOptions = SetUpRemoteCertificateValidationCallback(clientAuthenticationOptions, request);
 
-            QuicConnection con = new QuicConnection(quicImplementationProvider, endPoint, clientAuthenticationOptions);
+            MultiplexedConnection con = new QuicConnection(quicImplementationProvider, endPoint, clientAuthenticationOptions);
             try
             {
                 await con.ConnectAsync(cancellationToken).ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -162,6 +162,21 @@ namespace System.Net.Http
 
             try
             {
+                // Current usage
+                /*
+                quicStream = await _connection.OpenStreamAsync(StreamType.Bidirectional, waitOnCapacity: true, cancellationToken).ConfigureAwait(false);
+                */
+                // With multiple connections
+                /*foreach (var conn in connections) {
+                    // Will return immediately already completed ValueTask
+                    ValueTask<Stream> task = conn.OpenStreamAsync(StreamType.Bidirectional, waitOnCapacity: false);
+                    Debug.Assert(task.IsCompleted);
+                    if (task.IsFaulted) {
+                        continue;
+                    }
+                    stream = task.Result;
+                    break;
+                }*/
                 while (true)
                 {
                     lock (SyncObj)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -847,7 +847,7 @@ namespace System.Net.Http
                     Trace("Attempting new HTTP3 connection.");
                 }
 
-                QuicConnection quicConnection;
+                MultiplexedConnection quicConnection;
                 try
                 {
                     quicConnection = await ConnectHelper.ConnectQuicAsync(request, Settings._quicImplementationProvider ?? QuicImplementationProviders.Default, new DnsEndPoint(authority.IdnHost, authority.Port), _sslOptionsHttp3!, cancellationToken).ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -58,6 +58,7 @@ namespace System.Net.Http
 
         internal Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>>? _connectCallback;
         internal Func<SocketsHttpPlaintextStreamFilterContext, CancellationToken, ValueTask<Stream>>? _plaintextStreamFilter;
+        internal Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<MultiplexedConnection>>? _multiplexedConnectCallback;
 
         // !!! NOTE !!! This is temporary and will not ship.
         internal QuicImplementationProvider? _quicImplementationProvider;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -406,6 +406,19 @@ namespace System.Net.Http
         }
 
         /// <summary>
+        /// When non-null, a custom callback used to open new connections.
+        /// </summary>
+        public Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<MultiplexedConnection>>? MultiplexedConnectCallback
+        {
+            get => _settings._multiplexedConnectCallback;
+            set
+            {
+                CheckDisposedOrStarted();
+                _settings._multiplexedConnectCallback = value;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a custom callback that provides access to the plaintext HTTP protocol stream.
         /// </summary>
         public Func<SocketsHttpPlaintextStreamFilterContext, CancellationToken, ValueTask<Stream>>? PlaintextStreamFilter

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -4,6 +4,24 @@
 // Changes to this file must follow the https://aka.ms/api-review process.
 // ------------------------------------------------------------------------------
 
+namespace System.Net
+{
+    public partial class MultiplexedConnection : IDisposable
+    {
+        public virtual System.Threading.Tasks.ValueTask ConnectAsync(System.Threading.CancellationToken cancellationToken = default) => throw null;
+        public virtual System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default) => throw null;
+        public virtual void Dispose() => throw null;
+
+        public virtual System.Threading.Tasks.ValueTask<System.IO.Stream> AcceptStreamAsync(System.Threading.CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public virtual int GetRemoteAvailableUnidirectionalStreamCount() => throw null;
+        public virtual int GetRemoteAvailableBidirectionalStreamCount() => throw null;
+        public virtual System.Threading.Tasks.ValueTask WaitForAvailableUnidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default) => throw null;
+        public virtual System.Threading.Tasks.ValueTask WaitForAvailableBidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default) => throw null;
+        public virtual System.IO.Stream OpenUnidirectionalStream() => throw null;
+        public virtual System.IO.Stream OpenBidirectionalStream() => throw null;
+    }
+}
 namespace System.Net.Quic
 {
     public partial class QuicClientConnectionOptions : System.Net.Quic.QuicOptions
@@ -13,7 +31,7 @@ namespace System.Net.Quic
         public System.Net.IPEndPoint? LocalEndPoint { get { throw null; } set { } }
         public System.Net.EndPoint? RemoteEndPoint { get { throw null; } set { } }
     }
-    public sealed partial class QuicConnection : System.IDisposable
+    public sealed partial class QuicConnection : MultiplexedConnection//, System.IDisposable
     {
         public QuicConnection(System.Net.EndPoint remoteEndPoint, System.Net.Security.SslClientAuthenticationOptions? sslClientAuthenticationOptions, System.Net.IPEndPoint? localEndPoint = null) { }
         public QuicConnection(System.Net.Quic.Implementations.QuicImplementationProvider implementationProvider, System.Net.EndPoint remoteEndPoint, System.Net.Security.SslClientAuthenticationOptions? sslClientAuthenticationOptions, System.Net.IPEndPoint? localEndPoint = null) { }
@@ -23,17 +41,17 @@ namespace System.Net.Quic
         public System.Net.IPEndPoint? LocalEndPoint { get { throw null; } }
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
         public System.Net.EndPoint RemoteEndPoint { get { throw null; } }
-        public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> AcceptStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public void Dispose() { }
-        public int GetRemoteAvailableBidirectionalStreamCount() { throw null; }
-        public int GetRemoteAvailableUnidirectionalStreamCount() { throw null; }
-        public System.Net.Quic.QuicStream OpenBidirectionalStream() { throw null; }
-        public System.Net.Quic.QuicStream OpenUnidirectionalStream() { throw null; }
+        public override System.Threading.Tasks.ValueTask<System.IO.Stream> AcceptStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override void Dispose() { }
+        public override int GetRemoteAvailableBidirectionalStreamCount() { throw null; }
+        public override int GetRemoteAvailableUnidirectionalStreamCount() { throw null; }
+        public override System.IO.Stream OpenBidirectionalStream() { throw null; }
+        public override System.IO.Stream OpenUnidirectionalStream() { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
-        public System.Threading.Tasks.ValueTask WaitForAvailableBidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask WaitForAvailableUnidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask WaitForAvailableBidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask WaitForAvailableUnidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class QuicConnectionAbortedException : System.Net.Quic.QuicException
     {

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -20,6 +20,13 @@ namespace System.Net
         public virtual System.Threading.Tasks.ValueTask WaitForAvailableBidirectionalStreamsAsync(System.Threading.CancellationToken cancellationToken = default) => throw null;
         public virtual System.IO.Stream OpenUnidirectionalStream() => throw null;
         public virtual System.IO.Stream OpenBidirectionalStream() => throw null;
+
+        public virtual System.Threading.Tasks.ValueTask<System.IO.Stream> OpenStreamAsync(StreamType streamType, bool waitOnCapacity = false, System.Threading.CancellationToken cancellationToken = default) => throw null;
+    }
+
+    public enum StreamType {
+        Unidirectional,
+        Bidirectional
     }
 }
 namespace System.Net.Quic

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/MultiplexedConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/MultiplexedConnection.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net
+{
+    public class MultiplexedConnection : IDisposable
+    {
+        public virtual ValueTask ConnectAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public virtual ValueTask CloseAsync(long errorCode, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public virtual void Dispose() => throw new NotImplementedException();
+
+        public virtual ValueTask<Stream> AcceptStreamAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+        public virtual int GetRemoteAvailableUnidirectionalStreamCount() => throw new NotImplementedException();
+        public virtual int GetRemoteAvailableBidirectionalStreamCount() => throw new NotImplementedException();
+        public virtual ValueTask WaitForAvailableUnidirectionalStreamsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public virtual ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public virtual Stream OpenUnidirectionalStream() => throw new NotImplementedException();
+        public virtual Stream OpenBidirectionalStream() => throw new NotImplementedException();
+    }
+}

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/MultiplexedConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/MultiplexedConnection.cs
@@ -21,5 +21,12 @@ namespace System.Net
         public virtual ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public virtual Stream OpenUnidirectionalStream() => throw new NotImplementedException();
         public virtual Stream OpenBidirectionalStream() => throw new NotImplementedException();
+
+        public virtual ValueTask<Stream> OpenStreamAsync(StreamType streamType, bool waitOnCapacity = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+
+    public enum StreamType {
+        Unidirectional,
+        Bidirectional
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using System.Net.Quic.Implementations;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -9,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Quic
 {
-    public sealed class QuicConnection : IDisposable
+    public sealed class QuicConnection : MultiplexedConnection
     {
         private readonly QuicConnectionProvider _provider;
 
@@ -68,53 +69,53 @@ namespace System.Net.Quic
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public ValueTask ConnectAsync(CancellationToken cancellationToken = default) => _provider.ConnectAsync(cancellationToken);
+        public override ValueTask ConnectAsync(CancellationToken cancellationToken = default) => _provider.ConnectAsync(cancellationToken);
 
         /// <summary>
         /// Waits for available unidirectional stream capacity to be announced by the peer. If any capacity is available, returns immediately.
         /// </summary>
         /// <returns></returns>
-        public ValueTask WaitForAvailableUnidirectionalStreamsAsync(CancellationToken cancellationToken = default) => _provider.WaitForAvailableUnidirectionalStreamsAsync(cancellationToken);
+        public override ValueTask WaitForAvailableUnidirectionalStreamsAsync(CancellationToken cancellationToken = default) => _provider.WaitForAvailableUnidirectionalStreamsAsync(cancellationToken);
 
         /// <summary>
         /// Waits for available bidirectional stream capacity to be announced by the peer. If any capacity is available, returns immediately.
         /// </summary>
         /// <returns></returns>
-        public ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default) => _provider.WaitForAvailableBidirectionalStreamsAsync(cancellationToken);
+        public override ValueTask WaitForAvailableBidirectionalStreamsAsync(CancellationToken cancellationToken = default) => _provider.WaitForAvailableBidirectionalStreamsAsync(cancellationToken);
 
         /// <summary>
         /// Create an outbound unidirectional stream.
         /// </summary>
         /// <returns></returns>
-        public QuicStream OpenUnidirectionalStream() => new QuicStream(_provider.OpenUnidirectionalStream());
+        public override Stream OpenUnidirectionalStream() => new QuicStream(_provider.OpenUnidirectionalStream());
 
         /// <summary>
         /// Create an outbound bidirectional stream.
         /// </summary>
         /// <returns></returns>
-        public QuicStream OpenBidirectionalStream() => new QuicStream(_provider.OpenBidirectionalStream());
+        public override Stream OpenBidirectionalStream() => new QuicStream(_provider.OpenBidirectionalStream());
 
         /// <summary>
         /// Accept an incoming stream.
         /// </summary>
         /// <returns></returns>
-        public async ValueTask<QuicStream> AcceptStreamAsync(CancellationToken cancellationToken = default) => new QuicStream(await _provider.AcceptStreamAsync(cancellationToken).ConfigureAwait(false));
+        public async override ValueTask<Stream> AcceptStreamAsync(CancellationToken cancellationToken = default) => new QuicStream(await _provider.AcceptStreamAsync(cancellationToken).ConfigureAwait(false));
 
         /// <summary>
         /// Close the connection and terminate any active streams.
         /// </summary>
-        public ValueTask CloseAsync(long errorCode, CancellationToken cancellationToken = default) => _provider.CloseAsync(errorCode, cancellationToken);
+        public override ValueTask CloseAsync(long errorCode, CancellationToken cancellationToken = default) => _provider.CloseAsync(errorCode, cancellationToken);
 
-        public void Dispose() => _provider.Dispose();
+        public override void Dispose() => _provider.Dispose();
 
         /// <summary>
         /// Gets the maximum number of bidirectional streams that can be made to the peer.
         /// </summary>
-        public int GetRemoteAvailableUnidirectionalStreamCount() => _provider.GetRemoteAvailableUnidirectionalStreamCount();
+        public override int GetRemoteAvailableUnidirectionalStreamCount() => _provider.GetRemoteAvailableUnidirectionalStreamCount();
 
         /// <summary>
         /// Gets the maximum number of unidirectional streams that can be made to the peer.
         /// </summary>
-        public int GetRemoteAvailableBidirectionalStreamCount() => _provider.GetRemoteAvailableBidirectionalStreamCount();
+        public override int GetRemoteAvailableBidirectionalStreamCount() => _provider.GetRemoteAvailableBidirectionalStreamCount();
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -117,5 +117,7 @@ namespace System.Net.Quic
         /// Gets the maximum number of unidirectional streams that can be made to the peer.
         /// </summary>
         public override int GetRemoteAvailableBidirectionalStreamCount() => _provider.GetRemoteAvailableBidirectionalStreamCount();
+
+        public override ValueTask<Stream> OpenStreamAsync(StreamType streamType, bool waitOnCapacity = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Rough draft of a non-QUIC specific connection base for H/3 connection callback.
Ignores streams issues by explicitelly casting to `QuicStream`.