### PR TITLE
[wasm][aot] Disable (again) `Microsoft.Extensions.Logging.Generators.Roslyn3.11.Tests` failing due to OOM

### DIFF
--- a/eng/testing/WasmRunnerAOTTemplate.sh
+++ b/eng/testing/WasmRunnerAOTTemplate.sh
@@ -38,13 +38,22 @@ function _buildAOTFunc()
 	dotnet msbuild $binLog -clp:PerformanceSummary -v:q -nologo
 	if [[ "$(uname -s)" == "Linux" && $buildExitCode -ne 0 ]]; then
 		echo "\nLast few messages from dmesg:\n"
-		dmesg | tail -n 20
+		local lastLines=`dmesg | tail -n 20`
+		echo $lastLines
+
+		if [[ "$lastLines" =~ "oom-kill" ]]; then
+			return 9200 # OOM
+		fi
 	fi
 
 	echo
 	echo
 
-	return $buildExitCode
+    if [[ $buildExitCode -ne 0 ]]; then
+        return 9100 # aot build failure
+    fi
+
+	return 0
 }
 
 # RunCommands defined in tests.mobile.targets

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -14,6 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' == 'true'">
+    <!-- Exceeds VM resources in CI on compilation: https://github.com/dotnet/runtime/issues/61339 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Abstractions\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Roslyn3.11.Tests.csproj" />
   </ItemGroup>
 
   <!-- Projects that don't support code coverage measurement. -->


### PR DESCRIPTION
The tests have been OOMing on almost every rolling build since this was merged.

Example rolling builds:
https://dev.azure.com/dnceng/public/_build/results?buildId=1457592&view=results
https://dev.azure.com/dnceng/public/_build/results?buildId=1457989&view=results
https://dev.azure.com/dnceng/public/_build/results?buildId=1454720&view=results