### PR TITLE
Remove the "anything + null => null" optimization

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12332,27 +12332,9 @@ DONE_MORPHING_CHILDREN:
 
                 if (op2->IsCnsIntOrI() && varTypeIsIntegralOrI(typ))
                 {
-                    CLANG_FORMAT_COMMENT_ANCHOR;
-
                     // Fold (x + 0).
-
                     if ((op2->AsIntConCommon()->IconValue() == 0) && !gtIsActiveCSE_Candidate(tree))
                     {
-
-                        // If this addition is adding an offset to a null pointer,
-                        // avoid the work and yield the null pointer immediately.
-                        // Dereferencing the pointer in either case will have the
-                        // same effect.
-
-                        if (!optValnumCSE_phase && varTypeIsGC(op2->TypeGet()) &&
-                            ((op1->gtFlags & GTF_ALL_EFFECT) == 0))
-                        {
-                            op2->gtType = tree->gtType;
-                            DEBUG_DESTROY_NODE(op1);
-                            DEBUG_DESTROY_NODE(tree);
-                            return op2;
-                        }
-
                         // Remove the addition iff it won't change the tree type
                         // to TYP_REF.
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_61510/Runtime_61510.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_61510/Runtime_61510.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+unsafe class Runtime_61510
+{
+    [FixedAddressValueType]
+    private static byte s_field;
+
+    public static int Main()
+    {
+        ref byte result = ref AddZeroByrefToNativeInt((nint)Unsafe.AsPointer(ref s_field));
+
+        return Unsafe.AreSame(ref s_field, ref result) ? 100 : 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ref byte AddZeroByrefToNativeInt(nint addr)
+    {
+        return ref Unsafe.Add(ref Unsafe.NullRef<byte>(), addr);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_61510/Runtime_61510.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_61510/Runtime_61510.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This optimization is only legal if:
1) "Anything" is a sufficiently small constant itself.
2) We are in a context where we know the address will in fact be used for an indirection.

It is the second point that is problematic - one would like to use MorphAddrContext, but it is not suitable for this purpose, as an unknown context is counted as an indirecting one. Additionally, the value of this optimization is rather low. I am guessing it was meant to support the legacy nullchecks, before `GT_NULLCHECK` was introduced, and had higher impact then.

So, I propose we just remove the optimization and leave the 5 small regressions across all of [SPMI](https://dev.azure.com/dnceng/public/_build/results?buildId=1467088&view=ms.vss-build-web.run-extensions-tab) be.

<details>
<summary>What do the diffs look like?</summary>

Just as one would expect:
```diff
-       mov      byte  ptr [0000H], 255
-                                               ;; bbWeight=1    PerfScore 11.75
+       add      rcx, -16
+       mov      byte  ptr [rcx], 255
```
(Note that above is a size improvement)

```diff
+       mov      esi, ecx
+       add      rsi, -16
        mov      rcx, 0xD1FFAB1E      ; System.Byte
        call     CORINFO_HELP_NEWSFAST
        ; gcrRegs +[rax]
        ; gcr arg pop 0
-       movzx    rdx, byte  ptr [0000H]
+       movzx    rdx, byte  ptr [rsi]
```

```diff
-       mov      byte  ptr [0000H], 0
+       mov      ecx, eax
+       mov      byte  ptr [rcx], 0
```
</details>

Fixes #61510

Note I do not plan to do anything here with the GC-ness issue as it is separate.