### PR TITLE
Use GeneratedDllImport for blittable p/invokes in System.IO.Compression, System.IO.Compression.Brotli, System.Net.Http, System.Net.NameResolution

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Brotli.cs
+++ b/src/libraries/Common/src/Interop/Interop.Brotli.cs
@@ -18,11 +18,11 @@ internal static partial class Interop
             SafeBrotliDecoderHandle state, ref nuint availableIn, byte** nextIn,
             ref nuint availableOut, byte** nextOut, out nuint totalOut);
 
-        [DllImport(Libraries.CompressionNative)]
-        internal static extern unsafe BOOL BrotliDecoderDecompress(nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
+        [GeneratedDllImport(Libraries.CompressionNative)]
+        internal static unsafe partial BOOL BrotliDecoderDecompress(nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
 
-        [DllImport(Libraries.CompressionNative)]
-        internal static extern void BrotliDecoderDestroyInstance(IntPtr state);
+        [GeneratedDllImport(Libraries.CompressionNative)]
+        internal static partial void BrotliDecoderDestroyInstance(IntPtr state);
 
         [GeneratedDllImport(Libraries.CompressionNative)]
         internal static partial BOOL BrotliDecoderIsFinished(SafeBrotliDecoderHandle state);
@@ -41,10 +41,10 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CompressionNative)]
         internal static partial BOOL BrotliEncoderHasMoreOutput(SafeBrotliEncoderHandle state);
 
-        [DllImport(Libraries.CompressionNative)]
-        internal static extern void BrotliEncoderDestroyInstance(IntPtr state);
+        [GeneratedDllImport(Libraries.CompressionNative)]
+        internal static partial void BrotliEncoderDestroyInstance(IntPtr state);
 
-        [DllImport(Libraries.CompressionNative)]
-        internal static extern unsafe BOOL BrotliEncoderCompress(int quality, int window, int v, nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
+        [GeneratedDllImport(Libraries.CompressionNative)]
+        internal static unsafe partial BOOL BrotliEncoderCompress(int quality, int window, int v, nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
     }
 }

