### PR TITLE
[DllImportGenerator] Fix stub generation for char array marshalling

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Interop
                 case StubCodeContext.Stage.Setup:
                     break;
                 case StubCodeContext.Stage.Marshal:
-                    if (info.IsByRef && info.RefKind != RefKind.Out)
+                    if ((info.IsByRef && info.RefKind != RefKind.Out) || !context.SingleFrameSpansNativeContext)
                     {
                         yield return ExpressionStatement(
                             AssignmentExpression(

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/ArrayTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/ArrayTests.cs
@@ -35,6 +35,12 @@ namespace DllImportGenerator.IntegrationTests
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "create_range_array_out")]
             public static partial void CreateRange_Out(int start, int end, out int numValues, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] out int[] res);
 
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_char_array", CharSet = CharSet.Unicode)]
+            public static partial int SumChars(char[] chars, int numElements);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "reverse_char_array", CharSet = CharSet.Unicode)]
+            public static partial void ReverseChars([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] ref char[] chars, int numElements);
+
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_string_lengths")]
             public static partial int SumStringLengths([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] strArray);
 
@@ -116,6 +122,22 @@ namespace DllImportGenerator.IntegrationTests
             var newArray = array;
             NativeExportsNE.Arrays.Duplicate(ref newArray, array.Length);
             Assert.Equal((IEnumerable<int>)array, newArray);
+        }
+
+        [Fact]
+        public void CharArrayMarshalledToNativeAsExpected()
+        {
+            char[] array = CharacterTests.CharacterMappings().Select(o => (char)o[0]).ToArray();
+            Assert.Equal(array.Sum(c => c), NativeExportsNE.Arrays.SumChars(array, array.Length));
+        }
+
+        [Fact]
+        public void CharArrayRefParameter()
+        {
+            char[] array = CharacterTests.CharacterMappings().Select(o => (char)o[0]).ToArray();
+            var newArray = array;
+            NativeExportsNE.Arrays.ReverseChars(ref newArray, array.Length);
+            Assert.Equal(array.Reverse(), newArray);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Arrays.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Arrays.cs
@@ -90,6 +90,34 @@ namespace NativeExports
             }
         }
 
+        [UnmanagedCallersOnly(EntryPoint = "sum_char_array")]
+        public static int SumChars(ushort* values, int numValues)
+        {
+            if (values == null)
+            {
+                return -1;
+            }
+
+            int sum = 0;
+            for (int i = 0; i < numValues; i++)
+            {
+                sum += values[i];
+            }
+            return sum;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "reverse_char_array")]
+        public static void ReverseChars(ushort** values, int numValues)
+        {
+            if (*values == null)
+            {
+                return;
+            }
+
+            var span = new Span<ushort>(*values, numValues);
+            span.Reverse();
+        }
+
         [UnmanagedCallersOnly(EntryPoint = "sum_string_lengths")]
         public static int SumStringLengths(ushort** strArray)
         {


### PR DESCRIPTION
We were not properly copying the data over (just leaving it uninitailized). I broke this with the switch to pinning by-ref char parameters.

cc @AaronRobinsonMSFT @jkoritzinsky 