### PR TITLE
Upload checked JITs for Release branches and introduce jitmap.txt

### DIFF
--- a/eng/pipelines/coreclr/templates/update-checkedjit-map-job.yml
+++ b/eng/pipelines/coreclr/templates/update-checkedjit-map-job.yml
@@ -1,0 +1,88 @@
+parameters:
+  archType: ''
+  buildConfig: ''
+  container: ''
+  crossBuild: false
+  crossrootfsDir: ''
+  osGroup: ''
+  osSubgroup: ''
+  pool: ''
+  stagedBuild: false
+  timeoutInMinutes: ''
+  variables: {}
+  dependOnEvaluatePaths: false
+
+### Product build
+jobs:
+- template: xplat-pipeline-job.yml
+  parameters:
+    buildConfig: ${{ parameters.buildConfig }}
+    archType: ${{ parameters.archType }}
+    osGroup: ${{ parameters.osGroup }}
+    osSubgroup: ${{ parameters.osSubgroup }}
+    helixType: 'build/product/'
+    enableMicrobuild: true
+    stagedBuild: ${{ parameters.stagedBuild }}
+    pool: ${{ parameters.pool }}
+    dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
+
+    # Compute job name from template parameters
+    name: ${{ format('coreclr_jitmap_update_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    displayName: ${{ format('CoreCLR JITMAP Update {0}{1} {2} {3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+
+    # Run all steps in the container.
+    # Note that the containers are defined in platform-matrix.yml
+    container: ${{ parameters.container }}
+
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+
+    gatherAssetManifests: true
+
+    variables:
+    - name: osGroup
+      value: ${{ parameters.osGroup }}
+    - name: osSubgroup
+      value: ${{ parameters.osSubgroup }}
+
+    - name: publishLogsArtifactPrefix
+      value: 'BuildLogs_CoreCLR_JITMAP'
+
+    - ${{ if eq(parameters.osGroup, 'windows') }}:
+      - name: PythonScript
+        value: 'py -3'
+      - name: PipScript
+        value: 'py -3 -m pip'
+    - ${{ if ne(parameters.osGroup, 'windows') }}:
+      - name: PythonScript
+        value: 'python3'
+      - name: PipScript
+        value: 'pip3'
+
+    - ${{ parameters.variables }}
+
+    steps:
+
+    # Install internal tools on official builds
+    # Since our internal tools are behind an authenticated feed,
+    # we need to use the DotNetCli AzDO task to restore from the feed using a service connection.
+    # We can't do this from within the build, so we need to do this as a separate step.
+    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/pipelines/common/restore-internal-tools.yml
+
+    # Ensure the Python azure-storage-blob package is installed before doing the updatejitmap.
+    - script: $(PipScript) install --user --upgrade pip && $(PipScript) install --user azure.storage.blob==12.5.0 --force-reinstall
+      displayName: Upgrade Pip to latest and install azure-storage-blob Python package
+
+    - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/jitrollingbuild.py updatejitmap -build_type $(buildConfig) -arch $(archType) -host_os $(osGroup) -git_hash $(Build.SourceVersion)
+      displayName: Update jitmap.txt on Azure Storage
+      env:
+        CLRJIT_AZ_KEY: $(clrjit_key1) # secret key stored as variable in pipeline
+
+    # Publish Logs
+    - task: PublishPipelineArtifact@1
+      displayName: Publish Logs
+      inputs:
+        targetPath: $(Build.SourcesDirectory)/artifacts/log
+        artifactName: '$(publishLogsArtifactPrefix)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+      continueOnError: true
+      condition: always()

--- a/eng/pipelines/coreclr/update-checkedjit-map.yml
+++ b/eng/pipelines/coreclr/update-checkedjit-map.yml
@@ -6,8 +6,7 @@ trigger:
     - release/*.*
   paths:
     include:
-    - src/coreclr/jit/*
-    - src/coreclr/inc/jiteeversionguid.h
+    - '*'
 
 # This pipeline is supposed to be run only on merged changes
 # and should not be triggerable from a PR. 
@@ -17,7 +16,7 @@ jobs:
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/build-jit-job.yml
+    jobTemplate: /eng/pipelines/coreclr/templates/update-checkedjit-map-job.yml
     buildConfig: checked
     platforms:
     - OSX_arm64


### PR DESCRIPTION
This PR does two things:
1) It enables jitrollingbuilds for `Release/*.*` branches (in order to produce & publish checked JITs for every commit that touches jit sources in Release branches too - currently it's only done for Main branch -- single-line change in `jitrollingbuild.yml`
2) Introduces a `jitmap.txt` file that can be used to quickly get commit of `dotnet/runtime` that triggered `jitrollingbuild.yml` and produced checked JIT that will be friendly for input `dotnet/runtime` hash.

That will allow end-users (without local `dotnet/runtime` repos and git) to easily download checked jit that matches their own .NET installed in the system (release or daily build - it doesn't matter).


So the algorithm is simple - I just want to check that I'm moving in the right direction: Every non-PR commit `update-checkedjit-map-job.yml` is triggered and invokes `python jitrollingbuild.py updatejitmap` script that only calculates two things: current-git-hash and last-good-checked-jit hash and append them both to AzureStorage's `jitmap.txt` file by re-uploading it. Its content is basically a list:
```
hash1:hash_with_checked_jit_1
hash2:hash_with_checked_jit_1
hash3:hash_with_checked_jit_1
hash4:hash_with_checked_jit_2
hash5:hash_with_checked_jit_2
hash6:hash_with_checked_jit_3
```
The format or type of storage can be improved - it's just a draft, perhaps, you have better ideas how to handle it:
@dotnet/jit-contrib @BruceForstall @kunalspathak
