### PR TITLE
Use DllImportGenerator in System.Diagnostics.PerformanceCounter

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -32,7 +32,7 @@
                         and '$(IsFrameworkSupportFacade)' != 'true'
                         and '$(IsSourceProject)' == 'true'
                         and '$(MSBuildProjectExtension)' == '.csproj'
-                        and '$(TargetFrameworkIdentifier)' == '.NETStandard'" />
+                        and ('$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETFramework')" />
   </ItemGroup>
 
   <!-- Use this complex ItemGroup-based filtering to add the ProjectReference to make sure dotnet/runtime stays compatible with NuGet Static Graph Restore. -->

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSecurityDescriptorToSecurityDescriptor.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
-        internal static extern bool ConvertStringSecurityDescriptorToSecurityDescriptor(
-                string StringSecurityDescriptor,
-                int StringSDRevision,
-                out SafeLocalAllocHandle pSecurityDescriptor,
-                IntPtr SecurityDescriptorSize);
+        [GeneratedDllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static partial bool ConvertStringSecurityDescriptorToSecurityDescriptor(
+            string StringSecurityDescriptor,
+            int StringSDRevision,
+            out SafeLocalAllocHandle pSecurityDescriptor,
+            IntPtr SecurityDescriptorSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityDescriptorLength.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityDescriptorLength.cs
@@ -8,8 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityDescriptorLength", CallingConvention = CallingConvention.Winapi,
-            CharSet = CharSet.Unicode, ExactSpelling = true)]
-        internal static extern /*DWORD*/ uint GetSecurityDescriptorLength(IntPtr byteArray);
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "GetSecurityDescriptorLength", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial uint GetSecurityDescriptorLength(IntPtr byteArray);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation.cs
@@ -9,39 +9,24 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool GetTokenInformation(
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern bool GetTokenInformation(
-#endif
             SafeAccessTokenHandle TokenHandle,
             uint TokenInformationClass,
             SafeLocalAllocHandle TokenInformation,
             uint TokenInformationLength,
             out uint ReturnLength);
 
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool GetTokenInformation(
-#else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern bool GetTokenInformation(
-#endif
             IntPtr TokenHandle,
             uint TokenInformationClass,
             SafeLocalAllocHandle TokenInformation,
             uint TokenInformationLength,
             out uint ReturnLength);
 
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
         internal static partial bool GetTokenInformation(
-#else
-        [DllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool GetTokenInformation(
-#endif
             IntPtr TokenHandle,
             uint TokenInformationClass,
             IntPtr TokenInformation,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaNtStatusToWinError.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaNtStatusToWinError.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = false)]
-        internal static extern uint LsaNtStatusToWinError(uint status);
+        [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = false)]
+        internal static partial uint LsaNtStatusToWinError(uint status);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCloseKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCloseKey.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32)]
-        internal static extern int RegCloseKey(IntPtr hKey);
+        [GeneratedDllImport(Libraries.Advapi32)]
+        internal static partial int RegCloseKey(IntPtr hKey);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegConnectRegistry.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegConnectRegistry.cs
@@ -14,13 +14,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegConnectRegistryW", CharSet = CharSet.Unicode)]
         internal static partial int RegConnectRegistry(
-#else
-        [DllImport(Libraries.Advapi32, EntryPoint = "RegConnectRegistryW", CharSet = CharSet.Unicode, BestFitMapping = false)]
-        internal static extern int RegConnectRegistry(
-#endif
             string machineName,
             SafeRegistryHandle key,
             out SafeRegistryHandle result);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
@@ -12,8 +12,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumKeyExW", ExactSpelling = true)]
-        internal static extern int RegEnumKeyEx(
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegEnumKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial int RegEnumKeyEx(
             SafeRegistryHandle hKey,
             int dwIndex,
             char[] lpName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
         internal static partial int RegEnumKeyEx(
             SafeRegistryHandle hKey,
             int dwIndex,
-            char[] lpName,
+            [Out] char[] lpName,
             ref int lpcbName,
             int[]? lpReserved,
             [Out] char[]? lpClass,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         internal static partial int RegEnumValue(
             SafeRegistryHandle hKey,
             int dwIndex,
-            char[] lpValueName,
+            [Out] char[] lpValueName,
             ref int lpcbValueName,
             IntPtr lpReserved_MustBeZero,
             int[]? lpType,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
@@ -13,8 +13,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumValueW", ExactSpelling = true)]
-        internal static extern int RegEnumValue(
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegEnumValueW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial int RegEnumValue(
             SafeRegistryHandle hKey,
             int dwIndex,
             char[] lpValueName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryInfoKey.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryInfoKey.cs
@@ -14,8 +14,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryInfoKeyW")]
-        internal static extern int RegQueryInfoKey(
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegQueryInfoKeyW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial int RegQueryInfoKey(
             SafeRegistryHandle hKey,
             [Out] char[]? lpClass,
             int[]? lpcbClass,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
@@ -13,17 +13,17 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
-        internal static extern int RegQueryValueEx(
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegQueryValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
             int[]? lpReserved,
             ref int lpType,
-            [Out] byte[]? lpData,
+            byte[]? lpData,
             ref int lpcbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
-        internal static extern int RegQueryValueEx(
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegQueryValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
             int[]? lpReserved,
@@ -31,8 +31,8 @@ internal static partial class Interop
             ref int lpData,
             ref int lpcbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
-        internal static extern int RegQueryValueEx(
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegQueryValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
             int[]? lpReserved,
@@ -40,8 +40,8 @@ internal static partial class Interop
             ref long lpData,
             ref int lpcbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
-        internal static extern int RegQueryValueEx(
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegQueryValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        internal static partial int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
             int[]? lpReserved,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFileMapping.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFileMapping.cs
@@ -10,13 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial SafeMemoryMappedFileHandle CreateFileMapping(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern SafeMemoryMappedFileHandle CreateFileMapping(
-#endif
             SafeFileHandle hFile,
             ref SECURITY_ATTRIBUTES lpFileMappingAttributes,
             int flProtect,
@@ -24,13 +19,8 @@ internal static partial class Interop
             int dwMaximumSizeLow,
             string? lpName);
 
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial SafeMemoryMappedFileHandle CreateFileMapping(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern SafeMemoryMappedFileHandle CreateFileMapping(
-#endif
             IntPtr hFile,
             ref SECURITY_ATTRIBUTES lpFileMappingAttributes,
             int flProtect,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeWaitHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DuplicateHandle_SafeWaitHandle.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         internal static partial bool DuplicateHandle(
-#else
-        [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern bool DuplicateHandle(
-#endif
             IntPtr hSourceProcessHandle,
             SafeHandle hSourceHandle,
             IntPtr hTargetProcess,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FreeLibrary.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FreeLibrary.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        internal static extern bool FreeLibrary(IntPtr hModule);
+        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
+        internal static partial bool FreeLibrary(IntPtr hModule);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "GetComputerNameW", ExactSpelling = true)]
-        private static unsafe extern int GetComputerName(char* lpBuffer, uint* nSize);
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetComputerNameW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static unsafe partial int GetComputerName(char* lpBuffer, uint* nSize);
 
         // maximum length of the NETBIOS name (not including NULL)
         private const int MAX_COMPUTERNAME_LENGTH = 15;

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentProcess.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal static extern IntPtr GetCurrentProcess();
+        [GeneratedDllImport(Libraries.Kernel32)]
+        internal static partial IntPtr GetCurrentProcess();
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentProcessId.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentProcessId.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal static extern uint GetCurrentProcessId();
+        [GeneratedDllImport(Libraries.Kernel32)]
+        internal static partial uint GetCurrentProcessId();
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentThread.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentThread.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Interop.Libraries.Kernel32)]
-        internal static extern IntPtr GetCurrentThread();
+        [GeneratedDllImport(Interop.Libraries.Kernel32)]
+        internal static partial IntPtr GetCurrentThread();
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessTimes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetProcessTimes.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool GetProcessTimes(
-#else
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern bool GetProcessTimes(
-#endif
             SafeProcessHandle handle, out long creation, out long exit, out long kernel, out long user);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibrary.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibrary.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern IntPtr LoadLibrary(string libFilename);
+        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
+        public static partial IntPtr LoadLibrary(string libFilename);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MapViewOfFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MapViewOfFile.cs
@@ -9,13 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "MapViewOfFile", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial SafeMemoryMappedViewHandle MapViewOfFile(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "MapViewOfFile", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern SafeMemoryMappedViewHandle MapViewOfFile(
-#endif
             SafeMemoryMappedFileHandle hFileMappingObject,
             int dwDesiredAccess,
             int dwFileOffsetHigh,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenFileMapping.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenFileMapping.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "OpenFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "OpenFileMappingW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial SafeMemoryMappedFileHandle OpenFileMapping(
-#else
-        [DllImport(Libraries.Kernel32, EntryPoint = "OpenFileMappingW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern SafeMemoryMappedFileHandle OpenFileMapping(
-#endif
             int dwDesiredAccess,
             [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
             string lpName);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.OpenProcess.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial SafeProcessHandle OpenProcess(
-#else
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern SafeProcessHandle OpenProcess(
-#endif
             int access, bool inherit, int processId);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.UnmapViewOfFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.UnmapViewOfFile.cs
@@ -8,12 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         internal static partial bool UnmapViewOfFile(IntPtr lpBaseAddress);
-#else
-        [DllImport(Libraries.Kernel32, SetLastError = true)]
-        internal static extern bool UnmapViewOfFile(IntPtr lpBaseAddress);
-#endif
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualQuery.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualQuery.cs
@@ -8,13 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-#if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static partial UIntPtr VirtualQuery(
-#else
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        internal static extern UIntPtr VirtualQuery(
-#endif
             SafeHandle lpAddress,
             ref MEMORY_BASIC_INFORMATION lpBuffer,
             UIntPtr dwLength);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitForSingleObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitForSingleObject.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        internal static extern int WaitForSingleObject(SafeWaitHandle handle, int timeout);
+        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
+        internal static partial int WaitForSingleObject(SafeWaitHandle handle, int timeout);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Pdh/Interop.PdhFormatFromRawValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Pdh/Interop.PdhFormatFromRawValue.cs
@@ -7,8 +7,8 @@ internal static partial class Interop
 {
     internal static partial class Pdh
     {
-        [DllImport(Libraries.Pdh, CharSet = CharSet.Unicode)]
-        public static extern int PdhFormatFromRawValue(
+        [GeneratedDllImport(Libraries.Pdh, CharSet = CharSet.Unicode)]
+        public static partial int PdhFormatFromRawValue(
             uint dwCounterType,
             uint dwFormat,
             ref long pTimeBase,

--- a/src/libraries/Common/src/Interop/Windows/PerfCounter/Interop.PerformanceData.cs
+++ b/src/libraries/Common/src/Interop/Windows/PerfCounter/Interop.PerformanceData.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class PerfCounter
     {
-        [DllImport(Libraries.Advapi32, ExactSpelling = true)]
-        internal static extern uint PerfStopProvider(
+        [GeneratedDllImport(Libraries.Advapi32, ExactSpelling = true)]
+        internal static partial uint PerfStopProvider(
             IntPtr hProvider
         );
 
@@ -53,6 +53,7 @@ internal static partial class Interop
             internal uint InstanceNameSize;
         }
 
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
         [DllImport(Libraries.Advapi32, ExactSpelling = true)]
         internal static extern uint PerfStartProvider(
             ref Guid ProviderGuid,
@@ -60,6 +61,7 @@ internal static partial class Interop
             out SafePerfProviderHandle phProvider
         );
 
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
         [DllImport(Libraries.Advapi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
         internal static extern unsafe PerfCounterSetInstanceStruct* PerfCreateInstance(
             SafePerfProviderHandle hProvider,
@@ -68,21 +70,21 @@ internal static partial class Interop
             uint dwInstance
         );
 
-        [DllImport(Libraries.Advapi32, ExactSpelling = true)]
-        internal static extern unsafe uint PerfSetCounterSetInfo(
+        [GeneratedDllImport(Libraries.Advapi32, ExactSpelling = true)]
+        internal static unsafe partial uint PerfSetCounterSetInfo(
             SafePerfProviderHandle hProvider,
             PerfCounterSetInfoStruct* pTemplate,
             uint dwTemplateSize
         );
 
-        [DllImport(Libraries.Advapi32, ExactSpelling = true)]
-        internal static extern unsafe uint PerfDeleteInstance(
+        [GeneratedDllImport(Libraries.Advapi32, ExactSpelling = true)]
+        internal static unsafe partial uint PerfDeleteInstance(
             SafePerfProviderHandle hProvider,
             PerfCounterSetInstanceStruct* InstanceBlock
         );
 
-        [DllImport(Libraries.Advapi32, ExactSpelling = true)]
-        internal static extern unsafe uint PerfSetCounterRefValue(
+        [GeneratedDllImport(Libraries.Advapi32, ExactSpelling = true)]
+        internal static unsafe partial uint PerfSetCounterRefValue(
             SafePerfProviderHandle hProvider,
             PerfCounterSetInstanceStruct* pInstance,
             uint CounterId,

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaDeregisterLogonProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.LsaDeregisterLogonProcess.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class SspiCli
     {
-        [DllImport(Interop.Libraries.SspiCli)]
-        internal static extern int LsaDeregisterLogonProcess(IntPtr LsaHandle);
+        [GeneratedDllImport(Interop.Libraries.SspiCli)]
+        internal static partial int LsaDeregisterLogonProcess(IntPtr LsaHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -475,7 +475,7 @@ internal static partial class Interop
             string password,
             out SafeSspiAuthDataHandle authData);
 
-        // TODO: Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
         [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern SECURITY_STATUS SetCredentialsAttributesW(
             in CredHandle handlePtr,

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 //
 // Types in this file are used for generated p/invokes (docs/design/features/source-generator-pinvokes.md).
 // See the DllImportGenerator experiment in https://github.com/dotnet/runtimelab.

--- a/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 //
 // Types in this file are used for generated p/invokes (docs/design/features/source-generator-pinvokes.md).
 // See the DllImportGenerator experiment in https://github.com/dotnet/runtimelab.

--- a/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedMarshallingAttribute.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedMarshallingAttribute.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 //
 // Types in this file are used for generated p/invokes (docs/design/features/source-generator-pinvokes.md).
 // See the DllImportGenerator experiment in https://github.com/dotnet/runtimelab.

--- a/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedMarshallingAttribute.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedMarshallingAttribute.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 //
 // Types in this file are used for generated p/invokes (docs/design/features/source-generator-pinvokes.md).
 // See the DllImportGenerator experiment in https://github.com/dotnet/runtimelab.

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -8,6 +8,7 @@
       and instead use runtime checks.
     -->
     <TargetFrameworks>$(NetCoreAppMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)ILLink.Substitutions.AggressiveTrimming.xml"

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
@@ -129,9 +129,11 @@ Microsoft.Win32.SystemEvents</PackageDescription>
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />

--- a/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
@@ -3,6 +3,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1838;CA1847</NoWarn>
+    <!-- Suppressions to avoid ifdefs:
+            CA1845: Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring'
+            CA1846: Prefer 'AsSpan' over 'Substring' when span-based overloads are available -->
+    <NoWarn>$(NoWarn);CA1845;CA1846</NoWarn>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides the System.Diagnostics.EventLog class, which allows the applications to use the windows event log service.
 
@@ -125,8 +129,10 @@ System.Diagnostics.EventLog</PackageDescription>
     <Reference Include="System.Diagnostics.Tools" />
     <Reference Include="System.Diagnostics.TraceSource" />
     <Reference Include="System.IO.FileSystem" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Security.Principal.Windows" />

--- a/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
@@ -7,6 +7,7 @@
             CA1845: Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring'
             CA1846: Prefer 'AsSpan' over 'Substring' when span-based overloads are available -->
     <NoWarn>$(NoWarn);CA1845;CA1846</NoWarn>
+    <Nullable>annotations</Nullable>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides the System.Diagnostics.EventLog class, which allows the applications to use the windows event log service.
 

--- a/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/tests/System.Diagnostics.EventLog.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EventInstanceTests.cs" />

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1847</NoWarn>
+    <Nullable>annotations</Nullable>
     <IsPackable>true</IsPackable>
     <PackageDescription>Provides the System.Diagnostics.PerformanceCounter class, which allows access to Windows performance counters.
 

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -144,6 +144,7 @@ System.Diagnostics.PerformanceCounter</PackageDescription>
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Security.Claims" />
     <Reference Include="System.Security.Principal" />

--- a/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -5,6 +5,7 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CoreLibSharedDir)System\PasteArguments.cs"

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MemoryMappedFile.CreateFromFile.Tests.cs" />

--- a/src/libraries/System.Management/src/System.Management.csproj
+++ b/src/libraries/System.Management/src/System.Management.csproj
@@ -5,6 +5,7 @@
     <!-- Suppressins to avoid ifdefs:
             CA1845: Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring'. -->
     <NoWarn>$(NoWarn);CA1845</NoWarn>
+    <Nullable>annotations</Nullable>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>

--- a/src/libraries/System.Management/src/System.Management.csproj
+++ b/src/libraries/System.Management/src/System.Management.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);0618</NoWarn>
+    <!-- Suppressins to avoid ifdefs:
+            CA1845: Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring'. -->
+    <NoWarn>$(NoWarn);CA1845</NoWarn>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
@@ -70,9 +73,11 @@ System.Management.SelectQuery</PackageDescription>
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.ObjectModel" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Threading" />

--- a/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -4,6 +4,7 @@
     <ExternallyShipping>false</ExternallyShipping>
     <NoWarn>436</NoWarn> <!-- Type conflicts on "Interop" due to InternalsVisibleTo access -->
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"


### PR DESCRIPTION
Since we forwarding on down-level, this also enables `DllImportGenerator` by default when targeting Framework (as `System.Diagnostics.PerformanceCounter` does).

cc @AaronRobinsonMSFT @jkoritzinsky 