### PR TITLE
Generate .runsettings file to be able to run and debug tests on vscode in codespace with prebuild

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,11 @@
 
 	"settings": {
 		// Loading projects on demand is better for larger codebases
-		"omnisharp.enableMsBuildLoadProjectsOnDemand": true
+		"omnisharp.enableMsBuildLoadProjectsOnDemand": true,
+		"omnisharp.enableRoslynAnalyzers": true,
+		"omnisharp.enableEditorConfigSupport": true,
+		"omnisharp.enableAsyncCompletion": true,
+		"omnisharp.testRunSettings": "${containerWorkspaceFolder}/artifacts/obj/vscode/.runsettings"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -4,6 +4,8 @@ set -e
 
 # prebuild the repo, so it is ready for development
 ./build.sh libs+clr -rc Release
+# restore libs tests so that the project is ready to be loaded by OmniSharp
+./build.sh libs.tests -restore
 
 # save the commit hash of the currently built assemblies, so developers know which version was built
 git rev-parse HEAD > ./artifacts/prebuild.sha

--- a/eng/testing/runsettings.targets
+++ b/eng/testing/runsettings.targets
@@ -7,6 +7,7 @@
     <CreateIntermediateRunSettingsFile Condition="'$(CreateIntermediateRunSettingsFile)' == ''">false</CreateIntermediateRunSettingsFile>
     <RunSettingsOutputFilePath Condition="'$(CreateIntermediateRunSettingsFile)' == 'true'">$(RunSettingsIntermediateOutputFilePath)</RunSettingsOutputFilePath>
     <RunSettingsOutputFilePath Condition="'$(CreateIntermediateRunSettingsFile)' != 'true'">$(RunSettingsAppOutputFilePath)</RunSettingsOutputFilePath>
+    <VsCodeRunSettingsOutputFilePath>$(ArtifactsObjDir)vscode/.runsettings</VsCodeRunSettingsOutputFilePath>
 
     <!-- Set RunSettingsFilePath property which is read by VSTest. -->
     <RunSettingsFilePath Condition="Exists('$(RunSettingsAppOutputFilePath)')">$(RunSettingsAppOutputFilePath)</RunSettingsFilePath>
@@ -45,6 +46,12 @@
                       Lines="$(RunSettingsFileContent)"
                       WriteOnlyWhenDifferent="true"
                       Overwrite="true" />
+    
+    <WriteLinesToFile File="$(VsCodeRunSettingsOutputFilePath)"
+                      Lines="$(RunSettingsFileContent)"
+                      WriteOnlyWhenDifferent="true"
+                      Overwrite="true"
+                      Condition="'$(CreateVsCodeRunSettingsFile)' == 'true'" />
     
     <!-- Set RunSettingsFilePath property which is read by VSTest. -->
     <PropertyGroup>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -5,6 +5,7 @@
     <!-- Create an intermediate runsettings file to enable VSTest discovery. -->
     <EnableRunSettingsSupport>true</EnableRunSettingsSupport>
     <CreateIntermediateRunSettingsFile>true</CreateIntermediateRunSettingsFile>
+    <CreateVsCodeRunSettingsFile>true</CreateVsCodeRunSettingsFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Generate .runsettings file for VSCode as part of libs.pretest. Unfortunately we can't use the .runsettings file that we generate for Visual Studio as the paths that we use are specific for every test project containing configuration settings and for VSCode we need to point OmniSharp to the .runsettings file via a global setting that applies to all projects. However I'm not concerned about this as much as in VS we have more complex settings that are specific to each test project.

After adding this, people can open a test file and just click on "Debug Test" on intellicode and then debug it by just setting a breakpoint when in a codespace. 

![image](https://user-images.githubusercontent.com/22899328/142049798-f69225be-0f91-4f79-b693-66de58e0bc5b.png)

In order to support this locally we need a few more tweaks, I will put up a separate PR for that.
