### PR TITLE
fix unexpected TimeSeriesLimitReached after HistogramLimitReached(#60752)

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -302,7 +302,7 @@ namespace System.Diagnostics.Metrics
                 {
                     lock (this)
                     {
-                        return (!CheckTimeSeriesAllowed() || !CheckHistogramAllowed()) ?
+                        return (!CheckHistogramAllowed() || !CheckTimeSeriesAllowed()) ?
                             null :
                             new ExponentialHistogramAggregator(s_defaultHistogramConfig);
                     }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregationManager.cs
@@ -302,6 +302,7 @@ namespace System.Diagnostics.Metrics
                 {
                     lock (this)
                     {
+                        // checking currentHistograms first because avoiding unexpected increment of TimeSeries count.
                         return (!CheckHistogramAllowed() || !CheckTimeSeriesAllowed()) ?
                             null :
                             new ExponentialHistogramAggregator(s_defaultHistogramConfig);


### PR DESCRIPTION
The problem is from which `_currentTimeSeries` is always added even if `_currentHistograms` reaches `MaxHistograms`.
