### PR TITLE
Add additional binary operations into the RangeCheck analysis.

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1121,7 +1121,7 @@ bool RangeCheck::MultiplyOverflows(Limit& limit1, Limit& limit2)
         return true;
     }
 
-    return CheckedOps::MulOverflows(max1, max2, false);
+    return CheckedOps::MulOverflows(max1, max2, CheckedOps::Signed);
 }
 
 // Does the bin operation overflow.

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -420,7 +420,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
         return (ssaDef != nullptr) &&
                IsMonotonicallyIncreasing(ssaDef->GetAssignment()->gtGetOp2(), rejectNegativeConst);
     }
-    else if (expr->OperGet() == GT_ADD || expr->OperGet() == GT_MUL || expr->OperGet() == GT_LSH)
+    else if (expr->OperIs(GT_ADD, GT_MUL, GT_LSH))
     {
         return IsBinOpMonotonicallyIncreasing(expr->AsOp());
     }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -358,7 +358,8 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
     switch (op2->OperGet())
     {
         case GT_LCL_VAR:
-            // When adding two local variables, we also must ensure that any constant is non-negative.
+            // When adding/multiplying/shifting two local variables, we also must ensure that any constant is
+            // non-negative.
             return IsMonotonicallyIncreasing(op1, true) && IsMonotonicallyIncreasing(op2, true);
 
         case GT_CNS_INT:
@@ -1120,7 +1121,7 @@ bool RangeCheck::MultiplyOverflows(Limit& limit1, Limit& limit2)
         return true;
     }
 
