### PR TITLE
HostFactoryResolver - Increase default timeout to thirty seconds

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Hosting
         public const string CreateHostBuilder = nameof(CreateHostBuilder);
 
         // The amount of time we wait for the diagnostic source events to fire
-        private static readonly TimeSpan s_defaultWaitTimeout = Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan s_defaultWaitTimeout = Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromMinutes(1);
 
         public static Func<string[], TWebHost>? ResolveWebHostFactory<TWebHost>(Assembly assembly)
         {

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Extensions.Hosting
 
                         // Try to set an exception if the entry point returns gracefully, this will force
                         // build to throw
-                        _hostTcs.TrySetException(new InvalidOperationException("Unable to build IHost"));
+                        _hostTcs.TrySetException(new InvalidOperationException("The entry point exited without ever building an IHost."));
                     }
                     catch (TargetInvocationException tie) when (tie.InnerException is StopTheHostException)
                     {
@@ -268,7 +268,7 @@ namespace Microsoft.Extensions.Hosting
                     // Wait before throwing an exception
                     if (!_hostTcs.Task.Wait(_waitTimeout))
                     {
-                        throw new InvalidOperationException("Unable to build IHost");
+                        throw new InvalidOperationException($"Timed out waiting for the entry point to build the IHost after {s_defaultWaitTimeout}.");
                     }
                 }
                 catch (AggregateException) when (_hostTcs.Task.IsCompleted)

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Hosting
                 return TimeSpan.FromSeconds((int)timeoutInSeconds);
             }
 
-            return TimeSpan.FromSeconds(30);
+            return TimeSpan.FromMinutes(5);
         }
 
         public static Func<string[], TWebHost>? ResolveWebHostFactory<TWebHost>(Assembly assembly)

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Extensions.Hosting
                     // Wait before throwing an exception
                     if (!_hostTcs.Task.Wait(_waitTimeout))
                     {
-                        throw new InvalidOperationException($"Timed out waiting for the entry point to build the IHost after {s_defaultWaitTimeout}.");
+                        throw new InvalidOperationException($"Timed out waiting for the entry point to build the IHost after {s_defaultWaitTimeout}. This timeout can be modified using the '{TimeoutEnvironmentKey}' environment variable.");
                     }
                 }
                 catch (AggregateException) when (_hostTcs.Task.IsCompleted)

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -254,6 +254,16 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void TopLevelStatementsTestsTimeout()
+        {
+            var assembly = Assembly.Load("TopLevelStatementsTestsTimeout");
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(assembly, waitTimeout: null); // will use default timeout
+
+            Assert.NotNull(factory);
+            Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void ApplicationNameSetFromAgrument()
         {
             Assembly assembly = Assembly.Load("ApplicationNameSetFromAgrument");

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         public void TopLevelStatementsTestsTimeout()
         {
             var assembly = Assembly.Load("TopLevelStatementsTestsTimeout");
-            var factory = HostFactoryResolver.ResolveServiceProviderFactory(assembly, waitTimeout: null); // will use default timeout
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(assembly, s_WaitTimeout);
 
             Assert.NotNull(factory);
             Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="NoSpecialEntryPointPatternHangs\NoSpecialEntryPointPatternHangs.csproj" />
     <ProjectReference Include="NoSpecialEntryPointPatternMainNoArgs\NoSpecialEntryPointPatternMainNoArgs.csproj" />
     <ProjectReference Include="TopLevelStatements\TopLevelStatements.csproj" />
+    <ProjectReference Include="TopLevelStatementsTestsTimeout\TopLevelStatementsTestsTimeout.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/Program.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/Program.cs
@@ -6,5 +6,5 @@ using System.Threading;
 using Microsoft.Extensions.Hosting;
 
 var hostBuilder = new HostBuilder();
-Thread.Sleep(TimeSpan.FromMinutes(2));
+Thread.Sleep(TimeSpan.FromMinutes(6));
 hostBuilder.Build();

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/Program.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/Program.cs
@@ -6,5 +6,5 @@ using System.Threading;
 using Microsoft.Extensions.Hosting;
 
 var hostBuilder = new HostBuilder();
-Thread.Sleep(TimeSpan.FromMinutes(6));
+Thread.Sleep(TimeSpan.FromSeconds(30));
 hostBuilder.Build();

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/Program.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/Program.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using Microsoft.Extensions.Hosting;
+
+var hostBuilder = new HostBuilder();
+Thread.Sleep(TimeSpan.FromMinutes(2));
+hostBuilder.Build();

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/TopLevelStatementsTestsTimeout.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/TopLevelStatementsTestsTimeout/TopLevelStatementsTestsTimeout.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
+    <EnableDefaultItems>true</EnableDefaultItems>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MockHostTypes\MockHostTypes.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
#### Customer Impact

When customer has debugger attached or when using tools like EF, host startup path using WebApplicationBuilder for hosting and WebApplicationFactory<T> for testing, may fail to build and throw an InvalidOperationException with the message “Unable to build IHost.”, because the default timeout is only 5 seconds.

We are proposing to use a higher timeout (1 minute) to be used so that when an application is taking longer to build, we could allow startup code to complete, and the host can start successfully. 

Increasing the timeout should not have a negative impact on experience.

#### TODO
- [x] Add test for this scenario to ensure it works.
- [x] Add environment variable
- [x] improve exception message

#### Risk
Very low.

#### Regression
No, new 6.0 feature/code flow for discovering a host.
Even though this is not a regression (uses WebApplicationBuilder which is new), but since this code is in the ASP.NET Core templates, it regresses the scenario when using default templates.



Fixes https://github.com/dotnet/runtime/issues/60891, https://github.com/dotnet/aspnetcore/issues/33886