### PR TITLE
Use conditional statement instead of switch in System.Linq.Enumerable

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.cs
@@ -208,25 +208,25 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (_state)
+                if (_state == 1)
                 {
-                    case 1:
-                        _enumerator = _source.GetEnumerator();
-                        _state = 2;
-                        goto case 2;
-                    case 2:
-                        while (_enumerator.MoveNext())
-                        {
-                            TSource item = _enumerator.Current;
-                            if (_predicate(item))
-                            {
-                                _current = item;
-                                return true;
-                            }
-                        }
+                    _enumerator = _source.GetEnumerator();
+                    _state = 2;
+                }
 
-                        Dispose();
-                        break;
+                if (_state == 2)
+                {
+                    while (_enumerator.MoveNext())
+                    {
+                        TSource item = _enumerator.Current;
+                        if (_predicate(item))
+                        {
+                            _current = item;
+                            return true;
+                        }
+                    }
+
+                    Dispose();
                 }
 
                 return false;

--- a/src/libraries/System.Linq/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.cs
@@ -106,26 +106,26 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (_state)
+                if (_state == 1)
                 {
-                    case 1:
-                        _enumerator = _source.GetEnumerator();
-                        _state = 2;
-                        goto case 2;
-                    case 2:
-                        Debug.Assert(_enumerator != null);
-                        while (_enumerator.MoveNext())
-                        {
-                            TSource item = _enumerator.Current;
-                            if (_predicate(item))
-                            {
-                                _current = item;
-                                return true;
-                            }
-                        }
+                    _enumerator = _source.GetEnumerator();
+                    _state = 2;
+                }
 
-                        Dispose();
-                        break;
+                if (_state == 2)
+                {
+                    Debug.Assert(_enumerator != null);
+                    while (_enumerator.MoveNext())
+                    {
+                        TSource item = _enumerator.Current;
+                        if (_predicate(item))
+                        {
+                            _current = item;
+                            return true;
+                        }
+                    }
+
+                    Dispose();
                 }
 
                 return false;
@@ -314,25 +314,25 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (_state)
+                if (_state == 1)
                 {
-                    case 1:
-                        _enumerator = _source.GetEnumerator();
-                        _state = 2;
-                        goto case 2;
-                    case 2:
-                        while (_enumerator.MoveNext())
-                        {
-                            TSource item = _enumerator.Current;
-                            if (_predicate(item))
-                            {
-                                _current = _selector(item);
-                                return true;
-                            }
-                        }
+                    _enumerator = _source.GetEnumerator();
+                    _state = 2;
+                }
 
-                        Dispose();
-                        break;
+                if (_state == 2)
+                {
+                    while (_enumerator.MoveNext())
+                    {
+                        TSource item = _enumerator.Current;
+                        if (_predicate(item))
+                        {
+                            _current = _selector(item);
+                            return true;
+                        }
+                    }
+
+                    Dispose();
                 }
 
                 return false;
@@ -380,26 +380,26 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (_state)
+                if (_state == 1)
                 {
-                    case 1:
-                        _enumerator = _source.GetEnumerator();
-                        _state = 2;
-                        goto case 2;
-                    case 2:
-                        Debug.Assert(_enumerator != null);
-                        while (_enumerator.MoveNext())
-                        {
-                            TSource item = _enumerator.Current;
-                            if (_predicate(item))
-                            {
-                                _current = _selector(item);
-                                return true;
-                            }
-                        }
+                    _enumerator = _source.GetEnumerator();
+                    _state = 2;
+                }
 
-                        Dispose();
-                        break;
+                if (_state == 2)
+                {
+                    Debug.Assert(_enumerator != null);
+                    while (_enumerator.MoveNext())
+                    {
+                        TSource item = _enumerator.Current;
+                        if (_predicate(item))
+                        {
+                            _current = _selector(item);
+                            return true;
+                        }
+                    }
+
+                    Dispose();
                 }
 
                 return false;


### PR DESCRIPTION
Small improvement by using a conditional instead of switch+goto.

Baseline is c4d5f6dff367ba1197

```
PS C:\Users\acovingt\source\repos\performance> py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter LinqBenchmark* --corerun C:\Users\acovingt\source\repos\runtime-master\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe --bdn-artifacts D:\dotnet-micro-results\linq-use-conditional\base --bdn-arguments "--launchCount 5"
PS C:\Users\acovingt\source\repos\performance> py .\scripts\benchmarks_ci.py -c Release -f net6.0 --filter LinqBenchmark* --corerun C:\Users\acovingt\source\repos\runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe --bdn-artifacts D:\dotnet-micro-results\linq-use-conditional\diff --bdn-arguments "--launchCount 5"
PS C:\Users\acovingt\source\repos\performance\src\tools\ResultsComparer> dotnet run -- --base D:\dotnet-micro-results\linq-use-conditional\base\results\ --diff D:\dotnet-micro-results\linq-use-conditional\diff\results\ --threshold 3% --noise 5ns
summary:
better: 4, geomean: 1.057
total diff: 4

No Slower results for the provided threshold = 3% and noise filter = 5ns.

| Faster                            | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| LinqBenchmarks.Where00LinqQueryX  |      1.07 |     562294600.00 |     523471200.00 |         |
| LinqBenchmarks.Where00LinqMethodX |      1.07 |     561668600.00 |     523850750.00 |         |
| LinqBenchmarks.Where01LinqMethodX |      1.04 |     239930400.00 |     230370400.00 |         |
| LinqBenchmarks.Where01LinqQueryX  |      1.04 |     239949600.00 |     230396200.00 |         |
```