### PR TITLE
Lock non localizable strings on regex resources

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/Strings.resx
@@ -119,9 +119,11 @@
   </resheader>
   <data name="InvalidRegexGeneratorAttributeTitle" xml:space="preserve">
     <value>Invalid RegexGenerator usage</value>
+    <comment>{Locked="RegexGenerator"}</comment>
   </data>
   <data name="InvalidRegexGeneratorAttributeMessage" xml:space="preserve">
     <value>The RegexGeneratorAttribute is malformed</value>
+    <comment>{Locked="RegexGeneratorAttribute"}</comment>
   </data>
   <data name="MultipleRegexGeneratorAttributesMessage" xml:space="preserve">
     <value>Multiple RegexGeneratorAttributes were applied to the same method, but only one is allowed</value>
@@ -161,6 +163,7 @@
   </data>
   <data name="QuantifierOrCaptureGroupOutOfRange" xml:space="preserve">
     <value>Capture group numbers must be less than or equal to Int32.MaxValue.</value>
+    <comment>{Locked="Int32.MaxValue"}</comment>
   </data>
   <data name="CaptureGroupOfZero" xml:space="preserve">
     <value>Capture number cannot be zero.</value>
@@ -188,6 +191,7 @@
   </data>
   <data name="InternalError_ScanRegex" xml:space="preserve">
     <value>Internal error in ScanRegex.</value>
+    <comment>{Locked="ScanRegex"}</comment>
   </data>
   <data name="CaptureGroupNameInvalid" xml:space="preserve">
     <value>Invalid group name: Group names must begin with a word character.</value>
@@ -305,5 +309,6 @@
   </data>
   <data name="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups" xml:space="preserve">
     <value>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</value>
+    <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
   </data>
 </root>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.cs.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Vnitřní chyba v modulu ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Vnitřní chyba v modulu ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">Atribut RegexGeneratorAttribute je nesprávný.</target>
