### PR TITLE
[source-build][mono] Do not build Microsoft.NET.Runtime.MonoTargets.Sdk

### DIFF
--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -18,7 +18,7 @@
     <ProjectReference Include="Microsoft.NET.Runtime.MonoAOTCompiler.Task\Microsoft.NET.Runtime.MonoAOTCompiler.Task.pkgproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <ProjectReference Include="Microsoft.NET.Runtime.MonoTargets.Sdk\Microsoft.NET.Runtime.MonoTargets.Sdk.pkgproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Does not build due to missing Microsoft.DotNet.CilStrip.Sources
  external dependency in source-build.

* Package is not needed for source-build anyway.

CC @omajid @tmds @crummel @akoeplinger @steveisok 