### PR TITLE
Adding Regex source generator to Microsoft.netcore.app.ref pack

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -106,5 +106,8 @@
     <Reference Include="System.Reflection.Emit.ILGeneration" />
     <Reference Include="System.Reflection.Emit.Lightweight" />
     <Reference Include="System.Reflection.Primitives" />
+
+    <!-- Adding the source generator as an analyzer reference -->
+    <AnalyzerReference Include="..\gen\System.Text.RegularExpressions.Generator.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/61321

This is adding the Regex source generator to the netcoreapp ref pack so that it is easier for consumers to use it.