### PR TITLE
 Fix FileSystemAclExtensions.Create when passing a null FileSecurity

### DIFF
--- a/src/libraries/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
@@ -9,7 +9,7 @@ namespace System.IO
     public static partial class FileSystemAclExtensions
     {
         public static void Create(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.DirectorySecurity directorySecurity) { }
-        public static System.IO.FileStream Create(this System.IO.FileInfo fileInfo, System.IO.FileMode mode, System.Security.AccessControl.FileSystemRights rights, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options, System.Security.AccessControl.FileSecurity fileSecurity) { throw null; }
+        public static System.IO.FileStream Create(this System.IO.FileInfo fileInfo, System.IO.FileMode mode, System.Security.AccessControl.FileSystemRights rights, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options, System.Security.AccessControl.FileSecurity? fileSecurity) { throw null; }
         public static System.IO.DirectoryInfo CreateDirectory(this System.Security.AccessControl.DirectorySecurity directorySecurity, string path) { throw null; }
         public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo) { throw null; }
         public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.AccessControlSections includeSections) { throw null; }

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/Resources/Strings.resx
@@ -122,6 +122,9 @@
   <data name="Arg_MustBeIdentityReferenceType" xml:space="preserve">
     <value>Type must be an IdentityReference, such as NTAccount or SecurityIdentifier.</value>
   </data>
+  <data name="Argument_InvalidAppendMode" xml:space="preserve">
+    <value>Append access can be requested only in write-only mode.</value>
+  </data>
   <data name="Argument_InvalidEnumValue" xml:space="preserve">
     <value>The value '{0}' is not valid for this usage of the type {1}.</value>
   </data>

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -170,7 +170,7 @@ namespace System.IO
         /// <exception cref="IOException">An I/O error occurs.</exception>
         /// <exception cref="UnauthorizedAccessException">Access to the path is denied.</exception>
         /// <remarks>This extension method was added to .NET Core to bring the functionality that was provided by the `System.IO.FileStream.#ctor(System.String,System.IO.FileMode,System.Security.AccessControl.FileSystemRights,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.Security.AccessControl.FileSecurity)` .NET Framework constructor.</remarks>
-        public static FileStream Create(this FileInfo fileInfo, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+        public static FileStream Create(this FileInfo fileInfo, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity? fileSecurity)
         {
             if (fileInfo == null)
             {

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -284,7 +284,6 @@ namespace System.IO
                 (rights & FileSystemRights.ReadAttributes) != 0 ||
                 (rights & FileSystemRights.ReadPermissions) != 0 ||
                 (rights & FileSystemRights.TakeOwnership) != 0 ||
-                (rights & FileSystemRights.Synchronize) != 0 ||
                 ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_READ) != 0)
             {
                 access = FileAccess.Read;
@@ -302,7 +301,10 @@ namespace System.IO
                 access |= FileAccess.Write;
             }
 
-            Debug.Assert(access != 0);
+            if (access == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(rights));
+            }
 
             return access;
         }

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -159,10 +159,10 @@ namespace System.IO
         /// <param name="share">One of the enumeration values for controlling the kind of access other FileStream objects can have to the same file.</param>
         /// <param name="bufferSize">The number of bytes buffered for reads and writes to the file.</param>
         /// <param name="options">One of the enumeration values that describes how to create or overwrite the file.</param>
-        /// <param name="fileSecurity">An object that determines the access control and audit security for the file.</param>
+        /// <param name="fileSecurity">An optional object that determines the access control and audit security for the file.</param>
         /// <returns>A file stream for the newly created file.</returns>
         /// <exception cref="ArgumentException">The <paramref name="rights" /> and <paramref name="mode" /> combination is invalid.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="fileInfo" /> or <paramref name="fileSecurity" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="fileInfo" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="mode" /> or <paramref name="share" /> are out of their legal enum range.
         ///-or-
         /// <paramref name="bufferSize" /> is not a positive number.</exception>
@@ -175,11 +175,6 @@ namespace System.IO
             if (fileInfo == null)
             {
                 throw new ArgumentNullException(nameof(fileInfo));
-            }
-
-            if (fileSecurity == null)
-            {
-                throw new ArgumentNullException(nameof(fileSecurity));
             }
 
             // don't include inheritable in our bounds check for share
@@ -200,9 +195,24 @@ namespace System.IO
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
             }
 
-            // Do not allow using combinations of non-writing file system rights with writing file modes
+            // Do not combine writing modes with exclusively read rights
+            // Write contains AppendData, WriteAttributes, WriteData and WriteExtendedAttributes
             if ((rights & FileSystemRights.Write) == 0 &&
                 (mode == FileMode.Truncate || mode == FileMode.CreateNew || mode == FileMode.Create || mode == FileMode.Append))
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_InvalidFileModeAndFileSystemRightsCombo, mode, rights));
+            }
+
+            // Additionally, append is disallowed if any read rights are provided
+            // ReadAndExecute contains ExecuteFile, ReadAttributes, ReadData, ReadExtendedAttributes and ReadPermissions
+            if ((rights & FileSystemRights.ReadAndExecute) != 0 && mode == FileMode.Append)
+            {
+                throw new ArgumentException(SR.Argument_InvalidAppendMode);
+            }
+
+            // Cannot truncate unless all of the write rights are provided
+            // Write contains AppendData, WriteAttributes, WriteData and WriteExtendedAttributes
+            if (mode == FileMode.Truncate && (rights & FileSystemRights.Write) != FileSystemRights.Write)
             {
                 throw new ArgumentException(SR.Format(SR.Argument_InvalidFileModeAndFileSystemRightsCombo, mode, rights));
             }
