### PR TITLE
Add tests for CNG key algorithm mismatches

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/tests/AesCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/AesCngTests.cs
@@ -108,6 +108,15 @@ namespace System.Security.Cryptography.Cng.Tests
                 notSupportedFeedbackSizeInBits: 128);
         }
 
+        [OuterLoop("Creates/Deletes a persisted key, limit exposure to key leaking")]
+        [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
+        public static void VerifyRequiresAesCngKey()
+        {
+            SymmetricCngTestHelpers.VerifyMismatchAlgorithmFails(
+                s_cngAlgorithm,
+                keyName => new TripleDESCng(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider));
+        }
+
         public static bool SupportsPersistedSymmetricKeys
         {
             get { return SymmetricCngTestHelpers.SupportsPersistedSymmetricKeys; }

--- a/src/libraries/System.Security.Cryptography.Cng/tests/SymmetricCngTestHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/SymmetricCngTestHelpers.cs
@@ -348,6 +348,27 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
+        internal static void VerifyMismatchAlgorithmFails(
+            CngAlgorithm algorithm,
+            Func<string, SymmetricAlgorithm> createFromKey)
+        {
+            string keyName = Guid.NewGuid().ToString();
+
+            // We try to delete the key later which will also dispose of it, so no need
+            // to put this in a using.
+            CngKey cngKey = CngKey.Create(algorithm, keyName);
+
+            try
+            {
+                CryptographicException ce = Assert.Throws<CryptographicException>(() => createFromKey(keyName));
+                Assert.Contains($"'{algorithm.Algorithm}'", ce.Message);
+            }
+            finally
+            {
+                cngKey.Delete();
+            }
+        }
+
         private static bool? s_supportsPersistedSymmetricKeys;
         internal static bool SupportsPersistedSymmetricKeys
         {

--- a/src/libraries/System.Security.Cryptography.Cng/tests/SymmetricCngTestHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/SymmetricCngTestHelpers.cs
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.Cng.Tests
             PaddingMode paddingMode,
             int feedbackSizeInBits)
         {
-            byte[] plainBytes = GenerateRandom(plainBytesCount);
+            byte[] plainBytes = RandomNumberGenerator.GetBytes(plainBytesCount);
 
             using (SymmetricAlgorithm persisted = persistedFunc(keyName))
             using (SymmetricAlgorithm ephemeral = ephemeralFunc())
@@ -195,7 +195,7 @@ namespace System.Security.Cryptography.Cng.Tests
                     stable.GenerateIV();
 
                     // Generate (4 * 8) = 32 blocks of plaintext
-                    byte[] plainTextBytes = GenerateRandom(4 * stable.BlockSize);
+                    byte[] plainTextBytes = RandomNumberGenerator.GetBytes(4 * stable.BlockSize);
                     byte[] iv = stable.IV;
 
                     regenKey.IV = replaceKey.IV = iv;
@@ -369,43 +369,11 @@ namespace System.Security.Cryptography.Cng.Tests
             }
         }
 
-        private static bool? s_supportsPersistedSymmetricKeys;
-        internal static bool SupportsPersistedSymmetricKeys
-        {
-            get
-            {
-                if (!s_supportsPersistedSymmetricKeys.HasValue)
-                {
-                    // Windows 7 (Microsoft Windows 6.1) does not support persisted symmetric keys
-                    // in the Microsoft Software KSP
-                    s_supportsPersistedSymmetricKeys = !RuntimeInformation.OSDescription.Contains("Windows 6.1");
-                }
+        // Windows 7 (Microsoft Windows 6.1) does not support persisted symmetric keys
+        // in the Microsoft Software KSP
+        internal static bool SupportsPersistedSymmetricKeys => PlatformDetection.IsWindows8xOrLater;
 
-                return s_supportsPersistedSymmetricKeys.Value;
-            }
-        }
-
-        private static readonly Lazy<bool> s_isAdministrator = new Lazy<bool>(
-            () =>
-            {
-                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
-                {
-                    WindowsPrincipal principal = new WindowsPrincipal(identity);
-                    return principal.IsInRole(WindowsBuiltInRole.Administrator);
-                }
-            });
-
-        internal static bool IsAdministrator => s_isAdministrator.Value;
-
-        internal static byte[] GenerateRandom(int count)
-        {
-            byte[] buffer = new byte[count];
-            using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
-            {
-                rng.GetBytes(buffer);
-            }
-            return buffer;
-        }
+        internal static bool IsAdministrator => PlatformDetection.IsWindowsAndElevated;
 
         internal static void AssertTransformsEqual(byte[] plainTextBytes, ICryptoTransform decryptor, byte[] encryptedBytes)
         {

--- a/src/libraries/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
@@ -114,6 +114,15 @@ namespace System.Security.Cryptography.Cng.Tests
                 notSupportedFeedbackSizeInBits: 64);
         }
 
+        [OuterLoop("Creates/Deletes a persisted key, limit exposure to key leaking")]
+        [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
+        public static void VerifyRequiresTripleDESCngKey()
+        {
+            SymmetricCngTestHelpers.VerifyMismatchAlgorithmFails(
+                s_cngAlgorithm,
+                keyName => new AesCng(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider));
+        }
+
         public static bool SupportsPersistedSymmetricKeys
         {
             get { return SymmetricCngTestHelpers.SupportsPersistedSymmetricKeys; }


### PR DESCRIPTION
This adds tests for CNG key algorithm mismatches, e.g. prevent opening a 3DES persisted key with `AesCng` and vice versa.

This also cleans up some of the test code in a separate commit (reviewing the individual commits might be easier) but I can drop the cleanup from here if it is preferred to be in a separate PR.