### PR TITLE
Ensure MaxBy/MinBy return first element if all keys are null.

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Max.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Max.cs
@@ -583,15 +583,22 @@ namespace System.Linq
 
             if (default(TKey) is null)
             {
-                while (key == null)
+                if (key == null)
                 {
-                    if (!e.MoveNext())
-                    {
-                        return value;
-                    }
+                    TSource firstValue = value;
 
-                    value = e.Current;
-                    key = keySelector(value);
+                    do
+                    {
+                        if (!e.MoveNext())
+                        {
+                            // All keys are null, surface the first element.
+                            return firstValue;
+                        }
+
+                        value = e.Current;
+                        key = keySelector(value);
+                    }
+                    while (key == null);
                 }
 
                 while (e.MoveNext())

--- a/src/libraries/System.Linq/src/System/Linq/Min.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -541,15 +541,22 @@ namespace System.Linq
 
             if (default(TKey) is null)
             {
-                while (key == null)
+                if (key == null)
                 {
-                    if (!e.MoveNext())
-                    {
-                        return value;
-                    }
+                    TSource firstValue = value;
 
-                    value = e.Current;
-                    key = keySelector(value);
+                    do
+                    {
+                        if (!e.MoveNext())
+                        {
+                            // All keys are null, surface the first element.
+                            return firstValue;
+                        }
+
+                        value = e.Current;
+                        key = keySelector(value);
+                    }
+                    while (key == null);
                 }
 
                 while (e.MoveNext())

--- a/src/libraries/System.Linq/tests/MaxTests.cs
+++ b/src/libraries/System.Linq/tests/MaxTests.cs
@@ -890,27 +890,27 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public static void MaxBy_Generic_StructSourceAllKeysAreNull_ReturnsLastElement()
+        public static void MaxBy_Generic_StructSourceAllKeysAreNull_ReturnsFirstElement()
         {
-            Assert.Equal(4, Enumerable.Range(0, 5).MaxBy(x => default(string)));
-            Assert.Equal(4, Enumerable.Range(0, 5).MaxBy(x => default(string), comparer: null));
-            Assert.Equal(4, Enumerable.Range(0, 5).MaxBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
+            Assert.Equal(0, Enumerable.Range(0, 5).MaxBy(x => default(string)));
+            Assert.Equal(0, Enumerable.Range(0, 5).MaxBy(x => default(string), comparer: null));
+            Assert.Equal(0, Enumerable.Range(0, 5).MaxBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
         }
 
         [Fact]
-        public static void MaxBy_Generic_NullableSourceAllKeysAreNull_ReturnsLastElement()
+        public static void MaxBy_Generic_NullableSourceAllKeysAreNull_ReturnsFirstElement()
         {
-            Assert.Equal(4, Enumerable.Range(0, 5).Cast<int?>().MaxBy(x => default(int?)));
-            Assert.Equal(4, Enumerable.Range(0, 5).Cast<int?>().MaxBy(x => default(int?), comparer: null));
-            Assert.Equal(4, Enumerable.Range(0, 5).Cast<int?>().MaxBy(x => default(int?), Comparer<int?>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
+            Assert.Equal(0, Enumerable.Range(0, 5).Cast<int?>().MaxBy(x => default(int?)));
+            Assert.Equal(0, Enumerable.Range(0, 5).Cast<int?>().MaxBy(x => default(int?), comparer: null));
+            Assert.Equal(0, Enumerable.Range(0, 5).Cast<int?>().MaxBy(x => default(int?), Comparer<int?>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
         }
 
         [Fact]
-        public static void MaxBy_Generic_ReferenceSourceAllKeysAreNull_ReturnsLastElement()
+        public static void MaxBy_Generic_ReferenceSourceAllKeysAreNull_ReturnsFirstElement()
         {
-            Assert.Equal("4", Enumerable.Range(0, 5).Select(x => x.ToString()).MaxBy(x => default(string)));
-            Assert.Equal("4", Enumerable.Range(0, 5).Select(x => x.ToString()).MaxBy(x => default(string), comparer: null));
-            Assert.Equal("4", Enumerable.Range(0, 5).Select(x => x.ToString()).MaxBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
+            Assert.Equal("0", Enumerable.Range(0, 5).Select(x => x.ToString()).MaxBy(x => default(string)));
+            Assert.Equal("0", Enumerable.Range(0, 5).Select(x => x.ToString()).MaxBy(x => default(string), comparer: null));
+            Assert.Equal("0", Enumerable.Range(0, 5).Select(x => x.ToString()).MaxBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
         }
 
         [Theory]

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -868,27 +868,27 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public static void MinBy_Generic_StructSourceAllKeysAreNull_ReturnsLastElement()
+        public static void MinBy_Generic_StructSourceAllKeysAreNull_ReturnsFirstElement()
         {
-            Assert.Equal(4, Enumerable.Range(0, 5).MinBy(x => default(string)));
-            Assert.Equal(4, Enumerable.Range(0, 5).MinBy(x => default(string), comparer: null));
-            Assert.Equal(4, Enumerable.Range(0, 5).MinBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
+            Assert.Equal(0, Enumerable.Range(0, 5).MinBy(x => default(string)));
+            Assert.Equal(0, Enumerable.Range(0, 5).MinBy(x => default(string), comparer: null));
+            Assert.Equal(0, Enumerable.Range(0, 5).MinBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
         }
 
         [Fact]
-        public static void MinBy_Generic_NullableSourceAllKeysAreNull_ReturnsLastElement()
+        public static void MinBy_Generic_NullableSourceAllKeysAreNull_ReturnsFirstElement()
         {
-            Assert.Equal(4, Enumerable.Range(0, 5).Cast<int?>().MinBy(x => default(int?)));
-            Assert.Equal(4, Enumerable.Range(0, 5).Cast<int?>().MinBy(x => default(int?), comparer: null));
-            Assert.Equal(4, Enumerable.Range(0, 5).Cast<int?>().MinBy(x => default(int?), Comparer<int?>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
+            Assert.Equal(0, Enumerable.Range(0, 5).Cast<int?>().MinBy(x => default(int?)));
+            Assert.Equal(0, Enumerable.Range(0, 5).Cast<int?>().MinBy(x => default(int?), comparer: null));
+            Assert.Equal(0, Enumerable.Range(0, 5).Cast<int?>().MinBy(x => default(int?), Comparer<int?>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
         }
 
         [Fact]
-        public static void MinBy_Generic_ReferenceSourceAllKeysAreNull_ReturnsLastElement()
+        public static void MinBy_Generic_ReferenceSourceAllKeysAreNull_ReturnsFirstElement()
         {
-            Assert.Equal("4", Enumerable.Range(0, 5).Select(x => x.ToString()).MinBy(x => default(string)));
-            Assert.Equal("4", Enumerable.Range(0, 5).Select(x => x.ToString()).MinBy(x => default(string), comparer: null));
-            Assert.Equal("4", Enumerable.Range(0, 5).Select(x => x.ToString()).MinBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
+            Assert.Equal("0", Enumerable.Range(0, 5).Select(x => x.ToString()).MinBy(x => default(string)));
+            Assert.Equal("0", Enumerable.Range(0, 5).Select(x => x.ToString()).MinBy(x => default(string), comparer: null));
+            Assert.Equal("0", Enumerable.Range(0, 5).Select(x => x.ToString()).MinBy(x => default(string), Comparer<string>.Create((_, _) => throw new InvalidOperationException("comparer should not be called."))));
         }
 
         [Theory]


### PR DESCRIPTION
Following the null handling semantics of the `Max` and `Min` methods, the new `MaxBy` and `MinBy` methods have been designed to skip any elements yielding _null_ keys. As a side-effect of the behavior, the methods will return the _last element_ in a sequence if _every key_ turns out to be null. While this does not produce any observable difference in the `Max` and `Min` methods, it does do so in the `MaxBy` and `MinBy` case. In fact it is inconsistent with how the same methods treat sequences returning identical non-null keys, where the first element is always favored.

I do not believe this to be a breaking change, since our documentation provides no guarantee on what element will get returned in the event of a tie.

Fixes #61317.