--- a/src/libraries/Common/src/Interop/Interop.zlib.cs
+++ b/src/libraries/Common/src/Interop/Interop.zlib.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class zlib
     {
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateInit2_")]
-        internal static extern unsafe ZLibNative.ErrorCode DeflateInit2_(
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateInit2_")]
+        internal static unsafe partial ZLibNative.ErrorCode DeflateInit2_(
             ZLibNative.ZStream* stream,
             ZLibNative.CompressionLevel level,
             ZLibNative.CompressionMethod method,
@@ -17,28 +17,28 @@ internal static partial class Interop
             int memLevel,
             ZLibNative.CompressionStrategy strategy);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Deflate")]
-        internal static extern unsafe ZLibNative.ErrorCode Deflate(ZLibNative.ZStream* stream, ZLibNative.FlushCode flush);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Deflate")]
+        internal static unsafe partial ZLibNative.ErrorCode Deflate(ZLibNative.ZStream* stream, ZLibNative.FlushCode flush);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateReset")]
-        internal static extern unsafe ZLibNative.ErrorCode DeflateReset(ZLibNative.ZStream* stream);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateReset")]
+        internal static unsafe partial ZLibNative.ErrorCode DeflateReset(ZLibNative.ZStream* stream);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateEnd")]
-        internal static extern unsafe ZLibNative.ErrorCode DeflateEnd(ZLibNative.ZStream* stream);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateEnd")]
+        internal static unsafe partial ZLibNative.ErrorCode DeflateEnd(ZLibNative.ZStream* stream);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateInit2_")]
-        internal static extern unsafe ZLibNative.ErrorCode InflateInit2_(ZLibNative.ZStream* stream, int windowBits);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateInit2_")]
+        internal static unsafe partial ZLibNative.ErrorCode InflateInit2_(ZLibNative.ZStream* stream, int windowBits);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Inflate")]
-        internal static extern unsafe ZLibNative.ErrorCode Inflate(ZLibNative.ZStream* stream, ZLibNative.FlushCode flush);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Inflate")]
+        internal static unsafe partial ZLibNative.ErrorCode Inflate(ZLibNative.ZStream* stream, ZLibNative.FlushCode flush);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateReset")]
-        internal static extern unsafe ZLibNative.ErrorCode InflateReset(ZLibNative.ZStream* stream);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateReset")]
+        internal static unsafe partial ZLibNative.ErrorCode InflateReset(ZLibNative.ZStream* stream);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateEnd")]
-        internal static extern unsafe ZLibNative.ErrorCode InflateEnd(ZLibNative.ZStream* stream);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateEnd")]
+        internal static unsafe partial ZLibNative.ErrorCode InflateEnd(ZLibNative.ZStream* stream);
 
-        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Crc32")]
-        internal static extern unsafe uint crc32(uint crc, byte* buffer, int len);
+        [GeneratedDllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Crc32")]
+        internal static unsafe partial uint crc32(uint crc, byte* buffer, int len);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFNumber.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.CFNumber.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             kCFNumberIntType = 9,
         }
 
-        [DllImport(Libraries.CoreFoundationLibrary)]
-        private static unsafe extern int CFNumberGetValue(IntPtr handle, CFNumberType type, int* value);
+        [GeneratedDllImport(Libraries.CoreFoundationLibrary)]
+        private static unsafe partial int CFNumberGetValue(IntPtr handle, CFNumberType type, int* value);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.CoreFoundation.cs
@@ -156,14 +156,14 @@ internal static partial class Interop
         /// </summary>
         /// <param name="ptr">The CFType object to retain. This value must not be NULL</param>
         /// <returns>The input value</returns>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern IntPtr CFRetain(IntPtr ptr);
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial IntPtr CFRetain(IntPtr ptr);
 
         /// <summary>
         /// Decrements the reference count on the specified object and, if the ref count hits 0, cleans up the object.
         /// </summary>
         /// <param name="ptr">The pointer on which to decrement the reference count.</param>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern void CFRelease(IntPtr ptr);
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial void CFRelease(IntPtr ptr);
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/Interop.RunLoop.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.RunLoop.cs
@@ -28,31 +28,32 @@ internal static partial class Interop
         /// </summary>
 #if MONO
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-#else
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-#endif
         internal static extern void CFRunLoopRun();
+#else
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial void CFRunLoopRun();
+#endif
 
         /// <summary>
         /// Runs the current thread's CFRunLoop object in a particular mode.
         /// </summary>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern int CFRunLoopRunInMode(CFStringRef mode, double seconds, int returnAfterSourceHandled);
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial int CFRunLoopRunInMode(CFStringRef mode, double seconds, int returnAfterSourceHandled);
 
         /// <summary>
         /// Notifies a RunLoop to stop and return control to the execution context that called CFRunLoopRun
         /// </summary>
         /// <param name="rl">The RunLoop to notify to stop</param>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern void CFRunLoopStop(CFRunLoopRef rl);
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial void CFRunLoopStop(CFRunLoopRef rl);
 
         /// <summary>
         /// Retrieves the RunLoop associated with the current thread; all threads automatically have a RunLoop.
         /// Follows the "Get Rule" where you do not own the object unless you CFRetain it; in which case, you must also CFRelease it as well.
         /// </summary>
         /// <returns>Returns a pointer to a CFRunLoop on success; otherwise, returns IntPtr.Zero</returns>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern CFRunLoopRef CFRunLoopGetCurrent();
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial CFRunLoopRef CFRunLoopGetCurrent();
 
         /// <summary>
         /// Adds a CFRunLoopSource object to a run loop mode.
@@ -60,8 +61,8 @@ internal static partial class Interop
         /// <param name="rl">The run loop to modify.</param>
         /// <param name="source">The run loop source to add. The source is retained by the run loop.</param>
         /// <param name="mode">The run loop mode to which to add source.</param>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern void CFRunLoopAddSource(CFRunLoopRef rl, CFRunLoopSourceRef source, CFStringRef mode);
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial void CFRunLoopAddSource(CFRunLoopRef rl, CFRunLoopSourceRef source, CFStringRef mode);
 
         /// <summary>
         /// Removes a CFRunLoopSource object from a run loop mode.
@@ -69,15 +70,15 @@ internal static partial class Interop
         /// <param name="rl">The run loop to modify.</param>
         /// <param name="source">The run loop source to remove.</param>
         /// <param name="mode">The run loop mode of rl from which to remove source.</param>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern void CFRunLoopRemoveSource(CFRunLoopRef rl, CFRunLoopSourceRef source, CFStringRef mode);
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial void CFRunLoopRemoveSource(CFRunLoopRef rl, CFRunLoopSourceRef source, CFStringRef mode);
 
         /// <summary>
         /// Invalidates a CFRunLoopSource object, stopping it from ever firing again.
         /// </summary>
         /// <param name="source">The run loop source to invalidate.</param>
-        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
-        internal static extern void CFRunLoopSourceInvalidate(CFRunLoopSourceRef source);
+        [GeneratedDllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static partial void CFRunLoopSourceInvalidate(CFRunLoopSourceRef source);
 
         /// <summary>
         /// Returns a bool that indicates whether the run loop is waiting for an event.

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetNameInfo.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetNameInfo.cs
@@ -15,8 +15,8 @@ internal static partial class Interop
             NI_NUMERICHOST  = 0x2,
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNameInfo")]
-        internal static extern unsafe int GetNameInfo(
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNameInfo")]
+        internal static unsafe partial int GetNameInfo(
             byte* address,
             uint addressLength,
             byte isIpv6,

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.HostEntry.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.HostEntry.cs
@@ -35,7 +35,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetHostEntryForName", CharSet = CharSet.Ansi)]
         internal static unsafe partial int GetHostEntryForName(string address, AddressFamily family, HostEntry* entry);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeHostEntry")]
-        internal static extern unsafe void FreeHostEntry(HostEntry* entry);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeHostEntry")]
+        internal static unsafe partial void FreeHostEntry(HostEntry* entry);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
@@ -17,8 +17,8 @@ internal static partial class Interop
         /// <param name="timeout">The amount of time to wait; -1 for infinite, 0 for immediate return, and a positive number is the number of milliseconds</param>
         /// <param name="triggered">The number of events triggered (i.e. the number of entries in pollEvents with a non-zero TriggeredEvents). May be zero in the event of a timeout.</param>
         /// <returns>An error or Error.SUCCESS.</returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Poll")]
-        internal static extern unsafe Error Poll(PollEvent* pollEvents, uint eventCount, int timeout, uint* triggered);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Poll")]
+        internal static unsafe partial Error Poll(PollEvent* pollEvents, uint eventCount, int timeout, uint* triggered);
 
         /// <summary>
         /// Polls a File Descriptor for the passed in flags.

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
-        internal static extern unsafe Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, IntPtr* socket);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
+        internal static unsafe partial Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, IntPtr* socket);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
@@ -9,38 +9,38 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPSocketAddressSizes")]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPSocketAddressSizes")]
         [SuppressGCTransition]
-        internal static extern unsafe Error GetIPSocketAddressSizes(int* ipv4SocketAddressSize, int* ipv6SocketAddressSize);
+        internal static unsafe partial Error GetIPSocketAddressSizes(int* ipv4SocketAddressSize, int* ipv6SocketAddressSize);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetAddressFamily")]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetAddressFamily")]
         [SuppressGCTransition]
