### PR TITLE
Make JitPrintInlinedMethods less verbose

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -226,7 +226,7 @@ PhaseStatus Compiler::fgInline()
     {
         JITDUMP("**************** Inline Tree");
         printf("\n");
-        m_inlineStrategy->Dump(verbose);
+        m_inlineStrategy->Dump(verbose || JitConfig.JitPrintInlinedMethodsVerbose());
     }
 
 #endif // DEBUG

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -391,28 +391,45 @@ void InlineContext::Dump(unsigned indent)
     {
         // Root method
         InlinePolicy* policy = InlinePolicy::GetPolicy(compiler, true);
-        printf("Inlines into %08X [via %s] %s\n", calleeToken, policy->GetName(), calleeName);
+
+        if (JitConfig.JitPrintInlinedMethodsVerbose() > 0)
+        {
+            printf("\nInlines into %08X [via %s] %s:\n", calleeToken, policy->GetName(), calleeName);
+        }
+        else
+        {
+            printf("\nInlines into %s:\n", calleeName);
+        }
     }
     else
     {
         // Inline attempt.
         const char* inlineTarget  = InlGetTargetString(m_Observation);
         const char* inlineReason  = InlGetObservationString(m_Observation);
-        const char* inlineResult  = m_Success ? "" : "FAILED: ";
-        const char* devirtualized = m_Devirtualized ? " devirt" : "";
-        const char* guarded       = m_Guarded ? " guarded" : "";
-        const char* unboxed       = m_Unboxed ? " unboxed" : "";
+        const char* inlineResult  = m_Success ? "SUCCESSFUL: " : "FAILED: ";
+        const char* devirtualized = m_Devirtualized ? " DEVIRT" : "";
+        const char* guarded       = m_Guarded ? " GUARDED" : "";
+        const char* unboxed       = m_Unboxed ? " UNBOXED" : "";
 
-        if (m_Offset == BAD_IL_OFFSET)
+        if (JitConfig.JitPrintInlinedMethodsVerbose() > 0)
         {
-            printf("%*s[%u IL=???? TR=%06u %08X] [%s%s: %s%s%s%s] %s\n", indent, "", m_Ordinal, m_TreeID, calleeToken,
-                   inlineResult, inlineTarget, inlineReason, guarded, devirtualized, unboxed, calleeName);
+            if (m_Offset == BAD_IL_OFFSET)
+            {
+                printf("%*s[%u IL=???? TR=%06u %08X] [%s%s: %s%s%s%s] %s\n", indent, "", m_Ordinal, m_TreeID,
+                       calleeToken, inlineResult, inlineTarget, inlineReason, guarded, devirtualized, unboxed,
+                       calleeName);
+            }
+            else
+            {
+                printf("%*s[%u IL=%04d TR=%06u %08X] [%s%s: %s%s%s%s] %s\n", indent, "", m_Ordinal,
+                       jitGetILoffs(m_Offset), m_TreeID, calleeToken, inlineResult, inlineTarget, inlineReason, guarded,
+                       devirtualized, unboxed, calleeName);
+            }
         }
         else
         {
-            IL_OFFSET offset = jitGetILoffs(m_Offset);
-            printf("%*s[%u IL=%04d TR=%06u %08X] [%s%s: %s%s%s%s] %s\n", indent, "", m_Ordinal, offset, m_TreeID,
-                   calleeToken, inlineResult, inlineTarget, inlineReason, guarded, devirtualized, unboxed, calleeName);
+            printf("%*s[%s%s%s%s%s] %s\n", indent, "", inlineResult, inlineReason, guarded, devirtualized, unboxed,
+                   calleeName);
         }
     }
 
