### PR TITLE
Completely lock-free ClassLoader::LookupTypeKey

### DIFF
--- a/src/coreclr/vm/ceeload.inl
+++ b/src/coreclr/vm/ceeload.inl
@@ -35,7 +35,6 @@ void LookupMap<TYPE>::SetValueAt(PTR_TADDR pValue, TYPE value, TADDR flags)
 
     value = dac_cast<TYPE>((dac_cast<TADDR>(value) | flags));
 
-    // REVIEW: why this is not VolatileStore? What guarantees that we do not have concurrent readers?
     *(dac_cast<DPTR(TYPE)>(pValue)) = value;
 }
 

--- a/src/coreclr/vm/ceeload.inl
+++ b/src/coreclr/vm/ceeload.inl
@@ -35,6 +35,7 @@ void LookupMap<TYPE>::SetValueAt(PTR_TADDR pValue, TYPE value, TADDR flags)
 
     value = dac_cast<TYPE>((dac_cast<TADDR>(value) | flags));
 
+    // REVIEW: why this is not VolatileStore? What guarantees that we do not have concurrent readers?
     *(dac_cast<DPTR(TYPE)>(pValue)) = value;
 }
 

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -1140,18 +1140,18 @@ TypeHandle ClassLoader::LookupTypeHandleForTypeKey(TypeKey *pKey)
     // Make an initial lookup without taking any locks.
     TypeHandle th = LookupTypeHandleForTypeKeyInner(pKey, FALSE);
 
-    // A non-null TypeHandle for the above lookup indicates success
-    // A null TypeHandle only indicates "well, it might have been there,
-    // try again with a lock".  This kind of negative result will
-    // only happen while accessing the underlying EETypeHashTable
-    // during a resize, i.e. very rarely. In such a case, we just
-    // perform the lookup again, but indicate that appropriate locks
-    // should be taken.
+    //// A non-null TypeHandle for the above lookup indicates success
+    //// A null TypeHandle only indicates "well, it might have been there,
+    //// try again with a lock".  This kind of negative result will
+    //// only happen while accessing the underlying EETypeHashTable
+    //// during a resize, i.e. very rarely. In such a case, we just
+    //// perform the lookup again, but indicate that appropriate locks
+    //// should be taken.
 
-    if (th.IsNull())
-    {
-        th = LookupTypeHandleForTypeKeyInner(pKey, TRUE);
-    }
+    //if (th.IsNull())
+    //{
+    //    th = LookupTypeHandleForTypeKeyInner(pKey, TRUE);
+    //}
 
     return th;
 }

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -1061,27 +1061,8 @@ void ClassLoader::TryEnsureLoaded(TypeHandle typeHnd, ClassLoadLevel level)
 #endif // DACCESS_COMPILE
 }
 
-// This is separated out to avoid the overhead of C++ exception handling in the non-locking case.
 /* static */
