### PR TITLE
Delete `__DoCrossgen2`

### DIFF
--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -53,7 +53,6 @@ set __SkipManaged=
 set __SkipTestWrappers=
 set __BuildTestWrappersOnly=
 set __SkipNative=
-set __DoCrossgen2=
 set __CompositeBuildMode=
 set __TestBuildMode=
 set __CreatePdb=
@@ -115,8 +114,8 @@ if /i "%1" == "buildtestwrappersonly" (set __SkipNative=1&set __SkipManaged=1&se
 if /i "%1" == "-cmakeargs"            (set __CMakeArgs="%2=%3" %__CMakeArgs%&set "processedArgs=!processedArgs! %1 %2=%3"&shift&shift&goto Arg_Loop)
 if /i "%1" == "-msbuild"              (set __Ninja=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "buildagainstpackages"  (echo error: Remove /BuildAgainstPackages switch&&exit /b1)
-if /i "%1" == "crossgen2"             (set __DoCrossgen2=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "composite"             (set __CompositeBuildMode=1&set __DoCrossgen2=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "crossgen2"             (set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "composite"             (set __CompositeBuildMode=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "pdb"                   (set __CreatePdb=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "perfmap"               (set __CreatePerfmap=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "Exclude"               (set __Exclude=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -488,7 +488,7 @@
 
   <Target Name="CrossgenFramework"
       DependsOnTargets="GenerateLayout"
-      Condition="'$(__BuildTestWrappersOnly)' != '1' and '$(__CopyNativeTestBinaries)' != '1' and '$(__DoCrossgen2)' == '1' and !$(MonoAot) and !$(MonoFullAot)" >
+      Condition="'$(__BuildTestWrappersOnly)' != '1' and '$(__CopyNativeTestBinaries)' != '1' and '$(__TestBuildMode)' == 'crossgen2' and !$(MonoAot) and !$(MonoFullAot)" >
 
     <PropertyGroup>
       <CrossgenDir>$(__BinDir)</CrossgenDir>

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -99,7 +99,6 @@ build_Tests()
     export __CopyNativeProjectsAfterCombinedTestBuild
     export __CopyNativeTestBinaries
     export __Priority
-    export __DoCrossgen2
     export __CreatePerfmap
     export __CompositeBuildMode
     export __BuildTestWrappersOnly
@@ -188,13 +187,11 @@ handle_arguments_local() {
             ;;
 
         crossgen2|-crossgen2)
-            __DoCrossgen2=1
             __TestBuildMode=crossgen2
             ;;
 
         composite|-composite)
             __CompositeBuildMode=1
-            __DoCrossgen2=1
             __TestBuildMode=crossgen2
             ;;
 
@@ -294,7 +291,6 @@ __CopyNativeProjectsAfterCombinedTestBuild=true
 __CopyNativeTestBinaries=0
 __CrossBuild=0
 __DistroRid=""
-__DoCrossgen2=
 __CompositeBuildMode=
 __CreatePerfmap=
 __TestBuildMode=


### PR DESCRIPTION
`__DoCrossgen2` appears to be redundant with `__TestBuildMode=crossgen2`.