### PR TITLE
[wasm] Add task marshaling tests.

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -679,10 +679,31 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             await Task.Yield();
         }
 
+        public static ValueTask SynchronousValueTask() 
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public static ValueTask<int> SynchronousValueTaskInt(int i) 
+        {
+            return ValueTask.FromResult(i);
+        }
+
         public static async ValueTask<int> AsynchronousValueTaskInt(int i) 
         {
             await Task.Yield();
             return i;
+        }
+
+        public static ValueTask FailedSynchronousValueTask() 
+        {
+            return ValueTask.FromException(new Exception());
+        }
+
+        public static async ValueTask FailedAsynchronousValueTask() 
+        {
+            await Task.Yield();
+            throw new Exception();
         }
     }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -4,6 +4,7 @@
 using System.Runtime.InteropServices.JavaScript;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Runtime.InteropServices.JavaScript.Tests
@@ -641,6 +642,37 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             };
         }
 
+        public static Task SynchronousTask() 
+        {
+            return Task.CompletedTask;
+        }
+
+        public static async Task AsynchronousTask() 
+        {
+            await Task.Yield();
+        }
+
+        public static Task<int> SynchronousTaskInt(int i) 
+        {
+            return Task.FromResult(i);
+        }
+
+        public static async Task<int> AsynchronousTaskInt(int i) 
+        {
+            await Task.Yield();
+            return i;
+        }
+
+        public static Task FailedSynchronousTask() 
+        {
+            return Task.FromException(new Exception());
+        }
+
+        public static async Task FailedAsynchronousTask() 
+        {
+            await Task.Yield();
+            throw new Exception();
+        }
     }
 
     public enum TestEnum : uint {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -673,6 +673,17 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             await Task.Yield();
             throw new Exception();
         }
+
+        public static async ValueTask AsynchronousValueTask() 
+        {
+            await Task.Yield();
+        }
+
+        public static async ValueTask<int> AsynchronousValueTaskInt(int i) 
+        {
+            await Task.Yield();
+            return i;
+        }
     }
 
     public enum TestEnum : uint {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -923,6 +923,16 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             return resolved;
         }
 
