### PR TITLE
Skip HardwareIntrinsics/x86base/Pause tests on Mono

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -843,6 +843,9 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems in *all* runtime modes -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include = "$(XUnitTestBinBase/JIT/HardwareIntrinsics/X86/X86Base/Pause*/**">
+            <Issue>https://github.com/dotnet/runtime/issues/61693</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/reflection/GenericAttribute/**">
             <Issue>https://github.com/dotnet/runtime/issues/56887</Issue>
         </ExcludeList>


### PR DESCRIPTION
Caused by https://github.com/dotnet/runtime/issues/61693