### PR TITLE
Add ThrowIfNull overload for pointers

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ArgumentNullException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ArgumentNullException.cs
@@ -64,6 +64,18 @@ namespace System
             }
         }
 
+        /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
+        /// <param name="argument">The pointer argument to validate as non-null.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        [CLSCompliant(false)]
+        public static unsafe void ThrowIfNull([NotNull] void* argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        {
+            if (argument is null)
+            {
+                Throw(paramName);
+            }
+        }
+
         [DoesNotReturn]
         private static void Throw(string? paramName) =>
             throw new ArgumentNullException(paramName);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -285,6 +285,8 @@ namespace System
         public ArgumentNullException(string? message, System.Exception? innerException) { }
         public ArgumentNullException(string? paramName, string? message) { }
         public static void ThrowIfNull([System.Diagnostics.CodeAnalysis.NotNullAttribute] object? argument, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("argument")] string? paramName = null) { throw null; }
+        [System.CLSCompliant(false)]
+        public static unsafe void ThrowIfNull([System.Diagnostics.CodeAnalysis.NotNullAttribute] void* argument, [System.Runtime.CompilerServices.CallerArgumentExpressionAttribute("argument")] string? paramName = null) { throw null; }
     }
     public partial class ArgumentOutOfRangeException : System.ArgumentException
     {

--- a/src/libraries/System.Runtime/tests/System/ArgumentNullExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArgumentNullExceptionTests.cs
@@ -49,29 +49,37 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void ThrowIfNull_NonNull_DoesntThrow()
+        public static unsafe void ThrowIfNull_NonNull_DoesntThrow()
         {
             foreach (object o in new[] { new object(), "", "argument" })
             {
                 ArgumentNullException.ThrowIfNull(o);
                 ArgumentNullException.ThrowIfNull(o, "paramName");
             }
+
+            int i = 0;
+            ArgumentNullException.ThrowIfNull(&i);
+            ArgumentNullException.ThrowIfNull(&i, "paramName");
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("name")]
-        public static void ThrowIfNull_Null_ThrowsArgumentNullException(string paramName)
+        public static unsafe void ThrowIfNull_Null_ThrowsArgumentNullException(string paramName)
         {
-            AssertExtensions.Throws<ArgumentNullException>(paramName, () => ArgumentNullException.ThrowIfNull(null, paramName));
+            AssertExtensions.Throws<ArgumentNullException>(paramName, () => ArgumentNullException.ThrowIfNull((object)null, paramName));
+            AssertExtensions.Throws<ArgumentNullException>(paramName, () => ArgumentNullException.ThrowIfNull((void*)null, paramName));
         }
 
         [Fact]
-        public static void ThrowIfNull_UsesArgumentExpression()
+        public static unsafe void ThrowIfNull_UsesArgumentExpression()
         {
-            object something = null;
-            AssertExtensions.Throws<ArgumentNullException>(nameof(something), () => ArgumentNullException.ThrowIfNull(something));
+            object someObject = null;
+            AssertExtensions.Throws<ArgumentNullException>(nameof(someObject), () => ArgumentNullException.ThrowIfNull(someObject));
+
+            byte* somePointer = null;
+            AssertExtensions.Throws<ArgumentNullException>(nameof(somePointer), () => ArgumentNullException.ThrowIfNull(somePointer));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/58047

I'm purposefully not yet consuming it anywhere, as (as with the existing ThrowIfNull overload) I want to first switch to using the !! C# support when it's available (soon), and then only use these methods for anything that doesn't make sense with the new syntax.