### PR TITLE
Type key hash tweaks.

### DIFF
--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -3634,7 +3634,7 @@ retry:
     }
     EX_HOOK
     {
-        LOG((LF_CLASSLOADER, LL_INFO10, "Caught an exception loading: %x, %0x (Module)\n", pTypeKey->IsConstructed() ? pTypeKey->ComputeHash() : pTypeKey->GetTypeToken(), pTypeKey->GetModule()));
+        LOG((LF_CLASSLOADER, LL_INFO10, "Caught an exception loading: %x, %0x (Module)\n", pTypeKey->IsConstructed() ? HashTypeKey(pTypeKey) : pTypeKey->GetTypeToken(), pTypeKey->GetModule()));
 
         if (!GetThread()->HasThreadStateNC(Thread::TSNC_LoadsTypeViolation))
         {

--- a/src/coreclr/vm/gdbjit.h
+++ b/src/coreclr/vm/gdbjit.h
@@ -387,7 +387,7 @@ public:
         static count_t Hash(key_t k)
         {
             LIMITED_METHOD_CONTRACT;
-            return k->ComputeHash();
+            return HashTypeKey(k);
         }
 
         static const element_t Null() { LIMITED_METHOD_CONTRACT; return element_t(key_t(),VALUE()); }

--- a/src/coreclr/vm/pendingload.cpp
+++ b/src/coreclr/vm/pendingload.cpp
@@ -114,7 +114,7 @@ BOOL PendingTypeLoadTable::InsertValue(PendingTypeLoadEntry *pData)
 
     _ASSERTE(m_dwNumBuckets != 0);
 
-    DWORD           dwHash = pData->GetTypeKey().ComputeHash();
+    DWORD           dwHash = HashTypeKey(&pData->GetTypeKey());
     DWORD           dwBucket = dwHash % m_dwNumBuckets;
     PendingTypeLoadTable::TableEntry * pNewEntry = AllocNewEntry();
     if (pNewEntry == NULL)
@@ -130,6 +130,7 @@ BOOL PendingTypeLoadTable::InsertValue(PendingTypeLoadEntry *pData)
     return TRUE;
 }
 
+static int CollisionCount;
 
 BOOL PendingTypeLoadTable::DeleteValue(TypeKey *pKey)
 {
@@ -145,7 +146,7 @@ BOOL PendingTypeLoadTable::DeleteValue(TypeKey *pKey)
 
     _ASSERTE(m_dwNumBuckets != 0);
 
-    DWORD           dwHash = pKey->ComputeHash();
+    DWORD           dwHash = HashTypeKey(pKey);
     DWORD           dwBucket = dwHash % m_dwNumBuckets;
     PendingTypeLoadTable::TableEntry * pSearch;
     PendingTypeLoadTable::TableEntry **ppPrev = &m_pBuckets[dwBucket];
@@ -161,6 +162,7 @@ BOOL PendingTypeLoadTable::DeleteValue(TypeKey *pKey)
         }
 
         ppPrev = &pSearch->pNext;
+        printf("CollisionCount: %i \n", ++CollisionCount);
     }
 
     return FALSE;
@@ -182,7 +184,7 @@ PendingTypeLoadTable::TableEntry *PendingTypeLoadTable::FindItem(TypeKey *pKey)
     _ASSERTE(m_dwNumBuckets != 0);
 
 
-    DWORD           dwHash = pKey->ComputeHash();
+    DWORD           dwHash = HashTypeKey(pKey);
     DWORD           dwBucket = dwHash % m_dwNumBuckets;
     PendingTypeLoadTable::TableEntry * pSearch;
 

--- a/src/coreclr/vm/pendingload.cpp
+++ b/src/coreclr/vm/pendingload.cpp
@@ -130,8 +130,6 @@ BOOL PendingTypeLoadTable::InsertValue(PendingTypeLoadEntry *pData)
     return TRUE;
 }
 
-static int CollisionCount;
-
 BOOL PendingTypeLoadTable::DeleteValue(TypeKey *pKey)
 {
     CONTRACTL
@@ -162,7 +160,6 @@ BOOL PendingTypeLoadTable::DeleteValue(TypeKey *pKey)
         }
 
         ppPrev = &pSearch->pNext;
-        printf("CollisionCount: %i \n", ++CollisionCount);
     }
 
     return FALSE;

