### PR TITLE
Add RIDs for MIRACLE LINUX 8 and 9

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -4356,6 +4356,78 @@
     "any",
     "base"
   ],
+  "miraclelinux": [
+    "miraclelinux",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "miraclelinux-x64": [
+    "miraclelinux-x64",
+    "miraclelinux",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "miraclelinux.8": [
+    "miraclelinux.8",
+    "miraclelinux",
+    "rhel.8",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "miraclelinux.8-x64": [
+    "miraclelinux.8-x64",
+    "miraclelinux.8",
+    "miraclelinux-x64",
+    "rhel.8-x64",
+    "miraclelinux",
+    "rhel.8",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "miraclelinux.9": [
+    "miraclelinux.9",
+    "miraclelinux",
+    "rhel.9",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "miraclelinux.9-x64": [
+    "miraclelinux.9-x64",
+    "miraclelinux.9",
+    "miraclelinux-x64",
+    "rhel.9-x64",
+    "miraclelinux",
+    "rhel.9",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "ol": [
     "ol",
     "rhel",

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -1775,6 +1775,43 @@
         "arch-x64"
       ]
     },
+    "miraclelinux": {
+      "#import": [
+        "rhel"
+      ]
+    },
+    "miraclelinux-x64": {
+      "#import": [
+        "miraclelinux",
+        "rhel-x64"
+      ]
+    },
+    "miraclelinux.8": {
+      "#import": [
+        "miraclelinux",
+        "rhel.8"
+      ]
+    },
+    "miraclelinux.8-x64": {
+      "#import": [
+        "miraclelinux.8",
+        "miraclelinux-x64",
+        "rhel.8-x64"
+      ]
+    },
+    "miraclelinux.9": {
+      "#import": [
+        "miraclelinux",
+        "rhel.9"
+      ]
+    },
+    "miraclelinux.9-x64": {
+      "#import": [
+        "miraclelinux.9",
+        "miraclelinux-x64",
+        "rhel.9-x64"
+      ]
+    },
     "ol": {
       "#import": [
         "rhel"

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -137,6 +137,14 @@
       <Versions>1;2</Versions>
     </RuntimeGroup>
 
+    <RuntimeGroup Include="miraclelinux">
+      <Parent>rhel</Parent>
+      <Architectures>x64</Architectures>
+      <Versions>8;9</Versions>
+      <ApplyVersionsToParent>true</ApplyVersionsToParent>
+      <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
+    </RuntimeGroup>
+
     <RuntimeGroup Include="ol">
       <Parent>rhel</Parent>
       <Architectures>x64</Architectures>


### PR DESCRIPTION
Whenever we build dotnet RPMs for MIRACLE LINUX 8 (formerly Asianux Server 8) we have to
apply patches that add RIDs for MIRACLE LINUX. To streamline the build process, we would
like to add our RIDs to the upstream sources, in the same way CentOS and other RHEL-
derivatives do.

This commit adds the following runtime IDs:
 - "miraclelinux"
 - "miraclelinux-x64"
 - "miraclelinux.8"
 - "miraclelinux.8-x64"
 - "miraclelinux.9"
 - "miraclelinux.9-x64"