### PR TITLE
Proper VNs for zeroed structs

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7986,7 +7986,7 @@ public:
     bool eeIsJitIntrinsic(CORINFO_METHOD_HANDLE ftn);
     bool eeIsFieldStatic(CORINFO_FIELD_HANDLE fldHnd);
 
-    var_types eeGetFieldType(CORINFO_FIELD_HANDLE fldHnd);
+    var_types eeGetFieldType(CORINFO_FIELD_HANDLE fldHnd, CORINFO_CLASS_HANDLE* pStructHnd = nullptr);
 
 #if defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD) || defined(TRACK_LSRA_STATS)
 

--- a/src/coreclr/jit/ee_il_dll.hpp
+++ b/src/coreclr/jit/ee_il_dll.hpp
@@ -68,9 +68,9 @@ bool Compiler::eeIsFieldStatic(CORINFO_FIELD_HANDLE fldHnd)
 }
 
 FORCEINLINE
-var_types Compiler::eeGetFieldType(CORINFO_FIELD_HANDLE fldHnd)
+var_types Compiler::eeGetFieldType(CORINFO_FIELD_HANDLE fldHnd, CORINFO_CLASS_HANDLE* pStructHnd)
 {
-    return JITtype2varType(info.compCompHnd->getFieldType(fldHnd));
+    return JITtype2varType(info.compCompHnd->getFieldType(fldHnd, pStructHnd));
 }
 
 FORCEINLINE

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -464,11 +464,9 @@ ValueNumStore::ValueNumStore(Compiler* comp, CompAllocator alloc)
     {
         m_VNsForSmallIntConsts[i] = NoVN;
     }
-    // We will reserve chunk 0 to hold some special constants, like the constant NULL, the "exception" value, and the
-    // "zero map."
+    // We will reserve chunk 0 to hold some special constants.
     Chunk* specialConstChunk = new (m_alloc) Chunk(m_alloc, &m_nextChunkBase, TYP_REF, CEA_Const);
-    specialConstChunk->m_numUsed +=
-        SRC_NumSpecialRefConsts; // Implicitly allocate 0 ==> NULL, and 1 ==> Exception, 2 ==> ZeroMap.
+    specialConstChunk->m_numUsed += SRC_NumSpecialRefConsts;
     ChunkNum cn = m_chunks.Push(specialConstChunk);
     assert(cn == 0);
 
@@ -1787,8 +1785,6 @@ ValueNum ValueNumStore::VNForHandle(ssize_t cnsVal, GenTreeFlags handleFlags)
     }
 }
 
-// Returns the value number for zero of the given "typ".
-// It has an unreached() for a "typ" that has no zero value, such as TYP_VOID.
 ValueNum ValueNumStore::VNZeroForType(var_types typ)
 {
     switch (typ)
@@ -1812,8 +1808,6 @@ ValueNum ValueNumStore::VNZeroForType(var_types typ)
             return VNForNull();
         case TYP_BYREF:
             return VNForByrefCon(0);
-        case TYP_STRUCT:
-            return VNForZeroMap(); // Recursion!
 
 #ifdef FEATURE_SIMD
         case TYP_SIMD8:
@@ -1827,6 +1821,16 @@ ValueNum ValueNumStore::VNZeroForType(var_types typ)
         default:
             unreached(); // Should handle all types.
     }
+}
+
+ValueNum ValueNumStore::VNForZeroObj(CORINFO_CLASS_HANDLE structHnd)
+{
+    assert(structHnd != NO_CLASS_HANDLE);
+
+    ValueNum structHndVN = VNForHandle(ssize_t(structHnd), GTF_ICON_CLASS_HDL);
+    ValueNum zeroObjVN   = VNForFunc(TYP_STRUCT, VNF_ZeroObj, structHndVN);
+
+    return zeroObjVN;
 }
 
 // Returns the value number for one of the given "typ".
@@ -2317,14 +2321,9 @@ TailCall:
             return RecursiveVN;
         }
 
