### PR TITLE
Set some missing `GTF_GLOB_REF` and improve its checking.

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9277,7 +9277,7 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
             case GT_CNS_INT:
 
             {
-                unsigned handleKind = (tree->gtFlags & GTF_ICON_HDL_MASK);
+                GenTreeFlags handleKind = (tree->gtFlags & GTF_ICON_HDL_MASK);
 
                 switch (handleKind)
                 {
@@ -9517,7 +9517,7 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
             default:
 
             {
-                unsigned flags = (tree->gtFlags & (~(unsigned)(GTF_COMMON_MASK | GTF_OVERFLOW)));
+                GenTreeFlags flags = (tree->gtFlags & (~(GTF_COMMON_MASK | GTF_OVERFLOW)));
                 if (flags != 0)
                 {
                     chars += printf("[%08X]", flags);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3455,20 +3455,20 @@ public:
     void gtSetStmtInfo(Statement* stmt);
 
     // Returns "true" iff "node" has any of the side effects in "flags".
-    bool gtNodeHasSideEffects(GenTree* node, unsigned flags);
+    bool gtNodeHasSideEffects(GenTree* node, GenTreeFlags flags);
 
     // Returns "true" iff "tree" or its (transitive) children have any of the side effects in "flags".
-    bool gtTreeHasSideEffects(GenTree* tree, unsigned flags);
+    bool gtTreeHasSideEffects(GenTree* tree, GenTreeFlags flags);
 
     // Appends 'expr' in front of 'list'
     //    'list' will typically start off as 'nullptr'
     //    when 'list' is non-null a GT_COMMA node is used to insert 'expr'
     GenTree* gtBuildCommaList(GenTree* list, GenTree* expr);
 
-    void gtExtractSideEffList(GenTree*  expr,
-                              GenTree** pList,
-                              unsigned  flags      = GTF_SIDE_EFFECT,
-                              bool      ignoreRoot = false);
+    void gtExtractSideEffList(GenTree*     expr,
+                              GenTree**    pList,
+                              GenTreeFlags GenTreeFlags = GTF_SIDE_EFFECT,
+                              bool         ignoreRoot   = false);
 
     GenTree* gtGetThisArg(GenTreeCall* call);
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2841,9 +2841,9 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
 
 void Compiler::fgDebugCheckFlags(GenTree* tree)
 {
-    const unsigned   kind      = tree->OperKind();
-    GenTreeFlags     treeFlags = tree->gtFlags & GTF_ALL_EFFECT;
-    GenTreeFlags     chkFlags  = GTF_EMPTY;
+    const unsigned kind      = tree->OperKind();
+    GenTreeFlags   treeFlags = tree->gtFlags & GTF_ALL_EFFECT;
+    GenTreeFlags   chkFlags  = GTF_EMPTY;
 
     if (tree->OperMayThrow(this))
     {
@@ -2966,7 +2966,7 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                 {
                     // Is this constant a handle of some kind?
                     //
-                    unsigned handleKind = (op1->gtFlags & GTF_ICON_HDL_MASK);
+                    GenTreeFlags handleKind = (op1->gtFlags & GTF_ICON_HDL_MASK);
                     if (handleKind != 0)
                     {
                         const GenTreeFlags indAddFlags = (GTF_IND_NONFAULTING | GTF_IND_INVARIANT);
@@ -3102,11 +3102,11 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         }
 
         if (tree->OperIs(GT_ADDR) && (op1->OperIs(GT_LCL_VAR, GT_CLS_VAR) ||
-                                (op1->OperIs(GT_IND) && op1->AsOp()->gtOp1->gtOper == GT_CLS_VAR_ADDR)))
+                                      (op1->OperIs(GT_IND) && op1->AsOp()->gtOp1->gtOper == GT_CLS_VAR_ADDR)))
         {
             // TODO-Cleanup: This is a hack, because `GTF_GLOB_REF` description says:
             // `sub-expression uses global variable(s)`, so if a child has it set its parent
-            // must have it set as well. However, we clear it from the parent in cases 
+            // must have it set as well. However, we clear it from the parent in cases
             // ADDR(LCL_VAR or CLS_VAR).
             chkFlags &= ~GTF_GLOB_REF;
         }
@@ -3131,6 +3131,8 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 
                     if ((call->gtCallThisArg->GetNode()->gtFlags & GTF_ASG) != 0)
                     {
+                        // TODO-Cleanup: this is a patch for a violation in our GT_ASG propogation
+                        // see https://github.com/dotnet/runtime/issues/13758
                         treeFlags |= GTF_ASG;
                     }
                 }
@@ -3143,6 +3145,8 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 
                     if ((use.GetNode()->gtFlags & GTF_ASG) != 0)
                     {
+                        // TODO-Cleanup: this is a patch for a violation in our GT_ASG propogation
+                        // see https://github.com/dotnet/runtime/issues/13758
                         treeFlags |= GTF_ASG;
                     }
                 }

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3004,7 +3004,7 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                                 // We expect the GTF_GLOB_REF flag to be set for this handleKind
                                 // If it is not set then we will assert with "Missing flags on tree"
                                 //
-                                treeFlags |= GTF_GLOB_REF;
+                                chkFlags |= GTF_GLOB_REF;
                             }
                         }
                         else // All the other handle indirections are considered invariant
@@ -3012,12 +3012,12 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
                             // We expect the Invariant flag to be set for this handleKind
                             // If it is not set then we will assert with "Missing flags on tree"
                             //
-                            treeFlags |= GTF_IND_INVARIANT;
+                            chkFlags |= GTF_IND_INVARIANT;
                         }
 
                         // We currently expect all handle kinds to be nonFaulting
                         //
