### PR TITLE
Don't create a COM weak reference if the object is an aggregated COMWrappers RCW.

### DIFF
--- a/src/coreclr/vm/interoplibinterface.h
+++ b/src/coreclr/vm/interoplibinterface.h
@@ -34,7 +34,7 @@ public: // COM activation
     static void MarkWrapperAsComActivated(_In_ IUnknown* wrapperMaybe);
 
 public: // Unwrapping support
-    static IUnknown* GetIdentityForObject(_In_ OBJECTREF* objectPROTECTED, _In_ REFIID riid, _Out_ INT64* wrapperId);
+    static IUnknown* GetIdentityForObject(_In_ OBJECTREF* objectPROTECTED, _In_ REFIID riid, _Out_ INT64* wrapperId, _Out_ bool* isAggregated);
     static bool HasManagedObjectComWrapper(_In_ OBJECTREF object, _Out_ bool* isActive);
 
 public: // GC interaction

--- a/src/coreclr/vm/interoplibinterface_comwrappers.cpp
+++ b/src/coreclr/vm/interoplibinterface_comwrappers.cpp
@@ -903,12 +903,10 @@ namespace
                                 : ExternalObjectContext::Flags_None) |
                             (uniqueInstance
                                 ? ExternalObjectContext::Flags_None
-                                : ExternalObjectContext::Flags_InCache);
-
-                if (flags & CreateObjectFlags::CreateObjectFlags_Aggregated)
-                {
-                    eocFlags |= ExternalObjectContext::Flags_Aggregated;
-                }
+                                : ExternalObjectContext::Flags_InCache) |
+                            ((flags & CreateObjectFlags::CreateObjectFlags_Aggregated) != 0
+                                ? ExternalObjectContext::Flags_Aggregated
+                                : ExternalObjectContext::Flags_None);
 
                 ExternalObjectContext::Construct(
                     resultHolder.GetContext(),
@@ -1816,7 +1814,7 @@ IUnknown* ComWrappersNative::GetIdentityForObject(_In_ OBJECTREF* objectPROTECTE
     {
         ExternalObjectContext* context = reinterpret_cast<ExternalObjectContext*>(contextMaybe);
         *wrapperId = context->WrapperId;
-        *isAggregated = (context->Flags & ExternalObjectContext::Flags_Aggregated) != 0;
+        *isAggregated = context->IsSet(ExternalObjectContext::Flags_Aggregated);
 
         IUnknown* identity = reinterpret_cast<IUnknown*>(context->Identity);
         GCX_PREEMP();

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
@@ -35,9 +35,9 @@ namespace ComWrappersTests
     {
         private struct Vtbl
         {
-            public delegate*<IntPtr, Guid*, IntPtr*, int> QueryInterface;
-            public delegate*<IntPtr, int> AddRef;
-            public delegate*<IntPtr, int> Release;
+            public delegate* unmanaged<IntPtr, Guid*, IntPtr*, int> QueryInterface;
+            public delegate* unmanaged<IntPtr, int> AddRef;
+            public delegate* unmanaged<IntPtr, int> Release;
         }
 
         private readonly IntPtr instance;

--- a/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
+++ b/src/tests/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
@@ -14,6 +14,9 @@ namespace ComWrappersTests
     {
         [DllImport(nameof(WeakReferenceNative))]
         public static extern IntPtr CreateWeakReferencableObject();
+
+        [DllImport(nameof(WeakReferenceNative))]
+        public static extern IntPtr CreateAggregatedWeakReferenceObject(IntPtr outer);
     }
 
     public struct VtblPtr
@@ -28,70 +31,95 @@ namespace ComWrappersTests
         Marshalling,
     }
 
-    public class WeakReferenceableWrapper
+    public unsafe class WeakReferenceableWrapper
     {
         private struct Vtbl
         {
-            public IntPtr QueryInterface;
-            public _AddRef AddRef;
-            public _Release Release;
+            public delegate*<IntPtr, Guid*, IntPtr*, int> QueryInterface;
+            public delegate*<IntPtr, int> AddRef;
+            public delegate*<IntPtr, int> Release;
         }
-
-        private delegate int _AddRef(IntPtr This);
-        private delegate int _Release(IntPtr This);
 
         private readonly IntPtr instance;
         private readonly Vtbl vtable;
+        private readonly bool releaseInFinalizer;
 
         public WrapperRegistration Registration { get; }
 
-        public WeakReferenceableWrapper(IntPtr instance, WrapperRegistration reg)
+        public WeakReferenceableWrapper(IntPtr instance, WrapperRegistration reg, bool releaseInFinalizer = true)
         {
             var inst = Marshal.PtrToStructure<VtblPtr>(instance);
             this.vtable = Marshal.PtrToStructure<Vtbl>(inst.Vtbl);
             this.instance = instance;
+            this.releaseInFinalizer = releaseInFinalizer;
             Registration = reg;
+        }
+
+        public int QueryInterface(Guid iid, out IntPtr ptr)
+        {
+            fixed(IntPtr* ppv = &ptr)
+            {
+                return this.vtable.QueryInterface(this.instance, &iid, ppv);
+            }
         }
 
         ~WeakReferenceableWrapper()
         {
-            if (this.instance != IntPtr.Zero)
+            if (this.instance != IntPtr.Zero && this.releaseInFinalizer)
             {
                 this.vtable.Release(this.instance);
             }
         }
     }
 
+    class DerivedObject : ICustomQueryInterface
+    {
+        private WeakReferenceableWrapper inner;
+        public DerivedObject(TestComWrappers comWrappersInstance)
+        {
+            IntPtr innerInstance = WeakReferenceNative.CreateAggregatedWeakReferenceObject(
+                comWrappersInstance.GetOrCreateComInterfaceForObject(this, CreateComInterfaceFlags.None));
+            inner = new WeakReferenceableWrapper(innerInstance, comWrappersInstance.Registration, releaseInFinalizer: false);
+            comWrappersInstance.GetOrRegisterObjectForComInstance(innerInstance, CreateObjectFlags.Aggregation, this);
+        }
+
+        public CustomQueryInterfaceResult GetInterface(ref Guid iid, out IntPtr ppv)
+        {
+            return inner.QueryInterface(iid, out ppv) == 0 ? CustomQueryInterfaceResult.Handled : CustomQueryInterfaceResult.Failed;
+        }
+    }
+
+    class TestComWrappers : ComWrappers
+    {
+        public WrapperRegistration Registration { get; }
+
+        public TestComWrappers(WrapperRegistration reg = WrapperRegistration.Local)
+        {
+            Registration = reg;
+        }
+
+        protected unsafe override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
+        {
+            count = 0;
+            return null;
+        }
+
+        protected override object CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
+        {
+            Marshal.AddRef(externalComObject);
+            return new WeakReferenceableWrapper(externalComObject, Registration);
+        }
+
+        protected override void ReleaseObjects(IEnumerable objects)
+        {
+        }
+
+        public static readonly TestComWrappers TrackerSupportInstance = new TestComWrappers(WrapperRegistration.TrackerSupport);
+        public static readonly TestComWrappers MarshallingInstance = new TestComWrappers(WrapperRegistration.Marshalling);
+    }
+
     class Program
     {
-        class TestComWrappers : ComWrappers
-        {
-            public WrapperRegistration Registration { get; }
-
-            public TestComWrappers(WrapperRegistration reg = WrapperRegistration.Local)
-            {
-                Registration = reg;
-            }
-
-            protected unsafe override ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
-            {
-                count = 0;
-                return null;
-            }
-
-            protected override object CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
-            {
-                Marshal.AddRef(externalComObject);
-                return new WeakReferenceableWrapper(externalComObject, Registration);
-            }
-
-            protected override void ReleaseObjects(IEnumerable objects)
-            {
-            }
-
-            public static readonly TestComWrappers TrackerSupportInstance = new TestComWrappers(WrapperRegistration.TrackerSupport);
-            public static readonly TestComWrappers MarshallingInstance = new TestComWrappers(WrapperRegistration.Marshalling);
-        }
 
         private static void ValidateWeakReferenceState(WeakReference<WeakReferenceableWrapper> wr, bool expectedIsAlive, TestComWrappers sourceWrappers = null)
         {
@@ -135,7 +163,7 @@ namespace ComWrappersTests
             // a global ComWrappers instance. If the RCW was created throug a local ComWrappers instance, the weak
             // reference should be dead and stay dead once the RCW is collected.
             bool supportsRehydration = cw.Registration != WrapperRegistration.Local;
-            
+
             Console.WriteLine($"    -- Validate RCW recreation");
             ValidateWeakReferenceState(weakRef, expectedIsAlive: supportsRehydration, cw);
 
@@ -221,6 +249,26 @@ namespace ComWrappersTests
             Assert.IsNull(weakRef.Target);
         }
 
+        static void ValidateAggregatedWeakReference()
+        {
+            Console.WriteLine("Validate weak reference with aggregation.");
+            var (handle, weakRef) = GetWeakReference();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.IsNull(handle.Target);
+            Assert.IsFalse(weakRef.TryGetTarget(out _));
+
+            static (GCHandle handle, WeakReference<DerivedObject>) GetWeakReference()
+            {
+                DerivedObject obj = new DerivedObject(TestComWrappers.TrackerSupportInstance);
+                // We use an explicit weak GC handle here to enable us to validate that we are using "weak" GCHandle
+                // semantics with the weak reference.
+                return (GCHandle.Alloc(obj, GCHandleType.Weak), new WeakReference<DerivedObject>(obj));
+            }
+        }
+
         static int Main(string[] doNotUse)
         {
             try
@@ -235,6 +283,7 @@ namespace ComWrappersTests
 
                 ComWrappers.RegisterForTrackerSupport(TestComWrappers.TrackerSupportInstance);
                 ValidateGlobalInstanceTrackerSupport();
+                ValidateAggregatedWeakReference();
 
                 ValidateLocalInstance();
             }


### PR DESCRIPTION
This prevents us from trying to re-create a managed object that is a user-defined object deriving from an RCW type from a COM IWeakReference (which fails).

The included test crashes on main with an AV and passes with the changes in this PR.

Fixes https://github.com/microsoft/CsWinRT/issues/1025