@@ -211,7 +221,7 @@ namespace System.IO
 
             try
             {
-                return new FileStream(handle, GetFileStreamFileAccess(rights), bufferSize, (options & FileOptions.Asynchronous) != 0);
+                return new FileStream(handle, GetFileAccessFromRights(rights), bufferSize, (options & FileOptions.Asynchronous) != 0);
             }
             catch
             {
@@ -258,23 +268,46 @@ namespace System.IO
 
         // In the context of a FileStream, the only ACCESS_MASK ACE rights we care about are reading/writing data and the generic read/write rights.
         // See: https://docs.microsoft.com/en-us/windows/win32/secauthz/access-mask
-        private static FileAccess GetFileStreamFileAccess(FileSystemRights rights)
+        private static FileAccess GetFileAccessFromRights(FileSystemRights rights)
         {
             FileAccess access = 0;
-            if ((rights & FileSystemRights.ReadData) != 0 || ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_READ) != 0)
+
+            if ((rights & FileSystemRights.FullControl) != 0 ||
+                (rights & FileSystemRights.Modify) != 0)
+            {
+                return FileAccess.ReadWrite;
+            }
+
+            if ((rights & FileSystemRights.ReadData) != 0 || // Same as ListDirectory
+                (rights & FileSystemRights.ReadExtendedAttributes) != 0 ||
+                (rights & FileSystemRights.ExecuteFile) != 0 || // Same as Traverse
+                (rights & FileSystemRights.ReadAttributes) != 0 ||
+                (rights & FileSystemRights.ReadPermissions) != 0 ||
+                (rights & FileSystemRights.TakeOwnership) != 0 ||
+                (rights & FileSystemRights.Synchronize) != 0 ||
+                ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_READ) != 0)
             {
                 access = FileAccess.Read;
             }
 
-            if ((rights & FileSystemRights.WriteData) != 0 || ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_WRITE) != 0)
+            if ((rights & FileSystemRights.AppendData) != 0 || // Same as CreateDirectories
+                (rights & FileSystemRights.ChangePermissions) != 0 ||
+                (rights & FileSystemRights.Delete) != 0 ||
+                (rights & FileSystemRights.DeleteSubdirectoriesAndFiles) != 0 ||
+                (rights & FileSystemRights.WriteAttributes) != 0 ||
+                (rights & FileSystemRights.WriteData) != 0 || // Same as CreateFiles
+                (rights & FileSystemRights.WriteExtendedAttributes) != 0 ||
+                ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_WRITE) != 0)
             {
-                access = access == FileAccess.Read ? FileAccess.ReadWrite : FileAccess.Write;
+                access |= FileAccess.Write;
             }
+
+            Debug.Assert(access != 0);
 
             return access;
         }
 
-        private static unsafe SafeFileHandle CreateFileHandle(string fullPath, FileMode mode, FileSystemRights rights, FileShare share, FileOptions options, FileSecurity security)
+        private static unsafe SafeFileHandle CreateFileHandle(string fullPath, FileMode mode, FileSystemRights rights, FileShare share, FileOptions options, FileSecurity? security)
         {
             Debug.Assert(fullPath != null);
 
@@ -291,23 +324,39 @@ namespace System.IO
 
             SafeFileHandle handle;
 
-            fixed (byte* pSecurityDescriptor = security.GetSecurityDescriptorBinaryForm())
+            var secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
             {
-                var secAttrs = new Interop.Kernel32.SECURITY_ATTRIBUTES
-                {
-                    nLength = (uint)sizeof(Interop.Kernel32.SECURITY_ATTRIBUTES),
-                    bInheritHandle = ((share & FileShare.Inheritable) != 0) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE,
-                    lpSecurityDescriptor = (IntPtr)pSecurityDescriptor
-                };
+                nLength = (uint)sizeof(Interop.Kernel32.SECURITY_ATTRIBUTES),
+                bInheritHandle = ((share & FileShare.Inheritable) != 0) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE,
+            };
 
-                using (DisableMediaInsertionPrompt.Create())
+            if (security != null)
+            {
+                fixed (byte* pSecurityDescriptor = security.GetSecurityDescriptorBinaryForm())
                 {
-                    handle = Interop.Kernel32.CreateFile(fullPath, (int)rights, share, &secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
-                    ValidateFileHandle(handle, fullPath);
+                    secAttrs.lpSecurityDescriptor = (IntPtr)pSecurityDescriptor;
+                    handle = CreateFileHandleInternal(fullPath, mode, rights, share, flagsAndAttributes, &secAttrs);
                 }
+            }
+            else
+            {
+                handle = CreateFileHandleInternal(fullPath, mode, rights, share, flagsAndAttributes, &secAttrs);
             }
 
             return handle;
+
+            static unsafe SafeFileHandle CreateFileHandleInternal(string fullPath, FileMode mode, FileSystemRights rights, FileShare share, int flagsAndAttributes, Interop.Kernel32.SECURITY_ATTRIBUTES* secAttrs)
+            {
+                SafeFileHandle handle;
+                using (DisableMediaInsertionPrompt.Create())
+                {
+                    // The Inheritable bit is only set in the SECURITY_ATTRIBUTES struct,
+                    // and should not be passed to the CreateFile P/Invoke.
+                    handle = Interop.Kernel32.CreateFile(fullPath, (int)rights, (share & ~FileShare.Inheritable), secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
+                    ValidateFileHandle(handle, fullPath);
+                }
+                return handle;
+            }
         }
 
         private static void ValidateFileHandle(SafeFileHandle handle, string fullPath)

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -196,7 +196,7 @@ namespace System.IO
             var dirInfo = new DirectoryInfo(dirPath);
             var security = new DirectorySecurity();
             // Fails because the DirectorySecurity lacks any rights to create parent folder
-            Assert.Throws<UnauthorizedAccessException>(() =>  CreateDirectoryWithSecurity(dirInfo, security));
+            Assert.Throws<UnauthorizedAccessException>(() => CreateDirectoryWithSecurity(dirInfo, security));
         }
 
         [Fact]
@@ -284,156 +284,192 @@ namespace System.IO
         {
             FileInfo info = null;
             var security = new FileSecurity();
-
             Assert.Throws<ArgumentNullException>("fileInfo", () =>
-                CreateFileWithSecurity(info, FileMode.CreateNew, FileSystemRights.WriteData, FileShare.Delete, DefaultBufferSize, FileOptions.None, security));
+                info.Create(FileMode.CreateNew, FileSystemRights.FullControl, FileShare.None, DefaultBufferSize, FileOptions.None, security));
         }
 
         [Fact]
