### PR TITLE
Fix optIsLoopEntry to skip removed loops

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2649,7 +2649,11 @@ bool Compiler::optIsLoopEntry(BasicBlock* block) const
 {
     for (unsigned char loopInd = 0; loopInd < optLoopCount; loopInd++)
     {
-        // Traverse the outermost loops as entries into the loop nest; so skip non-outermost.
+        if ((optLoopTable[loopInd].lpFlags & LPFLG_REMOVED) != 0)
+        {
+            continue;
+        }
+
         if (optLoopTable[loopInd].lpEntry == block)
         {
             return true;


### PR DESCRIPTION
This was preventing block compaction with loop entry blocks in loops
that had been previously optimized away (and thus removed from the
loop table).

There are a few cases where we now delete dead code that was previously
left in the function. There are a number of spurious local weighting
and IG textual asm diffs changes, possibly due to how PerfScore is implemented
(there are some surprisingly large PerfScore changes in a few cases,
despite no change in (most) generated code).