-    return IntMultiplyOverflows(max1, max2);
+    return CheckedOps::MulOverflows(max1, max2, false);
 }
 
 // Does the bin operation overflow.

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -336,18 +336,20 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
 
 bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
 {
-    assert(binop->OperIs(GT_ADD));
+    assert(binop->OperIs(GT_ADD) || binop->OperIs(GT_MUL) || binop->OperIs(GT_LSH));
 
     GenTree* op1 = binop->gtGetOp1();
     GenTree* op2 = binop->gtGetOp2();
 
     JITDUMP("[RangeCheck::IsBinOpMonotonicallyIncreasing] [%06d], [%06d]\n", Compiler::dspTreeID(op1),
             Compiler::dspTreeID(op2));
-    // Check if we have a var + const.
-    if (op2->OperGet() == GT_LCL_VAR)
+
+    // Check if we have a var + const or var * const.
+    if (binop->OperIs(GT_ADD, GT_MUL) && op2->OperGet() == GT_LCL_VAR)
     {
         std::swap(op1, op2);
     }
+
     if (op1->OperGet() != GT_LCL_VAR)
     {
         JITDUMP("Not monotonically increasing because op1 is not lclVar.\n");
@@ -417,7 +419,7 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
         return (ssaDef != nullptr) &&
                IsMonotonicallyIncreasing(ssaDef->GetAssignment()->gtGetOp2(), rejectNegativeConst);
     }
-    else if (expr->OperGet() == GT_ADD)
+    else if (expr->OperGet() == GT_ADD || expr->OperGet() == GT_MUL || expr->OperGet() == GT_LSH)
     {
         return IsBinOpMonotonicallyIncreasing(expr->AsOp());
     }
@@ -894,11 +896,12 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
 // Compute the range for a binary operation.
 Range RangeCheck::ComputeRangeForBinOp(BasicBlock* block, GenTreeOp* binop, bool monIncreasing DEBUGARG(int indent))
 {
-    assert(binop->OperIs(GT_ADD, GT_AND, GT_RSH, GT_LSH, GT_UMOD));
+    assert(binop->OperIs(GT_ADD, GT_AND, GT_RSH, GT_LSH, GT_UMOD, GT_MUL));
 
     GenTree* op1 = binop->gtGetOp1();
     GenTree* op2 = binop->gtGetOp2();
 
+    // Special cases for binops where op2 is a constant
     if (binop->OperIs(GT_AND, GT_RSH, GT_LSH, GT_UMOD))
     {
         if (!op2->IsIntCnsFitsInI32())
@@ -929,17 +932,21 @@ Range RangeCheck::ComputeRangeForBinOp(BasicBlock* block, GenTreeOp* binop, bool
             }
         }
 
-        if (icon < 0)
+        if (icon >= 0)
+        {
+            Range range(Limit(Limit::keConstant, 0), Limit(Limit::keConstant, icon));
+            JITDUMP("Limit range to %s\n", range.ToString(m_pCompiler->getAllocatorDebugOnly()));
+            return range;
+        }
+        // Generalized range computation not implemented for these operators
+        else if (binop->OperIs(GT_AND, GT_UMOD, GT_RSH))
         {
             return Range(Limit::keUnknown);
         }
-        Range range(Limit(Limit::keConstant, 0), Limit(Limit::keConstant, icon));
-        JITDUMP("Limit range to %s\n", range.ToString(m_pCompiler->getAllocatorDebugOnly()));
-        return range;
     }
 
     // other operators are expected to be handled above.
-    assert(binop->OperIs(GT_ADD));
+    assert(binop->OperIs(GT_ADD, GT_MUL, GT_LSH));
 
     Range* op1RangeCached = nullptr;
     Range  op1Range       = Limit(Limit::keUndef);
@@ -985,9 +992,30 @@ Range RangeCheck::ComputeRangeForBinOp(BasicBlock* block, GenTreeOp* binop, bool
         op2Range = *op2RangeCached;
     }
 
-    Range r = RangeOps::Add(op1Range, op2Range);
-    JITDUMP("BinOp add ranges %s %s = %s\n", op1Range.ToString(m_pCompiler->getAllocatorDebugOnly()),
-            op2Range.ToString(m_pCompiler->getAllocatorDebugOnly()), r.ToString(m_pCompiler->getAllocatorDebugOnly()));
+    Range r = Range(Limit::keUnknown);
+    if (binop->OperIs(GT_ADD))
+    {
+        r = RangeOps::Add(op1Range, op2Range);
+        JITDUMP("BinOp add ranges %s %s = %s\n", op1Range.ToString(m_pCompiler->getAllocatorDebugOnly()),
+                op2Range.ToString(m_pCompiler->getAllocatorDebugOnly()),
+                r.ToString(m_pCompiler->getAllocatorDebugOnly()));
+    }
+    else if (binop->OperIs(GT_MUL))
+    {
+        r = RangeOps::Multiply(op1Range, op2Range);
+        JITDUMP("BinOp multiply ranges %s %s = %s\n", op1Range.ToString(m_pCompiler->getAllocatorDebugOnly()),
+                op2Range.ToString(m_pCompiler->getAllocatorDebugOnly()),
+                r.ToString(m_pCompiler->getAllocatorDebugOnly()));
+    }
+    else if (binop->OperIs(GT_LSH))
+    {
+        // help the next step a bit, convert the LSH rhs to a multiply
+        Range convertedOp2Range = RangeOps::ConvertShiftToMultiply(op2Range);
+        r                       = RangeOps::Multiply(op1Range, convertedOp2Range);
+        JITDUMP("BinOp multiply ranges %s %s = %s\n", op1Range.ToString(m_pCompiler->getAllocatorDebugOnly()),
+                convertedOp2Range.ToString(m_pCompiler->getAllocatorDebugOnly()),
+                r.ToString(m_pCompiler->getAllocatorDebugOnly()));
+    }
     return r;
 }
 
@@ -1077,6 +1105,24 @@ bool RangeCheck::AddOverflows(Limit& limit1, Limit& limit2)
     return IntAddOverflows(max1, max2);
 }
 
+// Check if the arithmetic overflows.
+bool RangeCheck::MultiplyOverflows(Limit& limit1, Limit& limit2)
+{
+    int max1;
+    if (!GetLimitMax(limit1, &max1))
+    {
+        return true;
+    }
+
+    int max2;
+    if (!GetLimitMax(limit2, &max2))
+    {
+        return true;
+    }
+
+    return IntMultiplyOverflows(max1, max2);
+}
+
 // Does the bin operation overflow.
 bool RangeCheck::DoesBinOpOverflow(BasicBlock* block, GenTreeOp* binop)
 {
@@ -1109,10 +1155,15 @@ bool RangeCheck::DoesBinOpOverflow(BasicBlock* block, GenTreeOp* binop)
     JITDUMP("Checking bin op overflow %s %s\n", op1Range->ToString(m_pCompiler->getAllocatorDebugOnly()),
             op2Range->ToString(m_pCompiler->getAllocatorDebugOnly()));
 
-    if (!AddOverflows(op1Range->UpperLimit(), op2Range->UpperLimit()))
+    if (binop->OperIs(GT_ADD))
     {
-        return false;
+        return AddOverflows(op1Range->UpperLimit(), op2Range->UpperLimit());
     }
+    else if (binop->OperIs(GT_MUL))
+    {
+        return MultiplyOverflows(op1Range->UpperLimit(), op2Range->UpperLimit());
+    }
+
     return true;
 }
 