-        public void FileInfo_Create_NullFileSecurity()
-        {
-            var info = new FileInfo("path");
-
-            Assert.Throws<ArgumentNullException>("fileSecurity", () =>
-                CreateFileWithSecurity(info, FileMode.CreateNew, FileSystemRights.WriteData, FileShare.Delete, DefaultBufferSize, FileOptions.None, null));
-        }
-
-        [Fact]
-        public void FileInfo_Create_NotFound()
+        public void FileInfo_Create_DirectoryNotFound()
         {
             using var tempRootDir = new TempAclDirectory();
             string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString(), "file.txt");
-            var fileInfo = new FileInfo(path);
+            var info = new FileInfo(path);
             var security = new FileSecurity();
-
             Assert.Throws<DirectoryNotFoundException>(() =>
-                CreateFileWithSecurity(fileInfo, FileMode.CreateNew, FileSystemRights.WriteData, FileShare.Delete, DefaultBufferSize, FileOptions.None, security));
+                info.Create(FileMode.CreateNew, FileSystemRights.FullControl, FileShare.None, DefaultBufferSize, FileOptions.None, security));
         }
 
         [Theory]
         [InlineData((FileMode)int.MinValue)]
         [InlineData((FileMode)0)]
         [InlineData((FileMode)int.MaxValue)]
-        public void FileInfo_Create_FileSecurity_InvalidFileMode(FileMode invalidMode)
-        {
-            var security = new FileSecurity();
-            var info = new FileInfo("path");
-
-            Assert.Throws<ArgumentOutOfRangeException>("mode", () =>
-                CreateFileWithSecurity(info, invalidMode, FileSystemRights.WriteData, FileShare.Delete, DefaultBufferSize, FileOptions.None, security));
-        }
+        public void FileInfo_Create_FileSecurity_OutOfRange_FileMode(FileMode invalidMode) =>
+            FileInfo_Create_FileSecurity_ArgumentOutOfRangeException("mode", mode: invalidMode);
 
         [Theory]
         [InlineData((FileShare)(-1))]
         [InlineData((FileShare)int.MaxValue)]
-        public void FileInfo_Create_FileSecurity_InvalidFileShare(FileShare invalidFileShare)
-        {
-            var security = new FileSecurity();
-            var info = new FileInfo("path");
-
-            Assert.Throws<ArgumentOutOfRangeException>("share", () =>
-                CreateFileWithSecurity(info, FileMode.CreateNew, FileSystemRights.WriteData, invalidFileShare, DefaultBufferSize, FileOptions.None, security));
-        }
+        public void FileInfo_Create_FileSecurity_OutOfRange_FileShare(FileShare invalidFileShare) =>
+            FileInfo_Create_FileSecurity_ArgumentOutOfRangeException("share", share: invalidFileShare);
 
         [Theory]
         [InlineData(int.MinValue)]
         [InlineData(0)]