-TypeHandle ClassLoader::LookupTypeKeyUnderLock(TypeKey *pKey,
-                                               EETypeHashTable *pTable,
-                                               CrstBase *pLock)
-{
-    WRAPPER_NO_CONTRACT;
-    SUPPORTS_DAC;
-
-    // m_AvailableTypesLock has to be taken in cooperative mode to avoid deadlocks during GC
-    GCX_MAYBE_COOP_NO_THREAD_BROKEN(!IsGCThread());
-
-    CrstHolder ch(pLock);
-    return pTable->GetValue(pKey);
-}
-
-/* static */
-TypeHandle ClassLoader::LookupTypeKey(TypeKey *pKey,
-                                      EETypeHashTable *pTable,
-                                      CrstBase *pLock,
-                                      BOOL fCheckUnderLock)
+TypeHandle ClassLoader::LookupTypeKey(TypeKey *pKey, EETypeHashTable *pTable)
 {
     CONTRACTL {
         NOTHROW;
@@ -1090,26 +1071,15 @@ TypeHandle ClassLoader::LookupTypeKey(TypeKey *pKey,
         PRECONDITION(CheckPointer(pKey));
         PRECONDITION(pKey->IsConstructed());
         PRECONDITION(CheckPointer(pTable));
-        PRECONDITION(!fCheckUnderLock || CheckPointer(pLock));
         MODE_ANY;
         SUPPORTS_DAC;
     } CONTRACTL_END;
 
-    TypeHandle th;
-
-    if (fCheckUnderLock)
-    {
-        th = LookupTypeKeyUnderLock(pKey, pTable, pLock);
-    }
-    else
-    {
-        th = pTable->GetValue(pKey);
-    }
-    return th;
+    return pTable->GetValue(pKey);
 }
 
 /* static */
-TypeHandle ClassLoader::LookupInLoaderModule(TypeKey *pKey, BOOL fCheckUnderLock)
+TypeHandle ClassLoader::LookupInLoaderModule(TypeKey *pKey)
 {
     CONTRACTL {
         NOTHROW;
@@ -1124,39 +1094,12 @@ TypeHandle ClassLoader::LookupInLoaderModule(TypeKey *pKey, BOOL fCheckUnderLock
     Module *pLoaderModule = ComputeLoaderModule(pKey);
     PREFIX_ASSUME(pLoaderModule!=NULL);
 
-    return LookupTypeKey(pKey,
-                         pLoaderModule->GetAvailableParamTypes(),
-                         &pLoaderModule->GetClassLoader()->m_AvailableTypesLock,
-                         fCheckUnderLock);
+    return LookupTypeKey(pKey, pLoaderModule->GetAvailableParamTypes());
 }
 
 
 /* static */
 TypeHandle ClassLoader::LookupTypeHandleForTypeKey(TypeKey *pKey)
-{
-    WRAPPER_NO_CONTRACT;
-    SUPPORTS_DAC;
-
-    // Make an initial lookup without taking any locks.
-    TypeHandle th = LookupTypeHandleForTypeKeyInner(pKey, FALSE);
-
-    //// A non-null TypeHandle for the above lookup indicates success
-    //// A null TypeHandle only indicates "well, it might have been there,
-    //// try again with a lock".  This kind of negative result will
-    //// only happen while accessing the underlying EETypeHashTable
-    //// during a resize, i.e. very rarely. In such a case, we just
-    //// perform the lookup again, but indicate that appropriate locks
-    //// should be taken.
-
-    //if (th.IsNull())
-    //{
-    //    th = LookupTypeHandleForTypeKeyInner(pKey, TRUE);
-    //}
-
-    return th;
-}
-/* static */
-TypeHandle ClassLoader::LookupTypeHandleForTypeKeyInner(TypeKey *pKey, BOOL fCheckUnderLock)
 {
     CONTRACTL
     {
@@ -1184,7 +1127,7 @@ TypeHandle ClassLoader::LookupTypeHandleForTypeKeyInner(TypeKey *pKey, BOOL fChe
     // If the thing is not NGEN'd then this may
     // be different to pPreferredZapModule.  If they are the same then
     // we can reuse the results of the lookup above.
-    TypeHandle thLM = LookupInLoaderModule(pKey, fCheckUnderLock);
+    TypeHandle thLM = LookupInLoaderModule(pKey);
     if (!thLM.IsNull())
     {
         return thLM;
@@ -2055,11 +1998,10 @@ VOID ClassLoader::Init(AllocMemTracker *pamTracker)
                              CrstAvailableClass,
                              CRST_REENTRANCY);
 
-    // This lock is taken within the classloader whenever we have to insert a new param. type into the table
-    // This lock also needs to be taken for a read operation in a GC_NOTRIGGER scope, thus the ANYMODE flag.
+    // This lock is taken within the classloader whenever we have to insert a new param. type into the table.
     m_AvailableTypesLock.Init(
-                                  CrstAvailableParamTypes,
-                                  (CrstFlags)(CRST_UNSAFE_ANYMODE | CRST_DEBUGGER_THREAD));
+                              CrstAvailableParamTypes,
+                              CRST_DEBUGGER_THREAD);
 
 #ifdef _DEBUG
     CorTypeInfo::CheckConsistency();
@@ -3104,9 +3046,6 @@ TypeHandle ClassLoader::PublishType(TypeKey *pTypeKey, TypeHandle typeHnd)
         Module *pLoaderModule = ComputeLoaderModule(pTypeKey);
         EETypeHashTable *pTable = pLoaderModule->GetAvailableParamTypes();
 
-        // m_AvailableTypesLock has to be taken in cooperative mode to avoid deadlocks during GC
-        GCX_COOP();
-
         CrstHolder ch(&pLoaderModule->GetClassLoader()->m_AvailableTypesLock);
 
         // The type could have been loaded by a different thread as side-effect of avoiding deadlocks caused by LoadsTypeViolation
@@ -3120,9 +3059,6 @@ TypeHandle ClassLoader::PublishType(TypeKey *pTypeKey, TypeHandle typeHnd)
     {
         Module *pModule = pTypeKey->GetModule();
         mdTypeDef typeDef = pTypeKey->GetTypeToken();
-
-        // m_AvailableTypesLock has to be taken in cooperative mode to avoid deadlocks during GC
-        GCX_COOP();
 
         CrstHolder ch(&pModule->GetClassLoader()->m_AvailableTypesLock);
 

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -899,21 +899,13 @@ private:
                                                   ClassLoadLevel level = CLASS_LOADED,
                                                   const InstantiationContext *pInstContext = NULL);
 
-    static TypeHandle LookupTypeKeyUnderLock(TypeKey *pKey,
-                                             EETypeHashTable *pTable,
-                                             CrstBase *pLock);
+    static TypeHandle LookupTypeKey(TypeKey *pKey, EETypeHashTable *pTable);
 
-    static TypeHandle LookupTypeKey(TypeKey *pKey,
-                                    EETypeHashTable *pTable,
-                                    CrstBase *pLock,
-                                    BOOL fCheckUnderLock);
-
-    static TypeHandle LookupInLoaderModule(TypeKey* pKey, BOOL fCheckUnderLock);
+    static TypeHandle LookupInLoaderModule(TypeKey* pKey);
 
     // Lookup a handle in the appropriate table
     // (declaring module for TypeDef or loader-module for constructed types)
     static TypeHandle LookupTypeHandleForTypeKey(TypeKey *pTypeKey);
-    static TypeHandle LookupTypeHandleForTypeKeyInner(TypeKey *pTypeKey, BOOL fCheckUnderLock);
 
     static void DECLSPEC_NORETURN  ThrowTypeLoadException(TypeKey *pKey, UINT resIDWhy);
 

--- a/src/coreclr/vm/dacenumerablehash.h
+++ b/src/coreclr/vm/dacenumerablehash.h
@@ -210,7 +210,6 @@ private:
     LoaderHeap             *m_pHeap;
 
     DPTR(PTR_VolatileEntry)                  m_pBuckets;  // Pointer to a simple bucket list (array of VolatileEntry pointers)
-    DWORD                                    m_cBuckets;  // Count of buckets in the above array (always non-zero)
     DWORD                                    m_cEntries;  // Count of elements
 };
 

--- a/src/coreclr/vm/dacenumerablehash.h
+++ b/src/coreclr/vm/dacenumerablehash.h
@@ -106,6 +106,7 @@ protected:
         TADDR   m_pEntry;               // The entry the caller is currently looking at (or NULL to begin
                                         // with). This is a VolatileEntry* and should always be a target address
                                         // not a DAC PTR_.
+        TADDR   m_curTable;
     };
 
     // This opaque structure provides enumeration context when walking all entries in the table. Initialized
@@ -186,6 +187,8 @@ private:
         PTR_VolatileEntry   m_pNextEntry;       // Pointer to the next entry in the bucket chain (or NULL)
         DacEnumerableHashValue       m_iHashValue;       // The hash value associated with the entry
     };
+
+    DPTR(VALUE) BaseFindFirstEntryByHashCore(PTR_VolatileEntry* curBuckets, DacEnumerableHashValue iHash, LookupContext* pContext);
 
 #ifndef DACCESS_COMPILE
     // Determine loader heap to be used for allocation of entries and bucket lists.

--- a/src/coreclr/vm/dacenumerablehash.h
+++ b/src/coreclr/vm/dacenumerablehash.h
@@ -96,6 +96,16 @@ public:
     void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);
 #endif // DACCESS_COMPILE
 
+private:
+    struct VolatileEntry;
+    typedef DPTR(struct VolatileEntry) PTR_VolatileEntry;
+    struct VolatileEntry
+    {
+        VALUE               m_sValue;           // The derived-class format of an entry
+        PTR_VolatileEntry   m_pNextEntry;       // Pointer to the next entry in the bucket chain (or NULL)
+        DacEnumerableHashValue       m_iHashValue;       // The hash value associated with the entry
+    };
+
 protected:
     // This opaque structure provides enumeration context when walking the set of entries which share a common
     // hash code. Initialized by BaseFindFirstEntryByHash and read/updated by BaseFindNextEntryByHash.
@@ -106,7 +116,7 @@ protected:
         TADDR   m_pEntry;               // The entry the caller is currently looking at (or NULL to begin
                                         // with). This is a VolatileEntry* and should always be a target address
                                         // not a DAC PTR_.
-        TADDR   m_curTable;
+        DPTR(PTR_VolatileEntry)   m_curBuckets;   // The bucket table we are working with.
     };
 
     // This opaque structure provides enumeration context when walking all entries in the table. Initialized
