### PR TITLE
Update workflow docs to indicate ARM64 macOS works

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -9,7 +9,7 @@ The repo can be built for the following platforms, using the provided setup and 
 | x64   | &#x2714; | &#x2714; | &#x2714; | &#x2714; |
 | x86   | &#x2714; |          |          |          |
 | ARM   | &#x2714; | &#x2714; |          |          |
-| ARM64 | &#x2714; | &#x2714; |          |          |
+| ARM64 | &#x2714; | &#x2714; | &#x2714; |          |
 |       | [Requirements](requirements/windows-requirements.md) | [Requirements](requirements/linux-requirements.md) | [Requirements](requirements/macos-requirements.md) | [Requirements](requirements/freebsd-requirements.md)
 
 Before proceeding further, please click on the link above that matches your machine and ensure you have installed all the prerequisites for the build to work.


### PR DESCRIPTION
I'm not aware of any shortcomings using an Apple Silicon to contribute (has been working fine for me), so might be nice to indicate that. The instructions for x86-64 work for Apple Silicon, too.