### PR TITLE
[wasm] [debugger] Eval fixes for static class eval

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -477,7 +477,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         private TypeDefinition type;
         private List<MethodInfo> methods;
         internal int Token { get; }
-
+        internal string Namespace { get; }
         public TypeInfo(AssemblyInfo assembly, TypeDefinitionHandle typeHandle, TypeDefinition type)
         {
             this.assembly = assembly;
@@ -486,21 +486,21 @@ namespace Microsoft.WebAssembly.Diagnostics
             this.type = type;
             methods = new List<MethodInfo>();
             Name = metadataReader.GetString(type.Name);
-            var namespaceName = "";
+            Namespace = "";
             if (type.IsNested)
             {
                 var declaringType = metadataReader.GetTypeDefinition(type.GetDeclaringType());
                 Name = metadataReader.GetString(declaringType.Name) + "/" + Name;
-                namespaceName = metadataReader.GetString(declaringType.Namespace);
+                Namespace = metadataReader.GetString(declaringType.Namespace);
             }
             else
             {
-                namespaceName = metadataReader.GetString(type.Namespace);
+                Namespace = metadataReader.GetString(type.Namespace);
             }
-
-            if (namespaceName.Length > 0)
-                namespaceName += ".";
-            FullName = namespaceName + Name;
+            if (Namespace.Length > 0)
+                FullName = Namespace + "." + Name;
+            else
+                FullName = Name;
         }
 
         public TypeInfo(AssemblyInfo assembly, string name)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -332,6 +332,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public int IsAsync { get; set; }
         public bool IsHiddenFromDebugger { get; }
         public TypeInfo TypeInfo { get; }