-        public void FileInfo_Create_FileSecurity_InvalidBufferSize(int invalidBufferSize)
-        {
-            var security = new FileSecurity();
-            var info = new FileInfo("path");
+        public void FileInfo_Create_FileSecurity_OutOfRange_BufferSize(int invalidBufferSize) =>
+            FileInfo_Create_FileSecurity_ArgumentOutOfRangeException("bufferSize", bufferSize: invalidBufferSize);
 
-            Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () =>
-                CreateFileWithSecurity(info, FileMode.CreateNew, FileSystemRights.WriteData, FileShare.Delete, invalidBufferSize, FileOptions.None, security));
-        }
+        public static IEnumerable<object[]> WriteModes_ReadRights_ForbiddenCombo_Data() =>
+            from mode in s_writableModes
+            from rights in s_readableRights
+            where
+                // These combinations are allowed, exclude them
+                !(rights == FileSystemRights.CreateFiles &&
+                  (mode == FileMode.Append || mode == FileMode.Create || mode == FileMode.CreateNew))
+            select new object[] { mode, rights };
 
+        // Do not combine writing modes with exclusively read rights
         [Theory]
-        [InlineData(FileMode.Truncate,  FileSystemRights.Read)]
-        [InlineData(FileMode.Truncate,  FileSystemRights.ReadData)]
-        [InlineData(FileMode.CreateNew, FileSystemRights.Read)]
-        [InlineData(FileMode.CreateNew, FileSystemRights.ReadData)]
-        [InlineData(FileMode.Create,    FileSystemRights.Read)]
-        [InlineData(FileMode.Create,    FileSystemRights.ReadData)]
-        [InlineData(FileMode.Append,    FileSystemRights.Read)]
-        [InlineData(FileMode.Append,    FileSystemRights.ReadData)]
-        public void FileInfo_Create_FileSecurity_ForbiddenCombo_FileModeFileSystemSecurity(FileMode mode, FileSystemRights rights)
-        {
-            var security = new FileSecurity();
-            var info = new FileInfo("path");
+        [MemberData(nameof(WriteModes_ReadRights_ForbiddenCombo_Data))]
+        public void FileInfo_Create_FileSecurity_WriteModes_ReadRights_ForbiddenCombo(FileMode mode, FileSystemRights rights) =>
+            FileInfo_Create_FileSecurity_ArgumentException(mode, rights);
 
-            Assert.Throws<ArgumentException>(() =>
-                CreateFileWithSecurity(info, mode, rights, FileShare.Delete, DefaultBufferSize, FileOptions.None, security));
-        }
+        public static IEnumerable<object[]> OpenOrCreateMode_ReadRights_AllowedCombo_Data() =>
+            from rights in s_readableRights
+            select new object[] { rights };
 
+        // OpenOrCreate allows using exclusively read rights
+        [Theory]
+        [MemberData(nameof(OpenOrCreateMode_ReadRights_AllowedCombo_Data))]
+        public void FileInfo_Create_FileSecurity_OpenOrCreateMode_ReadRights_AllowedCombo(FileSystemRights rights) =>
+            FileInfo_Create_FileSecurity_Successful(FileMode.OpenOrCreate, rights);
+
+        // Append, Craete and CreateNew allow using CreateFiles rights
+        // These combinations were excluded from WriteModes_ReadRights_ForbiddenCombo_Data
+        [Theory]
+        [InlineData(FileMode.Append)]
+        [InlineData(FileMode.Create)]
+        [InlineData(FileMode.CreateNew)]
+        public void FileInfo_Create_FileSecurity_WriteModes_CreateFilesRights_AllowedCombo(FileMode mode) =>
+            FileInfo_Create_FileSecurity_Successful(mode, FileSystemRights.CreateFiles);
+
+        public static IEnumerable<object[]> AppendMode_UnexpectedReadRights_Data() =>
+            from writeRights in s_writableRights
+            from readRights in new[] {
+                FileSystemRights.ExecuteFile,
+                FileSystemRights.ReadAttributes, FileSystemRights.ReadData, FileSystemRights.ReadExtendedAttributes, FileSystemRights.ReadPermissions,
+                FileSystemRights.Read, // Contains ReadAttributes, ReadData, ReadExtendedAttributes, ReadPermissions
+                FileSystemRights.ReadAndExecute, // Contains Read and ExecuteFile
+            }
+            select new object[] { writeRights | readRights };
+
+        // Append is allowed if at least one write permission is provided
+        // But append is disallowed if any read rights are provided
+        [Theory]
+        [MemberData(nameof(AppendMode_UnexpectedReadRights_Data))]
+        public void FileInfo_Create_FileSecurity_AppendMode_UnexpectedReadRights(FileSystemRights rights) =>
+            FileInfo_Create_FileSecurity_ArgumentException(FileMode.Append, rights);
+
+        public static IEnumerable<object[]> AppendMode_OnlyWriteRights_Data() =>
+            from writeRights in s_writableRights
+            select new object[] { writeRights };
+
+        // Append succeeds if only write permissions were provided (no read permissions)
+        [Theory]
+        [MemberData(nameof(AppendMode_OnlyWriteRights_Data))]
+        public void FileInfo_Create_FileSecurity_AppendMode_OnlyWriteRights(FileSystemRights rights) =>
+            FileInfo_Create_FileSecurity_Successful(FileMode.Append, rights);
+
+        public static IEnumerable<object[]> WritableRights_Data() =>
+            from rights in s_writableRights
+            select new object[] { rights };
+
+        // Cannot truncate unless all write rights are provided
+        [Theory]
+        [MemberData(nameof(WritableRights_Data))]
+        public void FileInfo_Create_FileSecurity_TruncateMode_IncompleteWriteRights(FileSystemRights rights) =>
+            FileInfo_Create_FileSecurity_ArgumentException(FileMode.Truncate, rights);
+
+        // Truncate suceeds if all write rights are included
+        
+        // In .NET Framework, throws Could not find file (filename)
+        // In .NET, throws IOException: The parameter is incorrect (filename)
         [Fact]