@@ -763,21 +780,7 @@ void InlineResult::Report()
 
         if ((m_Callee != nullptr) && (obs != InlineObservation::CALLEE_IS_NOINLINE))
         {
-
-#ifdef DEBUG
-
-            const char* obsString = InlGetObservationString(obs);
-
-            if (VERBOSE)
-            {
-                JITDUMP("\nINLINER: Marking %s as NOINLINE because of %s\n", callee, obsString);
-            }
-            else if (m_RootCompiler->fgPrintInlinedMethods)
-            {
-                printf("Marking %s as NOINLINE because of %s\n", callee, obsString);
-            }
-
-#endif // DEBUG
+            JITDUMP("\nINLINER: Marking %s as NOINLINE because of %s\n", callee, InlGetObservationString(obs));
 
             COMP_HANDLE comp = m_RootCompiler->info.compCompHnd;
             comp->setMethodAttribs(m_Callee, CORINFO_FLG_BAD_INLINEE);

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -407,7 +407,7 @@ void InlineContext::Dump(bool verbose, unsigned indent)
         // Inline attempt.
         const char* inlineTarget  = InlGetTargetString(m_Observation);
         const char* inlineReason  = InlGetObservationString(m_Observation);
-        const char* inlineResult  = m_Success ? "SUCCESSFUL: " : "FAILED: ";
+        const char* inlineResult  = m_Success ? "INLINED: " : "FAILED: ";
         const char* devirtualized = m_Devirtualized ? " DEVIRT" : "";
         const char* guarded       = m_Guarded ? " GUARDED" : "";
         const char* unboxed       = m_Unboxed ? " UNBOXED" : "";
@@ -1369,7 +1369,7 @@ InlineContext* InlineStrategy::NewFailure(Statement* stmt, InlineResult* inlineR
 
 void InlineStrategy::Dump(bool verbose)
 {
-    m_RootContext->Dump(verbose, 0);
+    m_RootContext->Dump(verbose);
 
     if (!verbose)
     {

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -386,13 +386,16 @@ void InlineContext::Dump(unsigned indent)
 
     mdMethodDef calleeToken = compiler->info.compCompHnd->getMethodDefFromMethod(m_Callee);
 
+    // Add more information when verbose mode or NgenDump/JitDump are set
+    bool verboseMode = (compiler->verbose) || (JitConfig.JitPrintInlinedMethodsVerbose() > 0);
+
     // Dump this node
     if (m_Parent == nullptr)
     {
         // Root method
         InlinePolicy* policy = InlinePolicy::GetPolicy(compiler, true);
 
-        if (JitConfig.JitPrintInlinedMethodsVerbose() > 0)
+        if (verboseMode)
         {
             printf("\nInlines into %08X [via %s] %s:\n", calleeToken, policy->GetName(), calleeName);
         }
@@ -411,7 +414,7 @@ void InlineContext::Dump(unsigned indent)
         const char* guarded       = m_Guarded ? " GUARDED" : "";
         const char* unboxed       = m_Unboxed ? " UNBOXED" : "";
 
-        if (JitConfig.JitPrintInlinedMethodsVerbose() > 0)
+        if (verboseMode)
         {
             if (m_Offset == BAD_IL_OFFSET)
             {

--- a/src/coreclr/jit/inline.cpp
+++ b/src/coreclr/jit/inline.cpp
@@ -356,13 +356,14 @@ InlineContext::InlineContext(InlineStrategy* strategy)
 //
 // Arguments:
 //    indent   - indentation level for this node
+//    verbose  - more verbose output if true
 
-void InlineContext::Dump(unsigned indent)
+void InlineContext::Dump(bool verbose, unsigned indent)
 {
     // Handle fact that siblings are in reverse order.
     if (m_Sibling != nullptr)
     {
-        m_Sibling->Dump(indent);
+        m_Sibling->Dump(verbose, indent);
     }
 
     // We may not know callee name in some of the failing cases
@@ -386,16 +387,13 @@ void InlineContext::Dump(unsigned indent)
 
     mdMethodDef calleeToken = compiler->info.compCompHnd->getMethodDefFromMethod(m_Callee);
 
-    // Add more information when verbose mode or NgenDump/JitDump are set
-    bool verboseMode = (compiler->verbose) || (JitConfig.JitPrintInlinedMethodsVerbose() > 0);
-
     // Dump this node
     if (m_Parent == nullptr)
     {
         // Root method
         InlinePolicy* policy = InlinePolicy::GetPolicy(compiler, true);
 
-        if (verboseMode)
+        if (verbose)
         {
             printf("\nInlines into %08X [via %s] %s:\n", calleeToken, policy->GetName(), calleeName);
         }
@@ -414,7 +412,7 @@ void InlineContext::Dump(unsigned indent)
         const char* guarded       = m_Guarded ? " GUARDED" : "";
         const char* unboxed       = m_Unboxed ? " UNBOXED" : "";
 
-        if (verboseMode)
+        if (verbose)
         {
             if (m_Offset == BAD_IL_OFFSET)
             {
@@ -439,7 +437,7 @@ void InlineContext::Dump(unsigned indent)
     // Recurse to first child
     if (m_Child != nullptr)
     {
-        m_Child->Dump(indent + 2);
+        m_Child->Dump(verbose, indent + 2);
     }
 }
 
@@ -1367,13 +1365,13 @@ InlineContext* InlineStrategy::NewFailure(Statement* stmt, InlineResult* inlineR
 // Dump: dump description of inline behavior
 //
 // Arguments:
-//   showBudget - also dump final budget values
+//   verbose - print more details such as final budget values and IL offsets
 
-void InlineStrategy::Dump(bool showBudget)
+void InlineStrategy::Dump(bool verbose)
 {
-    m_RootContext->Dump();
+    m_RootContext->Dump(verbose, 0);
 
-    if (!showBudget)
+    if (!verbose)
     {
         return;
     }

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -695,7 +695,7 @@ public:
 #if defined(DEBUG) || defined(INLINE_DATA)
 
     // Dump the full subtree, including failures
-    void Dump(unsigned indent = 0);
+    void Dump(bool verbose, unsigned indent = 0);
 
     // Dump only the success subtree, with rich data
     void DumpData(unsigned indent = 0);
@@ -923,7 +923,7 @@ public:
 #if defined(DEBUG) || defined(INLINE_DATA)
 
     // Dump textual description of inlines done so far.
-    void Dump(bool showBudget);
+    void Dump(bool verbose);
 
     // Dump data-format description of inlines done so far.
     void DumpData();

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -125,6 +125,7 @@ CONFIG_INTEGER(JitQueryCurrentStaticFieldClass, W("JitQueryCurrentStaticFieldCla
 CONFIG_INTEGER(JitReportFastTailCallDecisions, W("JitReportFastTailCallDecisions"), 0)
 CONFIG_INTEGER(JitPInvokeCheckEnabled, W("JITPInvokeCheckEnabled"), 0)
 CONFIG_INTEGER(JitPInvokeEnabled, W("JITPInvokeEnabled"), 1)
+CONFIG_INTEGER(JitPrintInlinedMethodsVerbose, W("JitPrintInlinedMethodsVerboseLevel"), 0)
 CONFIG_METHODSET(JitPrintInlinedMethods, W("JitPrintInlinedMethods"))
 CONFIG_METHODSET(JitPrintDevirtualizedMethods, W("JitPrintDevirtualizedMethods"))
 CONFIG_INTEGER(JitProfileChecks, W("JitProfileChecks"), 0) // 1 enable in dumps, 2 assert if issues found

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -125,8 +125,13 @@ CONFIG_INTEGER(JitQueryCurrentStaticFieldClass, W("JitQueryCurrentStaticFieldCla
 CONFIG_INTEGER(JitReportFastTailCallDecisions, W("JitReportFastTailCallDecisions"), 0)
 CONFIG_INTEGER(JitPInvokeCheckEnabled, W("JITPInvokeCheckEnabled"), 0)
 CONFIG_INTEGER(JitPInvokeEnabled, W("JITPInvokeEnabled"), 1)
+
+// Controls verbosity for JitPrintInlinedMethods. Ignored for JitDump/NgenDump where
+// it's always set.
 CONFIG_INTEGER(JitPrintInlinedMethodsVerbose, W("JitPrintInlinedMethodsVerboseLevel"), 0)
+// Prints a tree of inlinees for a specific method (use '*' for all methods)
 CONFIG_METHODSET(JitPrintInlinedMethods, W("JitPrintInlinedMethods"))
+
 CONFIG_METHODSET(JitPrintDevirtualizedMethods, W("JitPrintDevirtualizedMethods"))
 CONFIG_INTEGER(JitProfileChecks, W("JitProfileChecks"), 0) // 1 enable in dumps, 2 assert if issues found
 CONFIG_INTEGER(JitRequired, W("JITRequired"), -1)


### PR DESCRIPTION
Was:

![image](https://user-images.githubusercontent.com/523221/140319035-2c3190de-4766-4baa-a39b-b25c77615f20.png)

Now:

![image](https://user-images.githubusercontent.com/523221/140319112-6efd7388-746b-4f40-be34-ea2dd2c78b34.png)

We can also introduce a verbosity level e.g. to only print successful inlinees after [guarded] devirtualizations. The goal is to allow developers to easily find out which call-sites were devirtualized (_and inlined because devirtualization without inlining is not interesting_) with PGO and which were not.

cc @dotnet/jit-contrib @AndyAyersMS 