### PR TITLE
Give create codespaces prebuild action right permissions

### DIFF
--- a/.github/workflows/create-codespaces-prebuild.yml
+++ b/.github/workflows/create-codespaces-prebuild.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
 jobs:
   createPrebuild:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Now that default permissions changed, prebuild action started failing as it needs contents write permissions.