@@ -1180,7 +1231,7 @@ bool RangeCheck::ComputeDoesOverflow(BasicBlock* block, GenTree* expr)
         overflows = DoesVarDefOverflow(expr->AsLclVarCommon());
     }
     // Check if add overflows.
-    else if (expr->OperGet() == GT_ADD)
+    else if (expr->OperGet() == GT_ADD || expr->OperGet() == GT_MUL)
     {
         overflows = DoesBinOpOverflow(block, expr->AsOp());
     }
@@ -1276,7 +1327,7 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreas
         MergeAssertion(block, expr, &range DEBUGARG(indent + 1));
     }
     // compute the range for binary operation
-    else if (expr->OperIs(GT_ADD, GT_AND, GT_RSH, GT_LSH, GT_UMOD))
+    else if (expr->OperIs(GT_ADD, GT_AND, GT_RSH, GT_LSH, GT_UMOD, GT_MUL))
     {
         range = ComputeRangeForBinOp(block, expr->AsOp(), monIncreasing DEBUGARG(indent + 1));
     }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -336,7 +336,7 @@ void RangeCheck::Widen(BasicBlock* block, GenTree* tree, Range* pRange)
 
 bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
 {
-    assert(binop->OperIs(GT_ADD) || binop->OperIs(GT_MUL) || binop->OperIs(GT_LSH));
+    assert(binop->OperIs(GT_ADD, GT_MUL, GT_LSH));
 
     GenTree* op1 = binop->gtGetOp1();
     GenTree* op2 = binop->gtGetOp2();

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -155,7 +155,7 @@ struct Limit
                 return true;
             case keBinOpArray:
             case keConstant:
-                if (CheckedOps::MulOverflows(cns, i, false))
+                if (CheckedOps::MulOverflows(cns, i, CheckedOps::Signed))
                 {
                     return false;
                 }

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -72,6 +72,14 @@ static bool IntAddOverflows(int max1, int max2)
     return false;
 }
 
+static bool IntMultiplyOverflows(int max1, int max2)
+{
+    if (max1 == 0 || max2 == 0)
+        return false;
+    int res = max1 * max2;
+    return !(max1 == res / max2);
+}
+
 struct Limit
 {
     enum LimitType
@@ -138,6 +146,28 @@ struct Limit
                     return false;
                 }
                 cns += i;
+                return true;
+            case keUndef:
+            case keUnknown:
+                // For these values of 'type', conservatively return false
+                break;
+        }
+
+        return false;
+    }
+    bool MultiplyConstant(int i)
+    {
+        switch (type)
+        {
+            case keDependent:
+                return true;
+            case keBinOpArray:
+            case keConstant:
+                if (IntMultiplyOverflows(cns, i))
+                {
+                    return false;
+                }
+                cns *= i;
                 return true;
             case keUndef:
             case keUnknown:
@@ -250,6 +280,21 @@ struct RangeOps
         }
     }
 
+    // Given a constant limit in "l1", multiply it to l2 and mutate "l2".
+    static Limit MultiplyConstantLimit(Limit& l1, Limit& l2)
+    {
+        assert(l1.IsConstant());
+        Limit l = l2;
+        if (l.MultiplyConstant(l1.GetConstant()))
+        {
+            return l;
+        }
+        else
+        {
+            return Limit(Limit::keUnknown);
+        }
+    }
+
     // Given two ranges "r1" and "r2", perform an add operation on the
     // ranges.
     static Range Add(Range& r1, Range& r2)
