### PR TITLE
Remove BestFitMapping, CallingConvention, and ThrowOnUnmappableChar from GeneratedDllImportAttribute

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupPrivilegeValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupPrivilegeValue.cs
@@ -7,13 +7,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "LookupPrivilegeValueW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool LookupPrivilegeValue(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "LookupPrivilegeValueW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        internal static extern bool LookupPrivilegeValue(
-#endif
             [MarshalAs(UnmanagedType.LPTStr)] string? lpSystemName, [MarshalAs(UnmanagedType.LPTStr)] string lpName, out LUID lpLuid);
 
         internal const string SeDebugPrivilege = "SeDebugPrivilege";

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCreateKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCreateKeyEx.cs
@@ -14,13 +14,8 @@ internal static partial class Interop
     {
         // Note: RegCreateKeyEx won't set the last error on failure - it returns
         // an error code if it fails.
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegCreateKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegCreateKeyEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegCreateKeyExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegCreateKeyEx(
-#endif
             SafeRegistryHandle hKey,
             string lpSubKey,
             int Reserved,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteKeyEx.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegDeleteKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegDeleteKeyEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegDeleteKeyExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegDeleteKeyEx(
-#endif
             SafeRegistryHandle hKey,
             string lpSubKey,
             int samDesired,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteValue.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegDeleteValueW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegDeleteValue(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegDeleteValueW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegDeleteValue(
-#endif
             SafeRegistryHandle hKey,
             string? lpValueName);
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegFlushKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegFlushKey.cs
@@ -12,13 +12,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32)]
-        internal static partial int RegFlushKey(
-#else
-        [DllImport(Libraries.Advapi32)]
-        internal static extern int RegFlushKey(
-#endif
-            SafeRegistryHandle hKey);
+        internal static partial int RegFlushKey(SafeRegistryHandle hKey);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegOpenKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegOpenKeyEx.cs
@@ -13,27 +13,16 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegOpenKeyEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegOpenKeyEx(
-#endif
             SafeRegistryHandle hKey,
             string? lpSubKey,
             int ulOptions,
             int samDesired,
             out SafeRegistryHandle hkResult);
 
-
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegOpenKeyEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegOpenKeyEx(
-#endif
             IntPtr hKey,
             string? lpSubKey,
             int ulOptions,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegSetValueEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegSetValueEx.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegSetValueEx(
-#endif
             SafeRegistryHandle hKey,
             string? lpValueName,
             int Reserved,
@@ -26,13 +21,8 @@ internal static partial class Interop
             byte[]? lpData,
             int cbData);
 
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegSetValueEx(
-#endif
             SafeRegistryHandle hKey,
             string? lpValueName,
             int Reserved,
@@ -40,13 +30,8 @@ internal static partial class Interop
             char[]? lpData,
             int cbData);
 
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegSetValueEx(
-#endif
             SafeRegistryHandle hKey,
             string? lpValueName,
             int Reserved,
@@ -54,13 +39,8 @@ internal static partial class Interop
             ref int lpData,
             int cbData);
 
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegSetValueEx(
-#endif
             SafeRegistryHandle hKey,
             string? lpValueName,
             int Reserved,
@@ -68,13 +48,8 @@ internal static partial class Interop
             ref long lpData,
             int cbData);
 
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern int RegSetValueEx(
-#endif
             SafeRegistryHandle hKey,
             string? lpValueName,
             int Reserved,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
@@ -11,13 +11,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPathName or PathHelper.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint GetFullPathNameW(
-#else
-        [DllImport(Libraries.Kernel32, BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        internal static extern uint GetFullPathNameW(
-#endif
             ref char lpFileName,
             uint nBufferLength,
             ref char lpBuffer,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetLongPathNameW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetLongPathNameW.cs
@@ -10,13 +10,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPath/PathHelper.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint GetLongPathNameW(
-#else
-        [DllImport(Libraries.Kernel32, BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        internal static extern uint GetLongPathNameW(
-#endif
             ref char lpszShortPath,
             ref char lpszLongPath,
             uint cchBuffer);

--- a/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedDllImportAttribute.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedDllImportAttribute.cs
@@ -5,7 +5,6 @@
 
 //
 // Types in this file are used for generated p/invokes (docs/design/features/source-generator-pinvokes.md).
-// See the DllImportGenerator experiment in https://github.com/dotnet/runtimelab.
 //
 namespace System.Runtime.InteropServices
 {
@@ -20,14 +19,11 @@ namespace System.Runtime.InteropServices
 #endif
     sealed class GeneratedDllImportAttribute : Attribute
     {
-        public bool BestFitMapping { get; set; }
-        public CallingConvention CallingConvention { get; set; }
         public CharSet CharSet { get; set; }
         public string? EntryPoint { get; set; }
         public bool ExactSpelling { get; set; }
         public bool PreserveSig { get; set; }
         public bool SetLastError { get; set; }
-        public bool ThrowOnUnmappableChar { get; set; }
 
         public GeneratedDllImportAttribute(string dllName)
         {

--- a/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
+++ b/src/libraries/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.csproj
@@ -81,6 +81,7 @@
     <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/libraries/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);REGISTRY_ASSEMBLY</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows</TargetFrameworks>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratedDllImportData.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratedDllImportData.cs
@@ -15,14 +15,11 @@ namespace Microsoft.Interop
     public enum DllImportMember
     {
         None = 0,
-        BestFitMapping = 1 << 0,
-        CallingConvention = 1 << 1,
-        CharSet = 1 << 2,
-        EntryPoint = 1 << 3,
-        ExactSpelling = 1 << 4,
-        PreserveSig = 1 << 5,
-        SetLastError = 1 << 6,
-        ThrowOnUnmappableChar = 1 << 7,
+        CharSet = 1 << 0,
+        EntryPoint = 1 << 1,
+        ExactSpelling = 1 << 2,
+        PreserveSig = 1 << 3,
+        SetLastError = 1 << 4,
         All = ~None
     }
 
@@ -39,13 +36,10 @@ namespace Microsoft.Interop
         /// Value set by the user on the original declaration.
         /// </summary>
         public DllImportMember IsUserDefined { get; init; }
-        public bool BestFitMapping { get; init; }
-        public CallingConvention CallingConvention { get; init; }
         public CharSet CharSet { get; init; }
         public string? EntryPoint { get; init; }
         public bool ExactSpelling { get; init; }
         public bool PreserveSig { get; init; }
         public bool SetLastError { get; init; }
-        public bool ThrowOnUnmappableChar { get; init; }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -184,29 +184,9 @@ partial class Test
 ";
 
         /// <summary>
-        /// Declaration with all DllImport named arguments.
+        /// Declaration with all GeneratedDllImport named arguments.
         /// </summary>
-        public static readonly string AllDllImportNamedArguments = @"
-using System.Runtime.InteropServices;
-partial class Test
-{
-    [GeneratedDllImport(""DoesNotExist"",
-        BestFitMapping = false,
-        CallingConvention = CallingConvention.Cdecl,
-        CharSet = CharSet.Unicode,
-        EntryPoint = ""UserDefinedEntryPoint"",
-        ExactSpelling = true,
-        PreserveSig = false,
-        SetLastError = true,
-        ThrowOnUnmappableChar = true)]
-    public static partial void Method();
-}
-";
-
-        /// <summary>
-        /// Declaration with all supported DllImport named arguments.
-        /// </summary>
-        public static readonly string AllSupportedDllImportNamedArguments = @"
+        public static readonly string AllGeneratedDllImportNamedArguments = @"
 using System.Runtime.InteropServices;
 partial class Test
 {

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CompileFails.cs
@@ -58,10 +58,6 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.ByValueParameterWithModifier<byte>("Out"), 1, 0 };
             yield return new object[] { CodeSnippets.ByValueParameterWithModifier<byte>("In, Out"), 1, 0 };
 
-            // Unsupported named arguments
-            //  * BestFitMapping, ThrowOnUnmappableChar, CallingConvention
-            yield return new object[] { CodeSnippets.AllDllImportNamedArguments, 3, 0 };
-
             // LCIDConversion
             yield return new object[] { CodeSnippets.LCIDConversionAttribute, 1, 0 };
 

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Compiles.cs
@@ -24,7 +24,7 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.NestedTypes };
             yield return new[] { CodeSnippets.UnsafeContext };
             yield return new[] { CodeSnippets.UserDefinedEntryPoint };
-            yield return new[] { CodeSnippets.AllSupportedDllImportNamedArguments };
+            yield return new[] { CodeSnippets.AllGeneratedDllImportNamedArguments };
             yield return new[] { CodeSnippets.DefaultParameters };
             yield return new[] { CodeSnippets.UseCSharpFeaturesForConstants };
 
@@ -399,7 +399,7 @@ namespace DllImportGenerator.UnitTests
 
         public static IEnumerable<object[]> SnippetsWithBlittableTypesButNonBlittableDataToCompile()
         {
-            yield return new[] { CodeSnippets.AllSupportedDllImportNamedArguments };
+            yield return new[] { CodeSnippets.AllGeneratedDllImportNamedArguments };
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<int>() };
             yield return new[] { CodeSnippets.PreserveSigFalse<int>() };
         }


### PR DESCRIPTION
Also removed a few cases where `#if DLLIMPORTGENERATOR_ENABLED` is not needed.

Contributes to #61181

cc @AaronRobinsonMSFT @jkoritzinsky 