### PR TITLE
Set IL offsets for calls created during devirtualization

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6144,10 +6144,10 @@ public:
 #endif
 
 public:
-    Statement* fgNewStmtAtBeg(BasicBlock* block, GenTree* tree);
+    Statement* fgNewStmtAtBeg(BasicBlock* block, GenTree* tree, IL_OFFSETX offs = BAD_IL_OFFSET);
     void fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt);
-    Statement* fgNewStmtAtEnd(BasicBlock* block, GenTree* tree);
-    Statement* fgNewStmtNearEnd(BasicBlock* block, GenTree* tree);
+    Statement* fgNewStmtAtEnd(BasicBlock* block, GenTree* tree, IL_OFFSETX offs = BAD_IL_OFFSET);
+    Statement* fgNewStmtNearEnd(BasicBlock* block, GenTree* tree, IL_OFFSETX offs = BAD_IL_OFFSET);
 
 private:
     void fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt);

--- a/src/coreclr/jit/fgstmt.cpp
+++ b/src/coreclr/jit/fgstmt.cpp
@@ -101,13 +101,14 @@ void Compiler::fgInsertStmtAtBeg(BasicBlock* block, Statement* stmt)
 // Arguments:
 //   block - the block into which 'tree' will be inserted;
 //   tree  - the tree to be inserted.
+//   offs  - the offset to use for the statement
 //
 // Return Value:
 //    The new created statement with `tree` inserted into `block`.
 //
-Statement* Compiler::fgNewStmtAtBeg(BasicBlock* block, GenTree* tree)
+Statement* Compiler::fgNewStmtAtBeg(BasicBlock* block, GenTree* tree, IL_OFFSETX offs)
 {
-    Statement* stmt = gtNewStmt(tree);
+    Statement* stmt = gtNewStmt(tree, offs);
     fgInsertStmtAtBeg(block, stmt);
     return stmt;
 }
@@ -153,6 +154,7 @@ void Compiler::fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt)
 // Arguments:
 //   block - the block into which 'stmt' will be inserted;
 //   tree  - the tree to be inserted.
+//   offs  - the offset to use for the statement
 //
 // Return Value:
 //    The new created statement with `tree` inserted into `block`.
@@ -160,9 +162,9 @@ void Compiler::fgInsertStmtAtEnd(BasicBlock* block, Statement* stmt)
 // Note:
 //   If the block can be a conditional block, use fgNewStmtNearEnd.
 //
-Statement* Compiler::fgNewStmtAtEnd(BasicBlock* block, GenTree* tree)
+Statement* Compiler::fgNewStmtAtEnd(BasicBlock* block, GenTree* tree, IL_OFFSETX offs)
 {
-    Statement* stmt = gtNewStmt(tree);
+    Statement* stmt = gtNewStmt(tree, offs);
     fgInsertStmtAtEnd(block, stmt);
     return stmt;
 }
@@ -245,9 +247,9 @@ void Compiler::fgInsertStmtNearEnd(BasicBlock* block, Statement* stmt)
 // Return Value:
 //    The new created statement with `tree` inserted into `block`.
 //
-Statement* Compiler::fgNewStmtNearEnd(BasicBlock* block, GenTree* tree)
+Statement* Compiler::fgNewStmtNearEnd(BasicBlock* block, GenTree* tree, IL_OFFSETX offs)
 {
-    Statement* stmt = gtNewStmt(tree);
+    Statement* stmt = gtNewStmt(tree, offs);
     fgInsertStmtNearEnd(block, stmt);
     return stmt;
 }

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -781,14 +781,14 @@ private:
                 }
                 else
                 {
-                    compiler->fgNewStmtAtEnd(thenBlock, call);
+                    compiler->fgNewStmtAtEnd(thenBlock, call, stmt->GetILOffsetX());
                 }
             }
             else
             {
                 // Add the call.
                 //
-                compiler->fgNewStmtAtEnd(thenBlock, call);
+                compiler->fgNewStmtAtEnd(thenBlock, call, stmt->GetILOffsetX());
 
                 // Re-establish this call as an inline candidate.
                 //
@@ -831,7 +831,7 @@ private:
             elseBlock = CreateAndInsertBasicBlock(BBJ_NONE, thenBlock);
             elseBlock->bbFlags |= currBlock->bbFlags & BBF_SPLIT_GAINED;
             GenTreeCall* call    = origCall;
-            Statement*   newStmt = compiler->gtNewStmt(call);
+            Statement*   newStmt = compiler->gtNewStmt(call, stmt->GetILOffsetX());
 
             call->gtFlags &= ~GTF_CALL_INLINE_CANDIDATE;
             call->SetIsGuarded();


### PR DESCRIPTION
Since inlined statements use the IL location of the inliner's statement
all statements created while inlining devirtualized calls would get no
debug info before, while normally these will have IL location pointing
to the call statement in the root.

This behavior seems unwanted and was hard to keep with my upcoming debug info changes since there we are always able to walk back to the root context and get the IL offset from there, and it is hard to check for this particular case (call statement in an inlinee that previously would have had no debug info instead of pointing into root).

I've only changed this for the call statements and not for the various other statements inserted in this transformation as I need to think more about those first. For the call it seems logical that we do it, especially since we mainly use this information as a "stepping stone" since the devirtualized call should get inlined.

No code diffs, only debug info diffs. We see some more entries around devirtualized calls as expected. A lot of the time these diffs look like
```diff
-IL offs NO_MAP : 0x0000004A ( STACK_EMPTY )
+IL offs 0x0003 : 0x0000004A ( STACK_EMPTY )
```
since we can now associate a statement in an inlinee with the call in the root.

cc @dotnet/jit-contrib