### PR TITLE
Provide locations for src-gen diagnostic output

### DIFF
--- a/src/libraries/System.Text.Json/gen/ContextGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/ContextGenerationSpec.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using System.Text.Json.Reflection;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 
 namespace System.Text.Json.SourceGeneration
 {
@@ -15,6 +16,8 @@ namespace System.Text.Json.SourceGeneration
     [DebuggerDisplay("ContextTypeRef={ContextTypeRef}")]
     internal sealed class ContextGenerationSpec
     {
+        public Location Location { get; init; }
+
         public JsonSourceGenerationOptionsAttribute GenerationOptions { get; init; }
 
         public Type ContextType { get; init; }

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -274,8 +274,9 @@ namespace {@namespace}
                         break;
                     case ClassType.TypeUnsupportedBySourceGen:
                         {
+                            Location location = typeGenerationSpec.Type.GetDiagnosticLocation() ?? typeGenerationSpec.AttributeLocation ?? _currentContext.Location;
                             _sourceGenerationContext.ReportDiagnostic(
-                                Diagnostic.Create(TypeNotSupported, Location.None, new string[] { typeGenerationSpec.TypeRef }));
+                                Diagnostic.Create(TypeNotSupported, location, new string[] { typeGenerationSpec.TypeRef }));
                             return;
                         }
                     default:
@@ -293,7 +294,8 @@ namespace {@namespace}
                 }
                 else
                 {
-                    _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(DuplicateTypeName, Location.None, new string[] { typeGenerationSpec.TypeInfoPropertyName }));
+                    Location location = typeGenerationSpec.AttributeLocation ?? _currentContext.Location;
+                    _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(DuplicateTypeName, location, new string[] { typeGenerationSpec.TypeInfoPropertyName }));
                 }
             }
 

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -298,7 +298,7 @@ namespace System.Text.Json.SourceGeneration
                     INamedTypeSymbol contextTypeSymbol = (INamedTypeSymbol)compilationSemanticModel.GetDeclaredSymbol(classDeclarationSyntax);
                     Debug.Assert(contextTypeSymbol != null);
 
-                    Location contextLocation = contextTypeSymbol.Locations[0];
+                    Location contextLocation = contextTypeSymbol.Locations.Length > 0 ? contextTypeSymbol.Locations[0] : Location.None;
 
                     if (!TryGetClassDeclarationList(contextTypeSymbol, out List<string> classDeclarationList))
                     {

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -116,6 +116,8 @@ namespace System.Text.Json.SourceGeneration
 
             private readonly HashSet<TypeGenerationSpec> _implicitlyRegisteredTypes = new();
 
+            private readonly HashSet<ValueTuple<Type, DiagnosticDescriptor, string[]>> _typeLevelDiagnostics = new();
+
             private JsonKnownNamingPolicy _currentContextNamingPolicy;
 
             private static DiagnosticDescriptor ContextClassesMustBePartial { get; } = new DiagnosticDescriptor(
@@ -285,15 +287,18 @@ namespace System.Text.Json.SourceGeneration
                     INamedTypeSymbol contextTypeSymbol = (INamedTypeSymbol)compilationSemanticModel.GetDeclaredSymbol(classDeclarationSyntax);
                     Debug.Assert(contextTypeSymbol != null);
 
+                    Location contextLocation = contextTypeSymbol.Locations[0];
+
                     if (!TryGetClassDeclarationList(contextTypeSymbol, out List<string> classDeclarationList))
                     {
                         // Class or one of its containing types is not partial so we can't add to it.
-                        _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(ContextClassesMustBePartial, Location.None, new string[] { contextTypeSymbol.Name }));
+                        _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(ContextClassesMustBePartial, contextLocation, new string[] { contextTypeSymbol.Name }));
                         continue;
                     }
 
                     ContextGenerationSpec contextGenSpec = new()
                     {
+                        Location = contextLocation,
                         GenerationOptions = options ?? new JsonSourceGenerationOptionsAttribute(),
                         ContextType = contextTypeSymbol.AsType(_metadataLoadContext),
                         ContextClassDeclarationList = classDeclarationList
@@ -316,6 +321,22 @@ namespace System.Text.Json.SourceGeneration
                         continue;
                     }
 
