### PR TITLE
Enable DD117522 test

### DIFF
--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -12,7 +12,6 @@
       <DisabledProjects Include="$(TestRoot)FunctionalTests\**\*.csproj" /> <!-- They need to be isolated from the existing setup -->
       <DisabledProjects Include="$(TestRoot)BuildWasmApps\**\*.csproj" /> <!-- built and run with libraries -->
       <DisabledProjects Include="$(TestRoot)GC\Performance\Framework\GCPerfTestFramework.csproj" />
-      <DisabledProjects Include="$(TestRoot)Loader\classloader\generics\regressions\DD117522\Test.csproj" />
       <DisabledProjects Include="$(TestRoot)Loader\classloader\generics\GenericMethods\VSW491668.csproj" /> <!-- issue 5501 -->
       <DisabledProjects Include="$(TestRoot)Loader\classloader\StaticVirtualMethods\**\generatetest.csproj" /> <!-- test generators -->
       <DisabledProjects Include="$(TestRoot)Performance\Scenario\JitBench\unofficial_dotnet\JitBench.csproj" /> <!-- no official build support for SDK-style netcoreapp2.0 projects -->


### PR DESCRIPTION
Caught my attention because this is disabled outside issues.targets. This is apparently blocked on https://github.com/dotnet/runtime/issues/5907 which is a crossgen bug. I tried to /p:PublishReadyToRun=true this test locally and it seems to work fine with crossgen2.