### PR TITLE
Fix build options for native test lib to not enable avx-512

### DIFF
--- a/src/tests/Interop/PInvoke/Generics/CMakeLists.txt
+++ b/src/tests/Interop/PInvoke/Generics/CMakeLists.txt
@@ -22,9 +22,7 @@ if (MSVC)
   add_compile_options(/arch:AVX2)
 else()
   if (NOT CLR_CMAKE_TARGET_ARCH_ARM64 AND NOT CLR_CMAKE_TARGET_ARCH_ARM)
-    # We need -march=native so we can detect if AVX2 is present.
-    # ARM does not like that option too and it make no sense to have this detection there.
-    add_compile_options(-march=native)
+    add_compile_options(-mavx2)
   endif()
 endif()
 set(SOURCES

--- a/src/tests/Interop/PInvoke/Generics/CMakeLists.txt
+++ b/src/tests/Interop/PInvoke/Generics/CMakeLists.txt
@@ -22,7 +22,7 @@ if (MSVC)
   add_compile_options(/arch:AVX2)
 else()
   if (NOT CLR_CMAKE_TARGET_ARCH_ARM64 AND NOT CLR_CMAKE_TARGET_ARCH_ARM)
-    add_compile_options(-mavx2)
+    add_compile_options(-mavx)
   endif()
 endif()
 set(SOURCES


### PR DESCRIPTION
Just enable AVX2, so that we can run the lib on any of our test machines.

Should fix intermittent failures we're seeing in `Interop/PInvoke/Generics/GenericsTest` on linux x64, where the core dumps I've looked at show machines faulting on an AVX-512 instruction in libGenericsNative!GetVector128BOut:
```
00007f2f`30b98b20 c5f990442450    kmovb   k0,byte ptr [rsp+50h]
```

Presumably some of our test machines can't handle these instructions.