### PR TITLE
Minor File.ReadAllBytes* improvements

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -73,6 +73,21 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
+        public void ReadFileOverMaxArrayLength()
+        {
+            string path = GetTestFilePath();
+            using (FileStream fs = File.Create(path))
+            {
+                fs.SetLength(Array.MaxLength + 1L);
+            }
+
+            // File is too large for ReadAllBytes at once
+            Assert.Throws<IOException>(() => File.ReadAllBytes(path));
+        }
+
+        [Fact]
         public void Overwrite()
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
@@ -73,7 +73,7 @@ namespace System.IO.Tests
         [Fact]
         [OuterLoop]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
-        public Task ReadFileOver2GBAsync()
+        public async Task ReadFileOver2GBAsync()
         {
             string path = GetTestFilePath();
             using (FileStream fs = File.Create(path))
@@ -81,14 +81,14 @@ namespace System.IO.Tests
                 fs.SetLength(int.MaxValue + 1L);
             }
 
-            // File is too large for ReadAllBytes at once
-            return Assert.ThrowsAsync<IOException>(async () => await File.ReadAllBytesAsync(path));
+            // File is too large for ReadAllBytesAsync at once
+            await Assert.ThrowsAsync<IOException>(async () => await File.ReadAllBytesAsync(path));
         }
 
         [Fact]
         [OuterLoop]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
-        public Task MaxArrayLengthAsync()
+        public async Task ReadFileOverMaxArrayLengthAsync()
         {
             string path = GetTestFilePath();
             using (FileStream fs = File.Create(path))
@@ -96,8 +96,8 @@ namespace System.IO.Tests
                 fs.SetLength(Array.MaxLength + 1L);
             }
 
-            // File is too large for ReadAllBytes at once
-            return Assert.ThrowsAsync<IOException>(async () => await File.ReadAllBytesAsync(path));
+            // File is too large for ReadAllBytesAsync at once
+            await Assert.ThrowsAsync<IOException>(async () => await File.ReadAllBytesAsync(path));
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
@@ -86,6 +86,21 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [OuterLoop]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
+        public Task MaxArrayLengthAsync()
+        {
+            string path = GetTestFilePath();
+            using (FileStream fs = File.Create(path))
+            {
+                fs.SetLength(Array.MaxLength + 1L);
+            }
+
+            // File is too large for ReadAllBytes at once
+            return Assert.ThrowsAsync<IOException>(async () => await File.ReadAllBytesAsync(path));
+        }
+
+        [Fact]
         public async Task OverwriteAsync()
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -260,7 +260,7 @@ namespace System.IO
                 }
                 if (fileLength == 0)
                 {
-                    // Some file systems (e.g. procfs on Linux) return 0 for length even when there's content; also theree are non-seekable files.
+                    // Some file systems (e.g. procfs on Linux) return 0 for length even when there's content; also there are non-seekable files.
                     // Thus we need to assume 0 doesn't mean empty.
                     return ReadAllBytesUnknownLength(sfh);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -254,7 +254,7 @@ namespace System.IO
             using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.SequentialScan))
             {
                 long fileLength = 0;
-                if (sfh.CanSeek && (fileLength = RandomAccess.GetFileLength(sfh)) > int.MaxValue)
+                if (sfh.CanSeek && (fileLength = RandomAccess.GetFileLength(sfh)) > Array.MaxLength)
                 {
                     throw new IOException(SR.IO_FileTooLong2GB);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -526,7 +526,7 @@ namespace System.IO
             }
 
             // SequentialScan is a perf hint that requires extra sys-call on non-Windows OSes.
-            FileOptions options = (OperatingSystem.IsWindows() ? FileOptions.SequentialScan : FileOptions.None) | FileOptions.Asynchronous;
+            FileOptions options = FileOptions.Asynchronous | (OperatingSystem.IsWindows() ? FileOptions.SequentialScan : FileOptions.None);
             SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, options);
 
             long fileLength = 0L;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -251,7 +251,7 @@ namespace System.IO
 
         public static byte[] ReadAllBytes(string path)
         {
-            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.SequentialScan))
+            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 long fileLength = 0;
                 if (sfh.CanSeek && (fileLength = RandomAccess.GetFileLength(sfh)) > Array.MaxLength)
@@ -515,7 +515,7 @@ namespace System.IO
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.Asynchronous | FileOptions.SequentialScan))
+            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.Asynchronous))
             {
                 long fileLength = 0L;
                 if (sfh.CanSeek && (fileLength = RandomAccess.GetFileLength(sfh)) > Array.MaxLength)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -251,7 +251,9 @@ namespace System.IO
 
         public static byte[] ReadAllBytes(string path)
         {
-            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            // SequentialScan is a perf hint that requires extra sys-call on non-Windows OSes.
+            FileOptions options = OperatingSystem.IsWindows() ? FileOptions.SequentialScan : FileOptions.None;
+            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, options))
             {
                 long fileLength = 0;
                 if (sfh.CanSeek && (fileLength = RandomAccess.GetFileLength(sfh)) > Array.MaxLength)
@@ -515,7 +517,9 @@ namespace System.IO
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.Asynchronous))
+            // SequentialScan is a perf hint that requires extra sys-call on non-Windows OSes.
+            FileOptions options = (OperatingSystem.IsWindows() ? FileOptions.SequentialScan : FileOptions.None) | FileOptions.Asynchronous;
+            using (SafeFileHandle sfh = OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, options))
             {
                 long fileLength = 0L;
                 if (sfh.CanSeek && (fileLength = RandomAccess.GetFileLength(sfh)) > Array.MaxLength)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -260,6 +260,11 @@ namespace System.IO
                 {
                     throw new IOException(SR.IO_FileTooLong2GB);
                 }
+
+#if DEBUG
+                fileLength = 0; // improve the test coverage for ReadAllBytesUnknownLength
+#endif
+
                 if (fileLength == 0)
                 {
                     // Some file systems (e.g. procfs on Linux) return 0 for length even when there's content; also there are non-seekable files.
@@ -530,6 +535,10 @@ namespace System.IO
                 sfh.Dispose();
                 return Task.FromException<byte[]>(ExceptionDispatchInfo.SetCurrentStackTrace(new IOException(SR.IO_FileTooLong2GB)));
             }
+
+#if DEBUG
+            fileLength = 0; // improve the test coverage for InternalReadAllBytesUnknownLengthAsync
+#endif
 
             return fileLength > 0 ?
                 InternalReadAllBytesAsync(sfh, (int)fileLength, cancellationToken) :


### PR DESCRIPTION
Changes:
 * switch from using `FileStream` to `RandomAccess`, reduces the allocations by +- 100 bytes
 * stop using `FileOptions.SequentialScan` as it requires an additional sys-call on Unix. Modern kernels are really good at recognizing file access patterns, we don't get anything from this hint. Reading small files (< 1kb) on Unix is 8% faster.
 * use `Array.MaxLength` instead `int.MaxSize` for determining the limit. It fixes an edge case bug where for files of size `> Array.MaxLength` but `< int.MaxSize` where it was throwing `OOM `instead `IOException`:

```cs
string path = "here.dat";
using (FileStream fs = File.Create(path))
{
    fs.SetLength(Array.MaxLength + 1L);
}

File.ReadAllBytes(path);
```

```cmd
PS D:\projects\repros\maxArraySize> dotnet run -c Release
Out of memory.
```
* simplify the source code, get rid of `returningInternalTask`-related logic
* increase the test coverage for non-seekable files and for those which report 0 length despite not being empty by setting `fileLength = 0` for DEBUG builds