### PR TITLE
Rewrite selection for fields and always normalize SIMD types in VN

### DIFF
--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -591,9 +591,7 @@ public:
     // A specialized version of VNForFunc that is used for VNF_MapStore and provides some logging when verbose is set
     ValueNum VNForMapStore(var_types type, ValueNum map, ValueNum index, ValueNum value);
 
-    ValueNum VNForFieldSelector(CORINFO_FIELD_HANDLE  fieldHnd,
-                                var_types*            pFieldType,
-                                CORINFO_CLASS_HANDLE* pStructHnd = nullptr);
+    ValueNum VNForFieldSelector(CORINFO_FIELD_HANDLE fieldHnd, var_types* pFieldType, size_t* pStructSize = nullptr);
 
     // These functions parallel the ones above, except that they take liberal/conservative VN pairs
     // as arguments, and return such a pair (the pair of the function applied to the liberal args, and


### PR DESCRIPTION
This is mirroring the changes made in #61113 in preparation for typing the maps with placeholders, meaning that `ApplySelectors` is no longer suitable when selecting the first field.

There are small diffs ([`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61370/win-x64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61370/win-x86.md), [`win-arm64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-61370/win-x64.md)) with this change, all are coming from additional CSEs.

<details>
<summary>Notes on the diffs</summary>

The first kind is from the SIMD type normalization:
```cs
private static Vector128<int> Problem(StructWithVtors[] a)
{
    a[0].Vtor = Vector128<int>.Zero;

    return a[0].Vtor;
}

struct StructWithVtors
{
    public Vector128<int> Vtor;
}
```
We are now able to VN `return a[0].Vtor` properly, as we no longer run into [a type mismatch check](https://github.com/dotnet/runtime/blob/08aff106db7ddbb58cc341ce6a178cec4cd516ef/src/coreclr/jit/valuenum.cpp#L4275-L4285) where `indType` is some SIMD type while `arrElemFldType` is `TYP_STRUCT`, since it is effectively obtained from `VNApplySelectorsAssign`.

The second kind of diffs (show up on x86) are due to the new code not using this to get the first field's type:
https://github.com/dotnet/runtime/blob/08aff106db7ddbb58cc341ce6a178cec4cd516ef/src/coreclr/jit/valuenum.cpp#L9016

It was creating artificial mismatches in cases when we see maps of `TYP_REF`:
```scala
***** BB02, STMT00010(before)
N007 ( 11, 12) [000079] -A-XG---R---              *  ASG       int   
N006 (  1,  1) [000078] D------N----              +--*  LCL_VAR   int    V04 tmp2         d:2
N005 ( 11, 12) [000048] ---XG----U--              \--*  CAST_ovfl int <- ulong
N004 (  4,  4) [000047] ---XG-------                 \--*  IND       long  
N003 (  2,  2) [000137] -------N----                    \--*  ADD       byref 
N001 (  1,  1) [000046] ------------                       +--*  LCL_VAR   ref    V00 this         u:1
N002 (  1,  1) [000136] ------------                       \--*  CNS_INT   int    4 field offset Fseq[hackishFieldName]

N001 [000046]   LCL_VAR   V00 this         u:1 => $80 {InitVal($40)}
N002 [000136]   CNS_INT   4 field offset Fseq[hackishFieldName] => $45 {IntCns 4}
N003 [000137]   ADD       => $281 {ADD($45, $80)}
  VNApplySelectors:
    VNForHandle(hackishFieldName) is $182, fieldType is long
      AX2: $182 != $183 ==> select([$2c9]store($2c8, $183, $8d), $182) ==> select($2c8, $182) remaining budget is 99.
      AX1: select([$345]store($2c8, $182, $8c), $182) ==> $8c.
      ==> Not updating loop memory dependence of [000047], memory $345 not defined in a loop
    VNForMapSelect($2c9, $182):long returns $8c {MemOpaque:L00}
    VNForMapSelect($8c, $80):ref returns $220 {$8c[$80]}
    *** Mismatched types in VNApplySelectorsTypeCheck (reading beyond the end)
```
</details>

I was concerned about the new normalization code impacting TP, but it seems that the redundant `VNForMapSelect`s removed in #61113, combined with the redundant handle lookups removed in this PR actually result in a `~0.1%` TP improvement (according to my noisy PIN over SPMI-ing the benchmarks collection a few times, anyway):
```diff
 N006 [000000]   LCL_VAR   V00 this         u:1 => $80 {InitVal($40)}
 N007 [000096]   CNS_INT   12 field offset Fseq[mt] => $44 {IntCns 12}
 N008 [000097]   ADD       => $280 {ADD($44, $80)}
-  VNApplySelectors:
     VNForHandle(mt) is $181, fieldType is ref
     VNForMapSelect($81, $181):ref returns $203 {$81[$181]}
-    VNForMapSelect($203, $80):ref returns $204 {$203[$80]}
     VNForMapStore($203, $80, $240):ref in BB01 returns $2c0 {$203[$80 := $240]}
-  VNApplySelectorsAssign:
-    VNForHandle(mt) is $181, fieldType is ref
     VNForMapStore($81, $181, $2c0):ref in BB01 returns $2c1 {$81[$181 := $2c0]}
   fgCurMemoryVN[GcHeap] assigned for StoreField at [000005] to VN: $2c1.
```

Part of #58312.