### PR TITLE
[DllImportGenerator] Enable on projects without System.Memory and System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -10,10 +10,7 @@
     <!-- If the current project is not System.Private.CoreLib, we enable the DllImportGenerator source generator
          when the project is a C# source project that either:
          - references System.Private.CoreLib, or
-         - references the following assemblies:
-          - System.Runtime.InteropServices
-          - System.Runtime.CompilerServices.Unsafe
-          - System.Memory -->
+         - references System.Runtime.InteropServices -->
     <EnabledGenerators Include="DllImportGenerator"
                        Condition="'$(EnableDllImportGenerator)' == ''
                         and '$(IsFrameworkSupportFacade)' != 'true'
@@ -21,11 +18,7 @@
                         and '$(MSBuildProjectExtension)' == '.csproj'
                         and (
                           ('@(Reference)' != ''
-                            and @(Reference->AnyHaveMetadataValue('Identity', 'System.Runtime.InteropServices'))
-                            and (@(Reference->AnyHaveMetadataValue('Identity', 'System.Runtime.CompilerServices.Unsafe'))
-                              or ('@(ProjectReference)' != ''
-                                and @(ProjectReference->AnyHaveMetadataValue('Identity', $([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'System.Runtime.CompilerServices.Unsafe', 'src', 'System.Runtime.CompilerServices.Unsafe.ilproj'))))))
-                            and @(Reference->AnyHaveMetadataValue('Identity', 'System.Memory')))
+                            and @(Reference->AnyHaveMetadataValue('Identity', 'System.Runtime.InteropServices')))
                           or ('@(ProjectReference)' != ''
                             and @(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))))" />
     <EnabledGenerators Include="DllImportGenerator"
@@ -45,7 +38,19 @@
 
     <!-- Only add the following files if we are on the latest TFM (that is, net7). -->
     <Compile Condition="'$(NetCoreAppCurrentTargetFrameworkMoniker)' == '$(TargetFrameworkMoniker)'" Include="$(LibrariesProjectRoot)Common\src\System\Runtime\InteropServices\GeneratedMarshallingAttribute.cs" />
-    <Compile Condition="'$(NetCoreAppCurrentTargetFrameworkMoniker)' == '$(TargetFrameworkMoniker)'" Include="$(LibrariesProjectRoot)Common\src\System\Runtime\InteropServices\ArrayMarshaller.cs" />
+
+    <!-- Only add the following files if we are on the latest TFM (that is, net7) and the project is SPCL or has references to System.Runtime.CompilerServices.Unsafe and System.Memory -->
+    <Compile Condition="'$(NetCoreAppCurrentTargetFrameworkMoniker)' == '$(TargetFrameworkMoniker)'
+                        and (
+                          '$(MSBuildProjectName)' == 'System.Private.CoreLib'
+                          or '$(EnableDllImportGenerator)' == 'true'
+                          or ('@(Reference)' != ''
+                            and (@(Reference->AnyHaveMetadataValue('Identity', 'System.Runtime.CompilerServices.Unsafe'))
+                              or ('@(ProjectReference)' != ''
+                                and @(ProjectReference->AnyHaveMetadataValue('Identity', $([MSBuild]::NormalizePath('$(LibrariesProjectRoot)', 'System.Runtime.CompilerServices.Unsafe', 'src', 'System.Runtime.CompilerServices.Unsafe.ilproj'))))))
+                            and @(Reference->AnyHaveMetadataValue('Identity', 'System.Memory')))
+                          or ('@(ProjectReference)' != ''
+                            and @(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))))" Include="$(LibrariesProjectRoot)Common\src\System\Runtime\InteropServices\ArrayMarshaller.cs" />
   </ItemGroup>
 
   <Target Name="ConfigureGenerators"

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
@@ -4,6 +4,7 @@
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2249</NoWarn>
+    <Nullable>annotations</Nullable>
     <IsPackable>true</IsPackable>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -4,6 +4,7 @@
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum)-OSX;$(NetCoreAppMinimum)-Linux;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <Nullable>annotations</Nullable>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
     <PackageDescription>Provides the methods defined in the Lightweight Directory Access Protocol (LDAP) version 3 (V3) and Directory Services Markup Language (DSML) version 2.0 (V2) standards.</PackageDescription>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
@@ -197,6 +197,15 @@ namespace Microsoft.Interop
             {
                 try
                 {
+                    // TODO: Remove once helper types (like ArrayMarshaller) are part of the runtime
+                    // This check is to help with enabling the source generator for runtime libraries without making each
+                    // library directly reference System.Memory and System.Runtime.CompilerServices.Unsafe unless it needs to
+                    if (p.MarshallingAttributeInfo is MissingSupportMarshallingInfo
+                        && (environment.TargetFramework == TargetFramework.Net && environment.TargetFrameworkVersion.Major >= 7))
+                    {
+                        throw new MarshallingNotSupportedException(p, this);
+                    }
+
                     return new BoundGenerator(p, generatorFactory.Create(p, this));
                 }
                 catch (MarshallingNotSupportedException e)

--- a/src/libraries/System.Speech/src/System.Speech.csproj
+++ b/src/libraries/System.Speech/src/System.Speech.csproj
@@ -5,6 +5,7 @@
     <!-- CS0649: uninitialized interop type fields -->
     <!-- SA1129: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3277 -->
     <NoWarn>$(NoWarn);CS0649;SA1129;CA1847</NoWarn>
+    <Nullable>annotations</Nullable>
     <SetIsTrimmable>false</SetIsTrimmable>
     <IsPackable>true</IsPackable>
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>


### PR DESCRIPTION
Don't always add `ArrayMarshaller.cs` (which uses `System.Memory` and `System.Runtime.CompilerServices.Unsafe`). This stops requiring that all the libraries projects that use the source generator at all have those references (even though they may not actually need them for the generated code), such that the generator can be enabled for everything.

If the generated code does end up needing those references, it will just come through as a compilation error.

Added a check - that should be removed once we add APIs like ArrayMarshaller - so that the generator will fire a diagnostic if targeting 7.0+ and missing an API.

@AaronRobinsonMSFT @jkoritzinsky 