### PR TITLE
[DllImportGenerator] Use ElementMarshallingGeneratorFactory to create the marshalling generator for collection elements

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
@@ -200,8 +200,10 @@ namespace Microsoft.Interop
             else
             {
                 generatorFactory = new DefaultMarshallingGeneratorFactory(options);
-                AttributedMarshallingModelGeneratorFactory attributedMarshallingFactory = new(generatorFactory, options);
-                generatorFactory = attributedMarshallingFactory;
+                IMarshallingGeneratorFactory elementFactory = new AttributedMarshallingModelGeneratorFactory(generatorFactory, options);
+                // We don't need to include the later generator factories for collection elements
+                // as the later generator factories only apply to parameters or to the synthetic return value for PreserveSig support.
+                generatorFactory = new AttributedMarshallingModelGeneratorFactory(generatorFactory, elementFactory, options);
                 if (!dllImportData.PreserveSig)
                 {
                     // Create type info for native out param
@@ -231,7 +233,6 @@ namespace Microsoft.Interop
                 }
 
                 generatorFactory = new ByValueContentsMarshalKindValidator(generatorFactory);
-                attributedMarshallingFactory.ElementMarshallingGeneratorFactory = generatorFactory;
             }
             typeInfos.Add(retTypeInfo);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Interop
             ICustomNativeTypeMarshallingStrategy marshallingStrategy)
         {
             var elementInfo = new TypePositionInfo(collectionInfo.ElementType, collectionInfo.ElementMarshallingInfo) { ManagedIndex = info.ManagedIndex };
-            IMarshallingGenerator elementMarshaller = Create(
+            IMarshallingGenerator elementMarshaller = ElementMarshallingGeneratorFactory.Create(
                 elementInfo,
                 new ContiguousCollectionElementMarshallingCodeContext(StubCodeContext.Stage.Setup, string.Empty, context));
             TypeSyntax elementType = elementMarshaller.AsNativeType(elementInfo);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -15,21 +15,30 @@ namespace Microsoft.Interop
         private static readonly Forwarder s_forwarder = new Forwarder();
 
         private readonly IMarshallingGeneratorFactory _innerMarshallingGenerator;
+        private readonly IMarshallingGeneratorFactory _elementMarshallingGenerator;
 
-        public AttributedMarshallingModelGeneratorFactory(IMarshallingGeneratorFactory innerMarshallingGenerator, InteropGenerationOptions options)
+        public AttributedMarshallingModelGeneratorFactory(
+            IMarshallingGeneratorFactory innerMarshallingGenerator,
+            InteropGenerationOptions options)
         {
             Options = options;
             _innerMarshallingGenerator = innerMarshallingGenerator;
-            ElementMarshallingGeneratorFactory = this;
+            // Unless overridden, default to using this generator factory for creating generators for collection elements.
+            _elementMarshallingGenerator = this;
+        }
+
+        public AttributedMarshallingModelGeneratorFactory(
+            IMarshallingGeneratorFactory innerMarshallingGenerator,
+            IMarshallingGeneratorFactory elementMarshallingGenerator,
+            InteropGenerationOptions options)
+        {
+            Options = options;
+            _innerMarshallingGenerator = innerMarshallingGenerator;
+
+            _elementMarshallingGenerator = elementMarshallingGenerator;
         }
 
         public InteropGenerationOptions Options { get; }
-
-        /// <summary>
-        /// The <see cref="IMarshallingGeneratorFactory"/> to use for collection elements.
-        /// This property is settable to enable decorating factories to ensure that element marshalling also goes through the decorator support.
-        /// </summary>
-        public IMarshallingGeneratorFactory ElementMarshallingGeneratorFactory { get; set; }
 
         public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context)
         {
@@ -236,7 +245,7 @@ namespace Microsoft.Interop
             ICustomNativeTypeMarshallingStrategy marshallingStrategy)
         {
             var elementInfo = new TypePositionInfo(collectionInfo.ElementType, collectionInfo.ElementMarshallingInfo) { ManagedIndex = info.ManagedIndex };
-            IMarshallingGenerator elementMarshaller = ElementMarshallingGeneratorFactory.Create(
+            IMarshallingGenerator elementMarshaller = _elementMarshallingGenerator.Create(
                 elementInfo,
                 new ContiguousCollectionElementMarshallingCodeContext(StubCodeContext.Stage.Setup, string.Empty, context));
             TypeSyntax elementType = elementMarshaller.AsNativeType(elementInfo);


### PR DESCRIPTION
Fixes a typo. Currently doesn't cause test failures since `ElementMarshallingGeneratorFactory == this` in all current scenarios (this is not true in the struct marshalling generator hackathon branch).