+                    // Emit type-level diagnostics
+                    foreach ((Type Type, DiagnosticDescriptor Descriptor, string[] MessageArgs) diagnostic in _typeLevelDiagnostics)
+                    {
+                        Type type = diagnostic.Type;
+                        Location location = type.GetDiagnosticLocation();
+
+                        if (location == null)
+                        {
+                            TypeGenerationSpec spec = _typeGenerationSpecCache[type];
+                            location = spec.AttributeLocation;
+                        }
+
+                        location ??= contextLocation;
+                        _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(diagnostic.Descriptor, location, diagnostic.MessageArgs));
+                    }
+
                     contextGenSpec.ImplicitlyRegisteredTypes.UnionWith(_implicitlyRegisteredTypes);
 
                     contextGenSpecList ??= new List<ContextGenerationSpec>();
@@ -324,6 +345,7 @@ namespace System.Text.Json.SourceGeneration
                     // Clear the cache of generated metadata between the processing of context classes.
                     _typeGenerationSpecCache.Clear();
                     _implicitlyRegisteredTypes.Clear();
+                    _typeLevelDiagnostics.Clear();
                 }
 
                 if (contextGenSpecList == null)
@@ -486,6 +508,8 @@ namespace System.Text.Json.SourceGeneration
                 {
                     typeGenerationSpec.GenerationMode = generationMode;
                 }
+
+                typeGenerationSpec.AttributeLocation = attributeSyntax.GetLocation();
 
                 return typeGenerationSpec;
             }
@@ -877,7 +901,7 @@ namespace System.Text.Json.SourceGeneration
                     if (!type.TryGetDeserializationConstructor(useDefaultCtorInAnnotatedStructs, out ConstructorInfo? constructor))
                     {
                         classType = ClassType.TypeUnsupportedBySourceGen;
-                        _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(MultipleJsonConstructorAttribute, Location.None, new string[] { $"{type}" }));
+                        _typeLevelDiagnostics.Add((type, MultipleJsonConstructorAttribute, new string[] { $"{type}" }));
                     }
                     else
                     {
@@ -944,7 +968,7 @@ namespace System.Text.Json.SourceGeneration
                                 }
 
                                 spec = GetPropertyGenerationSpec(propertyInfo, isVirtual, generationMode);
-                                CacheMemberHelper();
+                                CacheMemberHelper(propertyInfo.GetDiagnosticLocation());
                             }
 
                             foreach (FieldInfo fieldInfo in currentType.GetFields(bindingFlags))
@@ -955,10 +979,10 @@ namespace System.Text.Json.SourceGeneration
                                 }
 
                                 spec = GetPropertyGenerationSpec(fieldInfo, isVirtual: false, generationMode);
-                                CacheMemberHelper();
+                                CacheMemberHelper(fieldInfo.GetDiagnosticLocation());
                             }
 
-                            void CacheMemberHelper()
+                            void CacheMemberHelper(Location memberLocation)
                             {
                                 CacheMember(spec, ref propGenSpecList, ref ignoredMembers);
 
@@ -972,13 +996,13 @@ namespace System.Text.Json.SourceGeneration
                                 {
                                     if (dataExtensionPropGenSpec != null)
                                     {
-                                        _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(MultipleJsonExtensionDataAttribute, Location.None, new string[] { type.Name }));
+                                        _typeLevelDiagnostics.Add((type, MultipleJsonExtensionDataAttribute, new string[] { type.Name }));
                                     }
 
                                     Type propType = spec.TypeGenerationSpec.Type;
                                     if (!IsValidDataExtensionPropertyType(propType))
                                     {
-                                        _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(DataExtensionPropertyInvalid, Location.None, new string[] { type.Name, spec.ClrName }));
+                                        _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(DataExtensionPropertyInvalid, memberLocation, new string[] { type.Name, spec.ClrName }));
                                     }
 
                                     dataExtensionPropGenSpec = GetOrAddTypeGenerationSpec(propType, generationMode);
