### PR TITLE
[release/6.0.1] Support async operations on unseekable files

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
@@ -86,8 +86,11 @@ namespace Microsoft.Win32.SafeHandles
                 _bufferSize = memory.Length;
                 _memoryHandle = memory.Pin();
                 _overlapped = _fileHandle.ThreadPoolBinding!.AllocateNativeOverlapped(_preallocatedOverlapped);
-                _overlapped->OffsetLow = (int)fileOffset;
-                _overlapped->OffsetHigh = (int)(fileOffset >> 32);
+                if (_fileHandle.CanSeek)
+                {
+                    _overlapped->OffsetLow = (int)fileOffset;
+                    _overlapped->OffsetHigh = (int)(fileOffset >> 32);
+                }
                 return _overlapped;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -333,15 +333,15 @@ namespace System.IO
             // bufferSize == 1 used to avoid unnecessary buffer in FileStream
             using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1, FileOptions.SequentialScan))
             {
-                long fileLength = fs.Length;
-                if (fileLength > int.MaxValue)
+                long fileLength = 0;
+                if (fs.CanSeek && (fileLength = fs.Length) > int.MaxValue)
                 {
                     throw new IOException(SR.IO_FileTooLong2GB);
                 }
-                else if (fileLength == 0)
+                if (fileLength == 0)
                 {
 #if !MS_IO_REDIST
-                    // Some file systems (e.g. procfs on Linux) return 0 for length even when there's content.
+                    // Some file systems (e.g. procfs on Linux) return 0 for length even when there's content; also there is non-seekable file stream.
                     // Thus we need to assume 0 doesn't mean empty.
                     return ReadAllBytesUnknownLength(fs);
 #endif
@@ -729,8 +729,8 @@ namespace System.IO
             bool returningInternalTask = false;
             try
             {
-                long fileLength = fs.Length;
-                if (fileLength > int.MaxValue)
+                long fileLength = 0L;
+                if (fs.CanSeek && (fileLength = fs.Length) > int.MaxValue)
                 {
                     var e = new IOException(SR.IO_FileTooLong2GB);
 #if !MS_IO_REDIST


### PR DESCRIPTION
This is a manual backport of #58434, the problem has been recently discussed for #60931 which has not been merged to 6.0 as it was simply too late.

## Customer Impact

This PR actually fixes two bugs.

The first one is a bug reported by customer via email, where an async read operation performed on a `FileStream` opened for **non-seekable device** file was throwing an `System.IO.IOException`: "The parameter is incorrect".

It turns out that `ReadFile` [doc](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-readfile#parameters) was wrong:

> For an hFile that does not support byte offsets, Offset and OffsetHigh are ignored.

And `OVERLAPPED` [doc](https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped#members) was right:

> This member is nonzero only when performing I/O requests on a seeking device that supports the concept of an offset (also referred to as a file pointer mechanism), such as a file. Otherwise, this member **must be zero**.

The second bug is #58383. To tell the long story short, `File.ReadAllBytes*(string path, ...)` methods were assuming that `path` can't point to a non-seekable file like named pipe.

## Testing

The fix was verified using tests added in the PR. It has been in main for a month (#58434) and we have already been doing that for sync file handles (the issue was originally discovered and fixed by @stephentoub):

https://github.com/dotnet/runtime/blob/cf7d5173d4d9ce0aac8212e78063a097e1f57c0a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs#L723-L732

## Risk

Very low. :shipit: 