### PR TITLE
Update .NET SDK to the .NET 6.0 RTM SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.2.21505.57",
+    "version": "6.0.100",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-rc.2.21505.57"
+    "dotnet": "6.0.100"
   },
   "native-tools": {
     "cmake": "3.16.4",


### PR DESCRIPTION
Putting out early so we can take a look at how the repo handles the SDK upgrade.