-        <note />
+        <target state="needs-review-translation">Atribut RegexGeneratorAttribute je nesprávný.</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Neplatné použití RegexGenerator</target>
-        <note />
+        <target state="needs-review-translation">Neplatné použití RegexGenerator</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Počty skupin digitalizace musí být menší nebo rovny hodnotě Int32.MaxValue.</target>
-        <note />
+        <target state="needs-review-translation">Počty skupin digitalizace musí být menší nebo rovny hodnotě Int32.MaxValue.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.de.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Interner Fehler in ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Interner Fehler in ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">Das RegexGeneratorAttribute ist falsch formatiert.</target>
-        <note />
+        <target state="needs-review-translation">Das RegexGeneratorAttribute ist falsch formatiert.</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Ungültige RegexGenerator-Verwendung</target>
-        <note />
+        <target state="needs-review-translation">Ungültige RegexGenerator-Verwendung</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Erfassungsgruppennummern müssen kleiner oder gleich Int32.MaxValue sein.</target>
-        <note />
+        <target state="needs-review-translation">Erfassungsgruppennummern müssen kleiner oder gleich Int32.MaxValue sein.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.es.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Error interno en ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Error interno en ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute tiene un formato incorrecto</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute tiene un formato incorrecto</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Uso de RegexGenerator no válido</target>
-        <note />
+        <target state="needs-review-translation">Uso de RegexGenerator no válido</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Los números del grupo de capturas deben ser menores o iguales que Int32.MaxValue.</target>
-        <note />
+        <target state="needs-review-translation">Los números del grupo de capturas deben ser menores o iguales que Int32.MaxValue.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.fr.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Erreur interne dans ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Erreur interne dans ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute est malformé</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute est malformé</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Utilisation de RegexGenerator non valide</target>
-        <note />
+        <target state="needs-review-translation">Utilisation de RegexGenerator non valide</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Les nombres de groupes de capture doivent être inférieurs ou égaux à Int32.MaxValue.</target>
-        <note />
+        <target state="needs-review-translation">Les nombres de groupes de capture doivent être inférieurs ou égaux à Int32.MaxValue.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.it.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Errore interno in ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Errore interno in ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute non è valido</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute non è valido</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Utilizzo di RegexGenerator non valido</target>
-        <note />
+        <target state="needs-review-translation">Utilizzo di RegexGenerator non valido</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">I numeri del gruppo Capture devono essere minori o uguali a Int32.MaxValue.</target>
-        <note />
+        <target state="needs-review-translation">I numeri del gruppo Capture devono essere minori o uguali a Int32.MaxValue.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ja.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">ScanRegex に内部エラーが発生しました。</target>
-        <note />
+        <target state="needs-review-translation">ScanRegex に内部エラーが発生しました。</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute の形式に誤りがあります</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute の形式に誤りがあります</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">RegexGenerator の使用法が無効です</target>
-        <note />
+        <target state="needs-review-translation">RegexGenerator の使用法が無効です</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">キャプチャ グループ数は、Int32.MaxValue 以下でなければなりません。</target>
-        <note />
+        <target state="needs-review-translation">キャプチャ グループ数は、Int32.MaxValue 以下でなければなりません。</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ko.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">ScanRegex에 내부 오류가 있습니다.</target>
-        <note />
+        <target state="needs-review-translation">ScanRegex에 내부 오류가 있습니다.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute의 형식이 잘못되었습니다.</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute의 형식이 잘못되었습니다.</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">잘못된 RegexGenerator 사용</target>
-        <note />
+        <target state="needs-review-translation">잘못된 RegexGenerator 사용</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">캡처 그룹 번호는 Int32.MaxValue보다 작거나 같아야 합니다.</target>
-        <note />
+        <target state="needs-review-translation">캡처 그룹 번호는 Int32.MaxValue보다 작거나 같아야 합니다.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pl.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Błąd wewnętrzny w elemencie ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Błąd wewnętrzny w elemencie ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">Atrybut RegexGeneratorAttribute jest źle sformułowany</target>
-        <note />
+        <target state="needs-review-translation">Atrybut RegexGeneratorAttribute jest źle sformułowany</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Nieprawidłowe użycie atrybutu RegexGenerator</target>
-        <note />
+        <target state="needs-review-translation">Nieprawidłowe użycie atrybutu RegexGenerator</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Numery grup przechwytywania muszą być mniejsze lub równe wartości Int32.MaxValue.</target>
-        <note />
+        <target state="needs-review-translation">Numery grup przechwytywania muszą być mniejsze lub równe wartości Int32.MaxValue.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Erro interno em ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Erro interno em ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">O RegexGeneratorAttribute está malformado</target>
-        <note />
+        <target state="needs-review-translation">O RegexGeneratorAttribute está malformado</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Uso Inválido do RegexGenerator</target>
-        <note />
+        <target state="needs-review-translation">Uso Inválido do RegexGenerator</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Os números de grupo de captura devem ser menores que ou iguais a Int32.MaxValue.</target>
-        <note />
+        <target state="needs-review-translation">Os números de grupo de captura devem ser menores que ou iguais a Int32.MaxValue.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.ru.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">Внутренняя ошибка в ScanRegex.</target>
-        <note />
+        <target state="needs-review-translation">Внутренняя ошибка в ScanRegex.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">Ошибка в регулярном выражении RegexGeneratorAttribute</target>
-        <note />
+        <target state="needs-review-translation">Ошибка в регулярном выражении RegexGeneratorAttribute</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Недопустимое использование RegexGenerator</target>
-        <note />
+        <target state="needs-review-translation">Недопустимое использование RegexGenerator</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Номера групп захвата должны быть меньше или равны Int32.MaxValue.</target>
-        <note />
+        <target state="needs-review-translation">Номера групп захвата должны быть меньше или равны Int32.MaxValue.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.tr.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">ScanRegex iç hatası.</target>
-        <note />
+        <target state="needs-review-translation">ScanRegex iç hatası.</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute hatalı biçimlendirilmiş</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute hatalı biçimlendirilmiş</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">Geçersiz RegexGenerator kullanımı</target>
-        <note />
+        <target state="needs-review-translation">Geçersiz RegexGenerator kullanımı</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">Yakalama grubu numaraları Int32.MaxValue değerine eşit veya bundan küçük olmalıdır.</target>
-        <note />
+        <target state="needs-review-translation">Yakalama grubu numaraları Int32.MaxValue değerine eşit veya bundan küçük olmalıdır.</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">ScanRegex 中的内部错误。</target>
-        <note />
+        <target state="needs-review-translation">ScanRegex 中的内部错误。</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute 格式不正确</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute 格式不正确</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">无效的 RegexGenerator 用法</target>
-        <note />
+        <target state="needs-review-translation">无效的 RegexGenerator 用法</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">捕获组的数量必须小于或等于 Int32.MaxValue。</target>
-        <note />
+        <target state="needs-review-translation">捕获组的数量必须小于或等于 Int32.MaxValue。</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.RegularExpressions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -109,8 +109,8 @@
       </trans-unit>
       <trans-unit id="InternalError_ScanRegex">
         <source>Internal error in ScanRegex.</source>
