### PR TITLE
Restrict GITHUB_TOKEN in markdownlint action

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,5 +1,8 @@
 name: Markdownlint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
The markdownlint workflow can be restricted from all access except the repository contents. This limits what the 3rd party `markdownlint-cli` npm package can do which is installed as part of the workflow.