+        private static async Task MarshalTaskReturningInt(string helperMethodName)
+        {
+            HelperMarshal._intValue = 0;
+
+            bool success = await MarshalTask(helperMethodName, "7", "App.call_test_method ('InvokeInt', [ result ], 'i');");
+
+            Assert.True(success, $"{helperMethodName} didn't succeeded.");
+            Assert.Equal(7, HelperMarshal._intValue);
+        }
+
         [Fact]
         public static async Task MarshalSynchronousTask()
         {
@@ -938,32 +948,21 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        public static async Task MarshalSynchronousTaskInt()
+        public static Task MarshalSynchronousTaskInt()
         {
-            HelperMarshal._intValue = 0;
-
-            bool success = await MarshalTask("SynchronousTaskInt", "7", "App.call_test_method ('InvokeInt', [ result ], 'i');");
-
-            Assert.True(success, "SynchronousTask didn't succeeded.");
-            Assert.Equal(7, HelperMarshal._intValue);
+            return MarshalTaskReturningInt("SynchronousTaskInt");
         }
 
         [Fact]
-        public static async Task MarshalAsynchronousTaskInt()
+        public static Task MarshalAsynchronousTaskInt()
         {
-            HelperMarshal._intValue = 0;
-
-            bool success = await MarshalTask("AsynchronousTaskInt", "7", "App.call_test_method ('InvokeInt', [ result ], 'i');");
-
-            Assert.True(success, "AsynchronousTask didn't succeeded.");
-            Assert.Equal(7, HelperMarshal._intValue);
+            return MarshalTaskReturningInt("AsynchronousTaskInt");
         }
 
         [Fact]
         public static async Task MarshalFailedSynchronousTask()
         {
             bool success = await MarshalTask("FailedSynchronousTask");
-
             Assert.False(success, "FailedSynchronousTask didn't failed.");
         }
 
@@ -971,24 +970,53 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static async Task MarshalFailedAsynchronousTask()
         {
             bool success = await MarshalTask("FailedAsynchronousTask");
-
             Assert.False(success, "FailedAsynchronousTask didn't failed.");
         }
 
         [Fact]
-        [Trait("Category","Marek")]
-        public static async Task MarshalAsynchronousValueTaskDoesNotWorkYet()
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61368")]
+        public static async Task MarshalSynchronousValueTaskDoesNotWorkYet()
         {
-            var exception = await Assert.ThrowsAsync<JSException>(() => MarshalTask("AsynchronousValueTask"));
-            Assert.StartsWith("Error: no idea on how to unbox value types", exception.Message);
+            bool success = await MarshalTask("SynchronousValueTask");
+            Assert.True(success, "SynchronousValueTask didn't succeeded.");
         }
 
         [Fact]
-        [Trait("Category","Marek")]
-        public static async Task MarshalAsynchronousValueTaskIntDoesNotWorkYet()
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61368")]
+        public static async Task MarshalAsynchronousValueTaskDoesNotWorkYet()
         {
-            var exception = await Assert.ThrowsAsync<JSException>(() => MarshalTask("AsynchronousValueTaskInt", "7"));
-            Assert.StartsWith("Error: no idea on how to unbox value types", exception.Message);
+            bool success = await MarshalTask("AsynchronousValueTask");
+            Assert.True(success, "AsynchronousValueTask didn't succeeded.");
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61368")]
+        public static Task MarshalSynchronousValueTaskIntDoesNotWorkYet()
+        {
+            return MarshalTaskReturningInt("SynchronousValueTaskInt");
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61368")]
+        public static Task MarshalAsynchronousValueTaskIntDoesNotWorkYet()
+        {
+            return MarshalTaskReturningInt("AsynchronousValueTaskInt");
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61368")]
+        public static async Task MarshalFailedSynchronousValueTaskDoesNotWorkYet()
+        {
+            bool success = await MarshalTask("FailedSynchronousValueTask");
+            Assert.False(success, "FailedSynchronousValueTask didn't failed.");
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61368")]
+        public static async Task MarshalFailedAsynchronousValueTaskDoesNotWorkYet()
+        {
+            bool success = await MarshalTask("FailedAsynchronousValueTask");
+            Assert.False(success, "FailedAsynchronousValueTask didn't failed.");
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -3,6 +3,8 @@
 
 using System.Runtime.InteropServices.JavaScript;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Runtime.InteropServices.JavaScript.Tests
@@ -898,6 +900,79 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             var result = Runtime.InvokeJS(@"var test_local_variable_name = 5; globalThis.test_local_variable_name");
             Assert.Null(result);
+        }
+
+        private static async Task<bool> MarshalTask(string helperMethodName, string helperMethodArgs = "", string resolvedBody = "") 
+        {
+            Runtime.InvokeJS(
+                @"globalThis.__test_promise_completed = false; " +
+                @"globalThis.__test_promise_resolved = false; " +
+                @"globalThis.__test_promise_failed = false; " +
+                $@"var t = App.call_test_method ('{helperMethodName}', [ {helperMethodArgs} ], 'i'); " +
+                "t.finally(result => { globalThis.__test_promise_completed = true; }); " + 
+                "t.then(result => { globalThis.__test_promise_resolved = true; " + resolvedBody + " }); " + 
+                "t.catch(e => { console.log(e); globalThis.__test_promise_failed = true; }); "
+            );
+
+            await Task.Delay(1);
+
+            var completed = bool.Parse(Runtime.InvokeJS(@"globalThis.__test_promise_completed"));
+            Assert.True(completed, "JavasScript promise did not completed.");
+
+            var resolved = bool.Parse(Runtime.InvokeJS(@"globalThis.__test_promise_resolved"));
+            return resolved;
+        }
+
+        [Fact]
+        public static async Task MarshalSynchronousTask()
+        {
+            bool success = await MarshalTask("SynchronousTask");
+            Assert.True(success, "SynchronousTask didn't succeeded.");
+        }
+
+        [Fact]
+        public static async Task MarshalAsynchronousTask()
+        {
+            bool success = await MarshalTask("AsynchronousTask");
+            Assert.True(success, "AsynchronousTask didn't succeeded.");
+        }
+
+        [Fact]
+        public static async Task MarshalSynchronousTaskInt()
+        {
+            HelperMarshal._intValue = 0;
+
+            bool success = await MarshalTask("SynchronousTaskInt", "7", "App.call_test_method ('InvokeInt', [ result ], 'i');");
+
+            Assert.True(success, "SynchronousTask didn't succeeded.");
+            Assert.Equal(7, HelperMarshal._intValue);
+        }
+
+        [Fact]
+        public static async Task MarshalAsynchronousTaskInt()
+        {
+            HelperMarshal._intValue = 0;
+
+            bool success = await MarshalTask("AsynchronousTaskInt", "7", "App.call_test_method ('InvokeInt', [ result ], 'i');");
+
+            Assert.True(success, "AsynchronousTask didn't succeeded.");
+            Assert.Equal(7, HelperMarshal._intValue);
+        }
+
+        [Fact]
+        public static async Task MarshalFailedSynchronousTask()
+        {
+            bool success = await MarshalTask("FailedSynchronousTask");
+
+            Assert.False(success, "FailedSynchronousTask didn't failed.");
+        }
+
+        [Fact]
+        public static async Task MarshalFailedAsynchronousTask()
+        {
+            bool success = await MarshalTask("FailedAsynchronousTask");
+
+            Assert.False(success, "FailedAsynchronousTask didn't failed.");
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -974,5 +974,21 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             Assert.False(success, "FailedAsynchronousTask didn't failed.");
         }
+
+        [Fact]
+        [Trait("Category","Marek")]
+        public static async Task MarshalAsynchronousValueTaskDoesNotWorkYet()
+        {
+            var exception = await Assert.ThrowsAsync<JSException>(() => MarshalTask("AsynchronousValueTask"));
+            Assert.StartsWith("Error: no idea on how to unbox value types", exception.Message);
+        }
+
+        [Fact]
+        [Trait("Category","Marek")]
+        public static async Task MarshalAsynchronousValueTaskIntDoesNotWorkYet()
+        {
+            var exception = await Assert.ThrowsAsync<JSException>(() => MarshalTask("AsynchronousValueTaskInt", "7"));
+            Assert.StartsWith("Error: no idea on how to unbox value types", exception.Message);
+        }
     }
 }


### PR DESCRIPTION
Add various tests for marshaling task to JavaScript promise.

- Sync and async.
- Generic and non-generic.
- Successful and failed.

These tests replace those added in the dotnet/runtime#47640.

@pavelsavara @kg  Do you have some ideas for additional scenarios to test?