### PR TITLE
[arm64] JIT: Make 0.0 containable for fcmp

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3571,7 +3571,6 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
     var_types op2Type = genActualType(op2->TypeGet());
 
     assert(!op1->isUsedFromMemory());
-    assert(!op2->isUsedFromMemory());
 
     genConsumeOperands(tree);
 
@@ -3585,7 +3584,7 @@ void CodeGen::genCodeForCompare(GenTreeOp* tree)
         assert(!op1->isContained());
         assert(op1Type == op2Type);
 
-        if (op2->IsIntegralConst(0))
+        if (op2->IsFPZero())
         {
             assert(op2->isContained());
             emit->emitIns_R_F(INS_fcmp, cmpSize, op1->GetRegNum(), 0.0);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -48,9 +48,6 @@ bool Lowering::IsCallTargetInRange(void* addr)
 //    True if the immediate can be folded into an instruction,
 //    for example small enough and non-relocatable.
 //
-// TODO-CQ: we can contain a floating point 0.0 constant in a compare instruction
-// (vcmp on arm, fcmp on arm64).
-//
 bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
 {
     if (!varTypeIsFloating(parentNode->TypeGet()))

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -53,7 +53,7 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
     if (!varTypeIsFloating(parentNode->TypeGet()))
     {
 #ifdef TARGET_ARM64
-        if (parentNode->OperIsRelop() && childNode->IsCnsFltOrDbl() && childNode->IsFPZero())
+        if (parentNode->OperIsRelop() && childNode->IsFPZero())
         {
             // Contain 0.0 constant in fcmp on arm64
             // TODO: Enable for arm too (vcmp)

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -55,6 +55,18 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
 {
     if (!varTypeIsFloating(parentNode->TypeGet()))
     {
+#ifdef TARGET_ARM64
+        if (parentNode->OperIsRelop() && childNode->IsCnsFltOrDbl() && childNode->IsFPZero())
+        {
+            // Contain 0.0 constant in fcmp on arm64
+            // TODO: Enable for arm too (vcmp)
+
+            // We currently don't emit these for floating points
+            assert(!parentNode->OperIs(GT_TEST_EQ, GT_TEST_NE));
+            return true;
+        }
+#endif
+
         // Make sure we have an actual immediate
         if (!childNode->IsCnsIntOrI())
             return false;


### PR DESCRIPTION
A quick fix for:
```csharp
void Test(double x)
{
    if (x < 0)
        Console.WriteLine();
}
```
codegen diff:
```diff
; Method MandelBrot:Test(double):this
G_M9914_IG01:              ;; offset=0000H
        A9BF7BFD          stp     fp, lr, [sp,#-16]!
        910003FD          mov     fp, sp
						;; bbWeight=1    PerfScore 1.50

G_M9914_IG02:              ;; offset=0008H
-       4F00E410          movi    v16.16b, #0x00
-       1E702000          fcmp    d0, d16
+       1E602008          fcmp    d0, #0.0
        54000042          bhs     G_M9914_IG04
						;; bbWeight=1    PerfScore 3.00

G_M9914_IG03:              ;; offset=0010H
        94000000          bl      System.Console:WriteLine()
						;; bbWeight=0.50 PerfScore 0.50

G_M9914_IG04:              ;; offset=0014H
        A8C17BFD          ldp     fp, lr, [sp],#16
        D65F03C0          ret     lr
						;; bbWeight=1    PerfScore 2.00
; Total bytes of code: 28
```
For arm32 it requires more efforts so I decided to leave that TODO (it was there before my changes)
@dotnet/jit-contrib @echesakovMSFT 