### PR TITLE
XArch: Trim the code block to match the actual code length

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -368,13 +368,12 @@ namespace Internal.JitInterface
 
             if (codeSize < _code.Length)
             {
-                if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.X64 ||
-                    _compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.X86)
+                if (_compilation.TypeSystemContext.Target.Architecture != TargetArchitecture.ARM64)
                 {
-                    // For xarch, the generated code is sometimes smaller than the memory allocated.
+                    // For xarch/arm32, the generated code is sometimes smaller than the memory allocated.
                     // In that case, trim the codeBlock to the actual value.
                     //
-                    // For armarch, the allocation request of `hotCodeSize` also includes the roData size
+                    // For arm64, the allocation request of `hotCodeSize` also includes the roData size
                     // while the `codeSize` returned just contains the size of the native code. As such,
                     // there is guarantee that for armarch, (codeSize == _code.Length) is always true.
                     //

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -374,6 +374,10 @@ namespace Internal.JitInterface
                     // For xarch, the generated code is sometimes smaller than the memory allocated.
                     // In that case, trim the codeBlock to the actual value.
                     //
+                    // For armarch, the allocation request of `hotCodeSize` also includes the roData size
+                    // while the `codeSize` returned just contains the size of the native code. As such,
+                    // there is guarantee that for armarch, (codeSize == _code.Length) is always true.
+                    //
                     // Currently, hot/cold splitting is not done and hence `codeSize` just includes the size of
                     // hotCode. Once hot/cold splitting is done, need to trim respective `_code` or `_coldCode`
                     // accordingly.

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -373,10 +373,7 @@ namespace Internal.JitInterface
                 // Currently, hot/cold splitting is not done and hence `codeSize` just includes the size of
                 // hotCode. Once hot/cold splitting is done, need to trim respective `_code` or `_coldCode`
                 // accordingly.
-                if (_compilation.Logger.IsVerbose)
-                {
-                    Log.WriteLine($"Trimming codeSize from {_code.Length} to {codeSize}, Savings: {_code.Length - codeSize}, Method: {_methodCodeNode.Method.Name}");
-                }
+
                 Debug.Assert(codeSize != 0);
                 Debug.Assert(_code.Length > codeSize);
                 Array.Resize(ref _code, (int)codeSize);

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -366,7 +366,7 @@ namespace Internal.JitInterface
 #endif
             }
 
-            if (codeSize != allocatedHotCodeSize)
+            if (codeSize != _code.Length)
             {
                 // If the generated code is smaller than allocatedHotCodeSize, then trim the codeBlock.
                 //
@@ -375,10 +375,10 @@ namespace Internal.JitInterface
                 // accordingly.
                 if (_compilation.Logger.IsVerbose)
                 {
-                    Log.WriteLine($"Trimming codeSize from {_code.Length} to {codeSize}, Savings: {allocatedHotCodeSize - codeSize}, Method: {_methodCodeNode.Method.Name}");
+                    Log.WriteLine($"Trimming codeSize from {_code.Length} to {codeSize}, Savings: {_code.Length - codeSize}, Method: {_methodCodeNode.Method.Name}");
                 }
                 Debug.Assert(codeSize != 0);
-                Debug.Assert(allocatedHotCodeSize > codeSize);
+                Debug.Assert(_code.Length > codeSize);
                 Array.Resize(ref _code, (int)codeSize);
             }
             PublishCode();
@@ -3257,8 +3257,6 @@ namespace Internal.JitInterface
         private byte[] _gcInfo;
         private CORINFO_EH_CLAUSE[] _ehClauses;
 
-        private long allocatedHotCodeSize = 0;
-
         private void allocMem(ref AllocMemArgs args)
         {
             args.hotCodeBlock = (void*)GetPin(_code = new byte[args.hotCodeSize]);
@@ -3269,7 +3267,6 @@ namespace Internal.JitInterface
                 args.coldCodeBlock = (void*)GetPin(_coldCode = new byte[args.coldCodeSize]);
                 args.coldCodeBlockRW = args.coldCodeBlock;
             }
-            allocatedHotCodeSize = args.hotCodeSize;
 
             _codeAlignment = -1;
             if ((args.flag & CorJitAllocMemFlag.CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -366,17 +366,20 @@ namespace Internal.JitInterface
 #endif
             }
 
-            if (codeSize != _code.Length)
+            if (codeSize < _code.Length)
             {
-                // If the generated code is smaller than allocatedHotCodeSize, then trim the codeBlock.
-                //
-                // Currently, hot/cold splitting is not done and hence `codeSize` just includes the size of
-                // hotCode. Once hot/cold splitting is done, need to trim respective `_code` or `_coldCode`
-                // accordingly.
-
-                Debug.Assert(codeSize != 0);
-                Debug.Assert(_code.Length > codeSize);
-                Array.Resize(ref _code, (int)codeSize);
+                if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.X64 ||
+                    _compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.X86)
+                {
+                    // For xarch, the generated code is sometimes smaller than the memory allocated.
+                    // In that case, trim the codeBlock to the actual value.
+                    //
+                    // Currently, hot/cold splitting is not done and hence `codeSize` just includes the size of
+                    // hotCode. Once hot/cold splitting is done, need to trim respective `_code` or `_coldCode`
+                    // accordingly.
+                    Debug.Assert(codeSize != 0);
+                    Array.Resize(ref _code, (int)codeSize);
+                }
             }
             PublishCode();
             PublishROData();


### PR DESCRIPTION
RyuJIT sometimes over-estimate the instruction sizes leading to allocating more code memory than actually utilized. This PR reads the actual code size value and trims the code block array so that the real code size bytes are embedded in the R2RImage.


Related: https://github.com/dotnet/runtime/issues/57368