-        public void FileInfo_Create_DefaultFileSecurity()
-        {
-            var security = new FileSecurity();
-            Verify_FileSecurity_CreateFile(security);
-        }
+        [ActiveIssue("Doesnt work in either .NET Framework or .NET, even though .NET Framework code expects this specific combo to succeed")]
+        public void FileInfo_Create_FileSecurity_TruncateMode_AllWriteRights() =>
+            // Write contains AppendData, WriteAttributes, WriteData and WriteExtendedAttributes
+            FileInfo_Create_FileSecurity_Successful(FileMode.Truncate, FileSystemRights.Write | FileSystemRights.ReadData);
 
-        private void CreateFileWithSecurity(FileInfo info, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity security)
-        {
-            if (PlatformDetection.IsNetFramework)
-            {
-                FileSystemAclExtensions.Create(info, mode, rights, share, bufferSize, options, security);
-            }
-            else
-            {
-                info.Create(mode, rights, share, bufferSize, options, security);
-            }
-        }
+        public static IEnumerable<object[]> WriteRights_AllArguments_Data() =>
+            from mode in s_writableModes
+            from rights in s_writableRights
+            from share in Enum.GetValues<FileShare>()
+            from options in Enum.GetValues<FileOptions>()
+            where !(rights == FileSystemRights.CreateFiles &&
+                    (mode == FileMode.Append || mode == FileMode.Create || mode == FileMode.CreateNew)) &&
+                  !(mode == FileMode.Truncate && rights != FileSystemRights.Write)
+            select new object[] { mode, rights, share, options };
 
         [Theory]
-        // Must have at least one Read, otherwise the TempAclDirectory will fail to delete that item on dispose
-        [MemberData(nameof(RightsToAllow))]
-        public void FileInfo_Create_AllowSpecific_AccessRules(FileSystemRights rights)
-        {
-            using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, "file.txt");
-            var fileInfo = new FileInfo(path);
+        [MemberData(nameof(WriteRights_AllArguments_Data))]
+        public void FileInfo_WriteRights_WithSecurity_Null(FileMode mode, FileSystemRights rights, FileShare share, FileOptions options) =>
+            Verify_FileSecurity_CreateFile(mode, rights, share, DefaultBufferSize, options, expectedSecurity: null); // Null security
 
-            FileSecurity expectedSecurity = GetFileSecurity(rights);
+        [Theory]
+        [MemberData(nameof(WriteRights_AllArguments_Data))]
+        public void FileInfo_WriteRights_WithSecurity_Default(FileMode mode, FileSystemRights rights, FileShare share, FileOptions options) =>
+            Verify_FileSecurity_CreateFile(mode, rights, share, DefaultBufferSize, options, new FileSecurity()); // Default security
 
-            using FileStream stream = fileInfo.Create(
-                FileMode.Create,
-                FileSystemRights.FullControl,
-                FileShare.ReadWrite | FileShare.Delete,
-                DefaultBufferSize,
-                FileOptions.None,
-                expectedSecurity);
+        [Theory]
+        [MemberData(nameof(WriteRights_AllArguments_Data))]
+        public void FileInfo_WriteRights_WithSecurity_Custom(FileMode mode, FileSystemRights rights, FileShare share, FileOptions options) =>
+            Verify_FileSecurity_CreateFile(mode, rights, share, DefaultBufferSize, options, GetFileSecurity(rights)); // Custom security (AccessRule Allow)
 
-            Assert.True(fileInfo.Exists);
-            tempRootDir.CreatedSubfiles.Add(fileInfo);
+        public static IEnumerable<object[]> ReadRights_AllArguments_Data() =>
+            from mode in new[] { FileMode.Create, FileMode.CreateNew, FileMode.OpenOrCreate }
+            from rights in s_readableRights
+            from share in Enum.GetValues<FileShare>()
+            from options in Enum.GetValues<FileOptions>()
+            select new object[] { mode, rights, share, options };
 
-            var actualInfo = new FileInfo(fileInfo.FullName);
-            FileSecurity actualSecurity = actualInfo.GetAccessControl(AccessControlSections.Access);
-            VerifyAccessSecurity(expectedSecurity, actualSecurity);
-        }
+        [Theory]
+        [MemberData(nameof(ReadRights_AllArguments_Data))]
+        public void FileInfo_ReadRights_WithSecurity_Null(FileMode mode, FileSystemRights rights, FileShare share, FileOptions options) =>
+            // Writable FileModes require at least one write right
+            Verify_FileSecurity_CreateFile(mode, rights | FileSystemRights.WriteData, share, DefaultBufferSize, options, expectedSecurity: null); // Null security
 
