### PR TITLE
A few follow up changes to LookupTypeKey change

### DIFF
--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -1536,19 +1536,19 @@ ClassLoader::LoadTypeHandleThrowing(
             pClsLdr = pFoundModule->GetClassLoader();
             pLookInThisModuleOnly = NULL;
         }
+    }
 
 #ifndef DACCESS_COMPILE
-        // Replace AvailableClasses Module entry with found TypeHandle
-        if (!typeHnd.IsNull() &&
-            typeHnd.IsRestored() &&
-            foundEntry.GetEntryType() == HashedTypeEntry::EntryType::IsHashedClassEntry &&
-            (foundEntry.GetClassHashBasedEntryValue() != NULL) &&
-            (foundEntry.GetClassHashBasedEntryValue()->GetData() != typeHnd.AsPtr()))
-        {
-            foundEntry.GetClassHashBasedEntryValue()->SetData(typeHnd.AsPtr());
-        }
-#endif // !DACCESS_COMPILE
+    // Replace AvailableClasses Module entry with found TypeHandle
+    if (!typeHnd.IsNull() &&
+        typeHnd.IsRestored() &&
+        foundEntry.GetEntryType() == HashedTypeEntry::EntryType::IsHashedClassEntry &&
+        (foundEntry.GetClassHashBasedEntryValue() != NULL) &&
+        (foundEntry.GetClassHashBasedEntryValue()->GetData() != typeHnd.AsPtr()))
+    {
+        foundEntry.GetClassHashBasedEntryValue()->SetData(typeHnd.AsPtr());
     }
+#endif // !DACCESS_COMPILE
 
     RETURN typeHnd;
 } // ClassLoader::LoadTypeHandleThrowing

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -627,7 +627,6 @@ void ClassLoader::GetClassValue(NameHandleTable nhTable,
     CONTRACTL_END
 
 
-    mdToken             mdEncloser;
     EEClassHashEntry_t  *pBucket = NULL;
 
     needsToBuildHashtable = FALSE;
@@ -642,8 +641,6 @@ void ClassLoader::GetClassValue(NameHandleTable nhTable,
                  pName->GetNameSpace(), pName->GetName()));
     }
 #endif
-
-    BOOL isNested = IsNested(pName, &mdEncloser);
 
     PTR_Assembly assembly = GetAssembly();
     PREFIX_ASSUME(assembly != NULL);
@@ -718,6 +715,9 @@ void ClassLoader::GetClassValue(NameHandleTable nhTable,
                 }
             }
             _ASSERTE(pTable);
+
+            mdToken             mdEncloser;
+            BOOL isNested = IsNested(pName, &mdEncloser);
 
             if (isNested)
             {


### PR DESCRIPTION
As a followup to the LookupTypeKey PR (https://github.com/dotnet/runtime/pull/61346) I looked at possibility of reducing nested types hash collisions in `EEClassHashTable`  by mixing hashes of enclosers into the hash. 

That was implemented in https://github.com/dotnet/runtime/pull/61652, but I was not convinced the results justify added complexity. 
I do not think we should take the whole https://github.com/dotnet/runtime/pull/61652.

So here I have a smaller PR with just few unambiguous improvements that I came up with while working on #61652 . I do not think we want the rest of the change.