@@ -987,13 +1011,13 @@ namespace System.Text.Json.SourceGeneration
 
                                 if (!hasInitOnlyProperties && spec.CanUseSetter && spec.IsInitOnlySetter)
                                 {
-                                    _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(InitOnlyPropertyDeserializationNotSupported, Location.None, new string[] { type.Name }));
+                                    _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(InitOnlyPropertyDeserializationNotSupported, memberLocation, new string[] { type.Name }));
                                     hasInitOnlyProperties = true;
                                 }
 
                                 if (spec.HasJsonInclude && (!spec.CanUseGetter || !spec.CanUseSetter || !spec.IsPublic))
                                 {
-                                    _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(InaccessibleJsonIncludePropertiesNotSupported, Location.None, new string[] { type.Name, spec.ClrName }));
+                                    _sourceGenerationContext.ReportDiagnostic(Diagnostic.Create(InaccessibleJsonIncludePropertiesNotSupported, memberLocation, new string[] { type.Name, spec.ClrName }));
                                 }
                             }
                         }

--- a/src/libraries/System.Text.Json/gen/Reflection/FieldInfoWrapper.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/FieldInfoWrapper.cs
@@ -100,5 +100,7 @@ namespace System.Text.Json.Reflection
         {
             throw new NotImplementedException();
         }
+
+        public Location? Location => _field.Locations.Length > 0 ? _field.Locations[0] : null;
     }
 }

--- a/src/libraries/System.Text.Json/gen/Reflection/PropertyInfoWrapper.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/PropertyInfoWrapper.cs
@@ -92,5 +92,7 @@ namespace System.Text.Json.Reflection
         {
             throw new NotSupportedException();
         }
+
+        public Location? Location => _property.Locations.Length > 0 ? _property.Locations[0] : null;
     }
 }

--- a/src/libraries/System.Text.Json/gen/Reflection/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/ReflectionExtensions.cs
@@ -49,23 +49,20 @@ namespace System.Text.Json.Reflection
 
         public static Location? GetDiagnosticLocation(this Type type)
         {
-            TypeWrapper? typeWrapper = type as TypeWrapper;
-            Debug.Assert(typeWrapper != null);
-            return typeWrapper.Location;
+            Debug.Assert(type is TypeWrapper);
+            return ((TypeWrapper)type).Location;
         }
 
         public static Location? GetDiagnosticLocation(this PropertyInfo propertyInfo)
         {
-            PropertyInfoWrapper? propertyInfoWrapper = propertyInfo as PropertyInfoWrapper;
-            Debug.Assert(propertyInfoWrapper != null);
-            return propertyInfoWrapper.Location;
+            Debug.Assert(propertyInfo is PropertyInfoWrapper);
+            return ((PropertyInfoWrapper)propertyInfo).Location;
         }
 
         public static Location? GetDiagnosticLocation(this FieldInfo fieldInfo)
         {
-            FieldInfoWrapper? fieldInfoWrapper = fieldInfo as FieldInfoWrapper;
-            Debug.Assert(fieldInfoWrapper != null);
-            return fieldInfoWrapper.Location;
+            Debug.Assert(fieldInfo is FieldInfoWrapper);
+            return ((FieldInfoWrapper)fieldInfo).Location;
         }
     }
 }

--- a/src/libraries/System.Text.Json/gen/Reflection/ReflectionExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/ReflectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 
 namespace System.Text.Json.Reflection
 {
@@ -44,6 +45,27 @@ namespace System.Text.Json.Reflection
             }
 
             return false;
