### PR TITLE
Allow runtimeconfig StartupHooks and Environment StartupHooks to both be present

### DIFF
--- a/src/installer/tests/HostActivation.Tests/StartupHooks.cs
+++ b/src/installer/tests/HostActivation.Tests/StartupHooks.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
     {
         private SharedTestState sharedTestState;
         private string startupHookVarName = "DOTNET_STARTUP_HOOKS";
+        private string startupHookRuntimeConfigName = "STARTUP_HOOKS";
         private string startupHookSupport = "System.StartupHookProvider.IsSupported";
 
         public StartupHooks(StartupHooks.SharedTestState fixture)
@@ -96,6 +97,59 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var startupHookVar = startupHookDll + Path.PathSeparator + startupHook2Dll;
             dotnet.Exec(appDll)
                 .EnvironmentVariable(startupHookVarName, startupHookVar)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello from startup hook!")
+                .And.HaveStdOutContaining("Hello from startup hook with dependency!")
+                .And.HaveStdOutContaining("Hello World");
+        }
+
+        [Fact]
+        public void Muxer_activation_of_RuntimeConfig_StartupHook_Succeeds()
+        {
+            var fixture = sharedTestState.PortableAppFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.StartupHookFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            RuntimeConfig.FromFile(fixture.TestProject.RuntimeConfigJson)
+                .WithProperty(startupHookRuntimeConfigName, startupHookDll)
+                .Save();
+
+            // RuntimeConfig defined startup hook
+            dotnet.Exec(appDll)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello from startup hook!")
+                .And.HaveStdOutContaining("Hello World");
+        }
+
+        [Fact]
+        public void Muxer_activation_of_RuntimeConfig_And_Environment_StartupHooks_Succeeds()
+        {
+            var fixture = sharedTestState.PortableAppFixture.Copy();
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+
+            var startupHookFixture = sharedTestState.StartupHookFixture.Copy();
+            var startupHookDll = startupHookFixture.TestProject.AppDll;
+
+            RuntimeConfig.FromFile(fixture.TestProject.RuntimeConfigJson)
+                .WithProperty(startupHookRuntimeConfigName, startupHookDll)
+                .Save();
+
+            var startupHook2Fixture = sharedTestState.StartupHookWithDependencyFixture.Copy();
+            var startupHook2Dll = startupHook2Fixture.TestProject.AppDll;
+
+            // RuntimeConfig and Environment startup hook
+            dotnet.Exec(appDll)
+                .EnvironmentVariable(startupHookVarName, startupHook2Dll)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -306,7 +306,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
 
         if (!coreclr_properties.add(common_property::BundleProbe, ptr_stream.str().c_str()))
         {
-            log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::StartUpHooks));
+            log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::BundleProbe));
             return StatusCode::LibHostDuplicateProperty;
         }
     }
@@ -321,7 +321,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
 
         if (!coreclr_properties.add(common_property::PInvokeOverride, ptr_stream.str().c_str()))
         {
-            log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::StartUpHooks));
+            log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::PInvokeOverride));
             return StatusCode::LibHostDuplicateProperty;
         }
     }
@@ -330,7 +330,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
 #if defined(HOSTPOLICY_EMBEDDED)
     if (!coreclr_properties.add(common_property::HostPolicyEmbedded, _X("true")))
     {
-        log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::StartUpHooks));
+        log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::HostPolicyEmbedded));
         return StatusCode::LibHostDuplicateProperty;
     }
 #endif

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -284,13 +284,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         const pal::char_t *config_startup_hooks;
         if (coreclr_properties.try_get(common_property::StartUpHooks, &config_startup_hooks))
         {
-#ifdef TARGET_UNIX
-            char separator = ':';
-#else
-            char separator = ';';
-#endif // TARGET_UNIX
-
-            startup_hooks.push_back(separator);
+            startup_hooks.push_back(PATH_SEPARATOR);
             startup_hooks.append(config_startup_hooks);
         }
         

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -284,6 +284,8 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         const pal::char_t *config_startup_hooks;
         if (coreclr_properties.try_get(common_property::StartUpHooks, &config_startup_hooks))
         {
+            // env startup hooks shoold have precedence over config startup hooks
+            // therefore append config_startup_hooks AFTER startup_hooks
             startup_hooks.push_back(PATH_SEPARATOR);
             startup_hooks.append(config_startup_hooks);
         }


### PR DESCRIPTION
When building/running an app via [our Bazel build implementation](https://github.com/AFASResearch/rules_dotnet) we rely on a startup hook for assembly loading. We specify this in the runtimeconfig.json as a configProperty STARTUP_HOOKS.

When another startup hook is bootstrapped via the environment variable DOTNET_STARTUP_HOOKS this results in the following error:
```
Duplicate runtime property found: STARTUP_HOOKS
It is invalid to specify values for properties populated by the hosting layer in the the application's .runtimeconfig.json
```

In our case this environment variable is added by the IDE to handle net6.0 HotReloading.

Technically it is allowed to specify multiple startup hooks with a delimiter. This pull request resolves above error by merging startup hooks when they are specified in both locations.

Since I rarely visit C++ a detailed review is very welcome. I could not find any existing tests for this code path to extend/replicate but have tested that it resolves my issue. I have also taken the opportunity to fix some log_duplicate_property_errors that mistakenly list the StartUpHooks property key.