### PR TITLE
Provide PEM implementations for AsymmetricAlgorithm.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DSA.cs
@@ -1173,20 +1173,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromPem(ReadOnlySpan<char> input)
         {
-            PemKeyImportHelpers.ImportPem(input, label => {
-                if (label.SequenceEqual(PemLabels.Pkcs8PrivateKey))
-                {
-                    return ImportPkcs8PrivateKey;
-                }
-                else if (label.SequenceEqual(PemLabels.SpkiPublicKey))
-                {
-                    return ImportSubjectPublicKeyInfo;
-                }
-                else
-                {
-                    return null;
-                }
-            });
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromPem(input);
         }
 
         /// <summary>
@@ -1255,7 +1244,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<char> password)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<char>(input, password, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, password);
         }
 
         /// <summary>
@@ -1325,7 +1316,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<byte> passwordBytes)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<byte>(input, passwordBytes, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, passwordBytes);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellman.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellman.cs
@@ -555,7 +555,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<char> password)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<char>(input, password, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, password);
         }
 
         /// <summary>
@@ -625,7 +627,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<byte> passwordBytes)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<byte>(input, passwordBytes, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, passwordBytes);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsa.cs
@@ -1419,7 +1419,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<char> password)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<char>(input, password, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, password);
         }
 
         /// <summary>
@@ -1489,7 +1491,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<byte> passwordBytes)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<byte>(input, passwordBytes, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, passwordBytes);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -769,7 +769,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<char> password)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<char>(input, password, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, password);
         }
 
         /// <summary>
@@ -839,7 +841,9 @@ namespace System.Security.Cryptography
         /// </remarks>
         public override void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<byte> passwordBytes)
         {
-            PemKeyImportHelpers.ImportEncryptedPem<byte>(input, passwordBytes, ImportEncryptedPkcs8PrivateKey);
+            // Implementation has been pushed down to AsymmetricAlgorithm. The
+            // override remains for compatibility.
+            base.ImportFromEncryptedPem(input, passwordBytes);
         }
 
         private static void ClearPrivateParameters(in RSAParameters rsaParameters)

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -90,6 +90,15 @@
   <data name="Argument_PemEncoding_EncodedSizeTooLarge" xml:space="preserve">
     <value>The encoded PEM size is too large to represent as a signed 32-bit integer.</value>
   </data>
+  <data name="Argument_PemImport_NoPemFound" xml:space="preserve">
+    <value>No supported key formats were found. Check that the input represents the contents of a PEM-encoded key file, not the path to such a file.</value>
+  </data>
+  <data name="Argument_PemImport_AmbiguousPem" xml:space="preserve">
+    <value>The input contains multiple keys, but only one key can be imported.</value>
+  </data>
+  <data name="Argument_PemImport_EncryptedPem" xml:space="preserve">
+    <value>An encrypted key was found, but no password was provided. Use ImportFromEncryptedPem to import this key.</value>
+  </data>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
     <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -21,12 +21,16 @@
              Link="Common\System\Obsoletions.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs"
              Link="Internal\Cryptography\Helpers.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\PemKeyImportHelpers.cs"
+             Link="Internal\Cryptography\PemKeyImportHelpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"
              Link="Common\System\Security\Cryptography\CryptoPool.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs"
              Link="Common\System\Security\Cryptography\KeySizeHelpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\Oids.cs"
              Link="Common\System\Security\Cryptography\Oids.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\PemLabels.cs"
+             Link="Common\System\Security\Cryptography\PemLabels.cs" />
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"
              Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="System\Security\Cryptography\AsnEncodedData.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