-        internal static extern unsafe Error GetAddressFamily(byte* socketAddress, int socketAddressLen, int* addressFamily);
+        internal static unsafe partial Error GetAddressFamily(byte* socketAddress, int socketAddressLen, int* addressFamily);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetAddressFamily")]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetAddressFamily")]
         [SuppressGCTransition]
-        internal static extern unsafe Error SetAddressFamily(byte* socketAddress, int socketAddressLen, int addressFamily);
+        internal static unsafe partial Error SetAddressFamily(byte* socketAddress, int socketAddressLen, int addressFamily);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPort")]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPort")]
         [SuppressGCTransition]
-        internal static extern unsafe Error GetPort(byte* socketAddress, int socketAddressLen, ushort* port);
+        internal static unsafe partial Error GetPort(byte* socketAddress, int socketAddressLen, ushort* port);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetPort")]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetPort")]
         [SuppressGCTransition]
-        internal static extern unsafe Error SetPort(byte* socketAddress, int socketAddressLen, ushort port);
+        internal static unsafe partial Error SetPort(byte* socketAddress, int socketAddressLen, ushort port);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4Address")]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4Address")]
         [SuppressGCTransition]
-        internal static extern unsafe Error GetIPv4Address(byte* socketAddress, int socketAddressLen, uint* address);
+        internal static unsafe partial Error GetIPv4Address(byte* socketAddress, int socketAddressLen, uint* address);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4Address")]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4Address")]
         [SuppressGCTransition]