-        <target state="translated">ScanRegex 發生內部錯誤。</target>
-        <note />
+        <target state="needs-review-translation">ScanRegex 發生內部錯誤。</target>
+        <note>{Locked="ScanRegex"}</note>
       </trans-unit>
       <trans-unit id="InvalidEmptyArgument">
         <source>Argument {0} cannot be zero-length.</source>
@@ -134,13 +134,13 @@
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeMessage">
         <source>The RegexGeneratorAttribute is malformed</source>
-        <target state="translated">RegexGeneratorAttribute 格式錯誤</target>
-        <note />
+        <target state="needs-review-translation">RegexGeneratorAttribute 格式錯誤</target>
+        <note>{Locked="RegexGeneratorAttribute"}</note>
       </trans-unit>
       <trans-unit id="InvalidRegexGeneratorAttributeTitle">
         <source>Invalid RegexGenerator usage</source>
-        <target state="translated">無效的 RegexGenerator 使用方式</target>
-        <note />
+        <target state="needs-review-translation">無效的 RegexGenerator 使用方式</target>
+        <note>{Locked="RegexGenerator"}</note>
       </trans-unit>
       <trans-unit id="InvalidUnicodePropertyEscape">
         <source>Incomplete \\p{X} character escape.</source>
@@ -195,7 +195,7 @@
       <trans-unit id="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups">
         <source>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</source>
         <target state="new">Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</target>
-        <note />
+        <note>{Locked="RegexOptions.NonBacktracking"}</note>
       </trans-unit>
       <trans-unit id="NotSupported_ReadOnlyCollection">
         <source>Collection is read-only.</source>
@@ -219,8 +219,8 @@
       </trans-unit>
       <trans-unit id="QuantifierOrCaptureGroupOutOfRange">
         <source>Capture group numbers must be less than or equal to Int32.MaxValue.</source>
-        <target state="translated">擷取的群組數目必須小於或等於 Int32.MaxValue。</target>
-        <note />
+        <target state="needs-review-translation">擷取的群組數目必須小於或等於 Int32.MaxValue。</target>
+        <note>{Locked="Int32.MaxValue"}</note>
       </trans-unit>
       <trans-unit id="RegexMatchTimeoutException_Occurred">
         <source>The RegEx engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.</source>

--- a/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -111,6 +111,7 @@
   </data>
   <data name="InternalError_ScanRegex" xml:space="preserve">
     <value>Internal error in ScanRegex.</value>
+    <comment>{Locked="ScanRegex"}</comment>
   </data>
   <data name="CaptureGroupNameInvalid" xml:space="preserve">
     <value>Invalid group name: Group names must begin with a word character.</value>
@@ -225,12 +226,15 @@
   </data>
   <data name="NotSupported_NonBacktrackingAndReplacementsWithSubstitutionsOfGroups" xml:space="preserve">
     <value>Regex replacements with substitutions of groups are not supported with RegexOptions.NonBacktracking.</value>
+    <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
   </data>
   <data name="NotSupported_NonBacktrackingConflictingOption" xml:space="preserve">
     <value>RegexOptions.NonBacktracking is not supported in conjunction with RegexOptions.{0}.</value>
+    <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
   </data>
   <data name="NotSupported_NonBacktrackingConflictingExpression" xml:space="preserve">
     <value>RegexOptions.NonBacktracking is not supported in conjunction with expressions containing: '{0}'.</value>
+    <comment>{Locked="RegexOptions.NonBacktracking"}</comment>
   </data>
   <data name="ExpressionDescription_Backreference" xml:space="preserve">
     <value>backreference (\\ number)</value>


### PR DESCRIPTION
These strings shouldn't be localized. For more context see the following discussion: https://github.com/dotnet/runtime/pull/61274/files#r747014118