+        [Theory]
+        [MemberData(nameof(ReadRights_AllArguments_Data))]
+        public void FileInfo_ReadRights_WithSecurity_Default(FileMode mode, FileSystemRights rights, FileShare share, FileOptions options) =>
+            // Writable FileModes require at least one write right
+            Verify_FileSecurity_CreateFile(mode, rights | FileSystemRights.WriteData, share, DefaultBufferSize, options, new FileSecurity()); // Default security
+
+        [Theory]
+        [MemberData(nameof(ReadRights_AllArguments_Data))]
+        public void FileInfo_ReadRights_WithSecurity_Custom(FileMode mode, FileSystemRights rights, FileShare share, FileOptions options) =>
+            // Writable FileModes require at least one write right
+            Verify_FileSecurity_CreateFile(mode, rights | FileSystemRights.WriteData, share, DefaultBufferSize, options, GetFileSecurity(rights)); // Custom security (AccessRule Allow)
 
         [Theory]
         [MemberData(nameof(RightsToDeny))]
-        public void FileInfo_Create_DenySpecific_AccessRules(FileSystemRights rightsToDeny)
+        public void FileInfo_Create_FileSecurity_DenyAccessRule(FileSystemRights rightsToDeny)
         {
             var expectedSecurity = new FileSecurity();
 
             var identity = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
-            var allowAccessRule = new FileSystemAccessRule(identity, FileSystemRights.Read, AccessControlType.Allow);
-            expectedSecurity.AddAccessRule(allowAccessRule);
 
+            // Add write deny rule
             var denyAccessRule = new FileSystemAccessRule(identity, rightsToDeny, AccessControlType.Deny);
             expectedSecurity.AddAccessRule(denyAccessRule);
 
             using var tempRootDir = new TempAclDirectory();
 
-            string path = Path.Combine(tempRootDir.Path, "file.txt");
+            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
             var fileInfo = new FileInfo(path);
 
             using FileStream stream = fileInfo.Create(
-                FileMode.Create,
-                FileSystemRights.FullControl,
-                FileShare.ReadWrite | FileShare.Delete,
+                FileMode.CreateNew,
+                FileSystemRights.Write, // Create expects at least one write right
+                FileShare.None,
                 DefaultBufferSize,
                 FileOptions.None,
                 expectedSecurity);
@@ -474,7 +510,7 @@ namespace System.IO
         public void DirectorySecurity_CreateDirectory_DirectoryAlreadyExists()
         {
             using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, "createMe");
+            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
 
             DirectorySecurity expectedSecurity = GetDirectorySecurity(FileSystemRights.FullControl);
             DirectoryInfo dirInfo = expectedSecurity.CreateDirectory(path);
@@ -496,84 +532,137 @@ namespace System.IO
 
         #region Helper methods
 
-        public static IEnumerable<object[]> RightsToDeny()
+        public static IEnumerable<object[]> RightsToDeny() =>
+            from rights in new[] {
+                FileSystemRights.AppendData, // Same as CreateDirectories
+                FileSystemRights.ChangePermissions,
+                FileSystemRights.Delete,
+                FileSystemRights.DeleteSubdirectoriesAndFiles,
+                FileSystemRights.ExecuteFile, // Same as Traverse
+                FileSystemRights.ReadAttributes,
+                FileSystemRights.ReadExtendedAttributes,
+                FileSystemRights.ReadPermissions,
+                FileSystemRights.TakeOwnership,
+                FileSystemRights.Write, // Contains AppendData, WriteData, WriteAttributes, WriteExtendedAttributes
+                FileSystemRights.WriteAttributes,
+                FileSystemRights.WriteData, // Same as CreateFiles
+                FileSystemRights.WriteExtendedAttributes,
+                // Rights that should not be denied:
+                // - Synchronize: CreateFile always requires Synchronize access
+                // - ReadData: Minimum right required to delete a file or directory
+                // - ListDirectory: Equivalent to ReadData
+                // - Modify: Contains ReadData
+                // - Read: Contains ReadData
+                // - ReadAndExecute: Contains ReadData
+                // - FullControl: Contains ReadData and Synchronize
+            }
+            select new object[] { rights };
+
+        public static IEnumerable<object[]> RightsToAllow() =>
+            from rights in new[] {
+                FileSystemRights.AppendData, // Same as CreateDirectories
+                FileSystemRights.ChangePermissions,
+                FileSystemRights.Delete,
+                FileSystemRights.DeleteSubdirectoriesAndFiles,
+                FileSystemRights.ExecuteFile, // Same as Traverse
+                FileSystemRights.Modify, // Contains Read, Write and ReadAndExecute
+                FileSystemRights.Read, // Contains ReadData, ReadPermissions, ReadAttributes, ReadExtendedAttributes
+                FileSystemRights.ReadAndExecute, // Contains Read and ExecuteFile
+                FileSystemRights.ReadAttributes,
+                FileSystemRights.ReadData, // Minimum right required to delete a file or directory. Equivalent to ListDirectory
+                FileSystemRights.ReadExtendedAttributes,
+                FileSystemRights.ReadPermissions,
+                FileSystemRights.Synchronize, // CreateFile always requires Synchronize access
+                FileSystemRights.TakeOwnership,
+                FileSystemRights.Write, // Contains AppendData, WriteData, WriteAttributes, WriteExtendedAttributes
+                FileSystemRights.WriteAttributes,
+                FileSystemRights.WriteData, // Same as CreateFiles
+                FileSystemRights.WriteExtendedAttributes,
+                FileSystemRights.FullControl, // Contains Modify, DeleteSubdirectoriesAndFiles, Delete, ChangePermissions, TakeOwnership, Synchronize
+            }
+            select new object[] { rights };
+
+        private static readonly FileMode[] s_writableModes = new[]
         {
-            yield return new object[] { FileSystemRights.AppendData };
-            yield return new object[] { FileSystemRights.ChangePermissions };
-            // yield return new object[] { FileSystemRights.CreateDirectories }; // CreateDirectories == AppendData
-            yield return new object[] { FileSystemRights.CreateFiles };
-            yield return new object[] { FileSystemRights.Delete };
-            yield return new object[] { FileSystemRights.DeleteSubdirectoriesAndFiles };
-            yield return new object[] { FileSystemRights.ExecuteFile };
-            // yield return new object[] { FileSystemRights.FullControl }; // Contains ReadData, should not deny that
-            // yield return new object[] { FileSystemRights.ListDirectory }; ListDirectory == ReadData
-            // yield return new object[] { FileSystemRights.Modify }; // Contains ReadData, should not deny that
-            // yield return new object[] { FileSystemRights.Read }; // Contains ReadData, should not deny that
-            // yield return new object[] { FileSystemRights.ReadAndExecute }; // Contains ReadData, should not deny that
-            yield return new object[] { FileSystemRights.ReadAttributes };
-            // yield return new object[] { FileSystemRights.ReadData }; // Minimum right required to delete a file or directory
-            yield return new object[] { FileSystemRights.ReadExtendedAttributes };
-            yield return new object[] { FileSystemRights.ReadPermissions };
-            // yield return new object[] { FileSystemRights.Synchronize }; // CreateFile always requires Synchronize access
-            yield return new object[] { FileSystemRights.TakeOwnership };
-            //yield return new object[] { FileSystemRights.Traverse }; // Traverse == ExecuteFile
-            yield return new object[] { FileSystemRights.Write };
-            yield return new object[] { FileSystemRights.WriteAttributes };
-            // yield return new object[] { FileSystemRights.WriteData }; // WriteData == CreateFiles
-            yield return new object[] { FileSystemRights.WriteExtendedAttributes };
+            FileMode.Append,
+            FileMode.Create,
+            FileMode.CreateNew,
+            FileMode.Truncate
+            // Excludes OpenOrCreate because it has a different behavior compared to Create/CreateNew
+        };
+
+        private static readonly FileSystemRights[] s_readableRights = new[]
+        {
+            // Excludes combined rights
+            FileSystemRights.ExecuteFile,
+            FileSystemRights.ReadAttributes,
+            FileSystemRights.ReadData,
+            FileSystemRights.ReadExtendedAttributes,
+            FileSystemRights.ReadPermissions
+        };
+
+        private static readonly FileSystemRights[] s_writableRights = new[]
+        {
+            // Excludes combined rights
+            FileSystemRights.AppendData, // Same as CreateDirectories
+            FileSystemRights.WriteAttributes,
+            FileSystemRights.WriteData,
+            FileSystemRights.WriteExtendedAttributes
+        };
+
+        private void FileInfo_Create_FileSecurity_ArgumentOutOfRangeException(string paramName, FileMode mode = FileMode.CreateNew, FileShare share = FileShare.None, int bufferSize = DefaultBufferSize)
+        {
+            var security = new FileSecurity();
+            var info = new FileInfo(Guid.NewGuid().ToString());
+            Assert.Throws<ArgumentOutOfRangeException>(paramName, () =>
+                info.Create(mode, FileSystemRights.FullControl, share, bufferSize, FileOptions.None, security));
         }
 
-        public static IEnumerable<object[]> RightsToAllow()
+        private void FileInfo_Create_FileSecurity_ArgumentException(FileMode mode, FileSystemRights rights)
         {
-            yield return new object[] { FileSystemRights.AppendData };
-            yield return new object[] { FileSystemRights.ChangePermissions };
-            // yield return new object[] { FileSystemRights.CreateDirectories }; // CreateDirectories == AppendData
-            yield return new object[] { FileSystemRights.CreateFiles };
-            yield return new object[] { FileSystemRights.Delete };
-            yield return new object[] { FileSystemRights.DeleteSubdirectoriesAndFiles };
-            yield return new object[] { FileSystemRights.ExecuteFile };
-            yield return new object[] { FileSystemRights.FullControl };
-            // yield return new object[] { FileSystemRights.ListDirectory }; ListDirectory == ReadData
-            yield return new object[] { FileSystemRights.Modify };
-            yield return new object[] { FileSystemRights.Read };
-            yield return new object[] { FileSystemRights.ReadAndExecute };
-            yield return new object[] { FileSystemRights.ReadAttributes };
-            // yield return new object[] { FileSystemRights.ReadData }; // Minimum right required to delete a file or directory
-            yield return new object[] { FileSystemRights.ReadExtendedAttributes };
-            yield return new object[] { FileSystemRights.ReadPermissions };
-            yield return new object[] { FileSystemRights.Synchronize };
-            yield return new object[] { FileSystemRights.TakeOwnership };
-            // yield return new object[] { FileSystemRights.Traverse }; // Traverse == ExecuteFile
-            yield return new object[] { FileSystemRights.Write };
-            yield return new object[] { FileSystemRights.WriteAttributes };
-            // yield return new object[] { FileSystemRights.WriteData }; // WriteData == CreateFiles
-            yield return new object[] { FileSystemRights.WriteExtendedAttributes };
+            var security = new FileSecurity();
+            var info = new FileInfo(Guid.NewGuid().ToString());
+            Assert.Throws<ArgumentException>(() =>
+                info.Create(mode, rights, FileShare.None, DefaultBufferSize, FileOptions.None, security));
         }
 
-        private void Verify_FileSecurity_CreateFile(FileSecurity expectedSecurity)
+        private void FileInfo_Create_FileSecurity_Successful(FileMode mode, FileSystemRights rights)
         {
-            Verify_FileSecurity_CreateFile(FileMode.Create, FileSystemRights.WriteData, FileShare.Read, DefaultBufferSize, FileOptions.None, expectedSecurity);
+            var security = new FileSecurity();
+            var info = new FileInfo(Guid.NewGuid().ToString());
+            info.Create(mode, rights, FileShare.None, DefaultBufferSize, FileOptions.None, security).Dispose();
         }
 
         private void Verify_FileSecurity_CreateFile(FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity expectedSecurity)
         {
             using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, "file.txt");
+            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
             var fileInfo = new FileInfo(path);
 
-            fileInfo.Create(mode, rights, share, bufferSize, options, expectedSecurity).Dispose();
-            Assert.True(fileInfo.Exists);
-            tempRootDir.CreatedSubfiles.Add(fileInfo);
+            using (FileStream fs = fileInfo.Create(mode, rights, share, bufferSize, options, expectedSecurity))
+            {
+                Assert.True(fileInfo.Exists);
+                tempRootDir.CreatedSubfiles.Add(fileInfo);
 
-            var actualFileInfo = new FileInfo(path);
-            FileSecurity actualSecurity = actualFileInfo.GetAccessControl(AccessControlSections.Access);
-            VerifyAccessSecurity(expectedSecurity, actualSecurity);
+                var actualFileInfo = new FileInfo(path);
+                FileSecurity actualSecurity = actualFileInfo.GetAccessControl();
+
+                if (expectedSecurity != null)
+                {
+                    VerifyAccessSecurity(expectedSecurity, actualSecurity);
+                }
+                else
+                {
+                    int count = actualSecurity.GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier)).Count;
+                    Assert.Equal(0, count);
+                }
+            }
         }
 
         private void Verify_DirectorySecurity_CreateDirectory(DirectorySecurity expectedSecurity)
         {
             using var tempRootDir = new TempAclDirectory();
-            string path = Path.Combine(tempRootDir.Path, "createMe");
+            string path = Path.Combine(tempRootDir.Path, Guid.NewGuid().ToString());
             DirectoryInfo dirInfo = expectedSecurity.CreateDirectory(path);
             Assert.True(dirInfo.Exists);
             tempRootDir.CreatedSubdirectories.Add(dirInfo);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57768

Trying once again. Resubmitting PR to make it easier to review, since I discovered some more things to fix.

Fixes:

- The ACL extension method `FileStream.Create` should accept a `null` `FileSecurity` parameter so the behavior can match .NET Framework. The ref definition had to be changed to a nullable parameter, and we should stop throwing if the argument is `null`. Added tests to ensure the extension method succeeds if the parameter is `null`, or a default `FileSecurity`, or a custom one.

-Bug fix: I found some cases where we were supposed to throw `ArgumentOutOfRangeException` or `ArgumentException` when the `FileMode` and `FileSystemRights` combinations were disallowed. I extended the unit tests to ensure we cover all those combinations.

- `FileStream` throws `ArgumentOutOfRangeException` if the passed `FileAccess` is not valid. In .NET Framework, this was not a problem because all the ACL logic was contained within the `FileStream` constructor, so it was possible to simply pass the `FileSystemRights` enum value, which was then internally casted as a `FileAccess` enum value to the p/invoke. In .NET, the ACL logic is in an extension method, and we don't want to do such casting. To address this, I am now mapping all the writeable `FileSystemRights` values to a `FileAccess` write or read value.

- Bug fix: The `FileShare.Inheritable` bit needs to be saved in the `SECURITY_ATTRIBUTES` struct (we are already doing this), but should not be passed to the `CreateFile` P/Invoke (we were not doing this). Otherwise, the P/Invoke causes an `IOException` to be thrown with the message `The parameter is incorrect`.

- Addressed suggestions provided in the [old PR](https://github.com/dotnet/runtime/pull/59389).

- Pending: There is one specific combination of `FileMode` and `FileSystemRights` that is supposed to succeed, but isn't. Strangely, it also fails in .NET Framework. I added a unit test to verify it, but temporarily added the `ActiveIssue` attribute while I investigate.