@@ -287,6 +332,47 @@ struct RangeOps
         if (r2hi.IsConstant())
         {
             result.uLimit = AddConstantLimit(r2hi, r1hi);
+        }
+        return result;
+    }
+
+    // Given two ranges "r1" and "r2", perform an multiply operation on the
+    // ranges.
+    static Range Multiply(Range& r1, Range& r2)
+    {
+        Limit& r1lo = r1.LowerLimit();
+        Limit& r1hi = r1.UpperLimit();
+        Limit& r2lo = r2.LowerLimit();
+        Limit& r2hi = r2.UpperLimit();
+
+        Range result = Limit(Limit::keUnknown);
+
+        // Check lo ranges if they are dependent and not unknown.
+        if ((r1lo.IsDependent() && !r1lo.IsUnknown()) || (r2lo.IsDependent() && !r2lo.IsUnknown()))
+        {
+            result.lLimit = Limit(Limit::keDependent);
+        }
+        // Check hi ranges if they are dependent and not unknown.
+        if ((r1hi.IsDependent() && !r1hi.IsUnknown()) || (r2hi.IsDependent() && !r2hi.IsUnknown()))
+        {
+            result.uLimit = Limit(Limit::keDependent);
+        }
+
+        if (r1lo.IsConstant())
+        {
+            result.lLimit = MultiplyConstantLimit(r1lo, r2lo);
+        }
+        if (r2lo.IsConstant())
+        {
+            result.lLimit = MultiplyConstantLimit(r2lo, r1lo);
+        }
+        if (r1hi.IsConstant())
+        {
+            result.uLimit = MultiplyConstantLimit(r1hi, r2hi);
+        }
+        if (r2hi.IsConstant())
+        {
+            result.uLimit = MultiplyConstantLimit(r2hi, r1hi);
         }
         return result;
     }
@@ -376,6 +462,32 @@ struct RangeOps
                 result.uLimit = r2hi;
             }
         }
+        return result;
+    }
+
+    // Given a Range C from an op (x << C), convert it to be used as
+    // (x * C'), where C' is a power of 2.
+    static Range ConvertShiftToMultiply(Range& r1)
+    {
+        Limit& r1lo = r1.LowerLimit();
+        Limit& r1hi = r1.UpperLimit();
+
+        if (!r1lo.IsConstant() || !r1hi.IsConstant())
+        {
+            return Limit(Limit::keUnknown);
+        }
+
+        // Keep it simple for now, check if 0 <= C < 31
+        int r1loConstant = r1lo.GetConstant();
+        int r1hiConstant = r1hi.GetConstant();
+        if (r1loConstant <= 0 || r1loConstant > 31 || r1hiConstant <= 0 || r1hiConstant > 31)
+        {
+            return Limit(Limit::keUnknown);
+        }
+
+        Range result  = Limit(Limit::keConstant);
+        result.lLimit = Limit(Limit::keConstant, 1 << r1loConstant);
+        result.uLimit = Limit(Limit::keConstant, 1 << r1hiConstant);
         return result;
     }
 };
@@ -483,6 +595,9 @@ public:
 
     // Does the addition of the two limits overflow?
     bool AddOverflows(Limit& limit1, Limit& limit2);
+
+    // Does the multiplication of the two limits overflow?
+    bool MultiplyOverflows(Limit& limit1, Limit& limit2);
 
     // Does the binary operation between the operands overflow? Check recursively.
     bool DoesBinOpOverflow(BasicBlock* block, GenTreeOp* binop);

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -72,14 +72,6 @@ static bool IntAddOverflows(int max1, int max2)
     return false;
 }
 
