### PR TITLE
Add single char lazy loop support to simplified Regex code gen

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1198,7 +1198,7 @@ namespace System.Text.RegularExpressions.Generator
                     case RegexNode.Onelazy:
                     case RegexNode.Notonelazy:
                     case RegexNode.Setlazy:
-                        EmitSingleCharFixedRepeater(node, emitLengthChecksIfRequired);
+                        EmitSingleCharLazy(node, subsequent, emitLengthChecksIfRequired);
                         break;
 
                     case RegexNode.Concatenate:
@@ -1615,7 +1615,6 @@ namespace System.Text.RegularExpressions.Generator
                 string endLoop = DefineLabel("EndLoop");
                 string startingPos = NextLocalName("startingRunTextPos");
                 string endingPos = NextLocalName("endingRunTextPos");
-                string crawlPos = NextLocalName("crawlPos");
 
                 // We're about to enter a loop, so ensure our text position is 0.
                 TransferTextSpanPosToRunTextPos();
@@ -1629,7 +1628,12 @@ namespace System.Text.RegularExpressions.Generator
                 EmitSingleCharAtomicLoop(node);
                 TransferTextSpanPosToRunTextPos();
                 writer.WriteLine($"int {endingPos} = runtextpos;");
-                writer.WriteLine($"int {crawlPos} = base.Crawlpos();");
+                string? crawlPos = null;
+                if (expressionHasCaptures)
+                {
+                    crawlPos = NextLocalName("crawlPos");
+                    writer.WriteLine($"int {crawlPos} = base.Crawlpos();");
+                }
                 if (node.M > 0)
                 {
                     writer.WriteLine($"{startingPos} += {node.M};");
@@ -1673,6 +1677,102 @@ namespace System.Text.RegularExpressions.Generator
                 writer.WriteLine();
 
                 MarkLabel(endLoop);
+
+                // We explicitly do not reset doneLabel back to originalDoneLabel.
+                // It's left pointing to the backtracking label for everything subsequent in the expression.
+            }
+
+            void EmitSingleCharLazy(RegexNode node, RegexNode? subsequent = null, bool emitLengthChecksIfRequired = true)
+            {
+                // Emit the min iterations as a repeater.  Any failures here don't necessitate backtracking,
+                // as the lazy itself failed to match.
+                if (node.M > 0)
+                {
+                    EmitSingleCharFixedRepeater(node, emitLengthChecksIfRequired);
+                }
+
+                // If the whole thing was actually that repeater, we're done.
+                if (node.M == node.N)
+                {
+                    return;
+                }
+
+                Debug.Assert(node.M < node.N);
+
+                // We now need to match one character at a time, each time allowing the remainder of the expression
+                // to try to match, and only matching another character if the subsequent expression fails to match.
+
+                // We're about to enter a loop, so ensure our text position is 0.
+                TransferTextSpanPosToRunTextPos();
+
+                // If the loop isn't unbounded, track the number of iterations and the max number to allow.
+                string? iterationCount = null;
+                string? maxIterations = null;
+                if (node.N != int.MaxValue)
+                {
+                    iterationCount = NextLocalName("i");
+                    maxIterations = NextLocalName("maxIterations");
+                    writer.WriteLine($"int {iterationCount} = 0;");
+                    writer.WriteLine($"int {maxIterations} = {node.N - node.M};");
+                }
+
+                // Track the current crawl position.  Upon backtracking, we'll unwind any captures beyond this point.
+                string? crawlPos = null;
+                if (expressionHasCaptures)
+                {
+                    crawlPos = NextLocalName("crawlPos");
+                    writer.WriteLine($"int {crawlPos} = base.Crawlpos();");
+                }
+
+                // Track the current runtextpos.  Each time we backtrack, we'll reset to the stored position, which
+                // is also incremented each time we match another character in the loop.
+                string nextPos = NextLocalName("nextPos");
+                writer.WriteLine($"int {nextPos} = runtextpos;");
+
+                // Skip the backtracking section for the initial subsequent matching.  We've already matched the
+                // minimum number of iterations, which means we can successfully match with zero additional iterations.
+                string endLoopLabel = DefineLabel("endLoop");
+                writer.WriteLine($"goto {endLoopLabel};");
+                writer.WriteLine();
+
+                // Backtracking section. Subsequent failures will jump to here.
+                string backtrackingLabel = DefineLabel("Backtrack");
+                MarkLabel(backtrackingLabel);
+
+                // Uncapture any captures if the expression has any.  It's possible the captures it has
+                // are before this node, in which case this is wasted effort, but still functionally correct.
+                if (expressionHasCaptures)
+                {
+                    EmitUncaptureUntil(crawlPos);
+                }
+
+                // If there's a max number of iterations, see if we've exceeded the maximum number of characters
+                // to match.  If we haven't, increment the iteration count.
+                if (maxIterations is not null)
+                {
+                    using (EmitBlock(writer, $"if ({iterationCount} >= {maxIterations})"))
+                    {
+                        writer.WriteLine($"goto {doneLabel};");
+                    }
+                    writer.WriteLine($"{iterationCount}++;");
+                }
+
+                // Now match the next character in the lazy loop.  We need to reset the runtextpos to the position
+                // just after the last character in this loop was matched, and we need to store the resulting position
+                // for the next time we backtrack.
+                writer.WriteLine($"runtextpos = {nextPos};");
+                LoadTextSpanLocal(writer);
+                EmitSingleChar(node);
+                TransferTextSpanPosToRunTextPos();
+                writer.WriteLine($"{nextPos} = runtextpos;");
+
+                // Update the done label for everything that comes after this node.  This is done after we emit the single char
+                // matching, as that failing indicates the loop itself has failed to match.
+                string originalDoneLabel = doneLabel;
+                doneLabel = backtrackingLabel; // leave set to the backtracking label for all subsequent nodes
+
+                writer.WriteLine();
+                MarkLabel(endLoopLabel);
 
                 // We explicitly do not reset doneLabel back to originalDoneLabel.
                 // It's left pointing to the backtracking label for everything subsequent in the expression.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2122,7 +2122,7 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Onelazy:
                     case RegexNode.Notonelazy:
                     case RegexNode.Setlazy:
-                        EmitSingleCharFixedRepeater(node, emitLengthChecksIfRequired);
+                        EmitSingleCharLazy(node, subsequent, emitLengthChecksIfRequired);
                         break;
 
                     case RegexNode.Concatenate:
@@ -2556,6 +2556,121 @@ namespace System.Text.RegularExpressions
                 LoadTextSpanLocal();
 
                 MarkLabel(endLoop);
+            }
+
+            void EmitSingleCharLazy(RegexNode node, RegexNode? subsequent = null, bool emitLengthChecksIfRequired = true)
+            {
+                // Emit the min iterations as a repeater.  Any failures here don't necessitate backtracking,
+                // as the lazy itself failed to match.
+                if (node.M > 0)
+                {
+                    EmitSingleCharFixedRepeater(node, emitLengthChecksIfRequired);
+                }
+
+                // If the whole thing was actually that repeater, we're done.
+                if (node.M == node.N)
+                {
+                    return;
+                }
+
+                Debug.Assert(node.M < node.N);
+
+                // We now need to match one character at a time, each time allowing the remainder of the expression
+                // to try to match, and only matching another character if the subsequent expression fails to match.
+
+                // We're about to enter a loop, so ensure our text position is 0.
+                TransferTextSpanPosToRunTextPos();
+
+                // If the loop isn't unbounded, track the number of iterations and the max number to allow.
+                LocalBuilder? iterationCount = null;
+                LocalBuilder? maxIterations = null;
+                if (node.N != int.MaxValue)
+                {
+                    // int iterationCount = 0;
+                    // int maxIterations = node.N - node.M;
+                    iterationCount = DeclareInt32();
+                    maxIterations = DeclareInt32();
+                    Ldc(0);
+                    Stloc(iterationCount);
+                    Ldc(node.N - node.M);
+                    Stloc(maxIterations);
+                }
+
+                // Track the current crawl position.  Upon backtracking, we'll unwind any captures beyond this point.
+                LocalBuilder? crawlPos = null;
+                if (expressionHasCaptures)
+                {
+                    // int crawlPos = base.Crawlpos();
+                    crawlPos = DeclareInt32();
+                    Ldthis();
+                    Call(s_crawlposMethod);
+                    Stloc(crawlPos);
+                }
+
+                // Track the current runtextpos.  Each time we backtrack, we'll reset to the stored position, which
+                // is also incremented each time we match another character in the loop.
+                // int nextPos = runtextpos;
+                LocalBuilder nextPos = DeclareInt32();
+                Ldloc(runtextposLocal);
+                Stloc(nextPos);
+
+                // Skip the backtracking section for the initial subsequent matching.  We've already matched the
+                // minimum number of iterations, which means we can successfully match with zero additional iterations.
+                // goto endLoopLabel;
+                Label endLoopLabel = DefineLabel();
+                BrFar(endLoopLabel);
+
+                // Backtracking section. Subsequent failures will jump to here.
+                Label backtrackingLabel = DefineLabel();
+                MarkLabel(backtrackingLabel);
+
+                // Uncapture any captures if the expression has any.  It's possible the captures it has
+                // are before this node, in which case this is wasted effort, but still functionally correct.
+                if (expressionHasCaptures)
+                {
+                    EmitUncaptureUntil(crawlPos!);
+                }
+
+                // If there's a max number of iterations, see if we've exceeded the maximum number of characters
+                // to match.  If we haven't, increment the iteration count.
+                if (maxIterations is not null)
+                {
+                    // if (iterationCount >= maxIterations) goto doneLabel;
+                    Ldloc(iterationCount!);
+                    Ldloc(maxIterations);
+                    BgeFar(doneLabel);
+
+                    // iterationCount++;
+                    Ldloc(iterationCount!);
+                    Ldc(1);
+                    Add();
+                    Stloc(iterationCount!);
+                }
+
+                // Now match the next character in the lazy loop.  We need to reset the runtextpos to the position
+                // just after the last character in this loop was matched, and we need to store the resulting position
+                // for the next time we backtrack.
+
+                // runtextpos = nextPos;
+                // MatchSingleChar();
+                // nextpos = runtextpos;
+                Ldloc(nextPos);
+                Stloc(runtextposLocal);
+                LoadTextSpanLocal();
+                EmitSingleChar(node);
+                TransferTextSpanPosToRunTextPos();
+                Ldloc(runtextposLocal);
+                Stloc(nextPos);
+
+                // Update the done label for everything that comes after this node.  This is done after we emit the single char
+                // matching, as that failing indicates the loop itself has failed to match.
+                Label originalDoneLabel = doneLabel;
+                doneLabel = backtrackingLabel; // leave set to the backtracking label for all subsequent nodes
+
+                MarkLabel(endLoopLabel);
+
+                // We explicitly do not reset doneLabel back to originalDoneLabel.
+                // It's left pointing to the backtracking label for everything subsequent in the expression.
             }
 
             // Emits the code to handle a loop (repeater) with a fixed number of iterations.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2240,11 +2240,14 @@ namespace System.Text.RegularExpressions
                         supported = true;
                         break;
 
