### PR TITLE
Updating src/tests/Interop/PInvoke/Generics/GenericsNative.Vector* to annotate individual methods as requiring AVX

### DIFF
--- a/src/tests/Common/Platform/platformdefines.h
+++ b/src/tests/Common/Platform/platformdefines.h
@@ -270,5 +270,11 @@ inline void CoreClrFree(void *p)
 #define strcpy_s TP_strcpy_s
 #endif
 
+#if defined(TARGET_XARCH) && !defined(_MSC_VER)
+#define ENABLE_AVX __attribute__ ((target("avx")))
+#else
+#define ENABLE_AVX
+#endif
+
 #endif
 

--- a/src/tests/Interop/PInvoke/Generics/CMakeLists.txt
+++ b/src/tests/Interop/PInvoke/Generics/CMakeLists.txt
@@ -17,14 +17,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # The ABI for passing parameters with 32-byte alignment has changed in GCC 4.6
   add_compile_options(-Wno-psabi)
 endif()
-if (MSVC)
-  # The MSVC require explicitly ask for AVX2 so define would be present.
-  add_compile_options(/arch:AVX2)
-else()
-  if (NOT CLR_CMAKE_TARGET_ARCH_ARM64 AND NOT CLR_CMAKE_TARGET_ARCH_ARM)
-    add_compile_options(-mavx)
-  endif()
-endif()
 set(SOURCES
   GenericsNative.IUnknown.cpp
   GenericsNative.NullableB.cpp

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256B.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256B.cpp
@@ -14,7 +14,7 @@
     #error Unsupported target architecture
 #endif
 
-#if defined(__AVX2__)
+#if defined(TARGET_XARCH)
     typedef __m256i Vector256B;
 #else
     typedef struct {

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256C.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256C.cpp
@@ -14,7 +14,7 @@
     #error Unsupported target architecture
 #endif
 
-#if defined(__AVX2__)
+#if defined(TARGET_XARCH)
     typedef __m256i Vector256C;
 #else
     typedef struct {

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256D.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256D.cpp
@@ -27,7 +27,7 @@
 
 static Vector256D Vector256DValue = { };
 
-extern "C" DLL_EXPORT Vector256D STDMETHODCALLTYPE GetVector256D(double e00, double e01, double e02, double e03)
+extern "C" DLL_EXPORT Vector256D STDMETHODCALLTYPE ENABLE_AVX GetVector256D(double e00, double e01, double e02, double e03)
 {
     union {
         double value[4];
@@ -42,7 +42,7 @@ extern "C" DLL_EXPORT Vector256D STDMETHODCALLTYPE GetVector256D(double e00, dou
     return result;
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVector256DOut(double e00, double e01, double e02, double e03, Vector256D* pValue)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ENABLE_AVX GetVector256DOut(double e00, double e01, double e02, double e03, Vector256D* pValue)
 {
     Vector256D value = GetVector256D(e00, e01, e02, e03);
 
@@ -54,18 +54,18 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVector256DOut(double e00, double
 #endif
 }
 
-extern "C" DLL_EXPORT const Vector256D* STDMETHODCALLTYPE GetVector256DPtr(double e00, double e01, double e02, double e03)
+extern "C" DLL_EXPORT const Vector256D* STDMETHODCALLTYPE ENABLE_AVX GetVector256DPtr(double e00, double e01, double e02, double e03)
 {
     GetVector256DOut(e00, e01, e02, e03, &Vector256DValue);
     return &Vector256DValue;
 }
 
-extern "C" DLL_EXPORT Vector256D STDMETHODCALLTYPE AddVector256D(Vector256D lhs, Vector256D rhs)
+extern "C" DLL_EXPORT Vector256D STDMETHODCALLTYPE ENABLE_AVX AddVector256D(Vector256D lhs, Vector256D rhs)
 {
     throw "P/Invoke for Vector256<double> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT Vector256D STDMETHODCALLTYPE AddVector256Ds(const Vector256D* pValues, uint32_t count)
+extern "C" DLL_EXPORT Vector256D STDMETHODCALLTYPE ENABLE_AVX AddVector256Ds(const Vector256D* pValues, uint32_t count)
 {
     throw "P/Invoke for Vector256<double> should be unsupported.";
 }

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256D.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256D.cpp
@@ -14,7 +14,7 @@
     #error Unsupported target architecture
 #endif
 
-#if defined(__AVX2__)
+#if defined(TARGET_XARCH)
     typedef __m256 Vector256D;
 #else
     typedef struct {

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256F.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256F.cpp
@@ -14,7 +14,7 @@
     #error Unsupported target architecture
 #endif
 
-#if defined(__AVX2__)
+#if defined(TARGET_XARCH)
     typedef __m256 Vector256F;
 #else
     typedef struct {

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256F.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256F.cpp
@@ -31,7 +31,7 @@
 
 static Vector256F Vector256FValue = { };
 
-extern "C" DLL_EXPORT Vector256F STDMETHODCALLTYPE GetVector256F(float e00, float e01, float e02, float e03, float e04, float e05, float e06, float e07)
+extern "C" DLL_EXPORT Vector256F STDMETHODCALLTYPE ENABLE_AVX GetVector256F(float e00, float e01, float e02, float e03, float e04, float e05, float e06, float e07)
 {
     union {
         float value[8];
@@ -50,7 +50,7 @@ extern "C" DLL_EXPORT Vector256F STDMETHODCALLTYPE GetVector256F(float e00, floa
     return result;
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVector256FOut(float e00, float e01, float e02, float e03, float e04, float e05, float e06, float e07, Vector256F* pValue)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ENABLE_AVX GetVector256FOut(float e00, float e01, float e02, float e03, float e04, float e05, float e06, float e07, Vector256F* pValue)
 {
     Vector256F value = GetVector256F(e00, e01, e02, e03, e04, e05, e06, e07);
 
@@ -62,18 +62,18 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVector256FOut(float e00, float e
 #endif
 }
 
-extern "C" DLL_EXPORT const Vector256F* STDMETHODCALLTYPE GetVector256FPtr(float e00, float e01, float e02, float e03, float e04, float e05, float e06, float e07)
+extern "C" DLL_EXPORT const Vector256F* STDMETHODCALLTYPE ENABLE_AVX GetVector256FPtr(float e00, float e01, float e02, float e03, float e04, float e05, float e06, float e07)
 {
     GetVector256FOut(e00, e01, e02, e03, e04, e05, e06, e07, &Vector256FValue);
     return &Vector256FValue;
 }
 
-extern "C" DLL_EXPORT Vector256F STDMETHODCALLTYPE AddVector256F(Vector256F lhs, Vector256F rhs)
+extern "C" DLL_EXPORT Vector256F STDMETHODCALLTYPE ENABLE_AVX AddVector256F(Vector256F lhs, Vector256F rhs)
 {
     throw "P/Invoke for Vector256<float> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT Vector256F STDMETHODCALLTYPE AddVector256Fs(const Vector256F* pValues, uint32_t count)
+extern "C" DLL_EXPORT Vector256F STDMETHODCALLTYPE ENABLE_AVX AddVector256Fs(const Vector256F* pValues, uint32_t count)
 {
     throw "P/Invoke for Vector256<float> should be unsupported.";
 }

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256L.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256L.cpp
@@ -14,7 +14,7 @@
     #error Unsupported target architecture
 #endif
 
-#if defined(__AVX2__)
+#if defined(TARGET_XARCH)
     typedef __m256i Vector256L;
 #else
     typedef struct {

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256U.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256U.cpp
@@ -31,7 +31,7 @@
 
 static Vector256U Vector256UValue = { };
 
-extern "C" DLL_EXPORT Vector256U STDMETHODCALLTYPE GetVector256U(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
+extern "C" DLL_EXPORT Vector256U STDMETHODCALLTYPE ENABLE_AVX GetVector256U(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
 {
     union {
         uint32_t value[8];
@@ -50,7 +50,7 @@ extern "C" DLL_EXPORT Vector256U STDMETHODCALLTYPE GetVector256U(uint32_t e00, u
     return result;
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVector256UOut(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07, Vector256U* pValue)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ENABLE_AVX GetVector256UOut(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07, Vector256U* pValue)
 {
     Vector256U value = GetVector256U(e00, e01, e02, e03, e04, e05, e06, e07);
 
@@ -62,18 +62,18 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVector256UOut(uint32_t e00, uint
 #endif
 }
 
-extern "C" DLL_EXPORT const Vector256U* STDMETHODCALLTYPE GetVector256UPtr(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
+extern "C" DLL_EXPORT const Vector256U* STDMETHODCALLTYPE ENABLE_AVX GetVector256UPtr(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
 {
     GetVector256UOut(e00, e01, e02, e03, e04, e05, e06, e07, &Vector256UValue);
     return &Vector256UValue;
 }
 
-extern "C" DLL_EXPORT Vector256U STDMETHODCALLTYPE AddVector256U(Vector256U lhs, Vector256U rhs)
+extern "C" DLL_EXPORT Vector256U STDMETHODCALLTYPE ENABLE_AVX AddVector256U(Vector256U lhs, Vector256U rhs)
 {
     throw "P/Invoke for Vector256<uint> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT Vector256U STDMETHODCALLTYPE AddVector256Us(const Vector256U* pValues, uint32_t count)
+extern "C" DLL_EXPORT Vector256U STDMETHODCALLTYPE ENABLE_AVX AddVector256Us(const Vector256U* pValues, uint32_t count)
 {
     throw "P/Invoke for Vector256<uint> should be unsupported.";
 }

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256U.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.Vector256U.cpp
@@ -14,7 +14,7 @@
     #error Unsupported target architecture
 #endif
 
-#if defined(__AVX2__)
+#if defined(TARGET_XARCH)
     typedef __m256i Vector256U;
 #else
     typedef struct {

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.VectorD.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.VectorD.cpp
@@ -27,7 +27,7 @@ extern "C" DLL_EXPORT VectorD128 STDMETHODCALLTYPE GetVectorD128(double e00, dou
     return *reinterpret_cast<VectorD128*>(value);
 }
 
-extern "C" DLL_EXPORT VectorD256 STDMETHODCALLTYPE GetVectorD256(double e00, double e01, double e02, double e03)
+extern "C" DLL_EXPORT VectorD256 STDMETHODCALLTYPE ENABLE_AVX GetVectorD256(double e00, double e01, double e02, double e03)
 {
     double value[4] = { e00, e01, e02, e03 };
     return *reinterpret_cast<VectorD256*>(value);
@@ -38,7 +38,7 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVectorD128Out(double e00, double
     *pValue = GetVectorD128(e00, e01);
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVectorD256Out(double e00, double e01, double e02, double e03, VectorD256* pValue)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ENABLE_AVX GetVectorD256Out(double e00, double e01, double e02, double e03, VectorD256* pValue)
 {
     *pValue = GetVectorD256(e00, e01, e02, e03);
 }
@@ -49,7 +49,7 @@ extern "C" DLL_EXPORT const VectorD128* STDMETHODCALLTYPE GetVectorD128Ptr(doubl
     return &VectorD128Value;
 }
 
-extern "C" DLL_EXPORT const VectorD256* STDMETHODCALLTYPE GetVectorD256Ptr(double e00, double e01, double e02, double e03)
+extern "C" DLL_EXPORT const VectorD256* STDMETHODCALLTYPE ENABLE_AVX GetVectorD256Ptr(double e00, double e01, double e02, double e03)
 {
     GetVectorD256Out(e00, e01, e02, e03, &VectorD256Value);
     return &VectorD256Value;
@@ -60,7 +60,7 @@ extern "C" DLL_EXPORT VectorD128 STDMETHODCALLTYPE AddVectorD128(VectorD128 lhs,
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT VectorD256 STDMETHODCALLTYPE AddVectorD256(VectorD256 lhs, VectorD256 rhs)
+extern "C" DLL_EXPORT VectorD256 STDMETHODCALLTYPE ENABLE_AVX AddVectorD256(VectorD256 lhs, VectorD256 rhs)
 {
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
@@ -70,7 +70,7 @@ extern "C" DLL_EXPORT VectorD128 STDMETHODCALLTYPE AddVectorD128s(const VectorD1
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT VectorD256 STDMETHODCALLTYPE AddVectorD256s(const VectorD256* pValues, double count)
+extern "C" DLL_EXPORT VectorD256 STDMETHODCALLTYPE ENABLE_AVX AddVectorD256s(const VectorD256* pValues, double count)
 {
     throw "P/Invoke for Vector<char> should be unsupported.";
 }

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.VectorL.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.VectorL.cpp
@@ -27,7 +27,7 @@ extern "C" DLL_EXPORT VectorL128 STDMETHODCALLTYPE GetVectorL128(int64_t e00, in
     return *reinterpret_cast<VectorL128*>(value);
 }
 
-extern "C" DLL_EXPORT VectorL256 STDMETHODCALLTYPE GetVectorL256(int64_t e00, int64_t e01, int64_t e02, int64_t e03)
+extern "C" DLL_EXPORT VectorL256 STDMETHODCALLTYPE ENABLE_AVX GetVectorL256(int64_t e00, int64_t e01, int64_t e02, int64_t e03)
 {
     int64_t value[4] = { e00, e01, e02, e03 };
     return *reinterpret_cast<VectorL256*>(value);
@@ -38,7 +38,7 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVectorL128Out(int64_t e00, int64
     *pValue = GetVectorL128(e00, e01);
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVectorL256Out(int64_t e00, int64_t e01, int64_t e02, int64_t e03, VectorL256* pValue)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ENABLE_AVX GetVectorL256Out(int64_t e00, int64_t e01, int64_t e02, int64_t e03, VectorL256* pValue)
 {
     *pValue = GetVectorL256(e00, e01, e02, e03);
 }
@@ -49,7 +49,7 @@ extern "C" DLL_EXPORT const VectorL128* STDMETHODCALLTYPE GetVectorL128Ptr(int64
     return &VectorL128Value;
 }
 
-extern "C" DLL_EXPORT const VectorL256* STDMETHODCALLTYPE GetVectorL256Ptr(int64_t e00, int64_t e01, int64_t e02, int64_t e03)
+extern "C" DLL_EXPORT const VectorL256* STDMETHODCALLTYPE ENABLE_AVX GetVectorL256Ptr(int64_t e00, int64_t e01, int64_t e02, int64_t e03)
 {
     GetVectorL256Out(e00, e01, e02, e03, &VectorL256Value);
     return &VectorL256Value;
@@ -60,7 +60,7 @@ extern "C" DLL_EXPORT VectorL128 STDMETHODCALLTYPE AddVectorL128(VectorL128 lhs,
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT VectorL256 STDMETHODCALLTYPE AddVectorL256(VectorL256 lhs, VectorL256 rhs)
+extern "C" DLL_EXPORT VectorL256 STDMETHODCALLTYPE ENABLE_AVX AddVectorL256(VectorL256 lhs, VectorL256 rhs)
 {
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
@@ -70,7 +70,7 @@ extern "C" DLL_EXPORT VectorL128 STDMETHODCALLTYPE AddVectorL128s(const VectorL1
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT VectorL256 STDMETHODCALLTYPE AddVectorL256s(const VectorL256* pValues, int64_t count)
+extern "C" DLL_EXPORT VectorL256 STDMETHODCALLTYPE ENABLE_AVX AddVectorL256s(const VectorL256* pValues, int64_t count)
 {
     throw "P/Invoke for Vector<char> should be unsupported.";
 }

--- a/src/tests/Interop/PInvoke/Generics/GenericsNative.VectorU.cpp
+++ b/src/tests/Interop/PInvoke/Generics/GenericsNative.VectorU.cpp
@@ -33,7 +33,7 @@ extern "C" DLL_EXPORT VectorU128 STDMETHODCALLTYPE GetVectorU128(uint32_t e00, u
     return *reinterpret_cast<VectorU128*>(value);
 }
 
-extern "C" DLL_EXPORT VectorU256 STDMETHODCALLTYPE GetVectorU256(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
+extern "C" DLL_EXPORT VectorU256 STDMETHODCALLTYPE ENABLE_AVX GetVectorU256(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
 {
     uint32_t value[8] = { e00, e01, e02, e03, e04, e05, e06, e07 };
     return *reinterpret_cast<VectorU256*>(value);
@@ -44,7 +44,7 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVectorU128Out(uint32_t e00, uint
     *pValue = GetVectorU128(e00, e01, e02, e03);
 }
 
-extern "C" DLL_EXPORT void STDMETHODCALLTYPE GetVectorU256Out(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07, VectorU256* pValue)
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ENABLE_AVX GetVectorU256Out(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07, VectorU256* pValue)
 {
     *pValue = GetVectorU256(e00, e01, e02, e03, e04, e05, e06, e07);
 }
@@ -55,7 +55,7 @@ extern "C" DLL_EXPORT const VectorU128* STDMETHODCALLTYPE GetVectorU128Ptr(uint3
     return &VectorU128Value;
 }
 
-extern "C" DLL_EXPORT const VectorU256* STDMETHODCALLTYPE GetVectorU256Ptr(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
+extern "C" DLL_EXPORT const VectorU256* STDMETHODCALLTYPE ENABLE_AVX GetVectorU256Ptr(uint32_t e00, uint32_t e01, uint32_t e02, uint32_t e03, uint32_t e04, uint32_t e05, uint32_t e06, uint32_t e07)
 {
     GetVectorU256Out(e00, e01, e02, e03, e04, e05, e06, e07, &VectorU256Value);
     return &VectorU256Value;
@@ -66,7 +66,7 @@ extern "C" DLL_EXPORT VectorU128 STDMETHODCALLTYPE AddVectorU128(VectorU128 lhs,
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT VectorU256 STDMETHODCALLTYPE AddVectorU256(VectorU256 lhs, VectorU256 rhs)
+extern "C" DLL_EXPORT VectorU256 STDMETHODCALLTYPE ENABLE_AVX AddVectorU256(VectorU256 lhs, VectorU256 rhs)
 {
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
@@ -76,7 +76,7 @@ extern "C" DLL_EXPORT VectorU128 STDMETHODCALLTYPE AddVectorU128s(const VectorU1
     throw "P/Invoke for Vector<char> should be unsupported.";
 }
 
-extern "C" DLL_EXPORT VectorU256 STDMETHODCALLTYPE AddVectorU256s(const VectorU256* pValues, uint32_t count)
+extern "C" DLL_EXPORT VectorU256 STDMETHODCALLTYPE ENABLE_AVX AddVectorU256s(const VectorU256* pValues, uint32_t count)
 {
     throw "P/Invoke for Vector<char> should be unsupported.";
 }


### PR DESCRIPTION
This is an "improved" version of https://github.com/dotnet/runtime/pull/61229 that only opts specific methods into requiring AVX rather than forcing it for the entire compilation