+
         public MethodInfo(AssemblyInfo assembly, MethodDefinitionHandle methodDefHandle, int token, SourceFile source, TypeInfo type, MetadataReader asmMetadataReader, MetadataReader pdbMetadataReader)
         {
             this.IsAsync = -1;
@@ -478,6 +479,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         private List<MethodInfo> methods;
         internal int Token { get; }
         internal string Namespace { get; }
+
         public TypeInfo(AssemblyInfo assembly, TypeDefinitionHandle typeHandle, TypeDefinition type)
         {
             this.assembly = assembly;
@@ -486,7 +488,6 @@ namespace Microsoft.WebAssembly.Diagnostics
             this.type = type;
             methods = new List<MethodInfo>();
             Name = metadataReader.GetString(type.Name);
-            Namespace = "";
             if (type.IsNested)
             {
                 var declaringType = metadataReader.GetTypeDefinition(type.GetDeclaringType());

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -331,6 +331,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public bool IsStatic() => (methodDef.Attributes & MethodAttributes.Static) != 0;
         public int IsAsync { get; set; }
         public bool IsHiddenFromDebugger { get; }
+        public TypeInfo TypeInfo { get; }
         public MethodInfo(AssemblyInfo assembly, MethodDefinitionHandle methodDefHandle, int token, SourceFile source, TypeInfo type, MetadataReader asmMetadataReader, MetadataReader pdbMetadataReader)
         {
             this.IsAsync = -1;
@@ -343,6 +344,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             this.Name = asmMetadataReader.GetString(methodDef.Name);
             this.pdbMetadataReader = pdbMetadataReader;
             this.IsEnCMethod = false;
+            this.TypeInfo = type;
             if (!DebugInformation.SequencePointsBlob.IsNil)
             {
                 var sps = DebugInformation.GetSequencePoints();

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -119,14 +119,17 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                 }
                 var store = await proxy.LoadStore(sessionId, token);
-                var info = ctx.CallStack.FirstOrDefault().Method.Info;
-                var classNameToFindWithNamespace = string.IsNullOrEmpty(info.TypeInfo.Namespace) ? classNameToFind : info.TypeInfo.Namespace + "." + classNameToFind;
+                var info = ctx.CallStack.FirstOrDefault(s => s.Id == scopeId).Method.Info;
+                var classNameToFindWithNamespace =
+                    string.IsNullOrEmpty(info.TypeInfo.Namespace) ?
+                    classNameToFind :
+                    info.TypeInfo.Namespace + "." + classNameToFind;
 
                 foreach (var asm in store.assemblies)
                 {
-                    if (await TryGetTypeIdFromName(classNameToFind, asm))
-                        break;
                     if (await TryGetTypeIdFromName(classNameToFindWithNamespace, asm))
+                        break;
+                    if (await TryGetTypeIdFromName(classNameToFind, asm))
                         break;
                 }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -120,21 +120,20 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
                 var store = await proxy.LoadStore(sessionId, token);
                 var info = ctx.CallStack.FirstOrDefault().Method.Info;
-                var currentAssembly = info.Assembly;
-                var namespaceName = info.TypeInfo.Namespace;
-                var classNameToFindWithNamespace = namespaceName + "." + classNameToFind;
-                var type = currentAssembly.GetTypeByName(classNameToFindWithNamespace);
+                var namespaceName = string.IsNullOrEmpty(info.TypeInfo.Namespace) ? classNameToFind : info.TypeInfo.Namespace + "." + classNameToFind;
+                var type = info.Assembly.GetTypeByName(namespaceName);
                 if (type != null)
                 {
-                    typeId = await sdbHelper.GetTypeIdFromToken(sessionId, currentAssembly.DebugId, type.Token, token);
+                    typeId = await sdbHelper.GetTypeIdFromToken(sessionId, info.Assembly.DebugId, type.Token, token);
                     continue;
                 }
+
                 foreach (var asm in store.assemblies)
                 {
                     type = asm.GetTypeByName(classNameToFind);
                     if (type != null)
                     {
-                        typeId = await sdbHelper.GetTypeIdFromToken(sessionId, asm.DebugId, type.Token, token);
+                        typeId = await sdbHelper.GetTypeIdFromToken(sessionId, info.Assembly.DebugId, type.Token, token);
                         break;
                     }
                 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -211,11 +211,11 @@ namespace Microsoft.WebAssembly.Diagnostics
                         }
                     }
                 }
-                else if (rootObject == null)
-                {
-                    rootObject = await TryToRunOnLoadedClasses(varName, token);
-                    return rootObject;
-                }
+            }
+            if (rootObject == null)
+            {
+                rootObject = await TryToRunOnLoadedClasses(varName, token);
+                return rootObject;
             }
             scopeCache.MemberReferences[varName] = rootObject;
             return rootObject;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -121,12 +121,12 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var store = await proxy.LoadStore(sessionId, token);
                 var info = ctx.CallStack.FirstOrDefault().Method.Info;
                 var classNameToFindWithNamespace = string.IsNullOrEmpty(info.TypeInfo.Namespace) ? classNameToFind : info.TypeInfo.Namespace + "." + classNameToFind;
-                if (await TryGetTypeIdFromName(classNameToFindWithNamespace, info.Assembly))
-                    continue;
 
                 foreach (var asm in store.assemblies)
                 {
                     if (await TryGetTypeIdFromName(classNameToFind, asm))
+                        break;
+                    if (await TryGetTypeIdFromName(classNameToFindWithNamespace, asm))
                         break;
                 }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -119,40 +119,15 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
                 }
                 var store = await proxy.LoadStore(sessionId, token);
-
-                // first - check the current assembly
-                var currentFrame = ctx.CallStack.FirstOrDefault();
-                var currentAssembly = currentFrame.Method.Info.TypeInfo.assembly;
-                string namespaceName = currentAssembly.Name;
-
-                // remove .dll from the end
-                if (namespaceName.Length > 4)
-                    namespaceName = currentAssembly.Name.Remove(currentAssembly.Name.Length - 4);
-
-                // look for classes in the current namespace
-                var matchingType = currentAssembly.TypesByName.Keys
-                    .Where(k => k == string.Join(".", new string[] { namespaceName, classNameToFind }))
-                    .Select(t => currentAssembly.GetTypeByName(t))
-                    .FirstOrDefault();
-
-                // if not found, look in all namespaces in the current assembly
-                if (matchingType == null)
-                {
-                    matchingType = currentAssembly.TypesByName.Keys
-                    .Where(k => k == classNameToFind)
-                    .Select(t => currentAssembly.GetTypeByName(t))
-                    .FirstOrDefault();
-                }
-                if (matchingType != null)
-                {
-                    typeId = await sdbHelper.GetTypeIdFromToken(sessionId, currentAssembly.DebugId, matchingType.Token, token);
-                    continue;
-                }
-
-                // if not found in the current assembly, look in the other assemblies
                 foreach (var asm in store.assemblies)
                 {
                     var type = asm.GetTypeByName(classNameToFind);
+                    if (type == null) //search in the current namespace
+                    {
+                        var namespaceName = ctx.CallStack.FirstOrDefault().Method.Info.TypeInfo.Namespace;
+                        var classNameToFindWithNamespace = namespaceName + "." + classNameToFind;
+                        type = asm.GetTypeByName(classNameToFindWithNamespace);
+                    }
                     if (type != null)
                     {
                         typeId = await sdbHelper.GetTypeIdFromToken(sessionId, asm.DebugId, type.Token, token);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -758,7 +758,29 @@ namespace DebuggerTests
                     ("EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")),
                     ("EvaluateNonStaticClassWithStaticFields.StaticPropertyWithError", TString("System.Exception: not implemented")));
            });