@@ -177,18 +187,9 @@ protected:
     PTR_Module m_pModule;
 
 private:
+    private:
     // Internal implementation details. Nothing of interest to sub-classers for here on.
-
-    struct VolatileEntry;
-    typedef DPTR(struct VolatileEntry) PTR_VolatileEntry;
-    struct VolatileEntry
-    {
-        VALUE               m_sValue;           // The derived-class format of an entry
-        PTR_VolatileEntry   m_pNextEntry;       // Pointer to the next entry in the bucket chain (or NULL)
-        DacEnumerableHashValue       m_iHashValue;       // The hash value associated with the entry
-    };
-
-    DPTR(VALUE) BaseFindFirstEntryByHashCore(PTR_VolatileEntry* curBuckets, DacEnumerableHashValue iHash, LookupContext* pContext);
+    DPTR(VALUE) BaseFindFirstEntryByHashCore(DPTR(PTR_VolatileEntry) curBuckets, DacEnumerableHashValue iHash, LookupContext* pContext);
 
 #ifndef DACCESS_COMPILE
     // Determine loader heap to be used for allocation of entries and bucket lists.
@@ -207,6 +208,21 @@ private:
         SUPPORTS_DAC;
 
         return m_pBuckets;
+    }
+
+    // our bucket table uses two extra slots - slot [0] contains the length of the table,
+    //                                         slot [1] will contain the next version of the table if it resizes
+    static const int SLOT_LENGTH = 0;
+    static const int SLOT_NEXT = 1;
+
+    static DWORD GetLength(DPTR(PTR_VolatileEntry) buckets)
+    {
+        return (DWORD)dac_cast<TADDR>(buckets[SLOT_LENGTH]);
+    }
+
+    static DPTR(PTR_VolatileEntry) GetNext(DPTR(PTR_VolatileEntry) buckets)
+    {
+        return (DPTR(PTR_VolatileEntry))dac_cast<TADDR>(buckets[SLOT_NEXT]);
     }
 
     // Loader heap provided at construction time. May be NULL (in which case m_pModule must *not* be NULL).

