### PR TITLE
Some more precise debug info improvements

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -432,10 +432,14 @@ void CodeGen::genCodeForBBlist()
             if (node->OperGet() == GT_IL_OFFSET)
             {
                 GenTreeILOffset* ilOffset = node->AsILOffset();
-                genEnsureCodeEmitted(currentDI);
-                currentDI = ilOffset->gtStmtDI;
-                genIPmappingAdd(IPmappingDscKind::Normal, currentDI, firstMapping);
-                firstMapping = false;
+                DebugInfo rootDI = ilOffset->gtStmtDI.GetRoot();
+                if (rootDI.IsValid())
+                {
+                    genEnsureCodeEmitted(currentDI);
+                    currentDI = rootDI;
+                    genIPmappingAdd(IPmappingDscKind::Normal, currentDI, firstMapping);
+                    firstMapping = false;
+                }
 #ifdef DEBUG
                 assert(ilOffset->gtStmtLastILoffs <= compiler->info.compILCodeSize ||
                        ilOffset->gtStmtLastILoffs == BAD_IL_OFFSET);

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -432,7 +432,7 @@ void CodeGen::genCodeForBBlist()
             if (node->OperGet() == GT_IL_OFFSET)
             {
                 GenTreeILOffset* ilOffset = node->AsILOffset();
-                DebugInfo rootDI = ilOffset->gtStmtDI.GetRoot();
+                DebugInfo        rootDI   = ilOffset->gtStmtDI.GetRoot();
                 if (rootDI.IsValid())
                 {
                     genEnsureCodeEmitted(currentDI);

--- a/src/coreclr/jit/debuginfo.h
+++ b/src/coreclr/jit/debuginfo.h
@@ -34,6 +34,7 @@ public:
         return m_isStackEmpty;
     }
 
+    // Is this a call instruction? Used for managed return values.
     bool IsCall() const
     {
         return m_isCall;

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4240,10 +4240,10 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
             if ((*riter)->gtOper == GT_IL_OFFSET)
             {
                 GenTreeILOffset* ilOffset = (*riter)->AsILOffset();
-                if (ilOffset->gtStmtDI.IsValid())
+                DebugInfo rootDI = ilOffset->gtStmtDI.GetRoot();
+                if (rootDI.IsValid())
                 {
-                    assert(ilOffset->gtStmtDI.GetInlineContext()->IsRoot());
-                    splitPointILOffset = ilOffset->gtStmtDI.GetLocation().GetOffset();
+                    splitPointILOffset = rootDI.GetLocation().GetOffset();
                     break;
                 }
             }

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4240,7 +4240,7 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
             if ((*riter)->gtOper == GT_IL_OFFSET)
             {
                 GenTreeILOffset* ilOffset = (*riter)->AsILOffset();
-                DebugInfo rootDI = ilOffset->gtStmtDI.GetRoot();
+                DebugInfo        rootDI   = ilOffset->gtStmtDI.GetRoot();
                 if (rootDI.IsValid())
                 {
                     splitPointILOffset = rootDI.GetLocation().GetOffset();

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11478,15 +11478,7 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
             break;
 
         case GT_IL_OFFSET:
-            printf(" IL offset: ");
-            if (!tree->AsILOffset()->gtStmtDI.IsValid())
-            {
-                printf("???");
-            }
-            else
-            {
-                printf("0x%x", tree->AsILOffset()->gtStmtDI.GetLocation().GetOffset());
-            }
+            tree->AsILOffset()->gtStmtDI.Dump(true);
             break;
 
         case GT_JCC:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11478,6 +11478,7 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
             break;
 
         case GT_IL_OFFSET:
+            printf(" ");
             tree->AsILOffset()->gtStmtDI.Dump(true);
             break;
 

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -293,7 +293,7 @@ GTNODE(MADD             , GenTreeOp          ,0, GTK_BINOP)                // Ge
 GTNODE(JMPTABLE         , GenTree            ,0, (GTK_LEAF|GTK_NOCONTAIN)) // Generates the jump table for switches
 GTNODE(SWITCH_TABLE     , GenTreeOp          ,0, (GTK_BINOP|GTK_NOVALUE))  // Jump Table based switch construct
 #ifdef TARGET_ARM64
-GTNODE(BFIZ,              GenTreeBfiz        ,0, GTK_BINOP)                // Bitfield Insert in Zero 
+GTNODE(BFIZ             , GenTreeOp          ,0, GTK_BINOP)                // Bitfield Insert in Zero 
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -958,12 +958,15 @@ PhaseStatus Rationalizer::DoPhase()
                 BlockRange().InsertAtEnd(LIR::Range(statement->GetTreeList(), statement->GetRootNode()));
 
                 // If this statement has correct debug information, change it
-                // into a debug info node and insert it into the LIR. Currently
-                // we do not support describing IL offsets in inlinees in the
-                // emitter, so we normalize all debug info to be in the inline
-                // root here.
-                DebugInfo di = statement->GetDebugInfo().GetRoot();
-                if (di.IsValid())
+                // into a debug info node and insert it into the LIR. Note that
+                // we are currently reporting root info only back to the EE, so
+                // if the leaf debug info is invalid we still attach it.
+                // Note that we would like to have the invariant di.IsValid()
+                // => parent.IsValid() but it is currently not the case for
+                // NEWOBJ IL instructions where the debug info ends up attached
+                // to the allocation instead of the constructor call.
+                DebugInfo di = statement->GetDebugInfo();
+                if (di.IsValid() || di.GetRoot().IsValid())
                 {
                     GenTreeILOffset* ilOffset =
                         new (comp, GT_IL_OFFSET) GenTreeILOffset(di DEBUGARG(statement->GetLastILOffset()));


### PR DESCRIPTION
* We were not recording precise info in inlinees except for at IL offset
  0 because most of the logic that handles determining when to attach
  debug info did not run for inlinees. There are no changes in what the
  EE sees since we were normalizing debug info back to the root anyway.

* Propagate debug info even further than just until rationalization, to
  make it simpler to dump the precise debug info. This means we create
  some more GT_IL_OFFSET nodes, in particular when the inlinee debug
  info is valid but the root info is invalid. This is currently
  happening for newobj IL instructions when the constructor is inlined.
  We generate two statements:
  GT_ASG(GT_LCL_VAR(X), ALLOCOBJ(CLS));
  GT_CALL(CTOR, GT_LCL_VAR(X))
  and the first statement ends up "consuming" the debug info, meaning we
  end up with no debug info for the GT_CALL, which eventually propagates
  into the inline tree. I have held off on fixing this for now since it
  causes debug info diffs in the data reported back to the EE.

  The additional nodes in LIR result in 0.15% more memory use and 0.015%
  more instructions retired for SPMI over libraries.

There is also a small fix in gtlist.h for GT_BFIZ when
MEASURE_NODE_SIZES is defined.

No SPMI diffs.