-           
+
+        [Fact]
+        public async Task EvaluateStaticClassesFromDifferentNamespaceInDifferentFrames() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTestsV2.EvaluateStaticClass", "Run", 1, "Run",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodTestsClass:EvaluateMethods'); })",
+            wait_for_event_fn: async (pause_location) =>
+            {
+                var id_top = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                var frame = pause_location["callFrames"][0];
+
+                await EvaluateOnCallFrameAndCheck(id_top,
+                ("EvaluateStaticClass.StaticField1", TNumber(20)),
+                ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty2")),
+                ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
+
+                var id_second = pause_location["callFrames"][1]["callFrameId"].Value<string>();
+
+                await EvaluateOnCallFrameAndCheck(id_second,
+                ("EvaluateStaticClass.StaticField1", TNumber(10)),
+                ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
+                ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
+           });
+
         [Fact]
         public async Task EvaluateStaticClassInvalidField() => await CheckInspectLocalsAtBreakpointSite(
             "DebuggerTests.EvaluateMethodTestsClass/TestEvaluate", "run", 9, "run",

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -760,9 +760,6 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
-                await EvaluateOnCallFrame(id, "staticClass", expect_ok: true);
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("staticClass", TObject("DebuggerTests.EvaluateNonStaticClassWithStaticFields", is_null: false)));
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -711,6 +711,7 @@ namespace DebuggerTests
                 var frame = pause_location["callFrames"][0];
 
                 await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticField1", TNumber(10)),
                     ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
                     ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")),
                     ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)),

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -711,16 +711,10 @@ namespace DebuggerTests
                 var frame = pause_location["callFrames"][0];
 
                 await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateStaticClass.StaticField1", TNumber(10)));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
-                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
+                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")),
+                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)),
+                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
                     ("DebuggerTests.EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
            });
 
@@ -737,16 +731,11 @@ namespace DebuggerTests
                 var frame = pause_location["callFrames"][0];
 
                 await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateStaticClass.StaticField1", TNumber(10)));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
-                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticField1", TNumber(10)),
+                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
+                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")),
+                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)),
+                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
                     ("DebuggerTests.EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
            });
 
@@ -761,16 +750,11 @@ namespace DebuggerTests
                 var frame = pause_location["callFrames"][0];
 
                 await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticPropertyWithError", TString("System.Exception: not implemented")));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")));
-                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)),
+                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")),
+                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticPropertyWithError", TString("System.Exception: not implemented")),
+                    ("EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)),
+                    ("EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")),
                     ("EvaluateNonStaticClassWithStaticFields.StaticPropertyWithError", TString("System.Exception: not implemented")));
            });
            

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -791,8 +791,8 @@ namespace DebuggerTests
                 AssertEqual("Failed to resolve member access for DebuggerTests.InvalidEvaluateStaticClass.StaticProperty2", res.Error["result"]?["description"]?.Value<string>(), "wrong error message");
            });
 
