### PR TITLE
Fix binplacing for (impl) System.Security.Cryptography.Encoding.dll

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
#61137 changed the System.Security.Cryptography.Encoding project from using TargetFrameworks (plural) to TargetFramework (singular), since it only built for one framework.

Apparently that made the library stop getting binplaced.

So now change it back to TargetFrameworks (plural) even though there's only one entry in it.