### PR TITLE
[DllImportGenerator] Remove unnecessary DLLIMPORTGENERATOR_ENABLED ifdefs

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.AdjustTokenPrivileges.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.AdjustTokenPrivileges.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
         internal static unsafe partial bool AdjustTokenPrivileges(
-#else
-        [DllImport(Libraries.Advapi32, SetLastError = true)]
-        internal static extern unsafe bool AdjustTokenPrivileges(
-#endif
             SafeTokenHandle TokenHandle,
             bool DisableAllPrivileges,
             TOKEN_PRIVILEGE* NewState,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CheckTokenMembership.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CheckTokenMembership.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool CheckTokenMembership(
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern bool CheckTokenMembership(
-#endif
             SafeAccessTokenHandle TokenHandle,
             byte[] SidToCheck,
             ref bool IsMember);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSidToSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSidToSid.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSidToSidW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSidToSidW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial int ConvertStringSidToSid(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSidToSidW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int ConvertStringSidToSid(
-#endif
             string stringSid,
             out IntPtr ByteArray);
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateWellKnownSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateWellKnownSid.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "CreateWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "CreateWellKnownSid", SetLastError = true)]
         internal static partial int CreateWellKnownSid(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "CreateWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int CreateWellKnownSid(
-#endif
             int sidType,
             byte[]? domainSid,
             byte[] resultSid,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool DuplicateTokenEx(
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern bool DuplicateTokenEx(
-#endif
             SafeAccessTokenHandle hExistingToken,
             uint dwDesiredAccess,
             IntPtr lpTokenAttributes,   // LPSECURITY_ATTRIBUTES

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx_SafeTokenHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.DuplicateTokenEx_SafeTokenHandle.cs
@@ -10,13 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool DuplicateTokenEx(
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern bool DuplicateTokenEx(
-#endif
             SafeTokenHandle ExistingTokenHandle,
             TokenAccessLevels DesiredAccess,
             IntPtr TokenAttributes,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByHandle.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityInfo", ExactSpelling = true)]
         internal static unsafe partial uint GetSecurityInfoByHandle(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityInfo", ExactSpelling = true)]
-        internal static unsafe extern /*DWORD*/ uint GetSecurityInfoByHandle(
-#endif
             SafeHandle handle,
             /*DWORD*/ uint objectType,
             /*DWORD*/ uint securityInformation,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint GetSecurityInfoByName(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        internal static extern /*DWORD*/ uint GetSecurityInfoByName(
-#endif
             string name,
             /*DWORD*/ uint objectType,
             /*DWORD*/ uint securityInformation,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetWindowsAccountDomainSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetWindowsAccountDomainSid.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetWindowsAccountDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetWindowsAccountDomainSid", SetLastError = true)]
         internal static partial int GetWindowsAccountDomainSid(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetWindowsAccountDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int GetWindowsAccountDomainSid(
-#endif
             byte[] sid,
             byte[] resultSid,
             ref uint resultSidLength);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ImpersonateLoggedOnUser.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ImpersonateLoggedOnUser.cs
@@ -9,12 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool ImpersonateLoggedOnUser(SafeAccessTokenHandle userToken);
-#else
-        [DllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool ImpersonateLoggedOnUser(SafeAccessTokenHandle userToken);
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsEqualDomainSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsEqualDomainSid.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "EqualDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "EqualDomainSid", SetLastError = true)]
         internal static partial int IsEqualDomainSid(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "EqualDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int IsEqualDomainSid(
-#endif
             byte[] sid1,
             byte[] sid2,
             out bool result);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsWellKnownSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsWellKnownSid.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "IsWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "IsWellKnownSid", SetLastError = true)]
         internal static partial int IsWellKnownSid(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "IsWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int IsWellKnownSid(
-#endif
             byte[] sid,
             int type);
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaClose.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaClose.cs
@@ -8,12 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial int LsaClose(IntPtr handle);
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern int LsaClose(IntPtr handle);
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaFreeMemory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaFreeMemory.cs
@@ -8,12 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial int LsaFreeMemory(IntPtr handle);
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern int LsaFreeMemory(IntPtr handle);
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaLookupSids.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaLookupSids.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaLookupSids", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaLookupSids", SetLastError = true)]
         internal static partial uint LsaLookupSids(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaLookupSids", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern uint LsaLookupSids(
-#endif
             SafeLsaPolicyHandle handle,
             int count,
             IntPtr[] sids,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaOpenPolicy.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaOpenPolicy.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaOpenPolicy", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaOpenPolicy", SetLastError = true)]
         private static partial uint LsaOpenPolicy(
-#else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaOpenPolicy", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern uint LsaOpenPolicy(
-#endif
             ref UNICODE_STRING SystemName,
             ref OBJECT_ATTRIBUTES ObjectAttributes,
             int AccessMask,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenProcessToken_IntPtr.cs
@@ -10,13 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
         internal static partial bool OpenProcessToken(
-#else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool OpenProcessToken(
-#endif
             IntPtr ProcessToken,
             TokenAccessLevels DesiredAccess,
             out SafeTokenHandle TokenHandle);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken.cs
@@ -10,13 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         private static partial bool OpenThreadToken(
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        private static extern bool OpenThreadToken(
-#endif
             IntPtr ThreadHandle,
             TokenAccessLevels dwDesiredAccess,
             bool bOpenAsSelf,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken_SafeTokenHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.OpenThreadToken_SafeTokenHandle.cs
@@ -10,13 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool OpenThreadToken(
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern bool OpenThreadToken(
-#endif
             IntPtr ThreadHandle,
             TokenAccessLevels dwDesiredAccess,
             bool bOpenAsSelf,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RevertToSelf.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RevertToSelf.cs
@@ -8,12 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, ExactSpelling = true, SetLastError = true)]
         internal static partial bool RevertToSelf();
-#else
-        [DllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        internal static extern bool RevertToSelf();
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetThreadToken.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetThreadToken.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, SetLastError = true)]
         internal static partial bool SetThreadToken(
-#else
-        [DllImport(Libraries.Advapi32, SetLastError = true)]
-        internal static extern bool SetThreadToken(
-#endif
             IntPtr ThreadHandle,
             SafeTokenHandle? hToken);
     }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFileEx.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use CopyFileEx.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool CopyFileExPrivate(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool CopyFileExPrivate(
-#endif
             string src,
             string dst,
             IntPtr progressRoutine,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use CreateDirectory.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool CreateDirectoryPrivate(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool CreateDirectoryPrivate(
-#endif
             string path,
             ref SECURITY_ATTRIBUTES lpSecurityAttributes);
 

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFile_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFile_IntPtr.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use CreateFile.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static unsafe partial IntPtr CreateFilePrivate_IntPtr(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        private static unsafe extern IntPtr CreateFilePrivate_IntPtr(
-#endif
             string lpFileName,
             int dwDesiredAccess,
             FileShare dwShareMode,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteFile.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use DeleteFile.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool DeleteFilePrivate(string path);
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool DeleteFilePrivate(string path);
-#endif
 
         internal static bool DeleteFile(string path)
         {

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteVolumeMountPoint.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteVolumeMountPoint.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use DeleteVolumeMountPoint.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial bool DeleteVolumeMountPointPrivate(string mountPoint);
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool DeleteVolumeMountPointPrivate(string mountPoint);
-#endif
 
         internal static bool DeleteVolumeMountPoint(string mountPoint)
         {

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeAccessTokenHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeAccessTokenHandle.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         internal static partial bool DuplicateHandle(
-#else
-        [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern bool DuplicateHandle(
-#endif
             IntPtr hSourceProcessHandle,
             IntPtr hSourceHandle,
             IntPtr hTargetProcessHandle,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindClose.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindClose.cs
@@ -8,12 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         internal static partial bool FindClose(IntPtr hFindFile);
-#else
-        [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern bool FindClose(IntPtr hFindFile);
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
@@ -11,13 +11,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use GetFileAttributesEx.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool GetFileAttributesExPrivate(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        private static extern bool GetFileAttributesExPrivate(
-#endif
             string? name,
             GET_FILEEX_INFO_LEVELS fileInfoLevel,
             ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetLogicalDrives.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetLogicalDrives.cs
@@ -7,12 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         internal static partial int GetLogicalDrives();
-#else
-        [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern int GetLogicalDrives();
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetVolumeInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetVolumeInformation.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial bool GetVolumeInformation(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetVolumeInformationW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static unsafe extern bool GetVolumeInformation(
-#endif
             string drive,
             char* volumeName,
             int volumeNameBufLen,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
@@ -15,13 +15,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use MoveFile.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool MoveFileExPrivate(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool MoveFileExPrivate(
-#endif
             string src, string dst, uint flags);
 
         /// <summary>

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RemoveDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RemoveDirectory.cs
@@ -12,13 +12,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use RemoveDirectory.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool RemoveDirectoryPrivate(string path);
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool RemoveDirectoryPrivate(string path);
-#endif
 
         internal static bool RemoveDirectory(string path)
         {

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReplaceFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReplaceFile.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool ReplaceFilePrivate(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool ReplaceFilePrivate(
-#endif
             string replacedFileName, string replacementFileName, string? backupFileName,
             int dwReplaceFlags, IntPtr lpExclude, IntPtr lpReserved);
 

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileAttributes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileAttributes.cs
@@ -11,13 +11,8 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use SetFileAttributes.
         /// </summary>
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool SetFileAttributesPrivate(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool SetFileAttributesPrivate(
-#endif
             string name,
             int attr);
 

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileInformationByHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileInformationByHandle.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial bool SetFileInformationByHandle(
-#else
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        internal static unsafe extern bool SetFileInformationByHandle(
-#endif
             SafeFileHandle hFile,
             int FileInformationClass,
             void* lpFileInformation,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
         [SuppressGCTransition]
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static partial bool SetThreadErrorMode(
-#else
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        internal static extern bool SetThreadErrorMode(
-#endif
             uint dwNewMode,
             out uint lpOldMode);
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaConnectUntrusted.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaConnectUntrusted.cs
@@ -10,12 +10,7 @@ internal static partial class Interop
 {
     internal static partial class SspiCli
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.SspiCli)]
         internal static partial int LsaConnectUntrusted(out SafeLsaHandle LsaHandle);
-#else
-        [DllImport(Interop.Libraries.SspiCli)]
-        internal static extern int LsaConnectUntrusted(out SafeLsaHandle LsaHandle);
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaFreeReturnBuffer.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaFreeReturnBuffer.cs
@@ -8,12 +8,7 @@ internal static partial class Interop
 {
     internal static partial class SspiCli
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.SspiCli, SetLastError = true)]
         internal static partial int LsaFreeReturnBuffer(IntPtr handle);
-#else
-        [DllImport(Interop.Libraries.SspiCli, SetLastError = true)]
-        internal static extern int LsaFreeReturnBuffer(IntPtr handle);
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaGetLogonSessionData.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaGetLogonSessionData.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class SspiCli
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.SspiCli, SetLastError = true)]
         internal static partial int LsaGetLogonSessionData(
-#else
-        [DllImport(Interop.Libraries.SspiCli, SetLastError = true)]
-        internal static extern int LsaGetLogonSessionData(
-#endif
             ref LUID LogonId,
             out SafeLsaReturnBufferHandle ppLogonSessionData);
     }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaLookupAuthenticationPackage.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaLookupAuthenticationPackage.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class SspiCli
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.SspiCli)]
         internal static partial int LsaLookupAuthenticationPackage(
-#else
-        [DllImport(Libraries.SspiCli)]
-        internal static extern int LsaLookupAuthenticationPackage(
-#endif
             SafeLsaHandle LsaHandle,
             ref Advapi32.LSA_STRING PackageName,
             out int AuthenticationPackage


### PR DESCRIPTION
Only went through the ones that are in projects that no longer even build down-level.
There's more we should be able to clean up now that we have the forwarding support.

cc @AaronRobinsonMSFT @jkoritzinsky 