### PR TITLE
System.Diagnostics.DiagnosticSource: ActivityContext.TryParse sampling issue

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -213,7 +213,7 @@ namespace System.Diagnostics
         public System.Diagnostics.ActivityTraceFlags TraceFlags  { get { throw null; } }
         public string? TraceState  { get { throw null; } }
         public bool IsRemote { get { throw null; } }
-        public static bool TryParse(string? traceParent, string? traceState, out System.Diagnostics.ActivityContext context) { throw null; }
+        public static bool TryParse(string? traceParent, string? traceState, out System.Diagnostics.ActivityContext context, bool isRemote = false) { throw null; }
         public static System.Diagnostics.ActivityContext Parse(string traceParent, string? traceState) { throw null; }
         public static bool operator ==(System.Diagnostics.ActivityContext left, System.Diagnostics.ActivityContext right) { throw null; }
         public static bool operator !=(System.Diagnostics.ActivityContext left, System.Diagnostics.ActivityContext right) { throw null; }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -920,7 +920,7 @@ namespace System.Diagnostics
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
         [System.Security.SecuritySafeCriticalAttribute]
 #endif
-        internal static bool TryConvertIdToContext(string traceParent, string? traceState, out ActivityContext context)
+        internal static bool TryConvertIdToContext(string traceParent, string? traceState, out ActivityContext context, bool isRemote = false)
         {
             context = default;
             if (!IsW3CId(traceParent))
@@ -941,7 +941,8 @@ namespace System.Diagnostics
                             new ActivityTraceId(traceIdSpan.ToString()),
                             new ActivitySpanId(spanIdSpan.ToString()),
                             (ActivityTraceFlags) ActivityTraceId.HexByteFromChars(traceParent[53], traceParent[54]),
-                            traceState);
+                            traceState,
+                            isRemote);
 
             return true;
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
@@ -66,7 +66,8 @@ namespace System.Diagnostics
         /// <param name="traceParent">W3C trace parent header.</param>
         /// <param name="traceState">W3C trace state.</param>
         /// <param name="context">The ActivityContext object created from the parsing operation.</param>
-        public static bool TryParse(string? traceParent, string? traceState, out ActivityContext context)
+        /// <param name="isRemote">Indicate the context is propagated from remote parent.</param>
+        public static bool TryParse(string? traceParent, string? traceState, out ActivityContext context, bool isRemote = false)
         {
             if (traceParent is null)
             {
@@ -74,7 +75,7 @@ namespace System.Diagnostics
                 return false;
             }
 
-            return Activity.TryConvertIdToContext(traceParent, traceState, out context);
+            return Activity.TryConvertIdToContext(traceParent, traceState, out context, isRemote);
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -471,6 +471,12 @@ namespace System.Diagnostics.Tests
             Assert.Equal(ActivityTraceFlags.Recorded, context.TraceFlags);
             Assert.Equal("k=v", context.TraceState);
 
+            Assert.True(ActivityContext.TryParse(w3cId, null, out context, isRemote: true));
+            Assert.Equal("99d43cb30a4cdb4fbeee3a19c29201b0", context.TraceId.ToHexString());
+            Assert.Equal("e82825765f051b47", context.SpanId.ToHexString());
+            Assert.Equal(ActivityTraceFlags.Recorded, context.TraceFlags);
+            Assert.True(context.IsRemote);
+
             context = ActivityContext.Parse(w3cId, "k=v");
             Assert.Equal("99d43cb30a4cdb4fbeee3a19c29201b0", context.TraceId.ToHexString());
             Assert.Equal("e82825765f051b47", context.SpanId.ToHexString());


### PR DESCRIPTION
An OpenTelemetry user raised a bug that our [ParentBasedSampler](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Trace/ParentBasedSampler.cs) did not work as expected. I tracked it down to a gap in the runtime API.

User is doing this:

```csharp
var traceparents = httpContext.Request.Headers[TraceParentRequestHeaderName];

ActivityContext context = default;

if (traceparents.Count > 0)
{
	ActivityContext.TryParse(traceparents.First(), httpContext.Request.Headers[TraceStateRequestHeaderName].FirstOrDefault(), out context);
}

using var activity = this.activitySource.StartActivity(name: ActivityName, ActivityKind.Server, context);
```

These spans were falling into this block: 

https://github.com/open-telemetry/opentelemetry-dotnet/blob/116a101732e2e6738c38529f529a239f67ed38c7/src/OpenTelemetry/Trace/ParentBasedSampler.cs#L126

Which is defaulted to always NOT sample: https://github.com/open-telemetry/opentelemetry-dotnet/blob/116a101732e2e6738c38529f529a239f67ed38c7/src/OpenTelemetry/Trace/ParentBasedSampler.cs#L54

The reason for this is `ActivityContext.TryParse` defaults the `IsRemote` property to `false` so we treat the span as local. In order to make this work, I think we need to expose a parameter for setting `IsRemote` on the `ActivityContext.TryParse` method. If we do that, user can do this...

```csharp
	ActivityContext.TryParse([traceParent], [traceState], out context, isRemote: true);
```

...and everything will work fine.

/cc @cijothomas @tarekgh @noahfalk 