### PR TITLE
[HTTP] Scavange fix

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1982,7 +1982,8 @@ namespace System.Net.Http
             // Dispose them asynchronously to not to block the caller on closing the SslStream or NetworkStream.
             if (toDispose is not null)
             {
-                Task.Run(() => toDispose.ForEach(c => c.Dispose()));
+                Task.Factory.StartNew(static s => ((List<HttpConnectionBase>)s!).ForEach(c => c.Dispose()), toDispose,
+                    CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
             }
 
             // Pool is active.  Should not be removed.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1979,7 +1979,11 @@ namespace System.Net.Http
             }
 
             // Dispose the stale connections outside the pool lock, to avoid holding the lock too long.
-            toDispose?.ForEach(c => c.Dispose());
+            // Dispose them asynchronously to not to block the caller on closing the SslStream or NetworkStream.
+            if (toDispose is not null)
+            {
+                Task.Run(() => toDispose.ForEach(c => c.Dispose()));
+            }
 
             // Pool is active.  Should not be removed.
             return false;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -51,12 +51,6 @@ namespace System.Net.Http
         /// <see cref="ConcurrentDictionary{TKey,TValue}.IsEmpty"/> call.
         /// </summary>
         private bool _timerIsRunning;
-
-        /// <summary>
-        /// Prevents parallel execution of RemoveStalePools in case the timer triggers faster than the method itself finishes.
-        /// </summary>
-        private int _removeStalePoolsIsRunning;
-
         /// <summary>Object used to synchronize access to state in the pool.</summary>
         private object SyncObj => _pools;
 
@@ -468,7 +462,7 @@ namespace System.Net.Http
         {
             try
             {
-                _cleaningTimer!.Change(timeout, timeout);
+                _cleaningTimer!.Change(timeout, Timeout.InfiniteTimeSpan);
                 _timerIsRunning = timeout != Timeout.InfiniteTimeSpan;
             }
             catch (ObjectDisposedException)
@@ -485,40 +479,23 @@ namespace System.Net.Http
         {
             Debug.Assert(_cleaningTimer != null);
 
-            // Check whether the method is not already running and prevent parallel execution.
-            if (Interlocked.CompareExchange(ref _removeStalePoolsIsRunning, 1, 0) != 0)
+            // Iterate through each pool in the set of pools.  For each, ask it to clear out
+            // any unusable connections (e.g. those which have expired, those which have been closed, etc.)
+            // The pool may detect that it's empty and long unused, in which case it'll dispose of itself,
+            // such that any connections returned to the pool to be cached will be disposed of.  In such
+            // a case, we also remove the pool from the set of pools to avoid a leak.
+            foreach (KeyValuePair<HttpConnectionKey, HttpConnectionPool> entry in _pools)
             {
-                return;
-            }
-
-            try
-            {
-                // Iterate through each pool in the set of pools.  For each, ask it to clear out
-                // any unusable connections (e.g. those which have expired, those which have been closed, etc.)
-                // The pool may detect that it's empty and long unused, in which case it'll dispose of itself,
-                // such that any connections returned to the pool to be cached will be disposed of.  In such
-                // a case, we also remove the pool from the set of pools to avoid a leak.
-                foreach (KeyValuePair<HttpConnectionKey, HttpConnectionPool> entry in _pools)
+                if (entry.Value.CleanCacheAndDisposeIfUnused())
                 {
-                    if (entry.Value.CleanCacheAndDisposeIfUnused())
-                    {
-                        _pools.TryRemove(entry.Key, out HttpConnectionPool _);
-                    }
-                }
-
-                // Stop running the timer if we don't have any pools to clean up.
-                lock (SyncObj)
-                {
-                    if (_pools.IsEmpty)
-                    {
-                        SetCleaningTimer(Timeout.InfiniteTimeSpan);
-                    }
+                    _pools.TryRemove(entry.Key, out HttpConnectionPool _);
                 }
             }
-            finally
+
+            // Restart the timer if we have any pools to clean up.
+            lock (SyncObj)
             {
-                // Make sure the guard value gets always reset back to 0 and that it's visible to other threads.
-                Volatile.Write(ref _removeStalePoolsIsRunning, 0);
+                SetCleaningTimer(!_pools.IsEmpty ? _cleanPoolTimeout : Timeout.InfiniteTimeSpan);
             }
 
             // NOTE: There is a possible race condition with regards to a pool getting cleaned up at the same


### PR DESCRIPTION
Disposes connection in a separate task to not to block the scavenging timer callback on the stream close.
Guards scavenging timer callback from parallel execution.

Fixes #61505
Fixes #61506

I plan to validate the fix with the customer before merging. But I'd like to know if the way I solved this is not completely wrong or too different from what you had in mind? @geoffkizer @stephentoub 