### PR TITLE
Include hashes of containing types when computing hash in EEClassHashTable

### DIFF
--- a/src/coreclr/vm/classhash.cpp
+++ b/src/coreclr/vm/classhash.cpp
@@ -40,7 +40,7 @@ PTR_VOID EEClassHashEntry::GetData()
     return m_Data;
 }
 
-int EEClassHashEntry::GetHash()
+DWORD EEClassHashEntry::GetHash()
 {
     CONTRACTL
     {
@@ -81,7 +81,7 @@ void EEClassHashEntry::SetEncloser(EEClassHashEntry *pEncloser)
     m_pEncloser = pEncloser;
 }
 
-void EEClassHashEntry::SetHash(int hash)
+void EEClassHashEntry::SetHash(DWORD hash)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/classhash.h
+++ b/src/coreclr/vm/classhash.h
@@ -69,7 +69,7 @@ public:
     //        when you are sure you want to insert the value in 'this' table. This function does not deal
     //        with case (as often the class loader has to)
     EEClassHashEntry_t *InsertValue(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID Data, EEClassHashEntry_t *pEncloser, AllocMemTracker *pamTracker);
-    EEClassHashEntry_t *InsertValueIfNotFound(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID *pData, EEClassHashEntry_t *pEncloser, BOOL IsNested, BOOL *pbFound, AllocMemTracker *pamTracker);
+    EEClassHashEntry_t *InsertTopLevelValueIfNotFound(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID *pData, BOOL *pbFound, AllocMemTracker *pamTracker);
     EEClassHashEntry_t *InsertValueUsingPreallocatedEntry(EEClassHashEntry_t *pStorageForNewEntry, LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID Data, EEClassHashEntry_t *pEncloser);
 
     EEClassHashEntry_t *GetValue(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID *pData, DWORD encloserHash, LookupContext *pContext);

--- a/src/coreclr/vm/classhash.h
+++ b/src/coreclr/vm/classhash.h
@@ -39,8 +39,8 @@ typedef struct EEClassHashEntry
     PTR_VOID GetData();
     void SetData(PTR_VOID data) DAC_EMPTY();
 
-    int GetHash();
-    void SetHash(int hash) DAC_EMPTY();
+    DWORD GetHash();
+    void SetHash(DWORD hash) DAC_EMPTY();
 
 private:
     PTR_VOID    m_Data;     // Either the token (if EECLASSHASH_TYPEHANDLE_DISCR), or the type handle encoded
@@ -50,7 +50,7 @@ private:
                                         // class, this field stores a
                                         // reference to the enclosing type
                                         // (which must be in this same table).
-    int       m_hash;
+    DWORD       m_hash;
 } EEClassHashEntry_t;
 
 // The hash type itself. All common logic is provided by the DacEnumerableHashTable templated base class. See

--- a/src/coreclr/vm/classhash.h
+++ b/src/coreclr/vm/classhash.h
@@ -39,6 +39,8 @@ typedef struct EEClassHashEntry
     PTR_VOID GetData();
     void SetData(PTR_VOID data) DAC_EMPTY();
 
+    int       m_hash;
+
 private:
     PTR_VOID    m_Data;     // Either the token (if EECLASSHASH_TYPEHANDLE_DISCR), or the type handle encoded
                             // as a relative pointer
@@ -69,19 +71,23 @@ public:
     EEClassHashEntry_t *InsertValue(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID Data, EEClassHashEntry_t *pEncloser, AllocMemTracker *pamTracker);
     EEClassHashEntry_t *InsertValueIfNotFound(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID *pData, EEClassHashEntry_t *pEncloser, BOOL IsNested, BOOL *pbFound, AllocMemTracker *pamTracker);
     EEClassHashEntry_t *InsertValueUsingPreallocatedEntry(EEClassHashEntry_t *pStorageForNewEntry, LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID Data, EEClassHashEntry_t *pEncloser);
-    EEClassHashEntry_t *GetValue(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID *pData, BOOL IsNested, LookupContext *pContext);
-    EEClassHashEntry_t *GetValue(LPCUTF8 pszFullyQualifiedName, PTR_VOID *pData, BOOL IsNested, LookupContext *pContext);
-    EEClassHashEntry_t *GetValue(const NameHandle* pName, PTR_VOID *pData, BOOL IsNested, LookupContext *pContext);
+
+    EEClassHashEntry_t *GetValue(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID *pData, DWORD encloserHash, LookupContext *pContext);
+    EEClassHashEntry_t *GetValue(LPCUTF8 pszFullyQualifiedName, PTR_VOID *pData, DWORD encloserHash, LookupContext *pContext);
+    EEClassHashEntry_t *GetValue(const NameHandle* pName, PTR_VOID *pData, DWORD encloserHash, LookupContext *pContext);
+    EEClassHashEntry_t *FindItem(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, DWORD encloserHash, LookupContext *pContext);
+
     EEClassHashEntry_t *AllocNewEntry(AllocMemTracker *pamTracker);
     EEClassHashTable   *MakeCaseInsensitiveTable(Module *pModule, AllocMemTracker *pamTracker);