-        [Fact]
-        public async Task AsyncLocalsInContinueWithBlock() => await CheckInspectLocalsAtBreakpointSite(
+         [Fact]
+         public async Task AsyncLocalsInContinueWithBlock() => await CheckInspectLocalsAtBreakpointSite(
             "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithStaticAsync", 4, "<ContinueWithStaticAsync>b__3_0",
             "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
             wait_for_event_fn: async (pause_location) =>

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -692,7 +692,6 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
-                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateStaticClass", expect_ok: true);
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
@@ -711,7 +710,6 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
-                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateStaticClass", expect_ok: true);
                 await EvaluateOnCallFrameAndCheck(id,
                     ("EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
@@ -738,7 +736,6 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
-                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateStaticClass", expect_ok: true);
                 await EvaluateOnCallFrameAndCheck(id,
                     ("EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
@@ -755,15 +752,17 @@ namespace DebuggerTests
 
         [Fact]
         public async Task EvaluateNonStaticClassWithStaticFields() => await CheckInspectLocalsAtBreakpointSite(
-            "DebuggerTests.EvaluateMethodTestsClass/TestEvaluate", "run", 9, "run",
-            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodTestsClass:EvaluateMethods'); })",
+            "DebuggerTests.EvaluateMethodTestsClass", "EvaluateAsyncMethods", 3, "EvaluateAsyncMethods",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodTestsClass:EvaluateAsyncMethods'); })",
             wait_for_event_fn: async (pause_location) =>
            {
                 var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
 
                 var frame = pause_location["callFrames"][0];
 
-                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateNonStaticClassWithStaticFields", expect_ok: true);
+                await EvaluateOnCallFrame(id, "staticClass", expect_ok: true);
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("staticClass", TObject("DebuggerTests.EvaluateNonStaticClassWithStaticFields", is_null: false)));
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -692,6 +692,7 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
+                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateStaticClass", expect_ok: true);
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
@@ -710,6 +711,7 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
+                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateStaticClass", expect_ok: true);
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
@@ -730,6 +732,7 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
+                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateStaticClass", expect_ok: true);
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
@@ -748,6 +751,7 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
+                await EvaluateOnCallFrame(id, "DebuggerTests.EvaluateNonStaticClassWithStaticFields", expect_ok: true);
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -442,6 +442,10 @@ namespace DebuggerTests
                   //BUG: TODO:
                   //("a)", "CompilationError"),
 
+                  ("this.c.e", "ReferenceError"), // this.<int-field>.<field>
+                  ("this.e.a", "ReferenceError"), // this.<int-local>.<field>
+                  ("this.dt.e", "ReferenceError"), // this.<field>.<local>
+
                   ("this.a.", "ReferenceError"),
                   ("a.", "ReferenceError"),
 
@@ -465,6 +469,9 @@ namespace DebuggerTests
                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
 
                await EvaluateOnCallFrameFail(id,
+                   ("EvaluateStaticClass.f_s.c", "ReferenceError"), // <static-type>.<local>.<field>
+                   ("EvaluateStaticClass.NonExistant.f_s.c", "ReferenceError"), // <static-type>.<non-existant>.<local>.<field>
+                   ("NonExistant.f_s.dateTime", "ReferenceError"), // <non-existant>.<local>...
                    ("me.foo", "ReferenceError"),
                    ("this", "ReferenceError"),
                    ("this.NullIfAIsNotZero.foo", "ReferenceError"));
@@ -693,10 +700,11 @@ namespace DebuggerTests
                 var frame = pause_location["callFrames"][0];
 
                 await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
-                await EvaluateOnCallFrameAndCheck(id,
-                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
-                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticDTProperty1.Hour", TNumber(4)), // <static-type>.<static-prop>.<instance member>
+                    ("EvaluateStaticClass.StaticDTField1.Hour", TNumber(3)), // <static-type>.<static-field>.<instance member>
+                    ("EvaluateStaticClass.StaticDTField1.Date.Year", TNumber(2000)), // <static-type>.<static-field>.<instance-member>.<instance member>
+                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)),
+                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
                     ("DebuggerTests.EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
            });
 
@@ -769,16 +777,16 @@ namespace DebuggerTests
                 var frame = pause_location["callFrames"][0];
 
                 await EvaluateOnCallFrameAndCheck(id_top,
-                ("EvaluateStaticClass.StaticField1", TNumber(20)),
-                ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty2")),
-                ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
+                    ("EvaluateStaticClass.StaticField1", TNumber(20)),
+                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty2")),
+                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
 
                 var id_second = pause_location["callFrames"][1]["callFrameId"].Value<string>();
 
                 await EvaluateOnCallFrameAndCheck(id_second,
-                ("EvaluateStaticClass.StaticField1", TNumber(10)),
-                ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
-                ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
+                    ("EvaluateStaticClass.StaticField1", TNumber(10)),
+                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")),
+                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
            });
 
         [Fact]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -711,6 +711,12 @@ namespace DebuggerTests
                 var frame = pause_location["callFrames"][0];
 
                 await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticField1", TNumber(10)));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
+                await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
@@ -730,6 +736,12 @@ namespace DebuggerTests
 
                 var frame = pause_location["callFrames"][0];
 
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticField1", TNumber(10)));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
                 await EvaluateOnCallFrameAndCheck(id,
@@ -754,6 +766,12 @@ namespace DebuggerTests
                     ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")));
                 await EvaluateOnCallFrameAndCheck(id,
                     ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticPropertyWithError", TString("System.Exception: not implemented")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("EvaluateNonStaticClassWithStaticFields.StaticPropertyWithError", TString("System.Exception: not implemented")));
            });
            
         [Fact]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -36,6 +36,11 @@ namespace DebuggerTests
             }
         }
 
+        public static IEnumerable<object[]> EvaluateStaticClassFromAsyncMethodTestData(string type_name)
+        {
+            yield return new object[] { type_name, "EvaluateAsyncMethods", "EvaluateAsyncMethods", true };
+        }
+
         [Theory]
         [MemberData(nameof(InstanceMethodForTypeMembersTestData), parameters: "DebuggerTests.EvaluateTestsStructWithProperties")]
         [MemberData(nameof(InstanceMethodForTypeMembersTestData), parameters: "DebuggerTests.EvaluateTestsClassWithProperties")]
@@ -696,6 +701,62 @@ namespace DebuggerTests
            });
 
         [Fact]
+        public async Task EvaluateStaticClassFromStaticMethod() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateMethodTestsClass", "EvaluateMethods", 1, "EvaluateMethods",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodTestsClass:EvaluateMethods'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+
+                var frame = pause_location["callFrames"][0];
+
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
+           });
+
+        [Theory]
+        [MemberData(nameof(EvaluateStaticClassFromAsyncMethodTestData), parameters: "DebuggerTests.EvaluateMethodTestsClass")]
+        public async Task EvaluateStaticClassFromAsyncMethod(string type, string method, string bp_function_name, bool is_async)
+        => await CheckInspectLocalsAtBreakpointSite(
+            type, method, 1, bp_function_name,
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodTestsClass:EvaluateAsyncMethods'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+
+                var frame = pause_location["callFrames"][0];
+
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateStaticClass.StaticField1", TNumber(10)));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateStaticClass.StaticProperty1", TString("StaticProperty1")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateStaticClass.StaticPropertyWithError", TString("System.Exception: not implemented")));
+           });
+
+        [Fact]
+        public async Task EvaluateNonStaticClassWithStaticFields() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateMethodTestsClass/TestEvaluate", "run", 9, "run",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodTestsClass:EvaluateMethods'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+                var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+
+                var frame = pause_location["callFrames"][0];
+
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticField1", TNumber(10)));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticProperty1", TString("StaticProperty1")));
+                await EvaluateOnCallFrameAndCheck(id,
+                    ("DebuggerTests.EvaluateNonStaticClassWithStaticFields.StaticPropertyWithError", TString("System.Exception: not implemented")));
+           });
+           
+        [Fact]
         public async Task EvaluateStaticClassInvalidField() => await CheckInspectLocalsAtBreakpointSite(
             "DebuggerTests.EvaluateMethodTestsClass/TestEvaluate", "run", 9, "run",
             "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateMethodTestsClass:EvaluateMethods'); })",
@@ -712,8 +773,8 @@ namespace DebuggerTests
                 AssertEqual("Failed to resolve member access for DebuggerTests.InvalidEvaluateStaticClass.StaticProperty2", res.Error["result"]?["description"]?.Value<string>(), "wrong error message");
            });
 
