### PR TITLE
Convert TryGetRawMetadata comment to XML documentation

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -16,8 +16,8 @@ namespace System.Reflection.Metadata
         /// Retrieves the metadata section of the assembly, for use with <see cref="T:System.Reflection.Metadata.MetadataReader" />.
         /// </summary>
         /// <returns>
-        /// Returns <see langword="false" /> upon failure. Metadata might not be available for some assemblies,
-        /// such as <see cref="System.Reflection.Emit.AssemblyBuilder" />, AOT images, etc.
+        /// <see langword="true" /> if the metadata retrieved successfully; <see langword="false" /> upon failure. 
+        /// Metadata might not be available for some assemblies, such as <see cref="System.Reflection.Emit.AssemblyBuilder" />, AOT images, etc.
         /// </returns>
         /// <remarks>
         /// <para>Callers should not write to the metadata blob.</para>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -21,8 +21,7 @@ namespace System.Reflection.Metadata
         /// </returns>
         /// <remarks>
         /// <para>Callers should not write to the metadata blob.</para>
-        /// <para>The metadata blob pointer will remain valid as long as the <see cref="System.Runtime.Loader.AssemblyLoadContext" />
-        ///   with which the assembly is associated, is alive.
+        /// <para>The metadata blob pointer will remain valid as long as the assembly is alive.
         ///   The caller is responsible for keeping the assembly object alive while accessing the metadata blob.</para>
         /// </remarks>
         [CLSCompliant(false)] // out byte* blob

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -15,8 +15,11 @@ namespace System.Reflection.Metadata
         /// <summary>
         /// Retrieves the metadata section of the assembly, for use with <see cref="T:System.Reflection.Metadata.MetadataReader" />.
         /// </summary>
+        /// <param name="assembly">The assembly for which retrieve metadata.</param>
+        /// <param name="blob">When this method returns, contains the pointer to the metadata section blob.</param>
+        /// <param name="length">When this method returns, contains the length of the metadata section blob.</param>
         /// <returns>
-        /// <see langword="true" /> if the metadata retrieved successfully; <see langword="false" /> upon failure. 
+        /// <see langword="true" /> if the metadata retrieved successfully; <see langword="false" /> upon failure.
         /// Metadata might not be available for some assemblies, such as <see cref="System.Reflection.Emit.AssemblyBuilder" />, AOT images, etc.
         /// </returns>
         /// <remarks>

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -12,13 +12,19 @@ namespace System.Reflection.Metadata
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern unsafe bool InternalTryGetRawMetadata(QCallAssembly assembly, ref byte* blob, ref int length);
 
-        // Retrieves the metadata section of the assembly, for use with System.Reflection.Metadata.MetadataReader.
-        //   - Returns false upon failure. Metadata might not be available for some assemblies, such as AssemblyBuilder, .NET
-        //     native images, etc.
-        //   - Callers should not write to the metadata blob
-        //   - The metadata blob pointer will remain valid as long as the AssemblyLoadContext with which the assembly is
-        //     associated, is alive. The caller is responsible for keeping the assembly object alive while accessing the
-        //     metadata blob.
+        /// <summary>
+        /// Retrieves the metadata section of the assembly, for use with <see cref="T:System.Reflection.Metadata.MetadataReader" />.
+        /// </summary>
+        /// <returns>
+        /// Returns <see langword="false" /> upon failure. Metadata might not be available for some assemblies,
+        /// such as <see cref="System.Reflection.Emit.AssemblyBuilder" />, AOT images, etc.
+        /// </returns>
+        /// <remarks>
+        /// <para>Callers should not write to the metadata blob.</para>
+        /// <para>The metadata blob pointer will remain valid as long as the <see cref="System.Runtime.Loader.AssemblyLoadContext" />
+        ///   with which the assembly is associated, is alive.
+        ///   The caller is responsible for keeping the assembly object alive while accessing the metadata blob.</para>
+        /// </remarks>
         [CLSCompliant(false)] // out byte* blob
         public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -15,17 +15,17 @@ namespace System.Reflection.Metadata
         /// <summary>
         /// Retrieves the metadata section of the assembly, for use with <see cref="T:System.Reflection.Metadata.MetadataReader" />.
         /// </summary>
-        /// <param name="assembly">The assembly for which retrieve metadata.</param>
+        /// <param name="assembly">The assembly from which to retrieve the metadata.</param>
         /// <param name="blob">When this method returns, contains the pointer to the metadata section blob.</param>
         /// <param name="length">When this method returns, contains the length of the metadata section blob.</param>
         /// <returns>
-        /// <see langword="true" /> if the metadata retrieved successfully; <see langword="false" /> upon failure.
-        /// Metadata might not be available for some assemblies, such as <see cref="System.Reflection.Emit.AssemblyBuilder" />, AOT images, etc.
+        /// <see langword="true" /> if the metadata is retrieved successfully; <see langword="false" /> upon failure.
+        /// The metadata might not be available for some assemblies, such as <see cref="System.Reflection.Emit.AssemblyBuilder" />, AOT images, etc.
         /// </returns>
         /// <remarks>
         /// <para>Callers should not write to the metadata blob.</para>
-        /// <para>The metadata blob pointer will remain valid as long as the assembly is alive.
-        ///   The caller is responsible for keeping the assembly object alive while accessing the metadata blob.</para>
+        /// <para>The metadata blob pointer will remain valid as long as the assembly is alive.</para>
+        /// <para>The caller is responsible for keeping the assembly object alive while accessing the metadata blob.</para>
         /// </remarks>
         [CLSCompliant(false)] // out byte* blob
         public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length)


### PR DESCRIPTION
I'm hoping this will automatically fill out [the documentation](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.metadata.assemblyextensions.trygetrawmetadata).

Also, I changed ".NET native images" to the more general (and less outdated) "AOT images".