### PR TITLE
Explicitly mark tests with CLRTestKind=SharedLibrary

### DIFF
--- a/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.csproj
+++ b/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -11,7 +11,6 @@
 
   <!-- Default priority building values. -->
   <PropertyGroup>
-    <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Library'">SharedLibrary</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildAndRun</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
@@ -3,6 +3,7 @@
     <TestRuntime>true</TestRuntime>
     <DeltaScript>deltascript.json</DeltaScript>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
     <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
     <Optimize>false</Optimize>
     <EmitDebugInformation>true</EmitDebugInformation>

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyA.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyA.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyA.cs" />

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyB.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyB.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyB.cs" />

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyC.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyC.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyC.cs" />

--- a/src/tests/Interop/COM/Activator/Servers/AssemblyContracts.csproj
+++ b/src/tests/Interop/COM/Activator/Servers/AssemblyContracts.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyContracts.cs" />

--- a/src/tests/Interop/COM/NETServer/NETServer.DefaultInterfaces.ilproj
+++ b/src/tests/Interop/COM/NETServer/NETServer.DefaultInterfaces.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NETServer.DefaultInterfaces.il" />

--- a/src/tests/Interop/COM/NETServer/NETServer.csproj
+++ b/src/tests/Interop/COM/NETServer/NETServer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CustomMarshaler.cs" />

--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler2.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/CustomMarshaler2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
     <DefineConstants>$(DefineConstants);CUSTOMMARSHALERS2</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/NativeLibrary/AssemblyLoadContext/TestAsm/TestAsm.csproj
+++ b/src/tests/Interop/NativeLibrary/AssemblyLoadContext/TestAsm/TestAsm.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorUtil.ilproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/CopyCtor/CopyCtorUtil.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CopyCtorUtil.il" />

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll1/ManagedDll1.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll1/ManagedDll1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll2/ManagedDll2.csproj
+++ b/src/tests/Interop/PInvoke/Miscellaneous/MultipleAssembliesWithSamePInvoke/ManagedDll2/ManagedDll2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionUtil.ilproj
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionUtil.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SuppressGCTransitionUtil.il" />

--- a/src/tests/Interop/UnmanagedCallConv/PInvokesIL.ilproj
+++ b/src/tests/Interop/UnmanagedCallConv/PInvokesIL.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="PInvokesIL.il" />

--- a/src/tests/Interop/UnmanagedCallersOnly/InvalidCSharp.ilproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/InvalidCSharp.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvalidCallbacks.il" />

--- a/src/tests/JIT/Regression/JitBlue/GitHub_22583/base.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_22583/base.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <GenerateRunScript>false</GenerateRunScript>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Regression/JitBlue/GitHub_22583/lib.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_22583/lib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <GenerateRunScript>false</GenerateRunScript>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/Regressions/coreclr/22021/provider.ilproj
+++ b/src/tests/Regressions/coreclr/22021/provider.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="provider.il" />

--- a/src/tests/baseservices/callconvs/CallFunctionPointers.ilproj
+++ b/src/tests/baseservices/callconvs/CallFunctionPointers.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CallFunctionPointers.il" />

--- a/src/tests/baseservices/compilerservices/RuntimeWrappedException/StringThrower.ilproj
+++ b/src/tests/baseservices/compilerservices/RuntimeWrappedException/StringThrower.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StringThrower.il" />

--- a/src/tests/baseservices/compilerservices/modulector/moduleCctor.ilproj
+++ b/src/tests/baseservices/compilerservices/modulector/moduleCctor.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="moduleCctor.il" />

--- a/src/tests/baseservices/typeequivalence/contracts/TypeContracts.csproj
+++ b/src/tests/baseservices/typeequivalence/contracts/TypeContracts.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Types.cs" />

--- a/src/tests/baseservices/typeequivalence/impl/TypeImpl.csproj
+++ b/src/tests/baseservices/typeequivalence/impl/TypeImpl.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Impls.cs" />

--- a/src/tests/ilverify/ILTests/ILTests.targets
+++ b/src/tests/ilverify/ILTests/ILTests.targets
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputPath>$(BaseOutputPathWithConfig)ilverify\Tests</OutputPath>
   </PropertyGroup>

--- a/src/tests/profiler/unittest/unloadlibrary.csproj
+++ b/src/tests/profiler/unittest/unloadlibrary.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/reflection/DefaultInterfaceMethods/GetInterfaceMapProvider.ilproj
+++ b/src/tests/reflection/DefaultInterfaceMethods/GetInterfaceMapProvider.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GetInterfaceMapProvider.il" />

--- a/src/tests/reflection/DefaultInterfaceMethods/InvokeProvider.ilproj
+++ b/src/tests/reflection/DefaultInterfaceMethods/InvokeProvider.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvokeProvider.il" />

--- a/src/tests/reflection/RefEmit/Dependency.csproj
+++ b/src/tests/reflection/RefEmit/Dependency.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Dependency.cs" />

--- a/src/tests/reflection/StaticInterfaceMembers/provider.ilproj
+++ b/src/tests/reflection/StaticInterfaceMembers/provider.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="provider.il" />


### PR DESCRIPTION
Previously the Directory.Build.targets script used to automatically
infer that OutputType=Library without a CLRTestKind implies
SharedLibrary. This is however hard to consolidate with the planned
test merging - as the SDK scripts set OutputType=Library by default,
we need the combination Library+(implicit)BuildAndRun to indicate
the "new-style" [Fact]-based tests. For this reason I propose to
remove this automatic inference and manually fix the handful of tests
that are missing an explicit CLRTestKind=SharedLibrary property.

In light of this description we can theoretically remove the
OutputType=Library specification from all test projects but even if
we decide to do that, I believe it will be easier to do it as a
separate mechanical change, not as part of this relatively small
change that has a different purpose. Additionally in the one case
of the GitHub_22583 regression test, I removed the explicit setting
of GenerateRunScript=false because that's the default.

Thanks

Tomas

Contributes to: https://github.com/dotnet/runtime/issues/54512

/cc @dotnet/runtime-infrastructure 