### PR TITLE
Allow for backport to report progress to PR

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,7 +5,7 @@ on:
 
 permissions:
   contents: write
-  issues: read
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Write permission is needed so the action can report success or failure on the backport requests.