### PR TITLE
[wasm][debugger] Correct the endian swapping and string implementation

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -438,8 +438,8 @@ namespace Microsoft.WebAssembly.Diagnostics
         public void WriteString(string val)
         {
             var bytes = Encoding.UTF8.GetBytes(val);
-            Write(val.Length);
-            Write(val.ToCharArray());
+            Write(bytes.Length);
+            Write(bytes);
         }
         public unsafe void WriteLong(long val)
         {


### PR DESCRIPTION
A limited change fix WriteString and only byte swap when needed.