-static bool IntMultiplyOverflows(int max1, int max2)
-{
-    if (max1 == 0 || max2 == 0)
-        return false;
-    int res = max1 * max2;
-    return !(max1 == res / max2);
-}
-
 struct Limit
 {
     enum LimitType
@@ -163,7 +155,7 @@ struct Limit
                 return true;
             case keBinOpArray:
             case keConstant:
-                if (IntMultiplyOverflows(cns, i))
+                if (CheckedOps::MulOverflows(cns, i, false))
                 {
                     return false;
                 }

--- a/src/tests/JIT/opt/AssertionPropagation/ArrBoundElim.cs
+++ b/src/tests/JIT/opt/AssertionPropagation/ArrBoundElim.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    private static int returnCode = 100;
+
+    public static int Main(string[] args)
+    {
+        RunTestThrows(Tests.MulOutsideRange);
+        RunTestThrows(Tests.MulOverflow);
+        RunTestThrows(Tests.LshOutsideRange);
+
+        RunTestNoThrow(Tests.MulInsideRange);
+        RunTestNoThrow(Tests.LshInsideRange);
+
+        return returnCode;
+    }
+
+    private static void RunTestThrows(Action action)
+    {
+        try
+        {
+            action();
+            Console.WriteLine("failed " + action.Method.Name);
+            returnCode--;
+        }
+        catch (Exception)
+        {
+
+        }
+    }
+
+    private static void RunTestNoThrow(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("failed " + action.Method.Name);
+            returnCode--;
+        }
+    }
+}
+
+public static class Tests
+{
+    private static byte[] smallArr => new byte[10];
+
+    // RangeCheck analysis should eliminate the bounds check on 
+    // smallArr.
+    public static void MulInsideRange()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            smallArr[i*3] = 17;
+        }
+    }
+
+    // RangeCheck analysis should keep the bounds check on 
+    // smallArr.
+    public static void MulOutsideRange()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            smallArr[i*5] = 17;
+        }
+    }
+
+    private static byte[] bigArr => new byte[2147483591];
+
+    // RangeCheck analysis should detect that the multiplcation
+    // overflows and keep all range checks for bigArr. bigArr
+    // size, and the bounds on the loop were carefully chosen to to 
+    // potentially spoof the RangeCheck analysis to eliminate a bound 
+    // check IF overflow detection on GT_MUL for RangeCheck is implemented 
+    // incorrectly.
+    public static void MulOverflow()
+    {
+        for (int i = 0; i < 14; i++)
+        {
+            bigArr[i*2147483591] = 17;
+        }
+    }
+
+    // RangeCheck analysis should eliminate the bounds check on 
+    // smallArr.
+    public static void LshInsideRange()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            smallArr[i<<1] = 17;
+        }
+    }
+
+    // RangeCheck analysis should keep the bounds check on 
+    // smallArr.
+    public static void LshOutsideRange()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            smallArr[i<<3] = 17;
+        }
+    }
+
+}

--- a/src/tests/JIT/opt/AssertionPropagation/ArrBoundElim.cs
+++ b/src/tests/JIT/opt/AssertionPropagation/ArrBoundElim.cs
@@ -72,7 +72,7 @@ public static class Tests
         }
     }
 
-    private static byte[] bigArr => new byte[2147483591];
+    private static byte[] bigArr => new byte[268435460]; 
 
     // RangeCheck analysis should detect that the multiplcation
     // overflows and keep all range checks for bigArr. bigArr
@@ -82,9 +82,9 @@ public static class Tests
     // incorrectly.
     public static void MulOverflow()
     {
-        for (int i = 0; i < 14; i++)
+        for (int i = 0; i < 39768215; i++)
         {
-            bigArr[i*2147483591] = 17;
+            bigArr[i*402653184] = 17;
         }
     }
 

--- a/src/tests/JIT/opt/AssertionPropagation/ArrBoundElim.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/ArrBoundElim.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Changes

GT_LSH and GT_MUL are now covered in the range analysis check. This
allows to catch and eliminate the range check for cases like

```
ReadOnlySpan<byte> readOnlySpan => new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };

byte byt = 0;
for (int i = 0; i < 5; i++)
{
  byt = readOnlySpan[i * 3];
  // ...
}
```

or

```
bool[] flags = new bool[Size + 1];

for (int i = 2; i <= Size; i++)
{
  for (int k = i * 2; k <= Size; k += i)
  {
    flags[k] = false;
  }
}
```

Note that without this change, the previous snippet would not eliminate
the range check on `flags[k]`, but the equivalent snippet would

```
for (int i = 2; i <= Size; i++)
{
  for (int k = i + i; k <= Size; k += i)
  {
    flags[k] = false;
  }
}

```

as additional was implemented in the range check analysis, but multiply
was not.

## Discussion

I stumbled on this limitation when implementing https://github.com/dotnet/runtime/issues/34938. Essentially, the strength reduction that I wrote was optimizing expressions like `arr[i + i]` to `arr[i * 2]`, which would then become `arr[i << 1]`. The issue is that in some cases, this was preventing the `RangeCheck` analysis from eliminating a range check, so it was a slight regression.

