### PR TITLE
Extend RegexCharClass.Canonicalize range inversion optimization

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1393,7 +1393,12 @@ namespace System.Text.RegularExpressions
                 // If the class now represents a single negated range, but does so by including every
                 // other character, invert it to produce a normalized form with a single range.  This
                 // is valuable for subsequent optimizations in most of the engines.
-                if (!isNonBacktracking && // TODO: Why is NonBacktracking special-cased?
+                // TODO: https://github.com/dotnet/runtime/issues/61048. The special-casing for NonBacktracking
+                // can be deleted once this issue is addressed.  The special-casing exists because NonBacktracking
+                // is on a different casing plan than the other engines and doesn't use ToLower on each input
+                // character at match time; this in turn can highlight differences between sets and their inverted
+                // versions of themselves, e.g. a difference between [0-AC-\uFFFF] and [^B].
+                if (!isNonBacktracking &&
                     !_negate &&
                     _subtractor is null &&
                     (_categories is null || _categories.Length == 0))

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1390,23 +1390,24 @@ namespace System.Text.RegularExpressions
                     rangelist.RemoveRange(j, rangelist.Count - j);
                 }
 
-                // If the class now represents a single negated character, but does so by including every
-                // other character, invert it to produce a normalized form recognized by IsSingletonInverse.
-                if (!isNonBacktracking && // do not produce the IsSingletonInverse transformation in NonBacktracking mode
+                // If the class now represents a single negated range, but does so by including every
+                // other character, invert it to produce a normalized form with a single range.  This
+                // is valuable for subsequent optimizations in most of the engines.
+                if (!isNonBacktracking && // TODO: Why is NonBacktracking special-cased?
                     !_negate &&
                     _subtractor is null &&
                     (_categories is null || _categories.Length == 0))
                 {
                     if (rangelist.Count == 2)
                     {
-                        // There are two ranges in the list.  See if there's one missing element between them.
+                        // There are two ranges in the list.  See if there's one missing range between them.
+                        // Such a range might be as small as a single character.
                         if (rangelist[0].First == 0 &&
-                            rangelist[0].Last == (char)(rangelist[1].First - 2) &&
-                            rangelist[1].Last == LastChar)
+                            rangelist[1].Last == LastChar &&
+                            rangelist[0].Last < rangelist[1].First - 1)
                         {
-                            char ch = (char)(rangelist[0].Last + 1);
+                            rangelist[0] = new SingleRange((char)(rangelist[0].Last + 1), (char)(rangelist[1].First - 1));
                             rangelist.RemoveAt(1);
-                            rangelist[0] = new SingleRange(ch, ch);
                             _negate = true;
                         }
                     }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
@@ -324,6 +324,13 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("[^\n]*", ".*")]
         [InlineData("(?>[^\n]*)", "(?>.*)")]
         [InlineData("[^\n]*?", ".*?")]
+        // Set reduction
+        [InlineData("[\u0001-\uFFFF]", "[^\u0000]")]
+        [InlineData("[\u0000-\uFFFE]", "[^\uFFFF]")]
+        [InlineData("[\u0000-AB-\uFFFF]", "[\u0000-\uFFFF]")]
+        [InlineData("[ABC-EG-J]", "[A-EG-J]")]
+        [InlineData("[\u0000-AC-\uFFFF]", "[^B]")]
+        [InlineData("[\u0000-AF-\uFFFF]", "[^B-E]")]
         // Large loop patterns
         [InlineData("a*a*a*a*a*a*a*b*b*?a+a*", "a*b*b*?a+")]
         [InlineData("a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?a?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "a{0,30}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]


### PR DESCRIPTION
There's a simple optimization in RegexCharClass.Canonicalize that was added in .NET 5, with the goal of taking a set that's made up of exactly two ranges and seeing whether those ranges were leaving out exactly one character.  If they were, the set can instead be rewritten as that character negated, which is a normalized form used downstream and optimized.  We can extend this normalization ever so slightly to be for two ranges separated not just be a single character but by more than that as well.  That in turn lights up existing optimizations in both RegexCompiler and the source generator that are looking for a single range, e.g. for the pattern `@"\P{IsGreek}"`, which is trying to match every character other than one that's Greek, FindFirstChar would previously have been emitted as:
```C#
for (int i = 0; i < span.Length; i++)
{
    if (((ch = span[i]) < 128 ? ("\uffff\uffff\uffff\uffff\uffff\uffff\uffff\uffff"[ch >> 4] & (1 << (ch & 0xF))) != 0 : CharInClass((char)ch, "\0\u0003\0\0ͰЀ")))
    {
        base.runtextpos = runtextpos + i;
        return true;
    }
}
```
and is now emitted as:
```C#
for (int i = 0; i < span.Length; i++)
{
    if ((((uint)span[i]) - 'Ͱ' > (uint)('Ͽ' - 'Ͱ')))
    {
        base.runtextpos = runtextpos + i;
        return true;
    }
}
```

cc: @joperezr 

ps Separately the above example highlights how after enumerating all of ASCII to compute the bit map lookup for a set being emitted, we could use the resulting knowledge to e.g. not emit the lookup at all if we find that every ASCII character matches.