-        internal static extern unsafe Error SetIPv4Address(byte* socketAddress, int socketAddressLen, uint address);
+        internal static unsafe partial Error SetIPv4Address(byte* socketAddress, int socketAddressLen, uint address);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6Address")]
-        internal static extern unsafe Error GetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint* scopeId);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6Address")]
+        internal static unsafe partial Error GetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint* scopeId);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6Address")]
-        internal static extern unsafe Error SetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint scopeId);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6Address")]
+        internal static unsafe partial Error SetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint scopeId);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
@@ -11,8 +11,8 @@ internal static partial class Interop
         [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_IsNtlmInstalled")]
         internal static partial bool IsNtlmInstalled();
 
-        [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint = "NetSecurityNative_EnsureGssInitialized")]
-        private static extern int EnsureGssInitialized();
+        [GeneratedDllImport(Interop.Libraries.NetSecurityNative, EntryPoint = "NetSecurityNative_EnsureGssInitialized")]
+        private static partial int EnsureGssInitialized();
 
         static NetSecurityNative()
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -15,8 +15,8 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjTxt2Obj", CharSet = CharSet.Ansi)]
         internal static partial SafeAsn1ObjectHandle ObjTxt2Obj(string s);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjObj2Txt")]
-        private static extern unsafe int ObjObj2Txt(byte* buf, int buf_len, IntPtr a);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjObj2Txt")]
+        private static unsafe partial int ObjObj2Txt(byte* buf, int buf_len, IntPtr a);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetObjectDefinitionByName", CharSet = CharSet.Ansi)]
         private static partial IntPtr CryptoNative_GetObjectDefinitionByName(string friendlyName);