--- a/src/coreclr/vm/pendingload.h
+++ b/src/coreclr/vm/pendingload.h
@@ -166,7 +166,7 @@ public:
     }
 #endif //DACCESS_COMPILE
 
-    TypeKey GetTypeKey()
+    TypeKey& GetTypeKey()
     {
         LIMITED_METHOD_CONTRACT;
         return m_typeKey;

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -161,8 +161,6 @@ static DWORD HashPossiblyInstantiatedType(mdTypeDef token, Instantiation inst)
     dwHash = ((dwHash << 5) + dwHash) ^ token;
     if (!inst.IsEmpty())
     {
-        dwHash = ((dwHash << 5) + dwHash) ^ inst.GetNumArgs();
-
         // Hash n type parameters
         for (DWORD i = 0; i < inst.GetNumArgs(); i++)
         {
@@ -224,10 +222,6 @@ static DWORD HashTypeHandle(TypeHandle t)
     {
         retVal = HashParamType(t.GetInternalCorElementType(), t.GetTypeParam());
     }
-    else if (t.IsGenericVariable())
-    {
-        retVal = (dac_cast<PTR_TypeVarTypeDesc>(t.AsTypeDesc())->GetToken());
-    }
     else if (t.HasInstantiation())
     {
         retVal = HashPossiblyInstantiatedType(t.GetCl(), t.GetInstantiation());
@@ -236,6 +230,11 @@ static DWORD HashTypeHandle(TypeHandle t)
     {
         FnPtrTypeDesc* pTD = t.AsFnPtrType();
         retVal = HashFnPtrType(pTD->GetCallConv(), pTD->GetNumArgs(), pTD->GetRetAndArgTypesPointer());
+    }
+    else if (t.IsGenericVariable())
+    {
+        _ASSERTE(!"Generic variables are unexpected here.");
+        retVal = t.AsTAddr();
     }
     else
         retVal = HashPossiblyInstantiatedType(t.GetCl(), Instantiation());

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -251,7 +251,7 @@ static DWORD HashTypeHandle(DWORD level, TypeHandle t)
 }
 
 // Calculate hash value from key
-static DWORD HashTypeKey(TypeKey* pKey)
+DWORD HashTypeKey(TypeKey* pKey)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -141,10 +141,10 @@ DWORD EETypeHashTable::GetCount()
     return BaseGetElementCount();
 }
 
-static DWORD HashTypeHandle(DWORD level, TypeHandle t);
+static DWORD HashTypeHandle(TypeHandle t);
 
 // Calculate hash value for a type def or instantiated type def
-static DWORD HashPossiblyInstantiatedType(DWORD level, mdTypeDef token, Instantiation inst)
+static DWORD HashPossiblyInstantiatedType(mdTypeDef token, Instantiation inst)
 {
     CONTRACTL
     {
@@ -163,15 +163,10 @@ static DWORD HashPossiblyInstantiatedType(DWORD level, mdTypeDef token, Instanti
     {
         dwHash = ((dwHash << 5) + dwHash) ^ inst.GetNumArgs();
 
-        // Hash two levels of the hiearchy. A simple nesting of generics instantiations is
-        // pretty common in generic collections, e.g.: ICollection<KeyValuePair<TKey, TValue>>
-        if (level < 2)
+        // Hash n type parameters
+        for (DWORD i = 0; i < inst.GetNumArgs(); i++)
         {
-            // Hash n type parameters
-            for (DWORD i = 0; i < inst.GetNumArgs(); i++)
-            {
-                dwHash = ((dwHash << 5) + dwHash) ^ HashTypeHandle(level+1, inst[i]);
-            }
+            dwHash = ((dwHash << 5) + dwHash) ^ inst[i].AsTAddr();
         }
     }
 
@@ -179,7 +174,7 @@ static DWORD HashPossiblyInstantiatedType(DWORD level, mdTypeDef token, Instanti
 }
 
 // Calculate hash value for a function pointer type
-static DWORD HashFnPtrType(DWORD level, BYTE callConv, DWORD numArgs, TypeHandle *retAndArgTypes)
+static DWORD HashFnPtrType(BYTE callConv, DWORD numArgs, TypeHandle *retAndArgTypes)
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -188,31 +183,29 @@ static DWORD HashFnPtrType(DWORD level, BYTE callConv, DWORD numArgs, TypeHandle
     dwHash = ((dwHash << 5) + dwHash) ^ ELEMENT_TYPE_FNPTR;
     dwHash = ((dwHash << 5) + dwHash) ^ callConv;
     dwHash = ((dwHash << 5) + dwHash) ^ numArgs;
-    if (level < 1)
+
+    for (DWORD i = 0; i <= numArgs; i++)
     {
-        for (DWORD i = 0; i <= numArgs; i++)
-        {
-            dwHash = ((dwHash << 5) + dwHash) ^ HashTypeHandle(level+1, retAndArgTypes[i]);
-        }
+        dwHash = ((dwHash << 5) + dwHash) ^ retAndArgTypes[i].AsTAddr();
     }
 
     return dwHash;
 }
 
 // Calculate hash value for an array/pointer/byref type
-static DWORD HashParamType(DWORD level, CorElementType kind, TypeHandle typeParam)
+static DWORD HashParamType(CorElementType kind, TypeHandle typeParam)
 {
     WRAPPER_NO_CONTRACT;
     INT_PTR dwHash = 5381;
 
     dwHash = ((dwHash << 5) + dwHash) ^ kind;
-    dwHash = ((dwHash << 5) + dwHash) ^ HashTypeHandle(level, typeParam);
+    dwHash = ((dwHash << 5) + dwHash) ^ typeParam.AsTAddr();
 
     return dwHash;
 }
 
 // Calculate hash value from type handle
-static DWORD HashTypeHandle(DWORD level, TypeHandle t)
+static DWORD HashTypeHandle(TypeHandle t)
 {
     CONTRACTL
     {
@@ -229,7 +222,7 @@ static DWORD HashTypeHandle(DWORD level, TypeHandle t)
 
     if (t.HasTypeParam())
     {
-        retVal = HashParamType(level, t.GetInternalCorElementType(), t.GetTypeParam());
+        retVal = HashParamType(t.GetInternalCorElementType(), t.GetTypeParam());
     }
     else if (t.IsGenericVariable())
     {
@@ -237,15 +230,15 @@ static DWORD HashTypeHandle(DWORD level, TypeHandle t)
     }
     else if (t.HasInstantiation())
     {
-        retVal = HashPossiblyInstantiatedType(level, t.GetCl(), t.GetInstantiation());
+        retVal = HashPossiblyInstantiatedType(t.GetCl(), t.GetInstantiation());
     }
     else if (t.IsFnPtrType())
     {
         FnPtrTypeDesc* pTD = t.AsFnPtrType();
-        retVal = HashFnPtrType(level, pTD->GetCallConv(), pTD->GetNumArgs(), pTD->GetRetAndArgTypesPointer());
+        retVal = HashFnPtrType(pTD->GetCallConv(), pTD->GetNumArgs(), pTD->GetRetAndArgTypesPointer());
     }
     else
-        retVal = HashPossiblyInstantiatedType(level, t.GetCl(), Instantiation());
+        retVal = HashPossiblyInstantiatedType(t.GetCl(), Instantiation());
 
     return retVal;
 }
@@ -265,15 +258,15 @@ DWORD HashTypeKey(TypeKey* pKey)
 
     if (pKey->GetKind() == ELEMENT_TYPE_CLASS)
     {
-        return HashPossiblyInstantiatedType(0, pKey->GetTypeToken(), pKey->GetInstantiation());
+        return HashPossiblyInstantiatedType(pKey->GetTypeToken(), pKey->GetInstantiation());
     }
     else if (pKey->GetKind() == ELEMENT_TYPE_FNPTR)
     {
-        return HashFnPtrType(0, pKey->GetCallConv(), pKey->GetNumArgs(), pKey->GetRetAndArgTypes());
+        return HashFnPtrType(pKey->GetCallConv(), pKey->GetNumArgs(), pKey->GetRetAndArgTypes());
     }
     else
     {
-        return HashParamType(0, pKey->GetKind(), pKey->GetElementType());
+        return HashParamType(pKey->GetKind(), pKey->GetElementType());
     }
 }
 
@@ -552,7 +545,7 @@ VOID EETypeHashTable::InsertValue(TypeHandle data)
 
     pNewEntry->SetTypeHandle(data);
 
-    BaseInsertEntry(HashTypeHandle(0, data), pNewEntry);
+    BaseInsertEntry(HashTypeHandle(data), pNewEntry);
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/typehash.h
+++ b/src/coreclr/vm/typehash.h
@@ -26,6 +26,8 @@
 //
 //========================================================================================
 
+DWORD HashTypeKey(TypeKey* pKey);
+
 // One of these is present for each element in the table
 // It simply chains together (hash,data) pairs
 typedef DPTR(struct EETypeHashEntry) PTR_EETypeHashEntry;

--- a/src/coreclr/vm/typekey.h
+++ b/src/coreclr/vm/typekey.h
@@ -213,7 +213,6 @@ public:
         return TypeKey::Equals(this, pKey);
     }
 
-    // Comparison and hashing
     static BOOL Equals(const TypeKey *pKey1, const TypeKey *pKey2)
     {
         WRAPPER_NO_CONTRACT;
@@ -256,33 +255,6 @@ public:
             }
             return TRUE;
         }
-    }
-
-    DWORD ComputeHash() const
-    {
-        LIMITED_METHOD_CONTRACT;
-        DWORD_PTR hashLarge;
-
-        if (m_kind == ELEMENT_TYPE_CLASS)
-        {
-            hashLarge = ((DWORD_PTR)u.asClass.m_pModule ^ (DWORD_PTR)u.asClass.m_numGenericArgs ^ (DWORD_PTR)u.asClass.m_typeDef);
-        }
-        else if (CorTypeInfo::IsModifier_NoThrow(m_kind) || m_kind == ELEMENT_TYPE_VALUETYPE)
-        {
-            hashLarge = (u.asParamType.m_paramType ^ (DWORD_PTR) u.asParamType.m_rank);
-        }
-        else hashLarge = 0;
-
-#if POINTER_BITS == 32
-        return hashLarge;
-#else
-        DWORD hash = *(DWORD *)&hashLarge;
-        for (unsigned i = 1; i < POINTER_BITS / 32; i++)
-        {
-            hash ^= ((DWORD *)&hashLarge)[i];
-        }
-        return hash;
-#endif
     }
 };
 


### PR DESCRIPTION
TL;DR:
This change considerably reduces how often we need to compare types to resolve hash collisions in `PendingTypeLoadTable` and `EETypeHashTable` dictionaries.


##### More details:

While working on hackathon project I noticed that `HashKey::ComputeHash` is not the best. - It mixes into the hash the number of generic arguments, which does not differ between instantiations of the same type and as such does not improve uniqueness of the hash, while it does not mix the arguments themselves, meaning all instantiations of a given type will have the same hash.

While looking at how to improve `HashKey::ComputeHash`, I've realized that only `PendingTypeLoadTable` uses that and otherwise we use `HashTypeKey()`,  which is a better hash function. So I switched `PendingTypeLoadTable` to use `HashTypeKey` as well.

This reduced the number of collisions in `PendingTypeLoadTable`:
HelloWorld:   190 -> 154      (20% reduction in something that is not using generics much)
System.Linq.Expressions.Tests:  ~5000 -> ~2900  (number varies between runs, but I see about 40% reduction)

---

I have also noticed that the `HashTypeKey()` computes hash of instantiated types by recursively hashing 2 levels of typedefs, which still can easily cause collisions if instantiation differences are one level lower. Considering that typehandles of type arguments are unique, simply hashing type argument pointers would produce much better hash. 
It would be cheaper too. Hashing a linearly laid out sequence of pointers would touch a lot less memory than recursive walk through their parts. 

With this change I see the number of collisions in `PendingTypeLoadTable`:
HelloWorld:  0 collisions      (**190 -> 0 overall reduction.**)
System.Linq.Expressions.Tests: ~300 collisions.      (**5000 -> 300,   ~95% reduction overall**)

---

Out of curiosity I have instrumented the `EETypeHashTable::FindItem` - to see how the change impacts collision rate on the read path.

On System.Linq.Expressions.Tests I see:
**before change: ~500000 - 700000 collisions.**
**after change: 0 - 5 collisions**

---

NOTE: `EETypeHashTable` has 2 levels of collision resolution. 
There is an upper level (in `FindItem`) that deals with poor hashing when different `TypeKey`s get the same hashcode - these are relatively expensive since we resolve them by comparing the type's constituent parts - is it the same module, the same number of type args, is it the same definition, have actually the same typeargs, etc... This is the kind of resolution that was reduced in this change up to 100000x times.

There is a lower level (`BaseFindFirstEntryByHash`, `BaseFindNextEntryByHash`) that deals with bucketization collisions that must happen when `int32` hash is mapped to a smaller number of buckets (the table uses a typical "mod prime" hash reducer). I see roughly the same number of hash comparisons before or after this change, as expected, since the change does not change the bucketing strategy.