### PR TITLE
Ignore missing data result from superpmi-replay run

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1479,11 +1479,12 @@ class SuperPMIReplayAsmDiffs:
                 artifacts_base_name = create_artifacts_base_name(self.coreclr_args, mch_file)
 
                 if return_code != 0:
-                    result = False
+
                     # Don't report as replay failure asm diffs (return code 2) or missing data (return code 3).
                     # Anything else, such as compilation failure (return code 1, typically a JIT assert) will be
                     # reported as a replay failure.
                     if return_code != 2 and return_code != 3:
+                        result = False
                         files_with_replay_failures.append(mch_file)
 
                         if is_nonzero_length_file(fail_mcl_file):

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -312,7 +312,6 @@ asm_diff_parser.add_argument("-diff_jit_path", help="Path to diff clrjit. Defaul
 asm_diff_parser.add_argument("-git_hash", help="Use this git hash as the current hash for use to find a baseline JIT. Defaults to current git hash of source tree.")
 asm_diff_parser.add_argument("-base_git_hash", help="Use this git hash as the baseline JIT hash. Default: search for the baseline hash.")
 asm_diff_parser.add_argument("--diff_jit_dump", action="store_true", help="Generate JitDump output for diffs. Default: only generate asm, not JitDump.")
-asm_diff_parser.add_argument("-temp_dir", help="Specify a temporary directory used for a previous ASM diffs run (for which --skip_cleanup was used) to view the results. The replay command is skipped.")
 asm_diff_parser.add_argument("--gcinfo", action="store_true", help="Include GC info in disassembly (sets COMPlus_JitGCDump/COMPlus_NgenGCDump; requires instructions to be prefixed by offsets).")
 asm_diff_parser.add_argument("--debuginfo", action="store_true", help="Include debug info after disassembly (sets COMPlus_JitDebugDump/COMPlus_NgenDebugDump).")
 asm_diff_parser.add_argument("-base_jit_option", action="append", help="Option to pass to the baseline JIT. Format is key=value, where key is the option name without leading COMPlus_...")
@@ -1264,21 +1263,21 @@ class SuperPMIReplay:
 
                 print_superpmi_result(return_code, self.coreclr_args, metrics, None)
                 if return_code != 0:
-                    result = False
                     # Don't report as replay failure missing data (return code 3).
                     # Anything else, such as compilation failure (return code 1, typically a JIT assert) will be
                     # reported as a replay failure.
                     if return_code != 3:
+                        result = False
                         files_with_replay_failures.append(mch_file)
 
-                if is_nonzero_length_file(fail_mcl_file):
-                    # Unclean replay. Examine the contents of the fail.mcl file to dig into failures.
-                    if return_code == 0:
-                        logging.warning("Warning: SuperPMI returned a zero exit code, but generated a non-zero-sized mcl file")
-                    print_fail_mcl_file_method_numbers(fail_mcl_file)
-                    repro_base_command_line = "{} {} {}".format(self.superpmi_path, " ".join(repro_flags), self.jit_path)
-                    artifacts_base_name = create_artifacts_base_name(self.coreclr_args, mch_file)
-                    save_repro_mc_files(temp_location, self.coreclr_args, artifacts_base_name, repro_base_command_line)
+                        if is_nonzero_length_file(fail_mcl_file):
+                            # Unclean replay. Examine the contents of the fail.mcl file to dig into failures.
+                            if return_code == 0:
+                                logging.warning("Warning: SuperPMI returned a zero exit code, but generated a non-zero-sized mcl file")
+                            print_fail_mcl_file_method_numbers(fail_mcl_file)
+                            repro_base_command_line = "{} {} {}".format(self.superpmi_path, " ".join(repro_flags), self.jit_path)
+                            artifacts_base_name = create_artifacts_base_name(self.coreclr_args, mch_file)
+                            save_repro_mc_files(temp_location, self.coreclr_args, artifacts_base_name, repro_base_command_line)
 
                 if not self.coreclr_args.skip_cleanup:
                     if os.path.isfile(fail_mcl_file):
@@ -1416,7 +1415,7 @@ class SuperPMIReplayAsmDiffs:
         # List of all Markdown summary files
         all_md_summary_files = []
 
-        with TempDir(self.coreclr_args.temp_dir, self.coreclr_args.skip_cleanup) as temp_location:
+        with TempDir(None, self.coreclr_args.skip_cleanup) as temp_location:
             logging.debug("")
             logging.debug("Temp Location: %s", temp_location)
             logging.debug("")
@@ -1438,68 +1437,62 @@ class SuperPMIReplayAsmDiffs:
                 base_metrics_summary_file = os.path.join(temp_location, os.path.basename(mch_file) + "_base_metrics.csv")
                 diff_metrics_summary_file = os.path.join(temp_location, os.path.basename(mch_file) + "_diff_metrics.csv")
 
-                # If the user passed -temp_dir, we skip the SuperPMI replay process,
-                # and rely on what we find from a previous run.
-                if self.coreclr_args.temp_dir is not None:
-                    return_code = 1
-                else:
-                    flags = [
-                        "-a",  # Asm diffs
-                        "-v", "ewmi",  # display errors, warnings, missing, jit info
-                        "-f", fail_mcl_file,  # Failing mc List
-                        "-diffMCList", diff_mcl_file,  # Create all of the diffs in an mcl file
-                        "-r", os.path.join(temp_location, "repro"),  # Repro name, create .mc repro files
-                        "-baseMetricsSummary", base_metrics_summary_file, # Create summary of metrics we can use to get total code size impact
-                        "-diffMetricsSummary", diff_metrics_summary_file,
-                    ]
-                    flags += altjit_asm_diffs_flags
-                    flags += base_option_flags
-                    flags += diff_option_flags
+                flags = [
+                    "-a",  # Asm diffs
+                    "-v", "ewmi",  # display errors, warnings, missing, jit info
+                    "-f", fail_mcl_file,  # Failing mc List
+                    "-diffMCList", diff_mcl_file,  # Create all of the diffs in an mcl file
+                    "-r", os.path.join(temp_location, "repro"),  # Repro name, create .mc repro files
+                    "-baseMetricsSummary", base_metrics_summary_file, # Create summary of metrics we can use to get total code size impact
+                    "-diffMetricsSummary", diff_metrics_summary_file,
+                ]
+                flags += altjit_asm_diffs_flags
+                flags += base_option_flags
+                flags += diff_option_flags
 
-                    if not self.coreclr_args.sequential:
-                        flags += [ "-p" ]
+                if not self.coreclr_args.sequential:
+                    flags += [ "-p" ]
 
-                    if self.coreclr_args.break_on_assert:
-                        flags += [ "-boa" ]
+                if self.coreclr_args.break_on_assert:
+                    flags += [ "-boa" ]
 
-                    if self.coreclr_args.break_on_error:
-                        flags += [ "-boe" ]
+                if self.coreclr_args.break_on_error:
+                    flags += [ "-boe" ]
 
-                    if self.coreclr_args.spmi_log_file is not None:
-                        flags += [ "-w", self.coreclr_args.spmi_log_file ]
+                if self.coreclr_args.spmi_log_file is not None:
+                    flags += [ "-w", self.coreclr_args.spmi_log_file ]
 
-                    if self.coreclr_args.error_limit is not None:
-                        flags += ["-failureLimit", self.coreclr_args.error_limit]
+                if self.coreclr_args.error_limit is not None:
+                    flags += ["-failureLimit", self.coreclr_args.error_limit]
 
-                    # Change the working directory to the Core_Root we will call SuperPMI from.
-                    # This is done to allow libcoredistools to be loaded correctly on unix
-                    # as the loadlibrary path will be relative to the current directory.
-                    with ChangeDir(self.coreclr_args.core_root):
-                        command = [self.superpmi_path] + flags + [self.base_jit_path, self.diff_jit_path, mch_file]
-                        return_code = run_and_log(command)
+                # Change the working directory to the Core_Root we will call SuperPMI from.
+                # This is done to allow libcoredistools to be loaded correctly on unix
+                # as the loadlibrary path will be relative to the current directory.
+                with ChangeDir(self.coreclr_args.core_root):
+                    command = [self.superpmi_path] + flags + [self.base_jit_path, self.diff_jit_path, mch_file]
+                    return_code = run_and_log(command)
 
-                    base_metrics = read_csv_metrics(base_metrics_summary_file)
-                    diff_metrics = read_csv_metrics(diff_metrics_summary_file)
+                base_metrics = read_csv_metrics(base_metrics_summary_file)
+                diff_metrics = read_csv_metrics(diff_metrics_summary_file)
 
-                    print_superpmi_result(return_code, self.coreclr_args, base_metrics, diff_metrics)
-
-                    if return_code != 0:
-                        result = False
-                        # Don't report as replay failure asm diffs (return code 2) or missing data (return code 3).
-                        # Anything else, such as compilation failure (return code 1, typically a JIT assert) will be
-                        # reported as a replay failure.
-                        if return_code != 2 and return_code != 3:
-                            files_with_replay_failures.append(mch_file)
-
+                print_superpmi_result(return_code, self.coreclr_args, base_metrics, diff_metrics)
                 artifacts_base_name = create_artifacts_base_name(self.coreclr_args, mch_file)
 
-                if is_nonzero_length_file(fail_mcl_file):
-                    # Unclean replay. Examine the contents of the fail.mcl file to dig into failures.
-                    if return_code == 0:
-                        logging.warning("Warning: SuperPMI returned a zero exit code, but generated a non-zero-sized mcl file")
-                    print_fail_mcl_file_method_numbers(fail_mcl_file)
-                    repro_base_command_line = "{} {} {}".format(self.superpmi_path, " ".join(altjit_asm_diffs_flags), self.diff_jit_path)
-                    save_repro_mc_files(temp_location, self.coreclr_args, artifacts_base_name, repro_base_command_line)
+                if return_code != 0:
+                    result = False
+                    # Don't report as replay failure asm diffs (return code 2) or missing data (return code 3).
+                    # Anything else, such as compilation failure (return code 1, typically a JIT assert) will be
+                    # reported as a replay failure.
+                    if return_code != 2 and return_code != 3:
+                        files_with_replay_failures.append(mch_file)
+
+                        if is_nonzero_length_file(fail_mcl_file):
+                            # Unclean replay. Examine the contents of the fail.mcl file to dig into failures.
+                            if return_code == 0:
+                                logging.warning("Warning: SuperPMI returned a zero exit code, but generated a non-zero-sized mcl file")
+                            print_fail_mcl_file_method_numbers(fail_mcl_file)
+                            repro_base_command_line = "{} {} {}".format(self.superpmi_path, " ".join(altjit_asm_diffs_flags), self.diff_jit_path)
+                            save_repro_mc_files(temp_location, self.coreclr_args, artifacts_base_name, repro_base_command_line)
 
                 # There were diffs. Go through each method that created diffs and
                 # create a base/diff asm file with diffable asm. In addition, create
@@ -3230,11 +3223,6 @@ def setup_args(args):
                             "Unable to set base_git_hash")
 
         coreclr_args.verify(args,
-                            "temp_dir",
-                            lambda unused: True,
-                            "Unable to set temp_dir.")
-
-        coreclr_args.verify(args,
                             "gcinfo",
                             lambda unused: True,
                             "Unable to set gcinfo.")
@@ -3316,10 +3304,6 @@ def setup_args(args):
                             "coredistools_location",
                             os.path.isfile,
                             "Unable to find coredistools.")
-
-        if coreclr_args.temp_dir is not None:
-            coreclr_args.temp_dir = os.path.abspath(coreclr_args.temp_dir)
-            logging.debug("Using temp_dir %s", coreclr_args.temp_dir)
 
     elif coreclr_args.mode == "upload":
 


### PR DESCRIPTION
If the errors are "missing data" related, ignore them and don't treat it as run failure. With this, `superpmi.log` will not list the method context ids under `Method numbers with compilation failures:` section.

Fixes: https://github.com/dotnet/runtime/issues/61616 and contributes to https://github.com/dotnet/runtime/issues/61483