+        }
+
+        public static Location? GetDiagnosticLocation(this Type type)
+        {
+            TypeWrapper? typeWrapper = type as TypeWrapper;
+            Debug.Assert(typeWrapper != null);
+            return typeWrapper.Location;
+        }
+
+        public static Location? GetDiagnosticLocation(this PropertyInfo propertyInfo)
+        {
+            PropertyInfoWrapper? propertyInfoWrapper = propertyInfo as PropertyInfoWrapper;
+            Debug.Assert(propertyInfoWrapper != null);
+            return propertyInfoWrapper.Location;
+        }
+
+        public static Location? GetDiagnosticLocation(this FieldInfo fieldInfo)
+        {
+            FieldInfoWrapper? fieldInfoWrapper = fieldInfo as FieldInfoWrapper;
+            Debug.Assert(fieldInfoWrapper != null);
+            return fieldInfoWrapper.Location;
         }
     }
 }

--- a/src/libraries/System.Text.Json/gen/Reflection/TypeWrapper.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/TypeWrapper.cs
@@ -600,5 +600,7 @@ namespace System.Text.Json.Reflection
             }
             return base.Equals(o);
         }
+
+        public Location? Location => _typeSymbol.Locations.Length > 0 ? _typeSymbol.Locations[0] : null;
     }
 }