-         [Fact]
-         public async Task AsyncLocalsInContinueWithBlock() => await CheckInspectLocalsAtBreakpointSite(
+        [Fact]
+        public async Task AsyncLocalsInContinueWithBlock() => await CheckInspectLocalsAtBreakpointSite(
             "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithStaticAsync", 4, "<ContinueWithStaticAsync>b__3_0",
             "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
             wait_for_event_fn: async (pause_location) =>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -427,9 +427,9 @@ namespace DebuggerTests
         public static string StaticPropertyWithError => throw new Exception("not implemented");
 
         private int HelperMethod()
-	    {
-		    return 5;
-	    }
+        {
+            return 5;
+        }
 
         public async void run()
         {

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -424,7 +424,7 @@ namespace DebuggerTests
     {
         public static int StaticField1 = 10;
         public static string StaticProperty1 => "StaticProperty1";
-	    public static string StaticPropertyWithError => throw new Exception("not implemented");
+        public static string StaticPropertyWithError => throw new Exception("not implemented");
 
         private int HelperMethod()
 	    {

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -418,7 +418,9 @@ namespace DebuggerTests
     public static class EvaluateStaticClass
     {
         public static int StaticField1 = 10;
+        public static DateTime StaticDTField1 = new DateTime(2000, 5, 4, 3, 2, 1);
         public static string StaticProperty1 => "StaticProperty1";
+        public static DateTime StaticDTProperty1 => new DateTime(2000, 8, 1, 4, 7, 1);
 		public static string StaticPropertyWithError => throw new Exception("not implemented");
     }
 
@@ -466,7 +468,7 @@ namespace DebuggerTests
                 textListOfLists = new List<List<string>> { textList, textList };
                 idx0 = 0;
                 idx1 = 1;
-            }        
+            }
         }
 
         public static void EvaluateLocals()

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -403,6 +403,8 @@ namespace DebuggerTests
         {
             TestEvaluate f = new TestEvaluate();
             f.run(100, 200, "9000", "test", 45);
+            DebuggerTestsV2.EvaluateStaticClass.Run();
+            var a = 0;
         }
 
         public static void EvaluateAsyncMethods()
@@ -476,4 +478,19 @@ namespace DebuggerTests
         }
     }
 