-        if (map == VNForZeroMap())
+        VNFuncApp funcApp;
+        if (GetVNFunc(map, &funcApp))
         {
-            return VNZeroForType(type);
-        }
-        else if (IsVNFunc(map))
-        {
-            VNFuncApp funcApp;
-            GetVNFunc(map, &funcApp);
             if (funcApp.m_func == VNF_MapStore)
             {
                 // select(store(m, i, v), i) == v
@@ -2475,6 +2474,22 @@ TailCall:
                     assert(FixedPointMapSelsTopHasValue(map, index));
                     m_fixedPointMapSels.Pop();
                 }
+            }
+            else if (funcApp.m_func == VNF_ZeroObj)
+            {
+                // For structs, we need to extract the handle from the selector.
+                if (type == TYP_STRUCT)
+                {
+                    // We only expect field selectors here.
+                    assert(GetHandleFlags(index) == GTF_ICON_FIELD_HDL);
+                    CORINFO_FIELD_HANDLE fieldHnd  = CORINFO_FIELD_HANDLE(ConstantValue<ssize_t>(index));
+                    CORINFO_CLASS_HANDLE structHnd = NO_CLASS_HANDLE;
+                    m_pComp->eeGetFieldType(fieldHnd, &structHnd);
+
+                    return VNForZeroObj(structHnd);
+                }
+
+                return VNZeroForType(type);
             }
         }
 
@@ -5792,11 +5807,6 @@ void ValueNumStore::vnDump(Compiler* comp, ValueNum vn, bool isPtr)
                 {
                     printf("void");
                 }
-                else
-                {
-                    assert(vn == VNForZeroMap());
-                    printf("zeroMap");
-                }
                 break;
             case TYP_BYREF:
                 printf("byrefVal");
@@ -5867,6 +5877,9 @@ void ValueNumStore::vnDump(Compiler* comp, ValueNum vn, bool isPtr)
             case VNF_Cast:
             case VNF_CastOvf:
                 vnDumpCast(comp, vn);
+                break;
+            case VNF_ZeroObj:
+                vnDumpZeroObj(comp, &funcApp);
                 break;
 
             default:
@@ -6089,6 +6102,12 @@ void ValueNumStore::vnDumpCast(Compiler* comp, ValueNum castVN)
     }
 }
 
+void ValueNumStore::vnDumpZeroObj(Compiler* comp, VNFuncApp* zeroObj)
+{
+    printf("ZeroObj(");
+    comp->vnPrint(zeroObj->m_args[0], 0);
+    printf(": %s)", comp->eeGetClassName(CORINFO_CLASS_HANDLE(ConstantValue<ssize_t>(zeroObj->m_args[0]))));
+}
 #endif // DEBUG
 
 // Static fields, methods.
@@ -6252,10 +6271,9 @@ static const char* s_reservedNameArr[] = {
     "$VN.Recursive",    // -2  RecursiveVN
     "$VN.No",           // -1  NoVN
     "$VN.Null",         //  0  VNForNull()
-    "$VN.ZeroMap",      //  1  VNForZeroMap()
-    "$VN.ReadOnlyHeap", //  2  VNForROH()
-    "$VN.Void",         //  3  VNForVoid()
-    "$VN.EmptyExcSet"   //  4  VNForEmptyExcSet()
+    "$VN.ReadOnlyHeap", //  1  VNForROH()
+    "$VN.Void",         //  2  VNForVoid()
+    "$VN.EmptyExcSet"   //  3  VNForEmptyExcSet()
 };
 
 // Returns the string name of "vn" when it is a reserved value number, nullptr otherwise