@@ -32,17 +32,17 @@ internal static partial class Interop
         }
 
         // Returns shared pointers, should not be tracked as a SafeHandle.
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjNid2Obj")]
-        internal static extern IntPtr ObjNid2Obj(int nid);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjNid2Obj")]
+        internal static partial IntPtr ObjNid2Obj(int nid);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1ObjectFree")]
-        internal static extern void Asn1ObjectFree(IntPtr o);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1ObjectFree")]
+        internal static partial void Asn1ObjectFree(IntPtr o);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeAsn1BitString")]
         internal static partial SafeAsn1BitStringHandle DecodeAsn1BitString(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1BitStringFree")]
-        internal static extern void Asn1BitStringFree(IntPtr o);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1BitStringFree")]
+        internal static partial void Asn1BitStringFree(IntPtr o);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringNew")]
         internal static partial SafeAsn1OctetStringHandle Asn1OctetStringNew();
@@ -51,11 +51,11 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool Asn1OctetStringSet(SafeAsn1OctetStringHandle o, byte[] d, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringFree")]
-        internal static extern void Asn1OctetStringFree(IntPtr o);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringFree")]
+        internal static partial void Asn1OctetStringFree(IntPtr o);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1StringFree")]
-        internal static extern void Asn1StringFree(IntPtr o);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1StringFree")]
+        internal static partial void Asn1StringFree(IntPtr o);
 
         internal static unsafe string GetOidValue(IntPtr asn1ObjectPtr)
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -82,11 +82,11 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(GetX509RootStoreFile_private(&unused));
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStorePath")]
-        private static unsafe extern IntPtr GetX509RootStorePath_private(byte* defaultPath);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStorePath")]
+        private static unsafe partial IntPtr GetX509RootStorePath_private(byte* defaultPath);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStoreFile")]
-        private static unsafe extern IntPtr GetX509RootStoreFile_private(byte* defaultPath);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStoreFile")]
+        private static unsafe partial IntPtr GetX509RootStoreFile_private(byte* defaultPath);
 
         [GeneratedDllImport(Libraries.CryptoNative)]
         private static partial int CryptoNative_X509StoreSetVerifyTime(

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -10,23 +10,23 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrClearError")]
-        internal static extern ulong ErrClearError();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrClearError")]
+        internal static partial ulong ErrClearError();
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetErrorAlloc")]
         private static partial ulong ErrGetErrorAlloc([MarshalAs(UnmanagedType.Bool)] out bool isAllocFailure);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrPeekError")]
-        internal static extern ulong ErrPeekError();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrPeekError")]
+        internal static partial ulong ErrPeekError();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrPeekLastError")]
-        internal static extern ulong ErrPeekLastError();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrPeekLastError")]
+        internal static partial ulong ErrPeekLastError();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrReasonErrorString")]
-        internal static extern IntPtr ErrReasonErrorString(ulong error);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrReasonErrorString")]
+        internal static partial IntPtr ErrReasonErrorString(ulong error);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrErrorStringN")]
-        private static extern unsafe void ErrErrorStringN(ulong e, byte* buf, int len);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrErrorStringN")]
+        private static unsafe partial void ErrErrorStringN(ulong e, byte* buf, int len);
 
         private static unsafe string ErrErrorStringN(ulong error)
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
@@ -27,7 +27,7 @@ internal static partial class Interop
         }
     }
 
-    internal static class CryptoInitializer
+    internal static partial class CryptoInitializer
     {
         static CryptoInitializer()
         {
@@ -48,7 +48,7 @@ internal static partial class Interop
             // No-op that exists to provide a hook for other static constructors.
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EnsureOpenSslInitialized")]
-        private static extern int EnsureOpenSslInitialized();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EnsureOpenSslInitialized")]
+        private static partial int EnsureOpenSslInitialized();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslVersion.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class OpenSsl
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslVersionNumber")]
-        internal static extern long OpenSslVersionNumber();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslVersionNumber")]
+        internal static partial long OpenSslVersionNumber();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SetProtocolOptions.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SetProtocolOptions.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
 {
     internal static partial class Ssl
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetProtocolOptions")]
-        internal static extern void SslCtxSetProtocolOptions(IntPtr ctx, SslProtocols protocols);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetProtocolOptions")]
+        internal static partial void SslCtxSetProtocolOptions(IntPtr ctx, SslProtocols protocols);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetProtocolOptions")]
-        internal static extern void SslCtxSetProtocolOptions(SafeSslContextHandle ctx, SslProtocols protocols);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetProtocolOptions")]
+        internal static partial void SslCtxSetProtocolOptions(SafeSslContextHandle ctx, SslProtocols protocols);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -18,11 +18,11 @@ internal static partial class Interop
         internal const int SSL_TLSEXT_ERR_ALERT_FATAL = 2;
         internal const int SSL_TLSEXT_ERR_NOACK = 3;
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EnsureLibSslInitialized")]
-        internal static extern void EnsureLibSslInitialized();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EnsureLibSslInitialized")]
+        internal static partial void EnsureLibSslInitialized();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslV2_3Method")]
-        internal static extern IntPtr SslV2_3Method();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslV2_3Method")]
+        internal static partial IntPtr SslV2_3Method();
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCreate")]
         internal static partial SafeSslHandle SslCreate(SafeSslContextHandle ctx);
@@ -30,14 +30,14 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetError")]
         internal static partial SslErrorCode SslGetError(SafeSslHandle ssl, int ret);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetError")]
-        internal static extern SslErrorCode SslGetError(IntPtr ssl, int ret);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetError")]
+        internal static partial SslErrorCode SslGetError(IntPtr ssl, int ret);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetQuietShutdown")]
         internal static partial void SslSetQuietShutdown(SafeSslHandle ssl, int mode);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDestroy")]
-        internal static extern void SslDestroy(IntPtr ssl);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDestroy")]
+        internal static partial void SslDestroy(IntPtr ssl);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetConnectState")]
         internal static partial void SslSetConnectState(SafeSslHandle ssl);
@@ -85,8 +85,8 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool IsSslRenegotiatePending(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslShutdown")]
-        internal static extern int SslShutdown(IntPtr ssl);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslShutdown")]
+        internal static partial int SslShutdown(IntPtr ssl);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslShutdown")]
         internal static partial int SslShutdown(SafeSslHandle ssl);
@@ -134,20 +134,20 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetOpenSslCipherSuiteName")]
         private static partial IntPtr GetOpenSslCipherSuiteName(SafeSslHandle ssl, int cipherSuite, out int isTls12OrLower);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetCiphers")]
-        internal static extern unsafe bool SslSetCiphers(SafeSslHandle ssl, byte* cipherList, byte* cipherSuites);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetCiphers")]
+        internal static unsafe partial bool SslSetCiphers(SafeSslHandle ssl, byte* cipherList, byte* cipherSuites);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetVerifyPeer")]
-        internal static extern void SslSetVerifyPeer(SafeSslHandle ssl);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetVerifyPeer")]
+        internal static partial void SslSetVerifyPeer(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetData")]
-        internal static extern IntPtr SslGetData(IntPtr ssl);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetData")]
+        internal static partial IntPtr SslGetData(IntPtr ssl);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetData")]
-        internal static extern int SslSetData(SafeSslHandle ssl, IntPtr data);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetData")]
+        internal static partial int SslSetData(SafeSslHandle ssl, IntPtr data);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetData")]
-        internal static extern int SslSetData(IntPtr ssl, IntPtr data);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetData")]
+        internal static partial int SslSetData(IntPtr ssl, IntPtr data);
 
         internal static unsafe int SslSetAlpnProtos(SafeSslHandle ssl, List<SslApplicationProtocol> protocols)
         {
@@ -190,8 +190,8 @@ internal static partial class Interop
             return ret;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Tls13Supported")]
-        private static extern int Tls13SupportedImpl();
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Tls13Supported")]
+        private static partial int Tls13SupportedImpl();
         internal static readonly bool Tls13Supported = Tls13SupportedImpl() != 0;
 
         internal static SafeSharedX509NameStackHandle SslGetClientCAList(SafeSslHandle ssl)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -16,8 +16,8 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxCreate")]
         internal static partial SafeSslContextHandle SslCtxCreate(IntPtr method);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxDestroy")]
-        internal static extern void SslCtxDestroy(IntPtr ctx);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxDestroy")]
+        internal static partial void SslCtxDestroy(IntPtr ctx);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAlpnSelectCb")]
         internal static unsafe partial void SslCtxSetAlpnSelectCb(SafeSslContextHandle ctx, delegate* unmanaged<IntPtr, byte**, byte*, byte*, uint, IntPtr, int> callback, IntPtr arg);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -47,8 +47,8 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodeX509")]
         internal static partial int EncodeX509(SafeX509Handle x, byte[] buf);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509Destroy")]
-        internal static extern void X509Destroy(IntPtr a);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509Destroy")]
+        internal static partial void X509Destroy(IntPtr a);
 
         /// <summary>
         /// Clone the input certificate into a new object.
@@ -131,12 +131,12 @@ internal static partial class Interop
         internal static partial IntPtr X509GetExt(SafeX509Handle x, int loc);
 
         // Returns a pointer already being tracked by a SafeX509Handle, shouldn't be SafeHandle tracked/freed.
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetOid")]
-        internal static extern IntPtr X509ExtensionGetOid(IntPtr ex);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetOid")]
+        internal static partial IntPtr X509ExtensionGetOid(IntPtr ex);
 
         // Returns a pointer already being tracked by a SafeX509Handle, shouldn't be SafeHandle tracked/freed.
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetData")]
-        internal static extern IntPtr X509ExtensionGetData(IntPtr ex);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetData")]
+        internal static partial IntPtr X509ExtensionGetData(IntPtr ex);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetCritical")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -157,8 +157,8 @@ internal static partial class Interop
             return store;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreDestory")]
-        internal static extern void X509StoreDestory(IntPtr v);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreDestory")]
+        internal static partial void X509StoreDestory(IntPtr v);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreAddCrl")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -244,11 +244,11 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(X509VerifyCertErrorString(n))!;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCertErrorString")]
-        private static extern IntPtr X509VerifyCertErrorString(int n);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCertErrorString")]
+        private static partial IntPtr X509VerifyCertErrorString(int n);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509CrlDestroy")]
-        internal static extern void X509CrlDestroy(IntPtr a);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509CrlDestroy")]
+        internal static partial void X509CrlDestroy(IntPtr a);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemWriteBioX509Crl")]
         internal static partial int PemWriteBioX509Crl(SafeBioHandle bio, SafeX509CrlHandle crl);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Ext.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Ext.cs
@@ -15,8 +15,8 @@ internal static partial class Interop
             [MarshalAs(UnmanagedType.Bool)] bool isCritical,
             SafeAsn1OctetStringHandle data);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionDestroy")]
-        internal static extern int X509ExtensionDestroy(IntPtr x);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionDestroy")]
+        internal static partial int X509ExtensionDestroy(IntPtr x);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509V3ExtPrint")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -34,7 +34,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeExtendedKeyUsage")]
         internal static partial SafeEkuExtensionHandle DecodeExtendedKeyUsage(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ExtendedKeyUsageDestory")]
-        internal static extern void ExtendedKeyUsageDestory(IntPtr a);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ExtendedKeyUsageDestory")]
+        internal static partial void ExtendedKeyUsageDestory(IntPtr a);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
@@ -12,8 +12,8 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_NewX509Stack")]
         internal static partial SafeX509StackHandle NewX509Stack();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RecursiveFreeX509Stack")]
-        internal static extern void RecursiveFreeX509Stack(IntPtr stack);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RecursiveFreeX509Stack")]
+        internal static partial void RecursiveFreeX509Stack(IntPtr stack);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509StackFieldCount")]
         internal static partial int GetX509StackFieldCount(SafeX509StackHandle stack);

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
@@ -12,8 +12,8 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxCreate")]
         internal static partial SafeX509StoreCtxHandle X509StoreCtxCreate();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxDestroy")]
-        internal static extern void X509StoreCtxDestroy(IntPtr v);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxDestroy")]
+        internal static partial void X509StoreCtxDestroy(IntPtr v);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetChain")]
         internal static partial SafeX509StackHandle X509StoreCtxGetChain(SafeX509StoreCtxHandle ctx);

--- a/src/libraries/Common/src/Interop/Windows/WebSocket/Interop.WebSocketDeleteHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/WebSocket/Interop.WebSocketDeleteHandle.cs
@@ -3,14 +3,13 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Security;
 
 internal static partial class Interop
 {
     internal static partial class WebSocket
     {
-        [DllImport(Libraries.WebSocket)]
-        internal static extern void WebSocketDeleteHandle(
-            [In] IntPtr webSocketHandle);
+        [GeneratedDllImport(Libraries.WebSocket)]
+        internal static partial void WebSocketDeleteHandle(
+            IntPtr webSocketHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoExW.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoExW.cs
@@ -30,11 +30,11 @@ internal static partial class Interop
             delegate* unmanaged<int, int, NativeOverlapped*, void> lpCompletionRoutine,
             IntPtr* lpNameHandle);
 
-        [DllImport(Libraries.Ws2_32, ExactSpelling = true)]
-        internal static extern unsafe int GetAddrInfoExCancel([In] IntPtr* lpHandle);
+        [GeneratedDllImport(Libraries.Ws2_32, ExactSpelling = true)]
+        internal static unsafe partial int GetAddrInfoExCancel(IntPtr* lpHandle);
 
-        [DllImport(Libraries.Ws2_32, ExactSpelling = true)]
-        internal static extern unsafe void FreeAddrInfoExW(AddressInfoEx* pAddrInfo);
+        [GeneratedDllImport(Libraries.Ws2_32, ExactSpelling = true)]
+        internal static unsafe partial void FreeAddrInfoExW(AddressInfoEx* pAddrInfo);
 
         [StructLayout(LayoutKind.Sequential)]
         internal unsafe struct AddressInfoEx

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAStartup.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAStartup.cs
@@ -39,11 +39,11 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.Ws2_32)]
-        private static extern unsafe SocketError WSAStartup(short wVersionRequested, WSAData* lpWSAData);
+        [GeneratedDllImport(Libraries.Ws2_32)]
+        private static unsafe partial SocketError WSAStartup(short wVersionRequested, WSAData* lpWSAData);
 
-        [DllImport(Libraries.Ws2_32)]
-        private static extern SocketError WSACleanup();
+        [GeneratedDllImport(Libraries.Ws2_32)]
+        private static partial SocketError WSACleanup();
 
         [StructLayout(LayoutKind.Sequential, Size = 408)]
         private struct WSAData

--- a/src/libraries/System.Net.WebSockets/src/System.Net.WebSockets.csproj
+++ b/src/libraries/System.Net.WebSockets/src/System.Net.WebSockets.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Net.Primitives" />
     <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Security.Cryptography.Algorithms" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -5,6 +5,8 @@
     <UseAppleCrypto Condition="'$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</UseAppleCrypto>
     <!-- SYSLIB0021: Derived cryptographic types are obsolete -->
     <NoWarn>$(NoWarn);SYSLIB0021</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\PositionValueStream.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -6,6 +6,8 @@
     <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
     <!-- The library is not supported on mobile platforms (PNSE) -->
     <IgnoreForCI Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</IgnoreForCI>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EcDsaOpenSslTests.cs" />


### PR DESCRIPTION
Mainly blittable p/invokes that we just forward now. Also a few that weren't converted yet, since they were added between our original conversion pass and merging into runtime.

cc @AaronRobinsonMSFT @jkoritzinsky 