-                    // Single character greedy loops are supported if they're either they're actually a repeater
+                    // Single character greedy/lazy loops are supported if either they're actually a repeater
                     // or they're not contained in any construct other than simple nesting (e.g. concat, capture).
                     case Oneloop:
                     case Notoneloop:
                     case Setloop:
+                    case Onelazy:
+                    case Notonelazy:
+                    case Setlazy:
                         Debug.Assert(Next == null || Next.Type != Atomic, "Loop should have been transformed into an atomic type.");
                         supported = M == N || AncestorsAllowBacktracking(Next);
                         static bool AncestorsAllowBacktracking(RegexNode? node)
@@ -2266,12 +2269,6 @@ namespace System.Text.RegularExpressions
 
                             return true;
                         }
-                        break;
-
-                    case Onelazy:
-                    case Notonelazy:
-                    case Setlazy:
-                        supported = M == N || (Next != null && Next.Type == Atomic);
                         break;
 
                     // {Lazy}Loop repeaters are the same, except their child also needs to be supported.

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
@@ -410,8 +410,6 @@ namespace System.Text.RegularExpressions.Tests
             {
                 throw new Xunit.Sdk.EqualException(result2, result1);
             }
-
-            Assert.NotEqual(GetRegexCodes(new Regex(pattern1, RegexOptions.RightToLeft)), GetRegexCodes(new Regex(pattern2)));
         }
 
         [Theory]