-    EEClassHashEntry_t *FindItem(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, BOOL IsNested, LookupContext *pContext);
+
     EEClassHashEntry_t *FindNextNestedClass(const NameHandle* pName, PTR_VOID *pData, LookupContext *pContext);
     EEClassHashEntry_t *FindNextNestedClass(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, PTR_VOID *pData, LookupContext *pContext);
     EEClassHashEntry_t *FindNextNestedClass(LPCUTF8 pszFullyQualifiedName, PTR_VOID *pData, LookupContext *pContext);
 
     BOOL     CompareKeys(PTR_EEClassHashEntry pEntry, LPCUTF8 * pKey2);
 
-    static DWORD    Hash(LPCUTF8 pszNamespace, LPCUTF8 pszClassName);
+    static DWORD    Hash(LPCUTF8 pszNamespace, LPCUTF8 pszClassName, DWORD encloserHash);
+    static DWORD    Hash(IMDInternalImport* pMDImport, mdToken token);
 
     class ConstructKeyCallback
     {

--- a/src/coreclr/vm/classhash.h
+++ b/src/coreclr/vm/classhash.h
@@ -39,7 +39,8 @@ typedef struct EEClassHashEntry
     PTR_VOID GetData();
     void SetData(PTR_VOID data) DAC_EMPTY();
 
-    int       m_hash;
+    int GetHash();
+    void SetHash(int hash) DAC_EMPTY();
 
 private:
     PTR_VOID    m_Data;     // Either the token (if EECLASSHASH_TYPEHANDLE_DISCR), or the type handle encoded
@@ -48,8 +49,8 @@ private:
     PTR_EEClassHashEntry  m_pEncloser;  // If this entry is a for a nested
                                         // class, this field stores a
                                         // reference to the enclosing type
-                                        // (which must be in this same
-                                        // hash).
+                                        // (which must be in this same table).
+    int       m_hash;
 } EEClassHashEntry_t;
 
 // The hash type itself. All common logic is provided by the DacEnumerableHashTable templated base class. See

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -596,7 +596,7 @@ BOOL ClassLoader::IsNested(const NameHandle* pName, mdToken *mdEncloser, DWORD* 
         {
             if (!pName->GetBucket().IsNull())
             {
-                *encloserHash = pName->GetBucket().GetClassHashBasedEntryValue()->m_hash;
+                *encloserHash = pName->GetBucket().GetClassHashBasedEntryValue()->GetHash();
                 return TRUE;
             }
         }

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -910,7 +910,7 @@ private:
     static void DECLSPEC_NORETURN  ThrowTypeLoadException(TypeKey *pKey, UINT resIDWhy);
 
 
-    BOOL IsNested(const NameHandle* pName, mdToken *mdEncloser);
+    BOOL IsNested(const NameHandle* pName, mdToken *mdEncloser, DWORD* encloserHash);
     static BOOL IsNested(Module *pModude, mdToken typeDefOrRef, mdToken *mdEncloser);
 
 public:


### PR DESCRIPTION
Prior to this change all nested types with the same name would be placed into the same hash bucket, regardless of their enclosing types. That ensures collisions for common type names like `Enumerator` or `<>c` .

The approach in this change is similar to what we do in R2R hash - the hash function will now include hashes of enclosing types if such exist. The main difference from R2R approach is that we do this only for case-sensitive flavor of the table. 
Case-insensitive table may be created as needed from case-sensitive prototype. Case-insensitive table by construction shares the encloser items with the prototype table and thus cannot use encloser hashes, since they would not be in the canonical casing. 
That basically means the case-insensitive use stays on the same plan as before. It appears to be a relatively rare scenario to support some reflection features.

+ some minor follow-ups to the changes in https://github.com/dotnet/runtime/pull/61346

---

After measuring, the effects of the change appear to be fairly minor. It does reduce some collisions, but it is not a lot to start with and in case-insensitive case the collisions are still there, so we still have outliers. 
I am not sure the result justifies the added complexity. 