+}
+
+namespace DebuggerTestsV2
+{
+    public static class EvaluateStaticClass
+    {
+        public static int StaticField1 = 20;
+        public static string StaticProperty1 => "StaticProperty2";
+		public static string StaticPropertyWithError => throw new Exception("not implemented");
+
+        public static void Run()
+        {
+            var a = 0;
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -424,7 +424,7 @@ namespace DebuggerTests
     {
         public static int StaticField1 = 10;
         public static string StaticProperty1 => "StaticProperty1";
-		public static string StaticPropertyWithError => throw new Exception("not implemented");
+	    public static string StaticPropertyWithError => throw new Exception("not implemented");
 
         private int HelperMethod()
 	    {

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -405,6 +405,12 @@ namespace DebuggerTests
             f.run(100, 200, "9000", "test", 45);
         }
 
+        public static void EvaluateAsyncMethods()
+        {
+            var staticClass = new EvaluateNonStaticClassWithStaticFields();
+            staticClass.run();
+        }
+
     }
 
     public static class EvaluateStaticClass
@@ -412,6 +418,23 @@ namespace DebuggerTests
         public static int StaticField1 = 10;
         public static string StaticProperty1 => "StaticProperty1";
 		public static string StaticPropertyWithError => throw new Exception("not implemented");
+    }
+
+    public class EvaluateNonStaticClassWithStaticFields
+    {
+        public static int StaticField1 = 10;
+        public static string StaticProperty1 => "StaticProperty1";
+		public static string StaticPropertyWithError => throw new Exception("not implemented");
+
+        private int HelperMethod()
+	    {
+		    return 5;
+	    }
+
+        public async void run()
+        {
+            var makeAwaitable = await Task.Run(() => HelperMethod());
+        }
     }
 
     public class EvaluateLocalsWithElementAccessTests


### PR DESCRIPTION
Covering skipped evaluation cases from [#61252](https://github.com/dotnet/runtime/pull/61252).