-                        treeFlags |= GTF_IND_NONFAULTING;
+                        chkFlags |= GTF_IND_NONFAULTING;
 
                         // Matrix for GTF_IND_INVARIANT (treeFlags and chkFlags)
                         //
@@ -3107,7 +3107,7 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
         {
             /* &aliasedVar doesn't need GTF_GLOB_REF, though alisasedVar does.
                Similarly for clsVar */
-            treeFlags |= GTF_GLOB_REF;
+            chkFlags |= GTF_GLOB_REF;
         }
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2792,9 +2792,10 @@ void Compiler::fgAddInternal()
     if (dbgHandle || pDbgHandle)
     {
         // Test the JustMyCode VM global state variable
+
         GenTree* embNode        = gtNewIconEmbHndNode(dbgHandle, pDbgHandle, GTF_ICON_GLOBAL_PTR, info.compMethodHnd);
-        GenTree* guardCheckVal  = gtNewOperNode(GT_IND, TYP_INT, embNode);
-        gtNewIndOfIconHandleNode(TYP_INT, reinterpret_cast<size_t>(dbgHandle), GTF_ICON_GLOBAL_PTR);
+        GenTree* guardCheckVal  = gtNewIndir(TYP_INT, embNode);
+
         GenTree* guardCheckCond = gtNewOperNode(GT_EQ, TYP_INT, guardCheckVal, gtNewZeroConNode(TYP_INT));
 
         // Create the callback which will yield the final answer

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2793,8 +2793,8 @@ void Compiler::fgAddInternal()
     {
         // Test the JustMyCode VM global state variable
 
-        GenTree* embNode        = gtNewIconEmbHndNode(dbgHandle, pDbgHandle, GTF_ICON_GLOBAL_PTR, info.compMethodHnd);
-        GenTree* guardCheckVal  = gtNewIndir(TYP_INT, embNode);
+        GenTree* embNode       = gtNewIconEmbHndNode(dbgHandle, pDbgHandle, GTF_ICON_GLOBAL_PTR, info.compMethodHnd);
+        GenTree* guardCheckVal = gtNewIndir(TYP_INT, embNode);
 
         GenTree* guardCheckCond = gtNewOperNode(GT_EQ, TYP_INT, guardCheckVal, gtNewZeroConNode(TYP_INT));
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2794,6 +2794,7 @@ void Compiler::fgAddInternal()
         // Test the JustMyCode VM global state variable
         GenTree* embNode        = gtNewIconEmbHndNode(dbgHandle, pDbgHandle, GTF_ICON_GLOBAL_PTR, info.compMethodHnd);
         GenTree* guardCheckVal  = gtNewOperNode(GT_IND, TYP_INT, embNode);
+        gtNewIndOfIconHandleNode(TYP_INT, reinterpret_cast<size_t>(dbgHandle), GTF_ICON_GLOBAL_PTR);
         GenTree* guardCheckCond = gtNewOperNode(GT_EQ, TYP_INT, guardCheckVal, gtNewZeroConNode(TYP_INT));
 
         // Create the callback which will yield the final answer

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6921,6 +6921,7 @@ GenTree* Compiler::gtNewCpObjNode(GenTree* dstAddr, GenTree* srcAddr, CORINFO_CL
     else
     {
         src = gtNewOperNode(GT_IND, lhs->TypeGet(), srcAddr);
+        src->gtFlags |= GTF_GLOB_REF;
     }
 
     GenTree* result = gtNewBlkOpNode(lhs, src, isVolatile, true);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15568,7 +15568,7 @@ GenTree* Compiler::gtNewRefCOMfield(GenTree*                objPtr,
  *  assignments too.
  */
 
-bool Compiler::gtNodeHasSideEffects(GenTree* tree, unsigned flags)
+bool Compiler::gtNodeHasSideEffects(GenTree* tree, GenTreeFlags flags)
 {
     if (flags & GTF_ASG)
     {
@@ -15644,10 +15644,10 @@ bool Compiler::gtNodeHasSideEffects(GenTree* tree, unsigned flags)
  * Returns true if the expr tree has any side effects.
  */
 
-bool Compiler::gtTreeHasSideEffects(GenTree* tree, unsigned flags /* = GTF_SIDE_EFFECT*/)
+bool Compiler::gtTreeHasSideEffects(GenTree* tree, GenTreeFlags flags /* = GTF_SIDE_EFFECT*/)
 {
     // These are the side effect flags that we care about for this tree
-    unsigned sideEffectFlags = tree->gtFlags & flags;
+    GenTreeFlags sideEffectFlags = tree->gtFlags & flags;
 
     // Does this tree have any Side-effect flags set that we care about?
     if (sideEffectFlags == 0)
@@ -15761,15 +15761,15 @@ GenTree* Compiler::gtBuildCommaList(GenTree* list, GenTree* expr)
 //    each comma node holds the side effect tree and op2 points to the
 //    next comma node. The original side effect execution order is preserved.
 //
-void Compiler::gtExtractSideEffList(GenTree*  expr,
-                                    GenTree** pList,
-                                    unsigned  flags /* = GTF_SIDE_EFFECT*/,
-                                    bool      ignoreRoot /* = false */)
+void Compiler::gtExtractSideEffList(GenTree*     expr,
+                                    GenTree**    pList,
+                                    GenTreeFlags flags /* = GTF_SIDE_EFFECT*/,
+                                    bool         ignoreRoot /* = false */)
 {
     class SideEffectExtractor final : public GenTreeVisitor<SideEffectExtractor>
     {
     public:
-        const unsigned       m_flags;
+        const GenTreeFlags   m_flags;
         ArrayStack<GenTree*> m_sideEffects;
 
         enum
@@ -15778,7 +15778,7 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
             UseExecutionOrder = true
         };
 
-        SideEffectExtractor(Compiler* compiler, unsigned flags)
+        SideEffectExtractor(Compiler* compiler, GenTreeFlags flags)
             : GenTreeVisitor(compiler), m_flags(flags), m_sideEffects(compiler->getAllocator(CMK_SideEffects))
         {
         }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -16816,6 +16816,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 else
                 {
                     op2 = gtNewOperNode(GT_IND, TYP_STRUCT, op2);
+                    op2->gtFlags |= GTF_GLOB_REF;
                 }
 
                 op1 = gtNewBlkOpNode(op1, op2, (prefixFlags & PREFIX_VOLATILE) != 0, true);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -548,8 +548,8 @@ inline void Compiler::impAppendStmt(Statement* stmt, unsigned chkLevel)
         /* If the statement being appended has any side-effects, check the stack
            to see if anything needs to be spilled to preserve correct ordering. */
 
-        GenTree* expr  = stmt->GetRootNode();
-        unsigned flags = expr->gtFlags & GTF_GLOB_EFFECT;
+        GenTree*     expr  = stmt->GetRootNode();
+        GenTreeFlags flags = expr->gtFlags & GTF_GLOB_EFFECT;
 
         // Assignment to (unaliased) locals don't count as a side-effect as
         // we handle them specially using impSpillLclRefs(). Temp locals should
@@ -558,7 +558,7 @@ inline void Compiler::impAppendStmt(Statement* stmt, unsigned chkLevel)
         if ((expr->gtOper == GT_ASG) && (expr->AsOp()->gtOp1->gtOper == GT_LCL_VAR) &&
             ((expr->AsOp()->gtOp1->gtFlags & GTF_GLOB_REF) == 0) && !gtHasLocalsWithAddrOp(expr->AsOp()->gtOp2))
         {
-            unsigned op2Flags = expr->AsOp()->gtOp2->gtFlags & GTF_GLOB_EFFECT;
+            GenTreeFlags op2Flags = expr->AsOp()->gtOp2->gtFlags & GTF_GLOB_EFFECT;
             assert(flags == (op2Flags | GTF_ASG));
             flags = op2Flags;
         }
@@ -2617,7 +2617,7 @@ inline void Compiler::impSpillSideEffects(bool spillGlobEffects, unsigned chkLev
 
     assert(chkLevel <= verCurrentState.esStackDepth);
 
-    unsigned spillFlags = spillGlobEffects ? GTF_GLOB_EFFECT : GTF_SIDE_EFFECT;
+    GenTreeFlags spillFlags = spillGlobEffects ? GTF_GLOB_EFFECT : GTF_SIDE_EFFECT;
 
     for (unsigned i = 0; i < chkLevel; i++)
     {
@@ -14263,7 +14263,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     // Spill side-effects AND global-data-accesses
                     if (verCurrentState.esStackDepth > 0)
                     {
-                        impSpillSideEffects(true, (unsigned)CHECK_SPILL_ALL DEBUGARG("spill side effects before STIND"));
+                        impSpillSideEffects(true,
+                                            (unsigned)CHECK_SPILL_ALL DEBUGARG("spill side effects before STIND"));
                     }
                 }
                 goto APPEND;
@@ -20732,7 +20733,7 @@ bool Compiler::impInlineIsGuaranteedThisDerefBeforeAnySideEffects(GenTree*      
 
     for (unsigned level = 0; level < verCurrentState.esStackDepth; level++)
     {
-        unsigned stackTreeFlags = verCurrentState.esStack[level].val->gtFlags;
+        GenTreeFlags stackTreeFlags = verCurrentState.esStack[level].val->gtFlags;
         if (GTF_GLOBALLY_VISIBLE_SIDE_EFFECTS(stackTreeFlags))
         {
             return false;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11703,9 +11703,12 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
         /* Propagate the new flags */
         tree->gtFlags |= (op1->gtFlags & GTF_ALL_EFFECT);
 
-        // &aliasedVar doesn't need GTF_GLOB_REF, though alisasedVar does
-        // Similarly for clsVar
-        if (oper == GT_ADDR && (op1->gtOper == GT_LCL_VAR || op1->gtOper == GT_CLS_VAR))
+        // TODO-Cleanup: This is a hack, because `GTF_GLOB_REF` description says:
+        // `sub-expression uses global variable(s)`, so if a child has it set its parent
+        // must have it set as well. However, we clear it from the parent in cases 
+        // ADDR(LCL_VAR or CLS_VAR).
+        if (oper == GT_ADDR && (op1->OperIs(GT_LCL_VAR, GT_CLS_VAR) ||
+            (op1->OperIs(GT_IND) && op1->AsOp()->gtOp1->OperIs(GT_CLS_VAR_ADDR))))
         {
             tree->gtFlags &= ~GTF_GLOB_REF;
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11705,10 +11705,10 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
 
         // TODO-Cleanup: This is a hack, because `GTF_GLOB_REF` description says:
         // `sub-expression uses global variable(s)`, so if a child has it set its parent
-        // must have it set as well. However, we clear it from the parent in cases 
+        // must have it set as well. However, we clear it from the parent in cases
         // ADDR(LCL_VAR or CLS_VAR).
         if (oper == GT_ADDR && (op1->OperIs(GT_LCL_VAR, GT_CLS_VAR) ||
-            (op1->OperIs(GT_IND) && op1->AsOp()->gtOp1->OperIs(GT_CLS_VAR_ADDR))))
+                                (op1->OperIs(GT_IND) && op1->AsOp()->gtOp1->OperIs(GT_CLS_VAR_ADDR))))
         {
             tree->gtFlags &= ~GTF_GLOB_REF;
         }
@@ -13026,7 +13026,7 @@ DONE_MORPHING_CHILDREN:
                 tree          = op1;
                 GenTree* addr = commaNode->AsOp()->gtOp2;
                 // TODO-1stClassStructs: we often create a struct IND without a handle, fix it.
-                GenTreeIndir* indir  = gtNewIndir(typ, addr);
+                GenTreeIndir* indir = gtNewIndir(typ, addr);
                 // This is very conservative
                 indir->gtFlags |= treeFlags & ~GTF_ALL_EFFECT & ~GTF_IND_NONFAULTING;
                 indir->gtFlags |= (addr->gtFlags & GTF_ALL_EFFECT);
@@ -14552,7 +14552,7 @@ GenTree* Compiler::fgRecognizeAndMorphBitwiseRotation(GenTree* tree)
         {
             noway_assert(GenTree::OperIsRotate(rotateOp));
 
-            unsigned inputTreeEffects = tree->gtFlags & GTF_ALL_EFFECT;
+            GenTreeFlags inputTreeEffects = tree->gtFlags & GTF_ALL_EFFECT;
 
             // We can use the same tree only during global morph; reusing the tree in a later morph
             // may invalidate value numbers.


### PR DESCRIPTION
The code in `fgDebugCheckFlags` had some mistakes that were easy to fix, for harder errors I added a comment explaining them.

The diff is a regression but a small one.

The diffs look like correctness fixes, for example, for such comparison:
```
Core_Root\superpmi.exe "Core_Root_base\clrjit.dll" "Core_Root_diff\clrjit.dll" D:\Sergey\git\runtime\artifacts\spmi\mch\3df3e3ec-b1f6-4e6d-8439-2e7f3f7fa2ac.windows.x64\libraries_tests.pmi.windows.x64.checked.mch  -a -c 78772
```
we forbid swapping `call` and `IND(global static field)`, if I understand correctly, nothing prevents the call from making a change in this field, so it should not be hard to create a correctness repro for this bug.

```diff
***** BB01
++STMT00002 (IL   ???...  ???)
++               [000013] -A--G-------              *  ASG       byref 
++               [000012] D------N----              +--*  LCL_VAR   byref  V03 tmp2         
++               [000003] ----G-------              \--*  ADD       byref 
++               [000001] n---G-------                 +--*  IND       ref   
++               [000000] I-----------                 |  \--*  CNS_INT(h) long   0xd1ffab1e static Fseq[hackishFieldName]
++               [000002] ------------                 \--*  CNS_INT   long   8 Fseq[#FirstElem]
***** BB01
STMT00001 (IL   ???...  ???)
               [000011] I-C-G-------              *  CALL      void   System.TimeSpan..ctor (exactContextHnd=0x00000000D1FFAB1E)
               [000010] ------------ this in rcx  +--*  ADDR      byref 
               [000009] -------N----              |  \--*  LCL_VAR   struct<System.TimeSpan, 8> V02 tmp1         
               [000005] ------------ arg1         \--*  CNS_INT   long   1

***** BB01
STMT00002 (IL 0x00C...  ???)
--               [000013] I-C-G-------              *  CALL      struct System.TimeSpan.Add (exactContextHnd=0x00000000D1FFAB1E)
--               [000003] ------------ this in rcx  +--*  ADD       byref 
--               [000001] ------------              |  +--*  IND       ref   
--               [000000] I-----------              |  |  \--*  CNS_INT(h) long   0xd1ffab1e static Fseq[hackishFieldName]
--               [000002] ------------              |  \--*  CNS_INT   long   8 Fseq[#FirstElem]
--               [000015] n----------- arg1         \--*  OBJ       struct<System.TimeSpan, 8>
--               [000014] ------------                 \--*  ADDR      byref 
--               [000012] -------N----                    \--*  LCL_VAR   struct<System.TimeSpan, 8> V02 tmp1 
++STMT00003 (IL 0x00C...  ???)
++               [000016] I-C-G-------              *  CALL      struct System.TimeSpan.Add (exactContextHnd=0x00000000D1FFAB1E)
++               [000014] ------------ this in rcx  +--*  LCL_VAR   byref  V03 tmp2         
++               [000018] n----------- arg1         \--*  OBJ       struct<System.TimeSpan, 8>
++               [000017] ------------                 \--*  ADDR      byref 
++               [000015] -------N----                    \--*  LCL_VAR   struct<System.TimeSpan, 8> V02 tmp1 
```

so if inside `[000011] I-C-G-------              *  CALL      void   System.TimeSpan..ctor` we change what is stored in 
```
[000001] n---G-------                 +--*  IND       ref   
[000000] I-----------                 |  \--*  CNS_INT(h) long   0xd1ffab1e static Fseq[hackishFieldName]
```
then before this change, we would read the changed value, not the correct one.

<details>
  <summary>diffs with misleading total numbers</summary>
  Ignore the total diff, see #60124

```
Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.windows.x64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.windows.x64.checked.4\diff
 Total bytes of delta: -6956 (-0.10 % of base)
 1 total files with Code Size differences (0 improved, 1 regressed), 1 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.windows.x64.checked.5\base D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.windows.x64.checked.5\diff
 Total bytes of delta: -1515 (-0.00 % of base)
 5 total files with Code Size differences (1 improved, 4 regressed), 4 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.windows.x64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.windows.x64.checked.4\diff
 Total bytes of delta: -3695 (-0.01 % of base)
 3 total files with Code Size differences (0 improved, 3 regressed), 2 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.windows.x64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.windows.x64.checked.4\diff
 Total bytes of delta: -21142 (-0.02 % of base)
 19 total files with Code Size differences (2 improved, 17 regressed), 2 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.Linux.arm64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.Linux.arm64.checked.4\diff
 Total bytes of delta: -1332 (-0.00 % of base)
 1 total files with Code Size differences (0 improved, 1 regressed), 3 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.Linux.arm64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.Linux.arm64.checked.4\diff
 Total bytes of delta: -2920 (-0.01 % of base)
 3 total files with Code Size differences (0 improved, 3 regressed), 1 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.Linux.arm64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.Linux.arm64.checked.4\diff
 Total bytes of delta: -20104 (-0.02 % of base)
 17 total files with Code Size differences (0 improved, 17 regressed), 4 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.Linux.x64.checked.5\base D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.Linux.x64.checked.5\diff
 Total bytes of delta: -7003 (-0.08 % of base)
 1 total files with Code Size differences (0 improved, 1 regressed), 0 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.Linux.x64.checked.5\base D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.Linux.x64.checked.5\diff
 Total bytes of delta: -1295 (-0.00 % of base)
 5 total files with Code Size differences (1 improved, 4 regressed), 4 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.Linux.x64.checked.5\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.Linux.x64.checked.5\diff
 Total bytes of delta: -2909 (-0.01 % of base)
 3 total files with Code Size differences (0 improved, 3 regressed), 1 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.Linux.x64.checked.5\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.Linux.x64.checked.5\diff
 Total bytes of delta: -23240 (-0.02 % of base)
 19 total files with Code Size differences (3 improved, 16 regressed), 2 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.windows.arm64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.windows.arm64.checked.4\diff
 Total bytes of delta: -6992 (-0.09 % of base)
 0 total files with Code Size differences (0 improved, 0 regressed), 2 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.windows.arm64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.windows.arm64.checked.4\diff
 Total bytes of delta: -1332 (-0.00 % of base)
 1 total files with Code Size differences (0 improved, 1 regressed), 3 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.windows.arm64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.windows.arm64.checked.4\diff
 Total bytes of delta: -3848 (-0.01 % of base)
 3 total files with Code Size differences (0 improved, 3 regressed), 2 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.windows.arm64.checked.4\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.windows.arm64.checked.4\diff
 Total bytes of delta: -20100 (-0.02 % of base)
 17 total files with Code Size differences (0 improved, 17 regressed), 4 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.windows.x86.checked.3\base D:\Sergey\git\runtime\artifacts\spmi\asm.benchmarks.run.windows.x86.checked.3\diff
 Total bytes of delta: -4922 (-0.09 % of base)
 0 total files with Code Size differences (0 improved, 0 regressed), 3 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.windows.x86.checked.3\base D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.windows.x86.checked.3\diff
 Total bytes of delta: -2182 (-0.00 % of base)
 7 total files with Code Size differences (0 improved, 7 regressed), 6 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.windows.x86.checked.3\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.windows.x86.checked.3\diff
 Total bytes of delta: -1532 (-0.00 % of base)
 3 total files with Code Size differences (0 improved, 3 regressed), 3 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.windows.x86.checked.3\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.windows.x86.checked.3\diff
 Total bytes of delta: -18554 (-0.02 % of base)
 8 total files with Code Size differences (0 improved, 8 regressed), 15 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.Linux.arm.checked.3\base D:\Sergey\git\runtime\artifacts\spmi\asm.coreclr_tests.pmi.Linux.arm.checked.3\diff
 Total bytes of delta: -2176 (-0.00 % of base)
 1 total files with Code Size differences (0 improved, 1 regressed), 6 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.Linux.arm.checked.3\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries.pmi.Linux.arm.checked.3\diff
 Total bytes of delta: -1016 (-0.00 % of base)
 3 total files with Code Size differences (2 improved, 1 regressed), 2 unchanged.

Creating dasm files: D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.Linux.arm.checked.3\base D:\Sergey\git\runtime\artifacts\spmi\asm.libraries_tests.pmi.Linux.arm.checked.3\diff
 Total bytes of delta: -27136 (-0.03 % of base)
 8 total files with Code Size differences (0 improved, 8 regressed), 12 unchanged.
```

</details>