@@ -362,7 +362,8 @@ namespace System.Security.Cryptography
         /// </remarks>
         public virtual void ImportFromPem(ReadOnlySpan<char> input)
         {
-            PemKeyImportHelpers.ImportPem(input, label => {
+            PemKeyImportHelpers.ImportPem(input, label =>
+            {
                 if (label.SequenceEqual(PemLabels.Pkcs8PrivateKey))
                 {
                     return ImportPkcs8PrivateKey;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsymmetricAlgorithm.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Internal.Cryptography;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Security.Cryptography
@@ -165,55 +166,217 @@ namespace System.Security.Cryptography
             throw new NotImplementedException(SR.NotSupported_SubclassOverride);
 
         /// <summary>
-        /// When overridden in a derived class, imports an encrypted RFC 7468
-        /// PEM-encoded key, replacing the keys for this object.
+        /// Imports an encrypted RFC 7468 PEM-encoded key, replacing the keys for this object.
         /// </summary>
         /// <param name="input">The PEM text of the encrypted key to import.</param>
         /// <param name="password">
         /// The password to use for decrypting the key material.
         /// </param>
+        /// <exception cref="ArgumentException">
+        /// <para>
+        ///   <paramref name="input"/> does not contain a PEM-encoded key with a recognized label.
+        /// </para>
+        /// <para>
+        ///    -or-
+        /// </para>
+        /// <para>
+        ///   <paramref name="input"/> contains multiple PEM-encoded keys with a recognized label.
+        /// </para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///   The password is incorrect.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The base-64 decoded contents of the PEM text from <paramref name="input" />
+        ///   do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The base-64 decoded contents of the PEM text from <paramref name="input" />
+        ///   indicate the key is for an algorithm other than the algorithm
+        ///   represented by this instance.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The base-64 decoded contents of the PEM text from <paramref name="input" />
+        ///   represent the key in a format that is not supported.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The algorithm-specific key import failed.
+        ///   </para>
+        /// </exception>
         /// <exception cref="NotImplementedException">
-        /// A derived type has not overridden this member.
+        ///   A derived type has not provided an implementation for
+        ///  <see cref="ImportEncryptedPkcs8PrivateKey(ReadOnlySpan{char}, ReadOnlySpan{byte}, out int)" />.
         /// </exception>
         /// <remarks>
-        /// Because each algorithm may have algorithm-specific PEM labels, the
-        /// default behavior will throw <see cref="NotImplementedException" />.
+        ///   <para>
+        ///   When the base-64 decoded contents of <paramref name="input" /> indicate an algorithm that uses PBKDF1
+        ///   (Password-Based Key Derivation Function 1) or PBKDF2 (Password-Based Key Derivation Function 2),
+        ///   the password is converted to bytes via the UTF-8 encoding.
+        ///   </para>
+        ///   <para>
+        ///   Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///   are found, an exception is thrown to prevent importing a key when
+        ///   the key is ambiguous.
+        ///   </para>
+        ///   <para>This method supports the <c>ENCRYPTED PRIVATE KEY</c> PEM label.</para>
+        ///   <para>
+        ///   Types that override this method may support additional PEM labels.
+        ///   </para>
         /// </remarks>
-        public virtual void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<char> password) =>
-            throw new NotImplementedException(SR.NotSupported_SubclassOverride);
+        public virtual void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<char> password)
+        {
+            PemKeyImportHelpers.ImportEncryptedPem<char>(input, password, ImportEncryptedPkcs8PrivateKey);
+        }
 
         /// <summary>
-        /// When overridden in a derived class, imports an encrypted RFC 7468
-        /// PEM-encoded key, replacing the keys for this object.
+        /// Imports an encrypted RFC 7468 PEM-encoded key, replacing the keys for this object.
         /// </summary>
         /// <param name="input">The PEM text of the encrypted key to import.</param>
         /// <param name="passwordBytes">
         /// The bytes to use as a password when decrypting the key material.
         /// </param>
+        /// <exception cref="ArgumentException">
+        ///   <para>
+        ///     <paramref name="input"/> does not contain a PEM-encoded key with a recognized label.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///     <paramref name="input"/> contains multiple PEM-encoded keys with a recognized label.
+        ///   </para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>
+        ///   The password is incorrect.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The base-64 decoded contents of the PEM text from <paramref name="input" />
+        ///   do not represent an ASN.1-BER-encoded PKCS#8 EncryptedPrivateKeyInfo structure.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The base-64 decoded contents of the PEM text from <paramref name="input" />
+        ///   indicate the key is for an algorithm other than the algorithm
+        ///   represented by this instance.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The base-64 decoded contents of the PEM text from <paramref name="input" />
+        ///   represent the key in a format that is not supported.
+        ///   </para>
+        ///   <para>
+        ///       -or-
+        ///   </para>
+        ///   <para>
+        ///   The algorithm-specific key import failed.
+        ///   </para>
+        /// </exception>
         /// <exception cref="NotImplementedException">
-        /// A derived type has not overridden this member.
+        ///   A derived type has not provided an implementation for
+        ///  <see cref="ImportEncryptedPkcs8PrivateKey(ReadOnlySpan{byte}, ReadOnlySpan{byte}, out int)" />.
         /// </exception>
         /// <remarks>
-        /// Because each algorithm may have algorithm-specific PEM labels, the
-        /// default behavior will throw <see cref="NotImplementedException" />.
+        ///   <para>
+        ///   The password bytes are passed directly into the Key Derivation Function (KDF)
+        ///   used by the algorithm indicated by <c>pbeParameters</c>. This enables compatibility
+        ///   with other systems which use a text encoding other than UTF-8 when processing
+        ///   passwords with PBKDF2 (Password-Based Key Derivation Function 2).
+        ///   </para>
+        ///   <para>
+        ///   Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///   are found, an exception is thrown to prevent importing a key when
+        ///   the key is ambiguous.
+        ///   </para>
+        ///   <para>This method supports the <c>ENCRYPTED PRIVATE KEY</c> PEM label.</para>
+        ///   <para>
+        ///   Types that override this method may support additional PEM labels.
+        ///   </para>
         /// </remarks>
-        public virtual void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<byte> passwordBytes) =>
-            throw new NotImplementedException(SR.NotSupported_SubclassOverride);
+        public virtual void ImportFromEncryptedPem(ReadOnlySpan<char> input, ReadOnlySpan<byte> passwordBytes)
+        {
+            PemKeyImportHelpers.ImportEncryptedPem<byte>(input, passwordBytes, ImportEncryptedPkcs8PrivateKey);
+        }
 
         /// <summary>
-        /// When overridden in a derived class, imports an RFC 7468 textually
-        /// encoded key, replacing the keys for this object.
+        /// Imports an RFC 7468 textually encoded key, replacing the keys for this object.
         /// </summary>
         /// <param name="input">The text of the PEM key to import.</param>
+        /// <exception cref="ArgumentException">
+        /// <para>
+        ///   <paramref name="input"/> does not contain a PEM-encoded key with a recognized label.
+        /// </para>
+        /// <para>
+        ///   -or-
+        /// </para>
+        /// <para>
+        ///   <paramref name="input"/> contains multiple PEM-encoded keys with a recognized label.
+        /// </para>
+        /// <para>
+        ///     -or-
+        /// </para>
+        /// <para>
+        ///   <paramref name="input"/> contains an encrypted PEM-encoded key.
+        /// </para>
+        /// </exception>
         /// <exception cref="NotImplementedException">
-        /// A derived type has not overridden this member.
+        ///   A derived type has not provided an implementation for <see cref="ImportPkcs8PrivateKey" />
+        ///   or <see cref="ImportSubjectPublicKeyInfo" />.
         /// </exception>
         /// <remarks>
-        /// Because each algorithm may have algorithm-specific PEM labels, the
-        /// default behavior will throw <see cref="NotImplementedException" />.
+        ///   <para>
+        ///   Unsupported or malformed PEM-encoded objects will be ignored. If multiple supported PEM labels
+        ///   are found, an exception is raised to prevent importing a key when
+        ///   the key is ambiguous.
+        ///   </para>
+        ///   <para>
+        ///   This method supports the following PEM labels:
+        ///   <list type="bullet">
+        ///     <item><description>PUBLIC KEY</description></item>
+        ///     <item><description>PRIVATE KEY</description></item>
+        ///   </list>
+        ///   </para>
+        ///   <para>
+        ///   Types that override this method may support additional PEM labels.
+        ///   </para>
         /// </remarks>
-        public virtual void ImportFromPem(ReadOnlySpan<char> input) =>
-            throw new NotImplementedException(SR.NotSupported_SubclassOverride);
+        public virtual void ImportFromPem(ReadOnlySpan<char> input)
+        {
+            PemKeyImportHelpers.ImportPem(input, label => {
+                if (label.SequenceEqual(PemLabels.Pkcs8PrivateKey))
+                {
+                    return ImportPkcs8PrivateKey;
+                }
+                else if (label.SequenceEqual(PemLabels.SpkiPublicKey))
+                {
+                    return ImportSubjectPublicKeyInfo;
+                }
+                else
+                {
+                    return null;
+                }
+            });
+        }
 
         private delegate bool TryExportPbe<T>(
             ReadOnlySpan<T> password,

--- a/src/libraries/System.Security.Cryptography/tests/AsymmetricAlgorithmTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/AsymmetricAlgorithmTests.cs
@@ -1,0 +1,257 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    public static class AsymmetricAlgorithmTests
+    {
+        [Fact]
+        public static void ImportFromPem_AcceptsSubjectPublicKeyInfo()
+        {
+            string pemText = @"
+                Test that this PEM block is skipped since it is not an understood PEM label.
+                -----BEGIN SLEEPING-----
+                zzzz
+                -----END SLEEPING-----
+                -----BEGIN PUBLIC KEY-----
+                c2xlZXA=
+                -----END PUBLIC KEY-----";
+
+            static void ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source, out int bytesRead)
+            {
+                ReadOnlySpan<byte> expected = new byte[] { 0x73, 0x6c, 0x65, 0x65, 0x70 };
+                AssertExtensions.SequenceEqual(expected, source);
+                bytesRead = expected.Length;
+            }
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                alg.ImportSubjectPublicKeyInfoImpl = ImportSubjectPublicKeyInfo;
+                alg.ImportFromPem(pemText);
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_AcceptsPkcs8PrivateKey()
+        {
+            string pemText = @"
+                Test that this PEM block is skipped since it is not an understood PEM label.
+                -----BEGIN SLEEPING-----
+                zzzz
+                -----END SLEEPING-----
+                -----BEGIN PRIVATE KEY-----
+                c2xlZXA=
+                -----END PRIVATE KEY-----";
+
+            static void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead)
+            {
+                ReadOnlySpan<byte> expected = new byte[] { 0x73, 0x6c, 0x65, 0x65, 0x70 };
+                AssertExtensions.SequenceEqual(expected, source);
+                bytesRead = expected.Length;
+            }
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                alg.ImportPkcs8PrivateKeyImpl = ImportPkcs8PrivateKey;
+                alg.ImportFromPem(pemText);
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_AcceptsEncryptedPkcs8PrivateKey_PasswordBytes()
+        {
+            string pemText = @"
+                Test that this PEM block is skipped since it is not an understood PEM label.
+                -----BEGIN SLEEPING-----
+                zzzz
+                -----END SLEEPING-----
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                c2xlZXA=
+                -----END ENCRYPTED PRIVATE KEY-----";
+            byte[] pemPassword = new byte[] { 1, 2, 3, 4, 5 };
+
+            void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ReadOnlySpan<byte> expected = new byte[] { 0x73, 0x6c, 0x65, 0x65, 0x70 };
+                AssertExtensions.SequenceEqual(expected, source);
+                AssertExtensions.SequenceEqual(pemPassword, passwordBytes);
+                bytesRead = expected.Length;
+            }
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                alg.ImportEncryptedPkcs8PrivateKeyByteFunc = ImportEncryptedPkcs8PrivateKey;
+                alg.ImportFromEncryptedPem(pemText, pemPassword);
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_AcceptsEncryptedPkcs8PrivateKey_PasswordChars()
+        {
+            string pemText = @"
+                Test that this PEM block is skipped since it is not an understood PEM label.
+                -----BEGIN SLEEPING-----
+                zzzz
+                -----END SLEEPING-----
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                c2xlZXA=
+                -----END ENCRYPTED PRIVATE KEY-----";
+            string pemPassword = "PLACEHOLDER";
+
+            void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ReadOnlySpan<byte> expected = new byte[] { 0x73, 0x6c, 0x65, 0x65, 0x70 };
+                AssertExtensions.SequenceEqual(expected, source);
+                AssertExtensions.SequenceEqual(pemPassword, password);
+                bytesRead = expected.Length;
+            }
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                alg.ImportEncryptedPkcs8PrivateKeyCharFunc = ImportEncryptedPkcs8PrivateKey;
+                alg.ImportFromEncryptedPem(pemText, pemPassword);
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_AmbiguousKey()
+        {
+            string pemText = @"
+                -----BEGIN PUBLIC KEY-----
+                c2xlZXA=
+                -----END PUBLIC KEY-----
+                -----BEGIN PUBLIC KEY-----
+                Y29mZmVl
+                -----END PUBLIC KEY-----";
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                AssertExtensions.Throws<ArgumentException>("input", () => alg.ImportFromPem(pemText));
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_Encrypted_AmbiguousKey()
+        {
+            string pemText = @"
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                c2xlZXA=
+                -----END ENCRYPTED PRIVATE KEY-----
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                Y29mZmVl
+                -----END ENCRYPTED PRIVATE KEY-----";
+            string pemPassword = "PLACEHOLDER";
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                AssertExtensions.Throws<ArgumentException>("input", () => alg.ImportFromEncryptedPem(pemText, pemPassword));
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_NoUnderstoodPemLabel()
+        {
+            string pemText = @"
+                -----BEGIN SLEEPING-----
+                zzzz
+                -----END SLEEPING-----";
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                AssertExtensions.Throws<ArgumentException>("input", () => alg.ImportFromPem(pemText));
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_Encrypted_NoUnderstoodPemLabel()
+        {
+            string pemText = @"
+                -----BEGIN SLEEPING-----
+                zzzz
+                -----END SLEEPING-----";
+            string pemPassword = "PLACEHOLDER";
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                AssertExtensions.Throws<ArgumentException>("input", () => alg.ImportFromEncryptedPem(pemText, pemPassword));
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_EncryptedPemWithoutPassword()
+        {
+            string pemText = @"
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                c2xlZXA=
+                -----END ENCRYPTED PRIVATE KEY-----";
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                AssertExtensions.Throws<ArgumentException>("input", () => alg.ImportFromPem(pemText));
+            }
+        }
+
+        [Fact]
+        public static void ImportFromPem_NotEncryptedWithPassword()
+        {
+            string pemText = @"
+                -----BEGIN PRIVATE KEY-----
+                c2xlZXA=
+                -----END PRIVATE KEY-----";
+            string pemPassword = "PLACEHOLDER";
+
+            using (ImportAsymmetricAlgorithm alg = new ImportAsymmetricAlgorithm())
+            {
+                AssertExtensions.Throws<ArgumentException>("input", () => alg.ImportFromEncryptedPem(pemText, pemPassword));
+            }
+        }
+
+        private class ImportAsymmetricAlgorithm : AsymmetricAlgorithm
+        {
+            public delegate void ImportSubjectPublicKeyInfoFunc(ReadOnlySpan<byte> source, out int bytesRead);
+            public delegate void ImportPkcs8PrivateKeyFunc(ReadOnlySpan<byte> source, out int bytesRead);
+            public delegate void ImportEncryptedPkcs8PrivateKeyFunc<TPass>(
+                ReadOnlySpan<TPass> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead);
+
+            public ImportSubjectPublicKeyInfoFunc ImportSubjectPublicKeyInfoImpl { get; set; }
+            public ImportPkcs8PrivateKeyFunc ImportPkcs8PrivateKeyImpl { get; set; }
+            public ImportEncryptedPkcs8PrivateKeyFunc<byte> ImportEncryptedPkcs8PrivateKeyByteFunc { get; set; }
+            public ImportEncryptedPkcs8PrivateKeyFunc<char> ImportEncryptedPkcs8PrivateKeyCharFunc { get; set; }
+
+            public override void ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source, out int bytesRead) =>
+                ImportSubjectPublicKeyInfoImpl(source, out bytesRead);
+
+            public override void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead) =>
+                ImportPkcs8PrivateKeyImpl(source, out bytesRead);
+
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ImportEncryptedPkcs8PrivateKeyByteFunc(passwordBytes, source, out bytesRead);
+            }
+
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ImportEncryptedPkcs8PrivateKeyCharFunc(password, source, out bytesRead);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="AsnEncodedDataTests.cs" />
     <Compile Include="AsnEncodedDataCollectionTests.cs" />
     <Compile Include="AsymmetricAlgorithm\Trivial.cs" />
+    <Compile Include="AsymmetricAlgorithmTests.cs" />
     <Compile Include="Base64TransformsTests.cs" />
     <Compile Include="CryptoConfigTests.cs" />
     <Compile Include="CryptographicException.cs" />


### PR DESCRIPTION
Now that the Encoding and Primitive assemblies are unified, an implementation for PKCS#8 and SPKI keys can be provided in the abstract `AsymmetricAlgorithm` when importing PEM. Derived types will continue to override these members to provide support for additional PEM labels.

This is essentially addressing the feedback at https://github.com/dotnet/runtime/pull/34086#discussion_r404377337

> If we move the class around perhaps we'll remember to come fill this in.

So here we are.