### PR TITLE
SPMI: Use diffed bytes for jit-analyze and print more info

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.cpp
@@ -369,15 +369,12 @@ JitInstance::Result JitInstance::CompileMethod(MethodContext* MethodToCompile, i
 
             pParam->pThis->mc->cr->recMessageLog("Successful Compile");
 
-            pParam->metrics->SuccessfulCompiles++;
             pParam->metrics->NumCodeBytes += NCodeSizeBlock;
         }
         else
         {
             LogDebug("compileMethod failed with result %d", jitResult);
             pParam->result = RESULT_ERROR;
-
-            pParam->metrics->FailingCompiles++;
         }
     }
     PAL_EXCEPT_FILTER(FilterSuperPMIExceptions_CaptureExceptionAndStop)
@@ -407,6 +404,20 @@ JitInstance::Result JitInstance::CompileMethod(MethodContext* MethodToCompile, i
     }
 
     mc->cr->secondsToCompile = stj.GetSeconds();
+
+    if (param.result == RESULT_SUCCESS)
+    {
+        metrics->SuccessfulCompiles++;
+    }
+    else
+    {
+        metrics->FailingCompiles++;
+    }
+
+    if (param.result == RESULT_MISSING)
+    {
+        metrics->MissingCompiles++;
+    }
 
     return param.result;
 }

--- a/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.h
@@ -7,14 +7,23 @@
 class MetricsSummary
 {
 public:
+    // Number of methods successfully jitted.
     int SuccessfulCompiles;
+    // Number of methods that failed jitting.
     int FailingCompiles;
+    // Number of methods that failed jitting due to missing SPMI data.
+    int MissingCompiles;
+    // Number of code bytes produced by the JIT for the successful compiles.
     long long NumCodeBytes;
+    // Number of code bytes that were diffed with the other compiler in diff mode.
+    long long NumDiffedCodeBytes;
 
     MetricsSummary()
         : SuccessfulCompiles(0)
         , FailingCompiles(0)
+        , MissingCompiles(0)
         , NumCodeBytes(0)
+        , NumDiffedCodeBytes(0)
     {
     }
 


### PR DESCRIPTION
Fix the misleading total bytes displayed when diffing with SPMI. If one
of the JITs encountered missing data, the code bytes would not be
included, while the other JIT could still have it included if it did not
encounter missing data.

Also add more information about missing SPMI data/successful replays
printed. For replays that is useful to be able to gauge whether there is
still ok coverage after a large change. For diffs, we print a warning
for missing SPMI data that the diff summary may be misleading.

Example for a successful replay:
    Clean SuperPMI replay (219868 contexts processed)

Example for a replay with missing data:
    SuperPMI encountered missing data for 6 out of 27272 contexts

Example warning printed:
    Warning: SuperPMI encountered missing data during the diff. The diff summary printed above may be misleading.
    Missing with base JIT: 0. Missing with diff JIT: 6. Total contexts: 27272.