### PR TITLE
Refine superpmi-replay trigger

### DIFF
--- a/eng/pipelines/coreclr/superpmi-asmdiffs.yml
+++ b/eng/pipelines/coreclr/superpmi-asmdiffs.yml
@@ -2,7 +2,8 @@
 trigger: none
 
 # Only run on changes to the JIT directory. Don't run if the JIT-EE GUID has changed,
-# since the SuperPMI collections will be invalid.
+# since there won't be any SuperPMI collections with the new GUID until the collection
+# pipeline completes after this PR is merged.
 pr:
   branches:
     include:

--- a/eng/pipelines/coreclr/superpmi-replay.yml
+++ b/eng/pipelines/coreclr/superpmi-replay.yml
@@ -1,3 +1,6 @@
+# Only run on changes to the JIT directory. Don't run if the JIT-EE GUID has changed,
+# since there won't be any SuperPMI collections with the new GUID until the collection
+# pipeline completes.
 trigger:
   batch: false
   branches:
@@ -6,6 +9,7 @@ trigger:
   paths:
     include:
     - src/coreclr/jit/*
+    exclude:
     - src/coreclr/inc/jiteeversionguid.h
 
 jobs:


### PR DESCRIPTION
Don't run if the JIT-EE GUID has changed, since there won't be any collections
to download, so the downloads will fail.

Also update the superpmi-asmdiffs trigger comment.