--- a/src/libraries/System.Text.Json/gen/TypeGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/TypeGenerationSpec.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json.Reflection;
 using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
 
 namespace System.Text.Json.SourceGeneration
 {
@@ -17,6 +18,11 @@ namespace System.Text.Json.SourceGeneration
         /// Fully qualified assembly name, prefixed with "global::", e.g. global::System.Numerics.BigInteger.
         /// </summary>
         public string TypeRef { get; private set; }
+
+        /// <summary>
+        /// If specified as a root type via <c>JsonSerializableAttribute</c>, specifies the location of the attribute application.
+        /// </summary>
+        public Location? AttributeLocation { get; set; }
 
         /// <summary>
         /// The name of the public <c>JsonTypeInfo&lt;T&gt;</c> property for this type on the generated context class.

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
@@ -11,7 +11,6 @@ using System.Runtime.Serialization;
 using System.Text.Encodings.Web;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace System.Text.Json.SourceGeneration.UnitTests
@@ -340,16 +339,20 @@ namespace System.Text.Json.SourceGeneration.UnitTests
         internal static void CheckDiagnosticMessages(
             DiagnosticSeverity level,
             ImmutableArray<Diagnostic> diagnostics,
-            (TextSpan Location, string Message)[] expectedDiags)
+            (Location Location, string Message)[] expectedDiags,
+            bool sort = true)
         {
-            (TextSpan Location, string Message)[] actualDiags = diagnostics
+            (Location Location, string Message)[] actualDiags = diagnostics
                 .Where(diagnostic => diagnostic.Severity == level)
-                .Select(diagnostic => (diagnostic.Location.SourceSpan, diagnostic.GetMessage()))
+                .Select(diagnostic => (diagnostic.Location, diagnostic.GetMessage()))
                 .ToArray();
 
-            // Can't depend on reflection order when generating type metadata.
-            Array.Sort(actualDiags);
-            Array.Sort(expectedDiags);
+            if (sort)
+            {
+                // Can't depend on reflection order when generating type metadata.
+                Array.Sort(actualDiags);
+                Array.Sort(expectedDiags);
+            }
 
             if (CultureInfo.CurrentUICulture.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -54,65 +56,88 @@ namespace System.Text.Json.SourceGeneration.UnitTests
 
             CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
         }
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/58226", TestPlatforms.Browser)]
         public void UnsuccessfulSourceGeneration()
         {
-            // Compile the referenced assembly first.
-            Compilation campaignCompilation = CompilationHelper.CreateCampaignSummaryViewModelCompilation();
-            Compilation eventCompilation = CompilationHelper.CreateActiveOrUpcomingEventCompilation();
+            static void RunTest(bool explicitRef)
+            {
+                // Compile the referenced assembly first.
+                Compilation campaignCompilation = CompilationHelper.CreateCampaignSummaryViewModelCompilation();
+                Compilation eventCompilation = CompilationHelper.CreateActiveOrUpcomingEventCompilation();
 
-            // Emit the image of the referenced assembly.
-            byte[] campaignImage = CompilationHelper.CreateAssemblyImage(campaignCompilation);
-            byte[] eventImage = CompilationHelper.CreateAssemblyImage(eventCompilation);
+                // Emit the image of the referenced assembly.
+                byte[] campaignImage = CompilationHelper.CreateAssemblyImage(campaignCompilation);
+                byte[] eventImage = CompilationHelper.CreateAssemblyImage(eventCompilation);
 
-            // Main source for current compilation.
-            string source = @"
+                string optionalAttribute = explicitRef ? "[JsonSerializable(typeof(ActiveOrUpcomingEvent[,])]" : null;
+
+                // Main source for current compilation.
+                string source = @$"
             using System.Collections.Generic;
             using System.Text.Json.Serialization;
             using ReferencedAssembly;
 
             namespace JsonSourceGenerator
-            {
+            {{
+                {optionalAttribute}
                 [JsonSerializable(typeof(JsonSourceGenerator.IndexViewModel)]
                 public partial class JsonContext : JsonSerializerContext
-                {
-                }
+                {{
+                }}
 
                 public class IndexViewModel
-                {
-                    public ActiveOrUpcomingEvent[,] ActiveOrUpcomingEvents { get; set; }
-                    public CampaignSummaryViewModel FeaturedCampaign { get; set; }
-                    public bool IsNewAccount { get; set; }
+                {{
+                    public ActiveOrUpcomingEvent[,] ActiveOrUpcomingEvents {{ get; set; }}
+                    public CampaignSummaryViewModel FeaturedCampaign {{ get; set; }}
+                    public bool IsNewAccount {{ get; set; }}
                     public bool HasFeaturedCampaign => FeaturedCampaign != null;
-                }
-            }";
+                }}
+            }}";
 
-            MetadataReference[] additionalReferences = {
+                MetadataReference[] additionalReferences = {
                 MetadataReference.CreateFromImage(campaignImage),
                 MetadataReference.CreateFromImage(eventImage),
             };
 
-            Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
+                Compilation compilation = CompilationHelper.CreateCompilation(source, additionalReferences);
 
-            JsonSourceGenerator generator = new JsonSourceGenerator();
+                JsonSourceGenerator generator = new JsonSourceGenerator();
+                CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
 
-            CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
+                Location location;
+                if (explicitRef)
+                {
+                    // Unsupported type is not in compiling assembly, but is indicated directly with [JsonSerializable], so location points to attribute application.
+                    INamedTypeSymbol symbol = (INamedTypeSymbol)compilation.GetSymbolsWithName("JsonContext").FirstOrDefault();
+                    SyntaxReference syntaxReference = symbol.GetAttributes().First().ApplicationSyntaxReference;
+                    TextSpan textSpan = syntaxReference.Span;
+                    location = syntaxReference.SyntaxTree.GetLocation(textSpan)!;
+                }
+                else
+                {
+                    // Unsupported type is not in compiling assembly, and isn't indicated directly with [JsonSerializable], so location points to context type.
+                    location = compilation.GetSymbolsWithName("JsonContext").First().Locations[0];
+                }
 
-            // Expected warning logs.
-            ValueTuple<TextSpan, string>[] expectedWarningDiagnostics = new ValueTuple<TextSpan, string>[]
-            {
-                (new TextSpan(315, 11), "Did not generate serialization metadata for type 'global::ReferencedAssembly.ActiveOrUpcomingEvent[]'.")
-            };
+                // Expected warning logs.
+                (Location, string)[] expectedWarningDiagnostics = new (Location, string)[]
+                {
+                    (location, "Did not generate serialization metadata for type 'global::ReferencedAssembly.ActiveOrUpcomingEvent[]'.")
+                };
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, expectedWarningDiagnostics);
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+                CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+                CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, expectedWarningDiagnostics);
+                CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
+            }
+
+            RunTest(explicitRef: true);
+            RunTest(false);
         }
 
         [Fact]
@@ -124,23 +149,28 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             JsonSourceGenerator generator = new JsonSourceGenerator();
             CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
 
-            ValueTuple<TextSpan, string>[] expectedWarningDiagnostics = new ValueTuple<TextSpan, string>[]
+            INamedTypeSymbol symbol = (INamedTypeSymbol)compilation.GetSymbolsWithName("JsonContext").FirstOrDefault();
+            SyntaxReference syntaxReference = new List<AttributeData>(symbol.GetAttributes())[1].ApplicationSyntaxReference;
+            TextSpan textSpan = syntaxReference.Span;
+            Location location = syntaxReference.SyntaxTree.GetLocation(textSpan)!;
+
+            (Location, string)[] expectedWarningDiagnostics = new (Location, string)[]
             {
-                (new TextSpan(303, 45), "There are multiple types named Location. Source was generated for the first one detected. Use 'JsonSerializableAttribute.TypeInfoPropertyName' to resolve this collision.")
+                (location, "There are multiple types named Location. Source was generated for the first one detected. Use 'JsonSerializableAttribute.TypeInfoPropertyName' to resolve this collision.")
             };
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
             CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, expectedWarningDiagnostics);
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
 
             // With resolution.
             compilation = CompilationHelper.CreateRepeatedLocationsWithResolutionCompilation();
             generator = new JsonSourceGenerator();
             CompilationHelper.RunGenerators(compilation, out generatorDiags, generator);
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
         }
 
         [Fact]
