### PR TITLE
[release/6.0] The 6.0 branch is no longer pre-release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -255,7 +255,7 @@
     <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</PackageReleaseNotes>
     <!-- Indicates this is not an officially supported release. Release branches should set this to false. -->
     <!-- Keep it in sync with PRERELEASE in eng/native/configureplatform.cmake -->
-    <IsPrerelease>true</IsPrerelease>
+    <IsPrerelease>false</IsPrerelease>
     <IsPrivateAssembly>$(MSBuildProjectName.Contains('Private'))</IsPrivateAssembly>
     <!-- Private packages should not be stable -->
     <SuppressFinalPackageVersion Condition="'$(SuppressFinalPackageVersion)' == '' and $(IsPrivateAssembly)">true</SuppressFinalPackageVersion>

--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -2,7 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/functions.cmake)
 
 # If set, indicates that this is not an officially supported release
 # Keep in sync with IsPrerelease in Directory.Build.props
-set(PRERELEASE 1)
+set(PRERELEASE 0)
 
 #----------------------------------------
 # Detect and set platform variable names


### PR DESCRIPTION
This has limited affects, but it should have been set to false since 6.0
is now stable/released.

The one difference it makes is that -Werror is disabled when building
native code.

cc @jkotas 