### PR TITLE
Actually use TargetOS=AnyOS in the build-test-job.

### DIFF
--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -89,9 +89,13 @@ jobs:
       - ${{ if eq(parameters.runtimeFlavor, 'coreclr') }}:
         - name: liveRuntimeBuildParams
           value: ${{ format('clr.corelib+libs.ref+libs.native -rc {0} -c {1} -arch {2} -ci', coalesce(parameters.liveRuntimeBuildConfig, parameters.buildConfig), parameters.liveLibrariesBuildConfig, parameters.archType) }}
+        - name: liveRuntimeArtifactsPathArg
+          value: ${{ format('/p:CoreCLROverridePath={0}/artifacts/bin/coreclr/{1}{2}.{3}.{4}', $(Build.SourcesDirectory), parameters.osGroup, parameters.osSubgroup, parameters.archType, coalesce(parameters.liveRuntimeBuildConfig, parameters.buildConfig)) }}
       - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
         - name: liveRuntimeBuildParams
           value: ${{ format('mono.corelib+libs.ref+libs.native -rc {0} -c {1} -arch {2} -ci', coalesce(parameters.liveRuntimeBuildConfig, parameters.buildConfig), parameters.liveLibrariesBuildConfig, parameters.archType) }}
+        - name: liveRuntimeArtifactsPathArg
+          value: ${{ format('/p:MonoOverridePath={0}/artifacts/bin/mono/{1}{2}.{3}.{4}', $(Build.SourcesDirectory), parameters.osGroup, parameters.osSubgroup, parameters.archType, coalesce(parameters.liveRuntimeBuildConfig, parameters.buildConfig)) }}
       - name: compilerArg
         value: ''
       - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.compilerName, 'gcc')) }}:
@@ -135,7 +139,7 @@ jobs:
         displayName: Disk Usage before Build
 
     # Build managed test components
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg) /p:RuntimeOS=${{ parameters.osGroup }}${{ parameters.osSubgroup }} /p:LibrariesTargetOSConfigurationArchitecture=${{ parameters.osGroup }}${{ parameters.osSubgroup }}-${{ parameters.liveLibrariesBuildConfig }}-${{ parameters.archType }} /p:TargetOS=AnyOS
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg) /p:RuntimeOS=${{ parameters.osGroup }}${{ parameters.osSubgroup }} /p:LibrariesTargetOSConfigurationArchitecture=${{ parameters.osGroup }}${{ parameters.osSubgroup }}-${{ parameters.liveLibrariesBuildConfig }}-${{ parameters.archType }} $(liveRuntimeArtifactsPathArg) /p:TargetOS=AnyOS
       displayName: Build managed test components
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -135,7 +135,7 @@ jobs:
         displayName: Disk Usage before Build
 
     # Build managed test components
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg) /p:RuntimeOS=$(parameters.osGroup)$(parameters.osSubgroup) /p:LibrariesTargetOSConfigurationArchitecture=$(parameters.osGroup)$(parameters.osSubgroup)-$(liveLibrariesBuildConfig)-$(parameters.archType) /p:TargetOS=AnyOS
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg) /p:RuntimeOS=${{ parameters.osGroup }}${{ parameters.osSubgroup }} /p:LibrariesTargetOSConfigurationArchitecture=${{ parameters.osGroup }}${{ parameters.osSubgroup }}-${{ liveLibrariesBuildConfig }}-${{ parameters.archType }} /p:TargetOS=AnyOS
       displayName: Build managed test components
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -135,7 +135,7 @@ jobs:
         displayName: Disk Usage before Build
 
     # Build managed test components
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg) /p:RuntimeOS=${{ parameters.osGroup }}${{ parameters.osSubgroup }} /p:LibrariesTargetOSConfigurationArchitecture=${{ parameters.osGroup }}${{ parameters.osSubgroup }}-${{ liveLibrariesBuildConfig }}-${{ parameters.archType }} /p:TargetOS=AnyOS
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg) /p:RuntimeOS=${{ parameters.osGroup }}${{ parameters.osSubgroup }} /p:LibrariesTargetOSConfigurationArchitecture=${{ parameters.osGroup }}${{ parameters.osSubgroup }}-${{ parameters.liveLibrariesBuildConfig }}-${{ parameters.archType }} /p:TargetOS=AnyOS
       displayName: Build managed test components
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -135,7 +135,7 @@ jobs:
         displayName: Disk Usage before Build
 
     # Build managed test components
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg)
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)Managed allTargets skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(runtimeFlavorArgs) $(crossArg) $(priorityArg) ci $(librariesOverrideArg) /p:RuntimeOS=$(parameters.osGroup)$(parameters.osSubgroup) /p:LibrariesTargetOSConfigurationArchitecture=$(parameters.osGroup)$(parameters.osSubgroup)-$(liveLibrariesBuildConfig)-$(parameters.archType) /p:TargetOS=AnyOS
       displayName: Build managed test components
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
@@ -147,7 +147,7 @@ jobs:
     # Zip and publish managed test components
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
-        rootFolder: $(managedTestArtifactRootFolderPath)
+        rootFolder: '$(binTestsPath)/AnyOS.$(archType).$(buildConfigUpper)'
         includeRootFolder: false
         archiveExtension: '.tar.gz'
         archiveType: tar

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -392,8 +392,6 @@
 
   <Target Name="BuildTargetingPack" AfterTargets="BatchRestorePackages">
     <Message Text="$(MsgPrefix)Building Targeting Pack" Importance="High" />
-    <Error Text="$(ErrMsgPrefix)$(MsgPrefix)ERROR: TargetOS has not been specified. Please do that then run build again."
-      Condition="'$(TargetOS)' == 'AnyOS'" />
     <MSBuild Projects="Common\external\external.csproj"
              Targets="Build" />
   </Target>

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -448,7 +448,9 @@
       <GroupBuildCmd>$(GroupBuildCmd) "/p:TargetArchitecture=$(TargetArchitecture)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:Configuration=$(Configuration)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:LibrariesConfiguration=$(LibrariesConfiguration)"</GroupBuildCmd>
+      <GroupBuildCmd>$(GroupBuildCmd) "/p:LibrariesTargetOSConfigurationArchitecture=$(LibrariesTargetOSConfigurationArchitecture)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:TargetOS=$(TargetOS)"</GroupBuildCmd>
+      <GroupBuildCmd>$(GroupBuildCmd) "/p:RuntimeOS=$(RuntimeOS)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:RuntimeFlavor=$(RuntimeFlavor)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:RuntimeVariant=$(RuntimeVariant)"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) "/p:CLRTestBuildAllTargets=$(CLRTestBuildAllTargets)"</GroupBuildCmd>
@@ -456,6 +458,7 @@
       <GroupBuildCmd>$(GroupBuildCmd) "/p:__SkipRestorePackages=1"</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) /nodeReuse:false</GroupBuildCmd>
       <GroupBuildCmd>$(GroupBuildCmd) /maxcpucount</GroupBuildCmd>
+      <GroupBuildCmd>$(GroupBuildCmd) /bl:$(ArtifactsDir)/log/$(Configuration)/InnerManagedTestBuild.$(__TestGroupToBuild).binlog</GroupBuildCmd>
     </PropertyGroup>
 
     <Message Importance="High" Text="$(MsgPrefix)Building managed test group $(__TestGroupToBuild): $(GroupBuildCmd)" />


### PR DESCRIPTION
Match the name that's used in the job title and enable us to use TargetOS to pre-filter OS-specific tests with the new Xunit test wrapper generator.