@@ -162,9 +192,9 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             JsonSourceGenerator generator = new JsonSourceGenerator();
             CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
 
             // With STJ usage.
             source = @"using System.Text.Json;
@@ -181,9 +211,9 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             generator = new JsonSourceGenerator();
             CompilationHelper.RunGenerators(compilation, out generatorDiags, generator);
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
         }
 
         [Fact]
@@ -194,14 +224,16 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             JsonSourceGenerator generator = new JsonSourceGenerator();
             CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
 
-            ValueTuple<TextSpan, string>[] expectedWarningDiagnostics = new ValueTuple<TextSpan, string>[]
+            Location location = compilation.GetSymbolsWithName("Id").First().Locations[0];
+
+            (Location, string)[] expectedWarningDiagnostics = new (Location, string)[]
             {
-                (new TextSpan(236, 2), "The type 'Location' defines init-only properties, deserialization of which is currently not supported in source generation mode.")
+                (location, "The type 'Location' defines init-only properties, deserialization of which is currently not supported in source generation mode.")
             };
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
             CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, expectedWarningDiagnostics);
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
         }
 
         [Fact]
@@ -212,16 +244,20 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             JsonSourceGenerator generator = new JsonSourceGenerator();
             CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
 
-            ValueTuple<TextSpan, string>[] expectedWarningDiagnostics = new ValueTuple<TextSpan, string>[]
+            Location idLocation = compilation.GetSymbolsWithName("Id").First().Locations[0];
+            Location address2Location = compilation.GetSymbolsWithName("Address2").First().Locations[0];
+            Location countryLocation = compilation.GetSymbolsWithName("Country").First().Locations[0];
+
+            (Location, string)[] expectedWarningDiagnostics = new (Location, string)[]
             {
-                (new TextSpan(271, 2), "The member 'Location.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                (new TextSpan(469, 8), "The member 'Location.Address2' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
-                (new TextSpan(667, 7), "The member 'Location.Country' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.")
+                (idLocation, "The member 'Location.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                (address2Location, "The member 'Location.Address2' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."),
+                (countryLocation, "The member 'Location.Country' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.")
             };
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, expectedWarningDiagnostics);
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, expectedWarningDiagnostics, sort: false);
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace System.Text.Json.SourceGeneration.UnitTests
@@ -291,9 +290,9 @@ namespace System.Text.Json.Serialization
                 Assert.Null(types);
             }
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<(Location, string)>());
         }
 
         [Theory]
