### PR TITLE
Use constant ids for RoArrayType GetMethodsCore

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoSyntheticMethod.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoSyntheticMethod.cs
@@ -75,9 +75,6 @@ namespace System.Reflection.TypeLoading
             if (DeclaringType != other.DeclaringType)
                 return false;
 
-            if (ReturnType != other.ReturnType)
-                return false;
-
             if (_uniquifier != other._uniquifier)
                 return false;
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoArrayType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoArrayType.cs
@@ -151,7 +151,6 @@ namespace System.Reflection.TypeLoading
         {
             int rank = _rank;
 
-            int uniquifier = 0;
             RoType systemInt32 = Loader.GetCoreType(CoreType.Int32);
             RoType elementType = GetRoElementType();
             RoType systemVoid = Loader.GetCoreType(CoreType.Void);
@@ -163,7 +162,7 @@ namespace System.Reflection.TypeLoading
                 {
                     getParameters[i] = systemInt32;
                 }
-                yield return new RoSyntheticMethod(this, uniquifier++, "Get", elementType, getParameters);
+                yield return new RoSyntheticMethod(this, 0, "Get", elementType, getParameters);
             }
 
             if (filter == null || filter.Matches("Set"))
@@ -174,7 +173,7 @@ namespace System.Reflection.TypeLoading
                     setParameters[i] = systemInt32;
                 }
                 setParameters[rank] = elementType;
-                yield return new RoSyntheticMethod(this, uniquifier++, "Set", systemVoid, setParameters);
+                yield return new RoSyntheticMethod(this, 1, "Set", systemVoid, setParameters);
             }
 
             if (filter == null || filter.Matches("Address"))
@@ -184,7 +183,7 @@ namespace System.Reflection.TypeLoading
                 {
                     addressParameters[i] = systemInt32;
                 }
-                yield return new RoSyntheticMethod(this, uniquifier++, "Address", elementType.GetUniqueByRefType(), addressParameters);
+                yield return new RoSyntheticMethod(this, 2, "Address", elementType.GetUniqueByRefType(), addressParameters);
             }
         }
     }

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
@@ -252,6 +252,20 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        static void TestArrayGetMethodsResultEqualsFilteredGetMethod()
+        {
+            Type type = typeof(int[]).Project();
+
+            Assert.Equal(type.GetMethod("Get"), type.GetMethods().First(m => m.Name == "Get"));
+            Assert.Equal(type.GetMethod("Set"), type.GetMethods().First(m => m.Name == "Set"));
+            Assert.Equal(type.GetMethod("Address"), type.GetMethods().First(m => m.Name == "Address"));
+
+            Assert.NotEqual(type.GetMethod("Get"), type.GetMethods().First(m => m.Name == "Set"));
+            Assert.NotEqual(type.GetMethod("Set"), type.GetMethods().First(m => m.Name == "Address"));
+            Assert.NotEqual(type.GetMethod("Address"), type.GetMethods().First(m => m.Name == "Get"));
+        }
+
+        [Fact]
         public static void TestArrayAddressMethod()
         {
             bool expectedDefaultValue = true;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57728#issuecomment-954612636
Related to https://github.com/dotnet/runtime/issues/57728#issuecomment-959781768 and https://github.com/dotnet/runtime/pull/60894