### PR TITLE
[release/6.0.x] Add System.Diagnostics.StackFrame.GetMethodInfoFromNativeIP API for VS4Mac

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -36,6 +36,10 @@
     <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
       <method name="LoadInMemoryAssembly" />
     </type>
+
+    <type fullname="System.Diagnostics.StackFrame">
+      <method name="GetMethodFromNativeIP" />
+    </type>
   </assembly>
 
   <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -36,7 +36,6 @@
     <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
       <method name="LoadInMemoryAssembly" />
     </type>
-
   </assembly>
 
   <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -37,9 +37,6 @@
       <method name="LoadInMemoryAssembly" />
     </type>
 
-    <type fullname="System.Diagnostics.StackFrame">
-      <method name="GetMethodFromNativeIP" />
-    </type>
   </assembly>
 
   <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
@@ -54,7 +54,9 @@ namespace System.Diagnostics
         private static bool AppendStackFrameWithoutMethodBase(StringBuilder sb) => false;
 
         /// <summary>
-        /// Returns the method info instance for the managed code IP address.
+        /// Returns the MethodBase instance for the managed code IP address.
+        ///
+        /// Warning: The implementation of this method has race for dynamic and collectible methods.
         /// </summary>
         /// <param name="ip">code address</param>
         /// <returns>MethodBase instance for the method or null if IP not found</returns>

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace System.Diagnostics
 {
@@ -50,5 +52,20 @@ namespace System.Diagnostics
         }
 
         private static bool AppendStackFrameWithoutMethodBase(StringBuilder sb) => false;
+
+        /// <summary>
+        /// Returns the method info instance for the managed code IP address.
+        /// </summary>
+        /// <param name="ip">code address</param>
+        /// <returns>MethodBase instance for the method or null if IP not found</returns>
+        internal static MethodBase? GetMethodFromNativeIP(IntPtr ip)
+        {
+            RuntimeMethodHandleInternal method = StackTrace.GetMethodDescFromNativeIP(ip);
+
+            if (method.Value == IntPtr.Zero)
+                return null;
+
+            return RuntimeType.GetMethodBase(null, method);
+        }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackTrace.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackTrace.CoreCLR.cs
@@ -1,8 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Diagnostics
 {
@@ -10,6 +11,9 @@ namespace System.Diagnostics
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void GetStackFramesInternal(StackFrameHelper sfh, int iSkip, bool fNeedFileInfo, Exception? e);
+
+        [DllImport(RuntimeHelpers.QCall)]
+        internal static extern RuntimeMethodHandleInternal GetMethodDescFromNativeIP(IntPtr ip);
 
         internal static int CalculateFramesToSkip(StackFrameHelper StackF, int iNumFrames)
         {

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -776,6 +776,28 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
 }
 FCIMPLEND
 
+MethodDesc* QCALLTYPE DebugStackTrace::GetMethodDescFromNativeIP(LPVOID ip)
+{
+    QCALL_CONTRACT;
+
+    MethodDesc* pResult = nullptr;
+
+    BEGIN_QCALL;
+
+    // TODO: There is a race for dynamic and collectible methods here between getting
+    // the MethodDesc here and when the managed wrapper converts it into a MethodBase
+    // where the method could be collected.
+    EECodeInfo codeInfo((PCODE)ip);
+    if (codeInfo.IsValid())
+    {
+        pResult = codeInfo.GetMethodDesc();
+    }
+
+    END_QCALL;
+
+    return pResult;
+}
+
 FORCEINLINE void HolderDestroyStrongHandle(OBJECTHANDLE h) { if (h != NULL) DestroyStrongHandle(h); }
 typedef Wrapper<OBJECTHANDLE, DoNothing<OBJECTHANDLE>, HolderDestroyStrongHandle, NULL> StrongHandleHolder;
 

--- a/src/coreclr/vm/debugdebugger.h
+++ b/src/coreclr/vm/debugdebugger.h
@@ -158,6 +158,8 @@ public:
                    Object* pException
                   );
 
+    static MethodDesc* QCALLTYPE GetMethodDescFromNativeIP(LPVOID ip);
+
     static void GetStackFramesFromException(OBJECTREF * e, GetStackFramesData *pData, PTRARRAYREF * pDynamicMethodArray = NULL);
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -128,6 +128,7 @@ FCFuncEnd()
 
 FCFuncStart(gDiagnosticsStackTrace)
     FCFuncElement("GetStackFramesInternal", DebugStackTrace::GetStackFramesInternal)
+    QCFuncElement("GetMethodDescFromNativeIP", DebugStackTrace::GetMethodDescFromNativeIP)
 FCFuncEnd()
 
 FCFuncStart(gEnvironmentFuncs)

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -4,5 +4,9 @@
       <!-- Internal API used by tests only. -->
       <method name="GetICUVersion" />
     </type>
+    <type fullname="System.Diagnostics.StackFrame">
+      <!-- Used by VS4Mac via reflection to symbolize stack traces -->
+      <method name="GetMethodFromNativeIP" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
# Customer Impact

VS4Mac needs a way to symbolize managed IPs when rethrowing a native NSException from Objective C++. This is a short term API needed for the next 6.0 service release discoverable only through reflection.

Issue: #61186

# Testing

Local testing.  Verified by the VS4Mac team.

# Risk

Low.  
