### PR TITLE
Fix -rebuild command

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/dotnet-pgo-pack.proj
+++ b/src/coreclr/tools/dotnet-pgo/dotnet-pgo-pack.proj
@@ -1,4 +1,4 @@
-<Project>
+<Project Sdk="Microsoft.Build.Traversal">
   <Target Name="Build">
     <Msbuild Targets="Pack" Projects="dotnet-pgo.csproj" />
   </Target>


### PR DESCRIPTION
```
build.cmd -rebuild
```
in the root folder fails with:
```
C:\prj\runtime-2\src\coreclr\tools\dotnet-pgo\dotnet-pgo-pack.proj : error MSB4057: The target "Clean" 
does not exist in the project.

Build FAILED.
```
I am not sure if this is a correct fix. I was trying to use `-rebuild` command to benchmark compilation speed between different hardware.