### PR TITLE
[mono] Add a 'inline_method' profiler event.

### DIFF
--- a/src/mono/mono/metadata/profiler-events.h
+++ b/src/mono/mono/metadata/profiler-events.h
@@ -106,3 +106,5 @@ MONO_PROFILER_EVENT_1(thread_exited, ThreadExited, uintptr_t, tid)
 MONO_PROFILER_EVENT_2(thread_name, ThreadName, uintptr_t, tid, const char *, name)
 
 MONO_PROFILER_EVENT_2(sample_hit, SampleHit, const mono_byte *, ip, const void *, context)
+
+MONO_PROFILER_EVENT_2(inline_method, InlineMethod, MonoMethod *, method, MonoMethod *, inlined_method)

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -82,6 +82,12 @@ prof_jit_done (MonoProfiler *prof, MonoMethod *method, MonoJitInfo *jinfo)
 }
 
 static void
+prof_inline_method (MonoProfiler *prof, MonoMethod *method, MonoMethod *inlined_method)
+{
+	prof_jit_done (prof, inlined_method, NULL);
+}
+
+static void
 usage (void)
 {
 	mono_profiler_printf ("AOT profiler.");
@@ -396,6 +402,7 @@ mono_profiler_init_aot (const char *desc)
 	MonoProfilerHandle handle = mono_profiler_create (&aot_profiler);
 	mono_profiler_set_runtime_initialized_callback (handle, runtime_initialized);
 	mono_profiler_set_jit_done_callback (handle, prof_jit_done);
+	mono_profiler_set_inline_method_callback (handle, prof_inline_method);
 }
 
 static void


### PR DESCRIPTION
Emit it in the interpreter when a method is inlined or replaced with
an intrinsic. This is needed so the AOT profiler can track these
methods.