--- a/src/coreclr/vm/dacenumerablehash.h
+++ b/src/coreclr/vm/dacenumerablehash.h
@@ -224,7 +224,7 @@ private:
 
     static DPTR(PTR_VolatileEntry) GetNext(DPTR(PTR_VolatileEntry) buckets)
     {
-        return dac_cast<DPTR(PTR_VolatileEntry)>(dac_cast<TADDR>(buckets[SLOT_NEXT]));
+        return dac_cast<DPTR(PTR_VolatileEntry)>(buckets[SLOT_NEXT]);
     }
 
     // Loader heap provided at construction time. May be NULL (in which case m_pModule must *not* be NULL).

--- a/src/coreclr/vm/dacenumerablehash.h
+++ b/src/coreclr/vm/dacenumerablehash.h
@@ -214,7 +214,9 @@ private:
     //                                         slot [1] will contain the next version of the table if it resizes
     static const int SLOT_LENGTH = 0;
     static const int SLOT_NEXT = 1;
-
+    // normal slots start at slot #2
+    static const int SKIP_SPECIAL_SLOTS = 2;
+    
     static DWORD GetLength(DPTR(PTR_VolatileEntry) buckets)
     {
         return (DWORD)dac_cast<TADDR>(buckets[SLOT_LENGTH]);
@@ -222,7 +224,7 @@ private:
 
     static DPTR(PTR_VolatileEntry) GetNext(DPTR(PTR_VolatileEntry) buckets)
     {
-        return (DPTR(PTR_VolatileEntry))dac_cast<TADDR>(buckets[SLOT_NEXT]);
+        return dac_cast<DPTR(PTR_VolatileEntry)>(dac_cast<TADDR>(buckets[SLOT_NEXT]));
     }
 
     // Loader heap provided at construction time. May be NULL (in which case m_pModule must *not* be NULL).

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -43,7 +43,7 @@ DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::DacEnumerableHashTable(Module *pModu
 
     // two extra slots - slot [0] contains the length of the table,
     //                   slot [1] will contain the next version of the table if it resizes
-    S_SIZE_T cbBuckets = S_SIZE_T(sizeof(VolatileEntry*)) * S_SIZE_T(cInitialBuckets + 2);
+    S_SIZE_T cbBuckets = S_SIZE_T(sizeof(VolatileEntry*)) * (S_SIZE_T(cInitialBuckets) + S_SIZE_T(2));
 
     m_cEntries = 0;
     PTR_VolatileEntry* pBuckets = (PTR_VolatileEntry*)(void*)GetHeap()->AllocMem(cbBuckets);

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -333,7 +333,7 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindFirstEntryByHash
         }
 
         // in a case if resize is in progress, look in the new table as well.
-        // if existing entry is ot in the old table, it must be in the new
+        // if existing entry is not in the old table, it must be in the new
         // since we unlink it from old only after linking into the new.
         curBuckets = (DPTR(PTR_VolatileEntry))dac_cast<TADDR>(curBuckets[1]);
     } while (curBuckets != nullptr);

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -303,7 +303,7 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindFirstEntryByHash
 
     do
     {
-        DWORD cBuckets = (DWORD)dac_cast<size_t>(curBuckets[0]);
+        DWORD cBuckets = (DWORD)dac_cast<TADDR>(curBuckets[0]);
 
         // Compute which bucket the entry belongs in based on the hash.
         // +2 to skip "length" and "next" slots
@@ -434,7 +434,7 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::EnumMemoryRegions(CLRDataEnumMe
     DacEnumMemoryRegion(dac_cast<TADDR>(this), sizeof(FINAL_CLASS));
 
     auto curBuckets = GetBuckets();
-    DWORD cBuckets = (DWORD)dac_cast<size_t>(curBuckets[0]);
+    DWORD cBuckets = (DWORD)dac_cast<TADDR>(curBuckets[0]);
 
     // Save the bucket list.
     DacEnumMemoryRegion(dac_cast<TADDR>(curBuckets), cBuckets * sizeof(VolatileEntry*));
@@ -495,7 +495,7 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseIterator::Next()
     CONTRACTL_END;
 
     auto curBuckets = m_pTable->GetBuckets();
-    DWORD cBuckets = (DWORD)dac_cast<size_t>(curBuckets[0]);
+    DWORD cBuckets = (DWORD)dac_cast<TADDR>(curBuckets[0]);
 
     while (m_dwBucket < cBuckets)
     {

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -332,9 +332,11 @@ DPTR(VALUE) DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::BaseFindFirstEntryByHash
             pEntry = pEntry->m_pNextEntry;
         }
 
-        // in a case if resize is in progress, look in the new table as well.
+        // in a rare case if resize is in progress, look in the new table as well.
         // if existing entry is not in the old table, it must be in the new
         // since we unlink it from old only after linking into the new.
+        // check for next table must hapen after we looked through the current.
+        VolatileLoadBarrier();
         curBuckets = (DPTR(PTR_VolatileEntry))dac_cast<TADDR>(curBuckets[1]);
     } while (curBuckets != nullptr);
 

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -46,7 +46,7 @@ DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::DacEnumerableHashTable(Module *pModu
     S_SIZE_T cbBuckets = S_SIZE_T(sizeof(VolatileEntry*)) * (S_SIZE_T(cInitialBuckets) + S_SIZE_T(2));
 
     m_cEntries = 0;
-    DPTR(PTR_VolatileEntry) pBuckets = (DPTR(PTR_VolatileEntry))(void*)GetHeap()->AllocMem(cbBuckets);
+    PTR_VolatileEntry* pBuckets = (PTR_VolatileEntry*)(void*)GetHeap()->AllocMem(cbBuckets);
     ((size_t*)pBuckets)[SLOT_LENGTH] = cInitialBuckets;
 
     // publish after setting the length
@@ -185,6 +185,7 @@ void DacEnumerableHashTable<DAC_ENUM_HASH_ARGS>::GrowTable()
     // element 0 stores the length of the table
     ((size_t*)pNewBuckets)[SLOT_LENGTH] = cNewBuckets;
     // element 1 stores the next version of the table (after length is written)
+    // NOTE: DAC does not call add/grow, so this cast is ok.
     VolatileStore(&((PTR_VolatileEntry**)curBuckets)[SLOT_NEXT], pNewBuckets);
 
     // All buckets are initially empty.

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -723,7 +723,7 @@ DomainAssembly::~DomainAssembly()
     if (m_fHostAssemblyPublished)
     {
         // Remove association first.
-        UnRegisterFromHostAssembly();
+        UnregisterFromHostAssembly();
     }
 
     ModuleIterator i = IterateModules(kModIterIncludeLoading);
@@ -873,7 +873,7 @@ void DomainAssembly::RegisterWithHostAssembly()
     }
 }
 
