### PR TITLE
Stabilize upgrade code and dependency key for host msi

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,9 +62,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>03adeadd89875039da245253a3f6038874e2fa88</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.21552.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.21565.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>03adeadd89875039da245253a3f6038874e2fa88</Sha>
+      <Sha>2f5d6d594674c80c57048dd9ba8b4f6ee9297171</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20200806.6">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/global.json
+++ b/global.json
@@ -14,7 +14,7 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.21552.7",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21552.7",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.21552.7",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.21565.1",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.21552.7",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20359.4",

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetHost/Microsoft.NETCore.DotNetHost.pkgproj
@@ -19,6 +19,11 @@
       <VSInsertionShortComponentName>SharedHost</VSInsertionShortComponentName>
 
       <PublishRootDir>$(IntermediateOutputPath)publishRoot/</PublishRootDir>
+
+      <!-- Stabilizes upgrade codes, using values from 5.0.12 release - do not change -->
+      <UpgradeCode Condition="'$(TargetArchitecture)' == 'arm64'">{01641E02-508B-44C0-03F9-9C24097910A8}</UpgradeCode>
+      <UpgradeCode Condition="'$(TargetArchitecture)' == 'x64'">{8DA8DDFA-591B-6F59-58DF-79F2FA881F7B}</UpgradeCode>
+      <UpgradeCode Condition="'$(TargetArchitecture)' == 'x86'">{49C53A16-52DB-5FC0-1519-43577C49406B}</UpgradeCode>
     </PropertyGroup>
 
     <!-- Always clean this up to avoid side-by-side versions in unclean dev builds. -->
@@ -46,6 +51,10 @@
 
       <CandleVariables Include="ExtraPropertyRefIds" Value="ProductCPU;RTM_ProductVersion" />
       <CandleVariables Include="HostSrc" Value="$(PublishRootDir)" />
+      <!-- Stabilizes provider key, using values from 5.0.12 release - do not change -->
+      <CandleVariables Condition="'$(TargetArchitecture)' == 'arm64'" Include="DependencyKey" Value="Dotnet_CLI_SharedHost_40.48.30622_arm64" />
+      <CandleVariables Condition="'$(TargetArchitecture)' == 'x64'" Include="DependencyKey" Value="Dotnet_CLI_SharedHost_40.48.30622_x64" />
+      <CandleVariables Condition="'$(TargetArchitecture)' == 'x86'" Include="DependencyKey" Value="Dotnet_CLI_SharedHost_40.48.30622_x86" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Stable upgrade codes and dependency key to allow proper msi upgrade experience.

We are using values from latest servicing release (5.0.12).