@@ -323,9 +322,9 @@ namespace System.Text.Json.Serialization
             CompilationHelper.RunGenerators(compilation, out ImmutableArray<Diagnostic> generatorDiags, generator);
             Assert.Null(generator.GetSerializableTypes());
 
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
-            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags,  Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<(Location, string)>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags,  Array.Empty<(Location, string)>());
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorTests.cs
@@ -3,10 +3,10 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace System.Text.Json.SourceGeneration.UnitTests
@@ -70,7 +70,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             Assert.Equal("HelloWorld.MyType", myType.FullName);
 
             // Check for received fields, properties and methods in created type.
-            string[] expectedPropertyNames = { "PublicPropertyInt", "PublicPropertyString",};
+            string[] expectedPropertyNames = { "PublicPropertyInt", "PublicPropertyString", };
             string[] expectedFieldNames = { "PublicChar", "PublicDouble" };
             string[] expectedMethodNames = { "get_PrivatePropertyInt", "get_PrivatePropertyString", "get_PublicPropertyInt", "get_PublicPropertyString", "MyMethod", "MySecondMethod", "set_PrivatePropertyInt", "set_PrivatePropertyString", "set_PublicPropertyInt", "set_PublicPropertyString", "UsePrivates" };
             CheckFieldsPropertiesMethods(myType, expectedFieldNames, expectedPropertyNames, expectedMethodNames);
@@ -245,7 +245,7 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             string[] expectedPropertyNamesNotMyType = { "Address1", "Address2", "City", "Country", "Id", "Name", "PhoneNumber", "PostalCode", "State" };
             string[] expectedMethodNamesNotMyType = { "get_Address1", "get_Address2", "get_City", "get_Country", "get_Id", "get_Name", "get_PhoneNumber", "get_PostalCode", "get_State",
                                                       "set_Address1", "set_Address2", "set_City", "set_Country", "set_Id", "set_Name", "set_PhoneNumber", "set_PostalCode", "set_State" };
-            CheckFieldsPropertiesMethods(notMyType, expectedFieldNamesNotMyType, expectedPropertyNamesNotMyType, expectedMethodNamesNotMyType );
+            CheckFieldsPropertiesMethods(notMyType, expectedFieldNamesNotMyType, expectedPropertyNamesNotMyType, expectedMethodNamesNotMyType);
         }
 
         [Theory]
@@ -291,9 +291,9 @@ namespace System.Text.Json.Serialization
                 Assert.Null(types);
             }
 
-            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Info, Array.Empty<string>());
-            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Warning, Array.Empty<string>());
-            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Error, Array.Empty<string>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
         }
 
         [Theory]
@@ -323,9 +323,9 @@ namespace System.Text.Json.Serialization
             CompilationHelper.RunGenerators(compilation, out ImmutableArray<Diagnostic> generatorDiags, generator);
             Assert.Null(generator.GetSerializableTypes());
 
-            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Info, Array.Empty<string>());
-            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Warning, Array.Empty<string>());
-            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Error, Array.Empty<string>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Info, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Warning, generatorDiags, Array.Empty<ValueTuple<TextSpan, string>>());
+            CompilationHelper.CheckDiagnosticMessages(DiagnosticSeverity.Error, generatorDiags,  Array.Empty<ValueTuple<TextSpan, string>>());
         }
 
         [Fact]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/60314. Next PR to fix the issue will be in dotnet/docs to provide more info on the docs website.