### PR TITLE
[release/6.0] Don't run the JIT formatting job in CI

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -150,13 +150,3 @@ jobs:
       crossgen2: true
       displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release
-
-#
-# Formatting
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-    platforms:
-    - Linux_x64
-    - windows_x64


### PR DESCRIPTION
The format job depends on the `main` branch of dotnet/jitutils (which isn't
properly versioned). Avoid future changes to jitutils causing a break in
servicing by disabling the formatting job.

Note that there is very little benefit to maintaining the formatting
CI requirement in servicing anyway.