### PR TITLE
Fix format.py to use jit-format.exe, not jit-format.bat

### DIFF
--- a/src/tests/Common/scripts/format.py
+++ b/src/tests/Common/scripts/format.py
@@ -199,7 +199,7 @@ def main(argv):
         if platform == 'Linux' or platform == 'OSX':
             jitformat = os.path.join(jitformat, "jit-format")
         elif platform == 'windows':
-            jitformat = os.path.join(jitformat,"jit-format.bat")
+            jitformat = os.path.join(jitformat,"jit-format.exe")
         errorMessage = ""
 
         builds = ["Checked", "Debug", "Release"]


### PR DESCRIPTION
Adjust for https://github.com/dotnet/jitutils/pull/343

Fixes https://github.com/dotnet/runtime/issues/61331