### PR TITLE
[DllImportGenerator] Initialize by-value out array to default

### DIFF
--- a/docs/design/libraries/DllImportGenerator/Compatibility.md
+++ b/docs/design/libraries/DllImportGenerator/Compatibility.md
@@ -71,6 +71,8 @@ Only single-dimensional arrays are supported for source generated marshalling.
 
 In the source-generated marshalling, arrays will be allocated on the stack (instead of through [`AllocCoTaskMem`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.alloccotaskmem)) if they are passed by value or by read-only reference if they contain at most 256 bytes of data. The built-in system does not support this optimization for arrays.
 
+In the built-in system, marshalling a `char` array by value with `CharSet.Unicode` would default to also marshalling data out. In the source-generated marshalling, the `char` array must be marked with the `[Out]` attribute for data to be marshalled out by value.
+
 ### `in` keyword
 
 For some types - blittable or Unicode `char` - passed by read-only reference via the [`in` keyword](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/in-parameter-modifier), the built-in system simply pins the parameter. The generated marshalling code does the same, such that there is no behavioural difference. A consequence of this behaviour is that any modifications made by the invoked function will be reflected in the caller. It is left to the user to avoid the situation in which `in` is used for a parameter that will actually be modified by the invoked function.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -977,6 +977,18 @@ namespace Microsoft.Interop
             if (!info.IsByRef && info.ByValueContentsMarshalKind == ByValueContentsMarshalKind.Out)
             {
                 // If the parameter is marshalled by-value [Out], then we don't marshal the contents of the collection.
+                // We do clear the span, so that if the invoke target doesn't fill it, we aren't left with undefined content.
+                // <nativeIdentifier>.NativeValueStorage.Clear();
+                string nativeIdentifier = context.GetIdentifiers(info).native;
+                yield return ExpressionStatement(
+                    InvocationExpression(
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                IdentifierName(nativeIdentifier),
+                                IdentifierName(ManualTypeMarshallingHelper.NativeValueStoragePropertyName)),
+                            IdentifierName("Clear"))));
                 yield break;
             }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Arrays.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Arrays.cs
@@ -106,6 +106,21 @@ namespace NativeExports
             return sum;
         }
 
+        [UnmanagedCallersOnly(EntryPoint = "fill_char_array")]
+        public static void FillChars(ushort* values, int length, ushort start)
+        {
+            if (values == null)
+            {
+                return;
+            }
+
+            ushort val = start;
+            for (int i = 0; i < length; i++)
+            {
+                values[i] = val++;
+            }
+        }
+
         [UnmanagedCallersOnly(EntryPoint = "reverse_char_array")]
         public static void ReverseChars(ushort** values, int numValues)
         {


### PR DESCRIPTION
When marshalling an array out by value, we were leaving the native storage uninitialized. This clears it out, so that we don't end up with whatever garbage was there in the array (matches built-in system behaviour).

This is the reason behind the failures in https://github.com/dotnet/runtime/pull/61389.

@AaronRobinsonMSFT @jkoritzinsky