### PR TITLE
Fix SuperPMI Python script Azure usage

### DIFF
--- a/src/coreclr/scripts/jitutil.py
+++ b/src/coreclr/scripts/jitutil.py
@@ -419,6 +419,13 @@ def require_azure_storage_libraries(need_azure_storage_blob=True, need_azure_ide
     """ Check for and import the Azure libraries.
         We do this lazily, only when we decide we're actually going to need them.
         Once we've done it once, we don't do it again.
+
+        For this to work for cross-module usage, after you call this function, you need to add a line like:
+            from jitutil import BlobClient, AzureCliCredential
+        naming all the types you want to use.
+
+        The full set of types this function loads:
+            BlobServiceClient, BlobClient, ContainerClient, AzureCliCredential
     """
     global azure_storage_libraries_check, BlobServiceClient, BlobClient, ContainerClient, AzureCliCredential
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2145,6 +2145,7 @@ def list_superpmi_collections_container_via_azure_api(path_filter=lambda unused:
     """
 
     require_azure_storage_libraries()
+    from jitutil import ContainerClient, AzureCliCredential
 
     superpmi_container_url = az_blob_storage_superpmi_container_uri
 
@@ -2356,6 +2357,7 @@ def upload_mch(coreclr_args):
     """
 
     require_azure_storage_libraries(need_azure_identity=False)
+    from jitutil import BlobServiceClient
 
     def upload_blob(file, blob_name):
         blob_client = blob_service_client.get_blob_client(container=az_superpmi_container_name, blob=blob_name)


### PR DESCRIPTION
The on-demand Azure module load was refactored to jitutil.py,
but that requires some cross-module importing to work. Do the
minimal required to make this work.