### PR TITLE
Fix race condition with cancellation tokens in Read/Flush operations …

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -267,7 +267,7 @@
   </Target>
 
   <Target Name="ValidateAssemblyVersionsInRefPack" 
-          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' == 'servicing' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'" 
+          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' == 'servicing' and '$(TargetFrameworkIdentifier)' != '.NETFramework'" 
           AfterTargets="CoreCompile" >
     <Error Condition="'$(AssemblyVersion)' != '$(LastReleasedStableAssemblyVersion)'" Text="AssemblyVersion should match last released assembly version $(LastReleasedStableAssemblyVersion)" />
   </Target>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -267,7 +267,7 @@
   </Target>
 
   <Target Name="ValidateAssemblyVersionsInRefPack" 
-          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' == 'servicing'" 
+          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' == 'servicing' and $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'" 
           AfterTargets="CoreCompile" >
     <Error Condition="'$(AssemblyVersion)' != '$(LastReleasedStableAssemblyVersion)'" Text="AssemblyVersion should match last released assembly version $(LastReleasedStableAssemblyVersion)" />
   </Target>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -44,9 +44,9 @@
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(ServicingVersion)</VersionPrefix>
     <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
     <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
-    <_AssemblyInTargetingPack Condition="'$(IsNETCoreAppSrc)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true'">true</_AssemblyInTargetingPack>
+    <_AssemblyInTargetingPack Condition="('$(IsNETCoreAppSrc)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true') and '$(TargetFrameworkIdentifier)' != '.NETFramework'">true</_AssemblyInTargetingPack>
     <!-- Assembly version do not get updated in non-netfx ref pack assemblies. -->
-    <AssemblyVersion Condition="'$(_AssemblyInTargetingPack)' != 'true' or '$(TargetFrameworkIdentifier)' == '.NETFramework'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
+    <AssemblyVersion Condition="'$(_AssemblyInTargetingPack)' != 'true'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnablePackageValidation)' == 'true'">
@@ -267,7 +267,7 @@
   </Target>
 
   <Target Name="ValidateAssemblyVersionsInRefPack" 
-          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' == 'servicing' and '$(TargetFrameworkIdentifier)' != '.NETFramework'" 
+          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' == 'servicing'" 
           AfterTargets="CoreCompile" >
     <Error Condition="'$(AssemblyVersion)' != '$(LastReleasedStableAssemblyVersion)'" Text="AssemblyVersion should match last released assembly version $(LastReleasedStableAssemblyVersion)" />
   </Target>

--- a/src/libraries/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/libraries/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -9,6 +9,8 @@ Commonly Used Types:
 System.IO.Pipelines.Pipe
 System.IO.Pipelines.PipeWriter
 System.IO.Pipelines.PipeReader</PackageDescription>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
@@ -47,16 +47,33 @@ namespace System.IO.Pipelines
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            _awaitableState |= AwaitableState.Running;
-
             // Don't register if already completed, we would immediately unregistered in ObserveCancellation
             if (cancellationToken.CanBeCanceled && !IsCompleted)
             {
+#if DEBUG
+                var previousAwaitableState = _awaitableState;
+#endif
+
+                _cancellationTokenRegistration = cancellationToken.UnsafeRegister(callback, state);
+
+                // If we get back the default CancellationTokenRegistration then it means the
+                // callback synchronously and we can throw inline. This is safe because we haven't changed
+                // the state of the awaitable as yet.
+                if (_cancellationTokenRegistration == default(CancellationTokenRegistration))
+                {
+#if DEBUG
+                    Debug.Assert(previousAwaitableState == _awaitableState, "The awaitable state changed!");
+#endif
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
 #if (NETSTANDARD2_0 || NETFRAMEWORK)
                 _cancellationToken = cancellationToken;
 #endif
-                _cancellationTokenRegistration = cancellationToken.UnsafeRegister(callback, state);
             }
+
+            _awaitableState |= AwaitableState.Running;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Backport of #59090 to release/6.0

## Customer Impact

@AArnott reported a race condition with PipeReader where the ReadAsync operation could hang in some hard to reproduce cases when used with a cancellation token. The race resulting in hangs in various usages of pipelines in https://github.com/AArnott/Nerdbank.Streams (which is used in VS).

## Testing

Manual testing. It's very hard to write a unit test for this scenario. Also verified by @AArnott 

## Risk

Low. The change was made to only affect a very narrow case (synchronous completion). Asserts were added to make sure existing invariants weren't broken.