@@ -6680,7 +6698,8 @@ void Compiler::fgValueNumber()
                     if (isZeroed)
                     {
                         // By default we will zero init these LclVars
-                        initVal = vnStore->VNZeroForType(typ);
+                        initVal = (typ == TYP_STRUCT) ? vnStore->VNForZeroObj(varDsc->GetStructHnd())
+                                                      : vnStore->VNZeroForType(typ);
                     }
                     else
                     {
@@ -7942,39 +7961,38 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
             // Should not have been recorded as updating the GC heap.
             assert(!GetMemorySsaMap(GcHeap)->Lookup(tree));
 
-            unsigned lclNum = lclVarTree->GetLclNum();
-
             unsigned lclDefSsaNum = GetSsaNumForLocalVarDef(lclVarTree);
+
             // Ignore vars that we excluded from SSA (for example, because they're address-exposed). They don't have
             // SSA names in which to store VN's on defs.  We'll yield unique VN's when we read from them.
-            if (lvaInSsa(lclNum) && lclDefSsaNum != SsaConfig::RESERVED_SSA_NUM)
+            if (lclDefSsaNum != SsaConfig::RESERVED_SSA_NUM)
             {
+                LclVarDsc* lclVarDsc = lvaGetDesc(lclVarTree);
+
                 // Should not have been recorded as updating ByrefExposed.
                 assert(!GetMemorySsaMap(ByrefExposed)->Lookup(tree));
 
-                ValueNum initBlkVN = ValueNumStore::NoVN;
-                GenTree* initConst = rhs;
-                if (isEntire && initConst->OperGet() == GT_CNS_INT)
+                ValueNum lclVarVN = ValueNumStore::NoVN;
+                if (isEntire && rhs->IsIntegralConst(0))
                 {
-                    unsigned initVal = 0xFF & (unsigned)initConst->AsIntConCommon()->IconValue();
-                    if (initVal == 0)
-                    {
-                        initBlkVN = vnStore->VNZeroForType(lclVarTree->TypeGet());
-                    }
+                    // Note that it is possible to see pretty much any kind of type for the local
+                    // (not just TYP_STRUCT) here because of the ASG(BLK(ADDR(LCL_VAR/FLD)), 0) form.
+                    lclVarVN = (lclVarDsc->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(lclVarDsc->GetStructHnd())
+                                                                    : vnStore->VNZeroForType(lclVarDsc->TypeGet());
                 }
-                ValueNum lclVarVN = (initBlkVN != ValueNumStore::NoVN)
-                                        ? initBlkVN
-                                        : vnStore->VNForExpr(compCurBB, var_types(lvaTable[lclNum].lvType));
+                else
+                {
+                    // Non-zero block init is very rare so we'll use a simple, unique VN here.
+                    lclVarVN = vnStore->VNForExpr(compCurBB, lclVarDsc->TypeGet());
+                }
 
-                lvaTable[lclNum].GetPerSsaData(lclDefSsaNum)->m_vnPair.SetBoth(lclVarVN);
+                lclVarDsc->GetPerSsaData(lclDefSsaNum)->m_vnPair.SetBoth(lclVarVN);
 #ifdef DEBUG
                 if (verbose)
                 {
-                    printf("N%03u ", tree->gtSeqNum);
+                    printf("Tree ");
                     Compiler::printTreeID(tree);
-                    printf(" ");
-                    gtDispNodeName(tree);
-                    printf(" V%02u/%d => ", lclNum, lclDefSsaNum);
+                    printf(" assigned VN to local var V%02u/%d: ", lclVarTree->GetLclNum(), lclDefSsaNum);
                     vnPrint(lclVarVN, 1);
                     printf("\n");
                 }

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -420,13 +420,6 @@ public:
         return ValueNum(SRC_Null);
     }
 
-    // The zero map is the map that returns a zero "for the appropriate type" when indexed at any index.
-    static ValueNum VNForZeroMap()
-    {
-        // We reserve Chunk 0 for "special" VNs.  Let SRC_ZeroMap (== 1) be the zero map.
-        return ValueNum(SRC_ZeroMap);
-    }
-
     // The ROH map is the map for the "read-only heap".  We assume that this is never mutated, and always
     // has the same value number.
     static ValueNum VNForROH()
@@ -462,6 +455,9 @@ public:
     // Returns the value number for zero of the given "typ".
     // It has an unreached() for a "typ" that has no zero value, such as TYP_VOID.
     ValueNum VNZeroForType(var_types typ);
+
+    // Returns the value number for a zero-initialized struct.
+    ValueNum VNForZeroObj(CORINFO_CLASS_HANDLE structHnd);
 
     // Returns the value number for one of the given "typ".
     // It returns NoVN for a "typ" that has no one value, such as TYP_REF.
@@ -1021,6 +1017,9 @@ public:
     // Prints the cast's representation mirroring GT_CAST's dump format.
     void vnDumpCast(Compiler* comp, ValueNum castVN);
 
+    // Requires "zeroObj" to be a VNF_ZeroObj. Prints its representation.
+    void vnDumpZeroObj(Compiler* comp, VNFuncApp* zeroObj);
+
     // Returns the string name of "vnf".
     static const char* VNFuncName(VNFunc vnf);
     // Used in the implementation of the above.
@@ -1449,7 +1448,6 @@ private:
     enum SpecialRefConsts
     {
         SRC_Null,
-        SRC_ZeroMap,
         SRC_ReadOnlyHeap,
         SRC_Void,
         SRC_EmptyExcSet,

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -463,6 +463,11 @@ public:
     // It returns NoVN for a "typ" that has no one value, such as TYP_REF.
     ValueNum VNOneForType(var_types typ);
 
+#ifdef FEATURE_SIMD
+    // A helper function for constructing VNF_SimdType VNs.
+    ValueNum VNForSimdType(unsigned simdSize, var_types simdBaseType);
+#endif // FEATURE_SIMD
+
     // Create or return the existimg value number representing a singleton exception set
     // for the the exception value "x".
     ValueNum VNExcSetSingleton(ValueNum x);

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -12,7 +12,6 @@ ValueNumFuncDef(MapSelect, 2, false, false, false)  // Args: 0: map, 1: key.
 
 ValueNumFuncDef(FieldSeq, 2, false, false, false)   // Sequence (VN of null == empty) of (VN's of) field handles.
 ValueNumFuncDef(NotAField, 0, false, false, false)  // Value number function for FieldSeqStore::NotAField.
-ValueNumFuncDef(ZeroMap, 0, false, false, false)    // The "ZeroMap": indexing at any index yields "zero of the desired type".
 
 ValueNumFuncDef(PtrToLoc, 2, false, false, false)           // Pointer (byref) to a local variable.  Args: VN's of: 0: var num, 1: FieldSeq.
 ValueNumFuncDef(PtrToArrElem, 4, false, false, false)       // Pointer (byref) to an array element.  Args: 0: array elem type eq class var_types value, VN's of: 1: array, 2: index, 3: FieldSeq.
@@ -22,6 +21,7 @@ ValueNumFuncDef(Phi, 2, false, false, false)        // A phi function.  Only occ
 ValueNumFuncDef(PhiDef, 3, false, false, false)     // Args: 0: local var # (or -1 for memory), 1: SSA #, 2: VN of definition.
 // Wouldn't need this if I'd made memory a regular local variable...
 ValueNumFuncDef(PhiMemoryDef, 2, false, false, false) // Args: 0: VN for basic block pointer, 1: VN of definition
+ValueNumFuncDef(ZeroObj, 1, false, false, false)    // Zero-initialized struct. Args: 0: VN of the class handle.
 ValueNumFuncDef(InitVal, 1, false, false, false)    // An input arg, or init val of a local Args: 0: a constant VN.
 
 


### PR DESCRIPTION
Previously, zero-initialized struct locals were given a special `$VNForZeroMap`, which had the nice property that `VNForMapSelect($VNForZeroMap, Field)` would always return zero of the appropriate type. However, the fact that this VN is not unique meant that it was dangerous to propagate it, e. g. through copies, which was hidden by the fact that `ApplySelectorsTypeCheck`'s logic is very conservative.

This change introduces a new `VNFunc` to represent zeroed objects - `VNF_ZeroObj`, that takes a struct handle as its argument and is thus free of the aforementioned problem and can be propagated freely and not treated specially. It also, of course, retains the `ZeroMap`'s selection property.

There are almost no diffs ([`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61285/win-x64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61285/win-x86.md), [`win-arm64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61285/win-arm64.md)) for this change because of some other deficiencies in assertion and copy propagation, they are being/will be fixed separately, so the main point of this change is to contribute to #58312.

<details>
<summary>Notes about the diffs</summary>

Some are exactly what we'd expect: dead code elimination due to better propagation of zeroes though struct copies:
```cs
Struct a = default;

{ ... other blocks ... }

Struct b = a;

{ ... other blocks ... }

if (b.Field == 0) { ... } // Now we can recognize this as always true
```

Others are bizarre: CSEs created for the `IND` trees like the following:
```scala
N011 ( 26, 17)              [000045] --CXG-------                 +--*  CALL      int    B.Test_Nested $14b
N010 ( 12, 14)              [000174] -c--G------- arg0 x0,x1      |  \--*  FIELD_LIST struct $8b
N004 (  6,  7) CSE #01 (use)[000175] n---G------- ofs 0           |     +--*  IND       long   $200
N003 (  3,  5)              [000046] ----G-------                 |     |  \--*  ADDR      byref  $1c6
N002 (  3,  4)              [000040] -------N----                 |     |     \--*  LCL_FLD   struct V00 loc0         u:2[+144] Fseq[hackishFieldName, hackishFieldName] $84
N009 (  6,  7)              [000180] n---G------- ofs 8           |     \--*  IND       int    $14a
N008 (  5,  8)              [000179] ----G--N----                 |        \--*  ADD       byref  $1c7
N006 (  3,  5)              [000176] ----G-------                 |           +--*  ADDR      byref  $1c6
N005 (  3,  4)              [000177] -------N----                 |           |  \--*  LCL_FLD   struct V00 loc0         u:2[+144] Fseq[hackishFieldName, hackishFieldName] (last use) $84
N007 (  1,  2)              [000178] ------------                 |           \--*  CNS_INT   long   8 $240
```

Here we have another case of type mismatch: VN thinks that the fields in the list are in fact struct fields:
```scala
***** BB07, STMT00005(before)
N014 ( 30, 22) [000050] --CXG-------              *  JTRUE     void  
N013 ( 28, 20) [000049] J-CXG--N----              \--*  EQ        int   
N011 ( 26, 17) [000045] --CXG-------                 +--*  CALL      int    B.Test_Nested
N010 ( 12, 14) [000174] -c--G------- arg0 x0,x1      |  \--*  FIELD_LIST struct
N004 (  6,  7) [000175] n---G------- ofs 0           |     +--*  IND       long  
N003 (  3,  5) [000046] ----G-------                 |     |  \--*  ADDR      byref 
N002 (  3,  4) [000040] -------N----                 |     |     \--*  LCL_FLD   struct V00 loc0         u:2[+144] Fseq[hackishFieldName, hackishFieldName]
N009 (  6,  7) [000180] n---G------- ofs 8           |     \--*  IND       int   
N008 (  5,  8) [000179] ----G--N----                 |        \--*  ADD       byref 
N006 (  3,  5) [000176] ----G-------                 |           +--*  ADDR      byref 
N005 (  3,  4) [000177] -------N----                 |           |  \--*  LCL_FLD   struct V00 loc0         u:2[+144] Fseq[hackishFieldName, hackishFieldName] (last use)
N007 (  1,  2) [000178] ------------                 |           \--*  CNS_INT   long   8
N012 (  1,  2) [000048] ------------                 \--*  CNS_INT   int    100

N001 [000173]   ARGPLACE  => $8a {MemOpaque:NotInLoop}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $46, fieldType is struct, size = 48
    VNForMapSelect($80, $46):struct returns $83 {ZeroObj($42)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $45, fieldType is struct, size = 12
    VNForMapSelect($83, $45):struct returns $84 {ZeroObj($44)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $46, fieldType is struct, size = 48
    VNForMapSelect($80, $46):struct returns $83 {ZeroObj($42)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $45, fieldType is struct, size = 12
    VNForMapSelect($83, $45):struct returns $84 {ZeroObj($44)}
N002 [000040]   LCL_FLD   V00 loc0         u:2[+144] Fseq[hackishFieldName, hackishFieldName] => $84 {ZeroObj($44)}
    FieldSeq {hackishFieldName} is $182
    FieldSeq {(hackishFieldName, hackishFieldName)} is $185
N003 [000046]   ADDR      => $1c6 {PtrToLoc($c0, $185)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $46, fieldType is struct, size = 48
    VNForMapSelect($80, $46):struct returns $83 {ZeroObj($42)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $45, fieldType is struct, size = 12
    VNForMapSelect($83, $45):struct returns $84 {ZeroObj($44)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $46, fieldType is struct, size = 48
    VNForMapSelect($80, $46):struct returns $83 {ZeroObj($42)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $45, fieldType is struct, size = 12
    VNForMapSelect($83, $45):struct returns $84 {ZeroObj($44)}
N004 [000175]   IND       => $200 {$84, long <- struct}
```

This is "ok" because it only thinks that for the first field (subsequent ones get `PtrToLoc` with `NotAField` VNs because the constant offsets do not have field sequences), and the `long` type of this "field" is fixed by the ABI, so this VN represents a properly unique value. It is definitely not by design though.

Previously such `IND`s got `$VN.ZeroMap` assigned to them (which is only supposed to be used for structs!) and did not get CSEd.

Reproduction for this:
```cs
private static int Problem(LargeStruct valueArg, int c)
{
    var value = valueArg;

    if (c is 1)
    {
        return 1;
    }

    CallForMultiRegStruct(value.SmallerStruct1.MultiRegStruct1);

    return 0;
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void CallForMultiRegStruct(MultiRegStruct value) { }

struct MultiRegStruct
{
    public long FirstValue;
    public long SecondValue;
}

struct LargeStruct
{
    public SmallerStruct SmallerStruct1;
    public SmallerStruct SmallerStruct2;
}

struct SmallerStruct
{
    public MultiRegStruct MultiRegStruct1;
    public MultiRegStruct MultiRegStruct2;
    public MultiRegStruct MultiRegStruct3;
}
```
</details>

Part of #58312.