### PR TITLE
Fix the WASM Iterator test

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -186,18 +186,31 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     return rangeIterator;
                 ");
 
-            for (int attempt = 0; attempt < 100_000; attempt++)
+            const int count = 500;
+            for (int attempt = 0; attempt < 100; attempt++)
             {
+                int index = 0;
                 try
                 {
-                    using (var entriesIterator = (JSObject)makeRangeIterator.Call(null, 0, 500))
-                    {
-                        var cnt = entriesIterator.ToEnumerable().Count();
+                    var entriesIterator = (JSObject)makeRangeIterator.Call(null, 0, count, 1);
+                    Assert.NotNull(entriesIterator);
+                    using (entriesIterator) {
+                        var enumerable = entriesIterator.ToEnumerable();
+                        var enumerator = enumerable.GetEnumerator();
+                        Assert.NotNull(enumerator);
+
+                        using (enumerator) {
+                            while (enumerator.MoveNext()) {
+                                Assert.NotNull(enumerator.Current);
+                                index++;
+                            }
+                        }
                     }
+                    Assert.Equal(count, index);
                 }
                 catch (Exception ex)
                 {
-                    throw new Exception(ex.Message + " At attempt=" + attempt, ex);
+                    throw new Exception($"At attempt={attempt}, index={index}: {ex.Message}", ex);
                 }
             }
         }


### PR DESCRIPTION
Because this test wasn't passing a step value to JavaScript, it only ever stepped the iterator for one iteration and then continued. This meant that the test rarely actually exercised the bug it was trying to detect.

By fixing it so that it runs for multiple iterations as intended, it reliably reproduces variations on the bug (it came back in one of my development branches) at the exact same point every run after a reasonably short number of steps.

This PR also improves the error output and does additional checks.