### PR TITLE
[wasm] Reduce the output from tests.

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -911,7 +911,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 $@"var t = App.call_test_method ('{helperMethodName}', [ {helperMethodArgs} ], 'i'); " +
                 "t.finally(result => { globalThis.__test_promise_completed = true; }); " + 
                 "t.then(result => { globalThis.__test_promise_resolved = true; " + resolvedBody + " }); " + 
-                "t.catch(e => { console.log(e); globalThis.__test_promise_failed = true; }); "
+                "t.catch(e => { globalThis.__test_promise_failed = true; }); "
             );
 
             await Task.Delay(1);

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -485,12 +485,12 @@ mono_wasm_load_runtime (const char *unused, int debug_level)
 #endif
 
 #ifdef DEBUG
-	monoeg_g_setenv ("MONO_LOG_LEVEL", "debug", 0);
-	monoeg_g_setenv ("MONO_LOG_MASK", "gc", 0);
+	// monoeg_g_setenv ("MONO_LOG_LEVEL", "debug", 0);
+	// monoeg_g_setenv ("MONO_LOG_MASK", "gc", 0);
     // Setting this env var allows Diagnostic.Debug to write to stderr.  In a browser environment this
     // output will be sent to the console.  Right now this is the only way to emit debug logging from
     // corlib assemblies.
-	monoeg_g_setenv ("COMPlus_DebugWriteToStdErr", "1", 0);
+	// monoeg_g_setenv ("COMPlus_DebugWriteToStdErr", "1", 0);
 #endif
 	// When the list of app context properties changes, please update RuntimeConfigReservedProperties for
 	// target _WasmGenerateRuntimeConfig in WasmApp.targets file


### PR DESCRIPTION
- Do not printout exceptions from failing task tests.
- Remove default MONO_LOG_MASK=gc from debug configuration.