### PR TITLE
Enable global constant propagation for `GT_LCL_FLD`

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5605,8 +5605,9 @@ Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, Sta
             break;
 
         case GT_LCL_VAR:
+        case GT_LCL_FLD:
             // Make sure the local variable is an R-value.
-            if ((tree->gtFlags & (GTF_VAR_DEF | GTF_DONT_CSE)))
+            if ((tree->gtFlags & (GTF_VAR_USEASG | GTF_VAR_DEF | GTF_DONT_CSE)) != GTF_EMPTY)
             {
                 return WALK_CONTINUE;
             }


### PR DESCRIPTION
These are leaf nodes without side effects, and we can sometimes evaluate them in VN, so it does not seem like there is any reason not to enable propagation for them.

Just a handful of diffs: [`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61209/win-x64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61209/win-x86.md), [`win-arm64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61209/win-arm64.md), [`linux-arm`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61209/linux-arm.md).