I have implemented `GT_MUL` and `GT_LSH` into the range check analysis and I am looking for some feedback, especially on whether other operations should be included in this change as well.

## Results

## aspnet.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 13670517 (overridden on cmd)
Total bytes of diff: 13670481 (overridden on cmd)
Total bytes of delta: -36 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -12 : 4829.dasm (-3.49% of base)
         -12 : 13972.dasm (-3.49% of base)
         -12 : 6069.dasm (-3.49% of base)

3 total files with Code Size differences (3 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -12 (-3.49% of base) : 4829.dasm - IPAddress:.ctor(ReadOnlySpan`1,long):this
         -12 (-3.49% of base) : 13972.dasm - IPAddress:.ctor(ReadOnlySpan`1,long):this
         -12 (-3.49% of base) : 6069.dasm - IPAddress:.ctor(ReadOnlySpan`1,long):this

Top method improvements (percentages):
         -12 (-3.49% of base) : 4829.dasm - IPAddress:.ctor(ReadOnlySpan`1,long):this
         -12 (-3.49% of base) : 13972.dasm - IPAddress:.ctor(ReadOnlySpan`1,long):this
         -12 (-3.49% of base) : 6069.dasm - IPAddress:.ctor(ReadOnlySpan`1,long):this

3 total methods with Code Size differences (3 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 7151027 (overridden on cmd)
Total bytes of diff: 7150965 (overridden on cmd)
Total bytes of delta: -62 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -31 : 23151.dasm (-11.19% of base)
         -19 : 4875.dasm (-7.17% of base)
         -12 : 4876.dasm (-3.49% of base)

3 total files with Code Size differences (3 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -31 (-11.19% of base) : 23151.dasm - System.Globalization.HebrewCalendar:GetLunarMonthDay(int,DateBuffer):int
         -19 (-7.17% of base) : 4875.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -12 (-3.49% of base) : 4876.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this

Top method improvements (percentages):
         -31 (-11.19% of base) : 23151.dasm - System.Globalization.HebrewCalendar:GetLunarMonthDay(int,DateBuffer):int
         -19 (-7.17% of base) : 4875.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -12 (-3.49% of base) : 4876.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this

3 total methods with Code Size differences (3 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 124162883 (overridden on cmd)
Total bytes of diff: 124162693 (overridden on cmd)
Total bytes of delta: -190 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -19 : 197466.dasm (-46.34% of base)
         -19 : 197418.dasm (-46.34% of base)
         -19 : 197474.dasm (-46.34% of base)
         -19 : 197438.dasm (-46.34% of base)
         -19 : 197454.dasm (-46.34% of base)
         -19 : 197430.dasm (-46.34% of base)
         -19 : 197424.dasm (-46.34% of base)
         -19 : 197460.dasm (-46.34% of base)
         -19 : 197432.dasm (-45.24% of base)
         -19 : 197468.dasm (-45.24% of base)

10 total files with Code Size differences (10 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -19 (-46.34% of base) : 197454.dasm - Tests:Test337_cns(int):ubyte
         -19 (-46.34% of base) : 197460.dasm - Tests:Test340_cns(int):ubyte
         -19 (-46.34% of base) : 197466.dasm - Tests:Test343_cns(int):ubyte
         -19 (-45.24% of base) : 197468.dasm - Tests:Test344_cns(int):ubyte
         -19 (-46.34% of base) : 197474.dasm - Tests:Test347_cns(int):ubyte
         -19 (-46.34% of base) : 197418.dasm - Tests:Test351_cns(int):ubyte
         -19 (-46.34% of base) : 197424.dasm - Tests:Test354_cns(int):ubyte
         -19 (-46.34% of base) : 197430.dasm - Tests:Test357_cns(int):ubyte
         -19 (-45.24% of base) : 197432.dasm - Tests:Test358_cns(int):ubyte
         -19 (-46.34% of base) : 197438.dasm - Tests:Test361_cns(int):ubyte

Top method improvements (percentages):
         -19 (-46.34% of base) : 197454.dasm - Tests:Test337_cns(int):ubyte
         -19 (-46.34% of base) : 197460.dasm - Tests:Test340_cns(int):ubyte
         -19 (-46.34% of base) : 197466.dasm - Tests:Test343_cns(int):ubyte
         -19 (-46.34% of base) : 197474.dasm - Tests:Test347_cns(int):ubyte
         -19 (-46.34% of base) : 197418.dasm - Tests:Test351_cns(int):ubyte
         -19 (-46.34% of base) : 197424.dasm - Tests:Test354_cns(int):ubyte
         -19 (-46.34% of base) : 197430.dasm - Tests:Test357_cns(int):ubyte
         -19 (-46.34% of base) : 197438.dasm - Tests:Test361_cns(int):ubyte
         -19 (-45.24% of base) : 197468.dasm - Tests:Test344_cns(int):ubyte
         -19 (-45.24% of base) : 197432.dasm - Tests:Test358_cns(int):ubyte

10 total methods with Code Size differences (10 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 34283537 (overridden on cmd)
Total bytes of diff: 34283498 (overridden on cmd)
Total bytes of delta: -39 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -31 : 116985.dasm (-11.83% of base)
          -8 : 153703.dasm (-0.80% of base)

2 total files with Code Size differences (2 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -31 (-11.83% of base) : 116985.dasm - System.Globalization.HebrewCalendar:GetLunarMonthDay(int,System.Globalization.HebrewCalendar+DateBuffer):int
          -8 (-0.80% of base) : 153703.dasm - System.Runtime.Serialization.DataContract:ComputeHash(System.Byte[]):System.Byte[]

Top method improvements (percentages):
         -31 (-11.83% of base) : 116985.dasm - System.Globalization.HebrewCalendar:GetLunarMonthDay(int,System.Globalization.HebrewCalendar+DateBuffer):int
          -8 (-0.80% of base) : 153703.dasm - System.Runtime.Serialization.DataContract:ComputeHash(System.Byte[]):System.Byte[]

2 total methods with Code Size differences (2 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 45344459 (overridden on cmd)
Total bytes of diff: 45344420 (overridden on cmd)
Total bytes of delta: -39 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -19 : 207710.dasm (-7.17% of base)
         -12 : 207706.dasm (-3.49% of base)
          -8 : 126617.dasm (-0.78% of base)

3 total files with Code Size differences (3 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -19 (-7.17% of base) : 207710.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -12 (-3.49% of base) : 207706.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this
          -8 (-0.78% of base) : 126617.dasm - System.Runtime.Serialization.DataContract:ComputeHash(System.Byte[]):System.Byte[]

Top method improvements (percentages):
         -19 (-7.17% of base) : 207710.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -12 (-3.49% of base) : 207706.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this
          -8 (-0.78% of base) : 126617.dasm - System.Runtime.Serialization.DataContract:ComputeHash(System.Byte[]):System.Byte[]

3 total methods with Code Size differences (3 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 114254056 (overridden on cmd)
Total bytes of diff: 114253969 (overridden on cmd)
Total bytes of delta: -87 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -19 : 304736.dasm (-7.17% of base)
         -19 : 304440.dasm (-7.17% of base)
         -13 : 279719.dasm (-5.80% of base)
         -12 : 304436.dasm (-3.49% of base)
         -12 : 303299.dasm (-3.23% of base)
         -12 : 304732.dasm (-3.49% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -19 (-7.17% of base) : 304736.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -19 (-7.17% of base) : 304440.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -13 (-5.80% of base) : 279719.dasm - System.ConsoleManualTests:Colors()
         -12 (-3.49% of base) : 304436.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this
         -12 (-3.49% of base) : 304732.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this
         -12 (-3.23% of base) : 303299.dasm - System.Net.NetworkInformation.StringParsingHelpers:ParseIPv6HexString(System.ReadOnlySpan`1[Char],bool):System.Net.IPAddress

Top method improvements (percentages):
         -19 (-7.17% of base) : 304736.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -19 (-7.17% of base) : 304440.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte]):this
         -13 (-5.80% of base) : 279719.dasm - System.ConsoleManualTests:Colors()
         -12 (-3.49% of base) : 304436.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this
         -12 (-3.49% of base) : 304732.dasm - System.Net.IPAddress:.ctor(System.ReadOnlySpan`1[Byte],long):this
         -12 (-3.23% of base) : 303299.dasm - System.Net.NetworkInformation.StringParsingHelpers:ParseIPv6HexString(System.ReadOnlySpan`1[Char],bool):System.Net.IPAddress

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------