-void DomainAssembly::UnRegisterFromHostAssembly()
+void DomainAssembly::UnregisterFromHostAssembly()
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -588,7 +588,7 @@ private:
     void DeliverSyncEvents();
     void DeliverAsyncEvents();
     void RegisterWithHostAssembly();
-    void UnRegisterFromHostAssembly();
+    void UnregisterFromHostAssembly();
 #endif
 
  public:

--- a/src/coreclr/vm/genmeth.cpp
+++ b/src/coreclr/vm/genmeth.cpp
@@ -1418,9 +1418,6 @@ void InstantiatedMethodDesc::SetupGenericMethodDefinition(IMDInternalImport *pIM
     {
         // Protect multi-threaded access to Module.m_GenericParamToDescMap. Other threads may be loading the same type
         // to break type recursion dead-locks
-
-        // m_AvailableTypesLock has to be taken in cooperative mode to avoid deadlocks during GC
-        GCX_COOP();
         CrstHolder ch(&pModule->GetClassLoader()->m_AvailableTypesLock);
 
         for (unsigned int i = 0; i < numTyPars; i++)

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -11771,9 +11771,6 @@ MethodTableBuilder::GatherGenericsInfo(
         {
             // Protect multi-threaded access to Module.m_GenericParamToDescMap. Other threads may be loading the same type
             // to break type recursion dead-locks
-
-            // m_AvailableTypesLock has to be taken in cooperative mode to avoid deadlocks during GC
-            GCX_COOP();
             CrstHolder ch(&pModule->GetClassLoader()->m_AvailableTypesLock);
 
             for (unsigned int i = 0; i < numGenericArgs; i++)


### PR DESCRIPTION
The goal is to simplify use of `m_AvailableTypesLock`

Currently `m_AvailableTypesLock` lock may be taken in lookups, and lookups may happen in a `GC_NOTRIGGER` scope. 
Thus the lock is `CRST_UNSAFE_ANYMODE` with an additional requirement that callers, with exception of GC threads, must switch to COOP mode before using this lock - to avoid deadlocks during GC.
The requirement it fragile. Besides all other uses of `m_AvailableTypesLock` are in preemptive mode and it is better when preemptive mode can stay preemptive.

Once we do not need to take locks in Lookup, we can make `m_AvailableTypesLock` just an ordinary lock.