@@ -476,9 +474,12 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(?:ab|cd|ae)f", "(?>ab|cd|ae)f")]
         public void PatternsReduceDifferently(string pattern1, string pattern2)
         {
-            var r1 = new Regex(pattern1);
-            var r2 = new Regex(pattern2);
-            Assert.NotEqual(GetRegexCodes(r1), GetRegexCodes(r2));
+            string result1 = GetRegexCodes(new Regex(pattern1));
+            string result2 = GetRegexCodes(new Regex(pattern2));
+            if (result1 == result2)
+            {
+                throw new Xunit.Sdk.EqualException(result2, result1);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/60385 added support for greedy loops to our "simplified" code gen for the Regex compiler and source generator.  This does the same for lazy loops.  In our stable of known real-world regex patterns, this increases the number supported by the simplified code gen by ~5% to ~70%.

(Note we can subsequently add vectorization into this to, for example, special-case .* and use IndexOf{Any} to search for what comes next.)

cc: @joperezr, @danmoseley 

<details>
<summary>Code generated for `<.*?>` before</summary>

```C#
protected override void Go()
{
    string runtext = base.runtext!;
    int runtextbeg = base.runtextbeg;
    int runtextend = base.runtextend;
    int runtextpos = base.runtextpos;
    int[] runtrack = base.runtrack!;
    int runtrackpos = base.runtrackpos;
    int[] runstack = base.runstack!;
    int runstackpos = base.runstackpos;
    int tmp1, tmp2, ch;
                    
    // 000000 *Lazybranch       addr = 13
    L0:
    runtrack[--runtrackpos] = runtextpos;
    runtrack[--runtrackpos] = 0;
                    
    // 000002 *Setmark
    L1:
    runstack[--runstackpos] = runtextpos;
    runtrack[--runtrackpos] = 1;
                    
    // 000003  One              '<'
    L2:
    if (runtextpos >= runtextend || runtext[runtextpos++] != 60)
    {
        goto Backtrack;
    }
                    
    // 000005 *Notonelazy       '\\n', rep = inf
    L3:
    tmp1 = runtextend - runtextpos; // count
    if (tmp1 <= 0)
    {
        goto L4;
    }
    runtrack[--runtrackpos] = tmp1 - 1;
    runtrack[--runtrackpos] = runtextpos;
    runtrack[--runtrackpos] = 2;
                    
    // 000008  One              '>'
    L4:
    if (runtextpos >= runtextend || runtext[runtextpos++] != 62)
    {
        goto Backtrack;
    }
                    
    // 000010 *Capturemark      index = 0
    L5:
    tmp1 = runstack[runstackpos++];
    base.Capture(0, tmp1, runtextpos);
    runtrack[--runtrackpos] = tmp1;
    runtrack[--runtrackpos] = 3;
                    
    // 000013  Stop
    L6:
    base.runtextpos = runtextpos;
    return;
                    
    Backtrack:
    int limit = base.runtrackcount * 4;
    if (runstackpos < limit)
    {
        base.runstackpos = runstackpos;
        base.DoubleStack(); // might change runstackpos and runstack
        runstackpos = base.runstackpos;
        runstack = base.runstack!;
    }
    if (runtrackpos < limit)
    {
        base.runtrackpos = runtrackpos;
        base.DoubleTrack(); // might change runtrackpos and runtrack
        runtrackpos = base.runtrackpos;
        runtrack = base.runtrack!;
    }
                    
    switch (runtrack[runtrackpos++])
    {
        case 0:
        {
            // 000000 *Lazybranch       addr = 13
            runtextpos = runtrack[runtrackpos++];
            goto L6;
        }
                        
        case 1:
        {
            // 000002 *Setmark
            runstackpos++;
            goto Backtrack;
        }
                        
        case 2:
        {
            // 000005 *Notonelazy       '\\n', rep = inf
            runtextpos = runtrack[runtrackpos++];
            tmp1 = runtrack[runtrackpos++]; // i
            if (runtext[runtextpos++] == '\n')
            {
                goto Backtrack;
            }
            if (tmp1 > 0)
            {
                runtrack[--runtrackpos] = tmp1 - 1;
                runtrack[--runtrackpos] = runtextpos;
                runtrack[--runtrackpos] = 2;
            }
            goto L4;
        }
                        
        case 3:
        {
            // 000010 *Capturemark      index = 0
            runstack[--runstackpos] = runtrack[runtrackpos++];
            base.Uncapture();
            goto Backtrack;
        }
                        
        default:
        {
            global::System.Diagnostics.Debug.Fail($"Unexpected backtracking state {runtrack[runtrackpos - 1]}");
            break;
        }
    }
}
```
</details>

<details>
<summary>Code generated for `<.*?>` after</summary>

```C#
protected override void Go()
{
    string runtext = base.runtext!;
    int runtextpos = base.runtextpos;
    int runtextend = base.runtextend;
    int originalruntextpos = runtextpos;
    global::System.ReadOnlySpan<byte> byteSpan;
    char ch;
    global::System.ReadOnlySpan<char> textSpan = global::System.MemoryExtensions.AsSpan(runtext, runtextpos, runtextend - runtextpos);
                    
    // Concatenate
    //{
        // One '<'
        {
            if ((uint)textSpan.Length < 1 || textSpan[0] != '<')
            {
                goto NoMatch;
            }
        }
                        
        // Notonelazy '\\n'*
        //{
            runtextpos++;
            textSpan = textSpan.Slice(1);
            int nextPos0 = runtextpos;
            goto endLoop0;
                            
            Backtrack1:
            runtextpos = nextPos0;
            textSpan = global::System.MemoryExtensions.AsSpan(runtext, runtextpos, runtextend - runtextpos);
            if ((uint)textSpan.Length < 1 || textSpan[0] == '\n')
            {
                goto NoMatch;
            }
            runtextpos++;
            textSpan = textSpan.Slice(1);
            nextPos0 = runtextpos;
                            
            endLoop0:
        //}
                        
        // One '>'
        {
            if ((uint)textSpan.Length < 1 || textSpan[0] != '>')
            {
                goto Backtrack1;
            }
        }
                        
    //}
                    
    // Match
    runtextpos++;
    base.runtextpos = runtextpos;
    base.Capture(0, originalruntextpos, runtextpos);
    return;
                    
    // No match
    NoMatch:
    return;
}
```
</details>