### PR TITLE
[System.Text.Json] Move inline throw statements to `ThrowHelper`

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -1107,7 +1107,7 @@ namespace System.Text.Json
         {
             if (expected != actual)
             {
-                throw ThrowHelper.GetJsonElementWrongTypeException(expected, actual);
+                ThrowHelper.ThrowJsonElementWrongTypeException(expected, actual);
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocumentOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocumentOptions.cs
@@ -52,7 +52,9 @@ namespace System.Text.Json
             set
             {
                 if (value < 0)
-                    throw ThrowHelper.GetArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                }
 
                 _maxDepth = value;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -336,7 +336,6 @@ namespace System.Text.Json
                 type == JsonTokenType.False ? false :
                 ThrowJsonElementWrongTypeException(type);
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             static bool ThrowJsonElementWrongTypeException(JsonTokenType actualType)
             {
                 throw ThrowHelper.GetJsonElementWrongTypeException(nameof(Boolean), actualType.ToValueKind());

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
@@ -333,7 +334,13 @@ namespace System.Text.Json
             return
                 type == JsonTokenType.True ? true :
                 type == JsonTokenType.False ? false :
-                throw ThrowHelper.GetJsonElementWrongTypeException(nameof(Boolean), type);
+                ThrowJsonElementWrongTypeException(type);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static bool ThrowJsonElementWrongTypeException(JsonTokenType actualType)
+            {
+                throw ThrowHelper.GetJsonElementWrongTypeException(nameof(Boolean), actualType.ToValueKind());
+            }
         }
 
         /// <summary>
@@ -400,12 +407,12 @@ namespace System.Text.Json
         /// <seealso cref="ToString"/>
         public byte[] GetBytesFromBase64()
         {
-            if (TryGetBytesFromBase64(out byte[]? value))
+            if (!TryGetBytesFromBase64(out byte[]? value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -645,12 +652,12 @@ namespace System.Text.Json
         /// </exception>
         public int GetInt32()
         {
-            if (TryGetInt32(out int value))
+            if (!TryGetInt32(out int value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -697,12 +704,12 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public uint GetUInt32()
         {
-            if (TryGetUInt32(out uint value))
+            if (!TryGetUInt32(out uint value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -747,12 +754,12 @@ namespace System.Text.Json
         /// </exception>
         public long GetInt64()
         {
-            if (TryGetInt64(out long value))
+            if (!TryGetInt64(out long value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -799,12 +806,12 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public ulong GetUInt64()
         {
-            if (TryGetUInt64(out ulong value))
+            if (!TryGetUInt64(out ulong value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -866,12 +873,12 @@ namespace System.Text.Json
         /// </exception>
         public double GetDouble()
         {
-            if (TryGetDouble(out double value))
+            if (!TryGetDouble(out double value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -933,12 +940,12 @@ namespace System.Text.Json
         /// </exception>
         public float GetSingle()
         {
-            if (TryGetSingle(out float value))
+            if (!TryGetSingle(out float value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -985,12 +992,12 @@ namespace System.Text.Json
         /// <seealso cref="GetRawText"/>
         public decimal GetDecimal()
         {
-            if (TryGetDecimal(out decimal value))
+            if (!TryGetDecimal(out decimal value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -1036,12 +1043,12 @@ namespace System.Text.Json
         /// <seealso cref="ToString"/>
         public DateTime GetDateTime()
         {
-            if (TryGetDateTime(out DateTime value))
+            if (!TryGetDateTime(out DateTime value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -1087,12 +1094,12 @@ namespace System.Text.Json
         /// <seealso cref="ToString"/>
         public DateTimeOffset GetDateTimeOffset()
         {
-            if (TryGetDateTimeOffset(out DateTimeOffset value))
+            if (!TryGetDateTimeOffset(out DateTimeOffset value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         /// <summary>
@@ -1138,12 +1145,12 @@ namespace System.Text.Json
         /// <seealso cref="ToString"/>
         public Guid GetGuid()
         {
-            if (TryGetGuid(out Guid value))
+            if (!TryGetGuid(out Guid value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException();
             }
 
-            throw ThrowHelper.GetFormatException();
+            return value;
         }
 
         internal string GetPropertyName()
@@ -1326,7 +1333,7 @@ namespace System.Text.Json
 
             if (tokenType != JsonTokenType.StartArray)
             {
-                throw ThrowHelper.GetJsonElementWrongTypeException(JsonTokenType.StartArray, tokenType);
+                ThrowHelper.ThrowJsonElementWrongTypeException(JsonTokenType.StartArray, tokenType);
             }
 
             return new ArrayEnumerator(this);
@@ -1352,7 +1359,7 @@ namespace System.Text.Json
 
             if (tokenType != JsonTokenType.StartObject)
             {
-                throw ThrowHelper.GetJsonElementWrongTypeException(JsonTokenType.StartObject, tokenType);
+                ThrowHelper.ThrowJsonElementWrongTypeException(JsonTokenType.StartObject, tokenType);
             }
 
             return new ObjectEnumerator(this);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.KeyCollection.cs
@@ -36,9 +36,9 @@ namespace System.Text.Json
                 }
             }
 
-            public void Add(string propertyName) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
+            public void Add(string propertyName) => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
 
-            public void Clear() => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
+            public void Clear() => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
 
             public bool Contains(string propertyName) => _parent.ContainsProperty(propertyName);
 
@@ -68,7 +68,7 @@ namespace System.Text.Json
                 }
             }
 
-            bool ICollection<string>.Remove(string propertyName) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
+            bool ICollection<string>.Remove(string propertyName) => throw ThrowHelper.GetNotSupportedException_NodeCollectionIsReadOnly();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.ValueCollection.cs
@@ -36,9 +36,9 @@ namespace System.Text.Json
                 }
             }
 
-            public void Add(T? jsonNode) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
+            public void Add(T? jsonNode) => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
 
-            public void Clear() => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
+            public void Clear() => ThrowHelper.ThrowNotSupportedException_NodeCollectionIsReadOnly();
 
             public bool Contains(T? jsonNode) => _parent.ContainsValue(jsonNode);
 
@@ -68,7 +68,7 @@ namespace System.Text.Json
                 }
             }
 
-            bool ICollection<T?>.Remove(T? node) => throw ThrowHelper.NotSupportedException_NodeCollectionIsReadOnly();
+            bool ICollection<T?>.Remove(T? node) => throw ThrowHelper.GetNotSupportedException_NodeCollectionIsReadOnly();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderOptions.cs
@@ -31,7 +31,9 @@ namespace System.Text.Json
             {
                 Debug.Assert(value >= 0);
                 if (value > JsonCommentHandling.Allow)
-                    throw ThrowHelper.GetArgumentOutOfRangeException_CommentEnumMustBeInRange(nameof(value));
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_CommentEnumMustBeInRange(nameof(value));
+                }
 
                 _commentHandling = value;
             }
@@ -52,7 +54,9 @@ namespace System.Text.Json
             set
             {
                 if (value < 0)
-                    throw ThrowHelper.GetArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                }
 
                 _maxDepth = value;
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -428,7 +428,6 @@ namespace System.Text.Json
                   && JsonHelpers.IsFinite(value)))
             {
                 ThrowHelper.ThrowFormatException(NumericType.Single);
-                Debug.Assert(false);
             }
 
             return value;
@@ -486,7 +485,6 @@ namespace System.Text.Json
                   && JsonHelpers.IsFinite(value)))
             {
                 ThrowHelper.ThrowFormatException(NumericType.Double);
-                Debug.Assert(false);
             }
 
             return value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json
 
             if (TokenType != JsonTokenType.String && TokenType != JsonTokenType.PropertyName)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedString(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -60,7 +60,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Comment)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedComment(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedComment(TokenType);
             }
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
             return JsonReaderHelper.TranscodeHelper(span);
@@ -76,22 +76,20 @@ namespace System.Text.Json
         /// </exception>
         public bool GetBoolean()
         {
-            ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-
-            if (TokenType == JsonTokenType.True)
+            JsonTokenType type = TokenType;
+            if (type == JsonTokenType.True)
             {
-                Debug.Assert(span.Length == 4);
+                Debug.Assert((HasValueSequence ? ValueSequence.ToArray() : ValueSpan).Length == 4);
                 return true;
             }
-            else if (TokenType == JsonTokenType.False)
+            else if (type != JsonTokenType.False)
             {
-                Debug.Assert(span.Length == 5);
-                return false;
+                ThrowHelper.ThrowInvalidOperationException_ExpectedBoolean(TokenType);
+                Debug.Fail("Throw helper should have thrown an exception.");
             }
-            else
-            {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedBoolean(TokenType);
-            }
+
+            Debug.Assert((HasValueSequence ? ValueSequence.ToArray() : ValueSpan).Length == 5);
+            return false;
         }
 
         /// <summary>
@@ -109,7 +107,7 @@ namespace System.Text.Json
         {
             if (!TryGetBytesFromBase64(out byte[]? value))
             {
-                throw ThrowHelper.GetFormatException(DataType.Base64String);
+                ThrowHelper.ThrowFormatException(DataType.Base64String);
             }
             return value;
         }
@@ -133,7 +131,7 @@ namespace System.Text.Json
         {
             if (!TryGetByte(out byte value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Byte);
+                ThrowHelper.ThrowFormatException(NumericType.Byte);
             }
             return value;
         }
@@ -143,7 +141,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetByteCore(out byte value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Byte);
+                ThrowHelper.ThrowFormatException(NumericType.Byte);
             }
             return value;
         }
@@ -168,7 +166,7 @@ namespace System.Text.Json
         {
             if (!TryGetSByte(out sbyte value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.SByte);
+                ThrowHelper.ThrowFormatException(NumericType.SByte);
             }
             return value;
         }
@@ -178,7 +176,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetSByteCore(out sbyte value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.SByte);
+                ThrowHelper.ThrowFormatException(NumericType.SByte);
             }
             return value;
         }
@@ -202,7 +200,7 @@ namespace System.Text.Json
         {
             if (!TryGetInt16(out short value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Int16);
+                ThrowHelper.ThrowFormatException(NumericType.Int16);
             }
             return value;
         }
@@ -212,7 +210,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetInt16Core(out short value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Int16);
+                ThrowHelper.ThrowFormatException(NumericType.Int16);
             }
             return value;
         }
@@ -236,7 +234,7 @@ namespace System.Text.Json
         {
             if (!TryGetInt32(out int value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Int32);
+                ThrowHelper.ThrowFormatException(NumericType.Int32);
             }
             return value;
         }
@@ -246,7 +244,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetInt32Core(out int value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Int32);
+                ThrowHelper.ThrowFormatException(NumericType.Int32);
             }
             return value;
         }
@@ -270,7 +268,7 @@ namespace System.Text.Json
         {
             if (!TryGetInt64(out long value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Int64);
+                ThrowHelper.ThrowFormatException(NumericType.Int64);
             }
             return value;
         }
@@ -280,7 +278,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetInt64Core(out long value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Int64);
+                ThrowHelper.ThrowFormatException(NumericType.Int64);
             }
             return value;
         }
@@ -305,7 +303,7 @@ namespace System.Text.Json
         {
             if (!TryGetUInt16(out ushort value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.UInt16);
+                ThrowHelper.ThrowFormatException(NumericType.UInt16);
             }
             return value;
         }
@@ -315,7 +313,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetUInt16Core(out ushort value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.UInt16);
+                ThrowHelper.ThrowFormatException(NumericType.UInt16);
             }
             return value;
         }
@@ -340,7 +338,7 @@ namespace System.Text.Json
         {
             if (!TryGetUInt32(out uint value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.UInt32);
+                ThrowHelper.ThrowFormatException(NumericType.UInt32);
             }
             return value;
         }
@@ -350,7 +348,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetUInt32Core(out uint value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.UInt32);
+                ThrowHelper.ThrowFormatException(NumericType.UInt32);
             }
             return value;
         }
@@ -375,7 +373,7 @@ namespace System.Text.Json
         {
             if (!TryGetUInt64(out ulong value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.UInt64);
+                ThrowHelper.ThrowFormatException(NumericType.UInt64);
             }
             return value;
         }
@@ -385,7 +383,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetUInt64Core(out ulong value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.UInt64);
+                ThrowHelper.ThrowFormatException(NumericType.UInt64);
             }
             return value;
         }
@@ -408,7 +406,7 @@ namespace System.Text.Json
         {
             if (!TryGetSingle(out float value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Single);
+                ThrowHelper.ThrowFormatException(NumericType.Single);
             }
             return value;
         }
@@ -422,31 +420,30 @@ namespace System.Text.Json
                 return value;
             }
 
-            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed)
-                && span.Length == bytesConsumed)
+            // NETCOREAPP implementation of the TryParse method above permits case-insensitive variants of the
+            // float constants "NaN", "Infinity", "-Infinity". This differs from the NETFRAMEWORK implementation.
+            // The following logic reconciles the two implementations to enforce consistent behavior.
+            if (!(Utf8Parser.TryParse(span, out value, out int bytesConsumed)
+                  && span.Length == bytesConsumed
+                  && JsonHelpers.IsFinite(value)))
             {
-                // NETCOREAPP implementation of the TryParse method above permits case-insenstive variants of the
-                // float constants "NaN", "Infinity", "-Infinity". This differs from the NETFRAMEWORK implementation.
-                // The following logic reconciles the two implementations to enforce consistent behavior.
-                if (JsonHelpers.IsFinite(value))
-                {
-                    return value;
-                }
+                ThrowHelper.ThrowFormatException(NumericType.Single);
+                Debug.Assert(false);
             }
 
-            throw ThrowHelper.GetFormatException(NumericType.Single);
+            return value;
         }
 
         internal float GetSingleFloatingPointConstant()
         {
             ReadOnlySpan<byte> span = GetUnescapedSpan();
 
-            if (JsonReaderHelper.TryGetFloatingPointConstant(span, out float value))
+            if (!JsonReaderHelper.TryGetFloatingPointConstant(span, out float value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException(NumericType.Single);
             }
 
-            throw ThrowHelper.GetFormatException(NumericType.Single);
+            return value;
         }
 
         /// <summary>
@@ -467,7 +464,7 @@ namespace System.Text.Json
         {
             if (!TryGetDouble(out double value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Double);
+                ThrowHelper.ThrowFormatException(NumericType.Double);
             }
             return value;
         }
@@ -481,31 +478,30 @@ namespace System.Text.Json
                 return value;
             }
 
-            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed)
-                && span.Length == bytesConsumed)
+            // NETCOREAPP implementation of the TryParse method above permits case-insensitive variants of the
+            // float constants "NaN", "Infinity", "-Infinity". This differs from the NETFRAMEWORK implementation.
+            // The following logic reconciles the two implementations to enforce consistent behavior.
+            if (!(Utf8Parser.TryParse(span, out value, out int bytesConsumed)
+                  && span.Length == bytesConsumed
+                  && JsonHelpers.IsFinite(value)))
             {
-                // NETCOREAPP implementation of the TryParse method above permits case-insenstive variants of the
-                // float constants "NaN", "Infinity", "-Infinity". This differs from the NETFRAMEWORK implementation.
-                // The following logic reconciles the two implementations to enforce consistent behavior.
-                if (JsonHelpers.IsFinite(value))
-                {
-                    return value;
-                }
+                ThrowHelper.ThrowFormatException(NumericType.Double);
+                Debug.Assert(false);
             }
 
-            throw ThrowHelper.GetFormatException(NumericType.Double);
+            return value;
         }
 
         internal double GetDoubleFloatingPointConstant()
         {
             ReadOnlySpan<byte> span = GetUnescapedSpan();
 
-            if (JsonReaderHelper.TryGetFloatingPointConstant(span, out double value))
+            if (!JsonReaderHelper.TryGetFloatingPointConstant(span, out double value))
             {
-                return value;
+                ThrowHelper.ThrowFormatException(NumericType.Double);
             }
 
-            throw ThrowHelper.GetFormatException(NumericType.Double);
+            return value;
         }
 
         /// <summary>
@@ -526,7 +522,7 @@ namespace System.Text.Json
         {
             if (!TryGetDecimal(out decimal value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Decimal);
+                ThrowHelper.ThrowFormatException(NumericType.Decimal);
             }
             return value;
         }
@@ -536,7 +532,7 @@ namespace System.Text.Json
             ReadOnlySpan<byte> span = GetUnescapedSpan();
             if (!TryGetDecimalCore(out decimal value, span))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Decimal);
+                ThrowHelper.ThrowFormatException(NumericType.Decimal);
             }
             return value;
         }
@@ -558,7 +554,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTime(out DateTime value))
             {
-                throw ThrowHelper.GetFormatException(DataType.DateTime);
+                ThrowHelper.ThrowFormatException(DataType.DateTime);
             }
 
             return value;
@@ -568,7 +564,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTimeCore(out DateTime value))
             {
-                throw ThrowHelper.GetFormatException(DataType.DateTime);
+                ThrowHelper.ThrowFormatException(DataType.DateTime);
             }
 
             return value;
@@ -591,7 +587,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTimeOffset(out DateTimeOffset value))
             {
-                throw ThrowHelper.GetFormatException(DataType.DateTimeOffset);
+                ThrowHelper.ThrowFormatException(DataType.DateTimeOffset);
             }
 
             return value;
@@ -601,7 +597,7 @@ namespace System.Text.Json
         {
             if (!TryGetDateTimeOffsetCore(out DateTimeOffset value))
             {
-                throw ThrowHelper.GetFormatException(DataType.DateTimeOffset);
+                ThrowHelper.ThrowFormatException(DataType.DateTimeOffset);
             }
 
             return value;
@@ -624,7 +620,7 @@ namespace System.Text.Json
         {
             if (!TryGetGuid(out Guid value))
             {
-                throw ThrowHelper.GetFormatException(DataType.Guid);
+                ThrowHelper.ThrowFormatException(DataType.Guid);
             }
 
             return value;
@@ -634,7 +630,7 @@ namespace System.Text.Json
         {
             if (!TryGetGuidCore(out Guid value))
             {
-                throw ThrowHelper.GetFormatException(DataType.Guid);
+                ThrowHelper.ThrowFormatException(DataType.Guid);
             }
 
             return value;
@@ -654,7 +650,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.String)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedString(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -684,7 +680,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -720,7 +716,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -755,7 +751,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -790,7 +786,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -825,7 +821,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -861,7 +857,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -897,7 +893,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -933,7 +929,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -968,7 +964,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -998,7 +994,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -1028,7 +1024,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.Number)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedNumber(TokenType);
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
@@ -1063,7 +1059,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.String)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedString(TokenType);
             }
 
             return TryGetDateTimeCore(out value);
@@ -1131,7 +1127,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.String)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedString(TokenType);
             }
 
             return TryGetDateTimeOffsetCore(out value);
@@ -1200,7 +1196,7 @@ namespace System.Text.Json
         {
             if (TokenType != JsonTokenType.String)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedString(TokenType);
             }
 
             return TryGetGuidCore(out value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -304,7 +304,7 @@ namespace System.Text.Json
         {
             if (!_isFinalBlock)
             {
-                throw ThrowHelper.GetInvalidOperationException_CannotSkipOnPartial();
+                ThrowHelper.ThrowInvalidOperationException_CannotSkipOnPartial();
             }
 
             SkipHelper();
@@ -429,8 +429,9 @@ namespace System.Text.Json
         {
             if (!IsTokenTypeString(TokenType))
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedStringComparison(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedStringComparison(TokenType);
             }
+
             return TextEqualsHelper(utf8Text);
         }
 
@@ -499,7 +500,7 @@ namespace System.Text.Json
         {
             if (!IsTokenTypeString(TokenType))
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedStringComparison(TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedStringComparison(TokenType);
             }
 
             if (MatchNotPossible(text.Length))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers.Text;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -20,13 +21,13 @@ namespace System.Text.Json.Serialization.Converters
         internal override bool ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             ReadOnlySpan<byte> propertyName = reader.GetSpan();
-            if (Utf8Parser.TryParse(propertyName, out bool value, out int bytesConsumed)
-                && propertyName.Length == bytesConsumed)
+            if (!(Utf8Parser.TryParse(propertyName, out bool value, out int bytesConsumed)
+                  && propertyName.Length == bytesConsumed))
             {
-                return value;
+                ThrowHelper.ThrowFormatException(DataType.Boolean);
             }
 
-            throw ThrowHelper.GetFormatException(DataType.Boolean);
+            return value;
         }
 
         internal override void WriteAsPropertyNameCore(Utf8JsonWriter writer, bool value, JsonSerializerOptions options, bool isWritingExtensionDataProperty)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Converters
             string? str = reader.GetString();
             if (string.IsNullOrEmpty(str) || str.Length > 1)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedChar(reader.TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedChar(reader.TokenType);
             }
             return str[0];
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             if (reader.TokenType != JsonTokenType.String)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(reader.TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedString(reader.TokenType);
             }
 
             bool isEscaped = reader._stringHasEscaping;
@@ -32,7 +32,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 if (!JsonHelpers.IsInRangeInclusive(sequenceLength, MinimumTimeSpanFormatLength, maximumLength))
                 {
-                    throw ThrowHelper.GetFormatException(DataType.TimeSpan);
+                    ThrowHelper.ThrowFormatException(DataType.TimeSpan);
                 }
 
                 Span<byte> stackSpan = stackalloc byte[isEscaped ? MaximumEscapedTimeSpanFormatLength : MaximumTimeSpanFormatLength];
@@ -45,7 +45,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 if (!JsonHelpers.IsInRangeInclusive(source.Length, MinimumTimeSpanFormatLength, maximumLength))
                 {
-                    throw ThrowHelper.GetFormatException(DataType.TimeSpan);
+                    ThrowHelper.ThrowFormatException(DataType.TimeSpan);
                 }
             }
 
@@ -68,7 +68,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 // Note: Utf8Parser.TryParse allows for leading whitespace so we
                 // need to exclude that case here.
-                throw ThrowHelper.GetFormatException(DataType.TimeSpan);
+                ThrowHelper.ThrowFormatException(DataType.TimeSpan);
             }
 
             bool result = Utf8Parser.TryParse(source, out TimeSpan tmpValue, out int bytesConsumed, 'c');
@@ -78,12 +78,12 @@ namespace System.Text.Json.Serialization.Converters
             // "1$$$$$$$$$$". We need to check bytesConsumed to know if the
             // entire source was actually valid.
 
-            if (result && source.Length == bytesConsumed)
+            if (!result || source.Length != bytesConsumed)
             {
-                return tmpValue;
+                ThrowHelper.ThrowFormatException(DataType.TimeSpan);
             }
 
-            throw ThrowHelper.GetFormatException(DataType.TimeSpan);
+            return tmpValue;
         }
 
         public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             if (reader.TokenType != JsonTokenType.String)
             {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(reader.TokenType);
+                ThrowHelper.ThrowInvalidOperationException_ExpectedString(reader.TokenType);
             }
 
 #if BUILDING_INBOX_LIBRARY
@@ -33,7 +33,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 if (!JsonHelpers.IsInRangeInclusive(reader.ValueSequence.Length, MinimumVersionLength, maxLength))
                 {
-                    throw ThrowHelper.GetFormatException(DataType.Version);
+                    ThrowHelper.ThrowFormatException(DataType.Version);
                 }
 
                 Span<byte> stackSpan = stackalloc byte[isEscaped ? MaximumEscapedVersionLength : MaximumVersionLength];
@@ -46,7 +46,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 if (!JsonHelpers.IsInRangeInclusive(source.Length, MinimumVersionLength, maxLength))
                 {
-                    throw ThrowHelper.GetFormatException(DataType.Version);
+                    ThrowHelper.ThrowFormatException(DataType.Version);
                 }
             }
 
@@ -72,7 +72,7 @@ namespace System.Text.Json.Serialization.Converters
                 // we need to make sure that our input doesn't have them,
                 // and if it has - we need to throw, to match behaviour of other converters
                 // since Version.TryParse allows them and silently parses input to Version
-                throw ThrowHelper.GetFormatException(DataType.Version);
+                ThrowHelper.ThrowFormatException(DataType.Version);
             }
 
             Span<char> charBuffer = stackalloc char[MaximumVersionLength];
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Converters
                 // we need to make sure that our input doesn't have them,
                 // and if it has - we need to throw, to match behaviour of other converters
                 // since Version.TryParse allows them and silently parses input to Version
-                throw ThrowHelper.GetFormatException(DataType.Version);
+                ThrowHelper.ThrowFormatException(DataType.Version);
             }
             if (Version.TryParse(versionString, out Version? result))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -433,7 +433,7 @@ namespace System.Text.Json
 
                 if (value < 0)
                 {
-                    throw ThrowHelper.GetArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                    ThrowHelper.ThrowArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
                 }
 
                 _maxDepth = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
@@ -9,56 +9,48 @@ namespace System.Text.Json
     internal static partial class ThrowHelper
     {
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_NodeValueNotAllowed(string paramName)
         {
             throw new ArgumentException(SR.NodeValueNotAllowed, paramName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_NodeArrayTooSmall(string paramName)
         {
             throw new ArgumentException(SR.NodeArrayTooSmall, paramName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentOutOfRangeException_NodeArrayIndexNegative(string paramName)
         {
             throw new ArgumentOutOfRangeException(paramName, SR.NodeArrayIndexNegative);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_DuplicateKey(string propertyName)
         {
             throw new ArgumentException(SR.NodeDuplicateKey, propertyName);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NodeAlreadyHasParent()
         {
             throw new InvalidOperationException(SR.NodeAlreadyHasParent);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NodeCycleDetected()
         {
             throw new InvalidOperationException(SR.NodeCycleDetected);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NodeElementCannotBeObjectOrArray()
         {
             throw new InvalidOperationException(SR.NodeElementCannotBeObjectOrArray);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_NodeCollectionIsReadOnly()
         {
             throw GetNotSupportedException_NodeCollectionIsReadOnly();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Node.cs
@@ -61,10 +61,10 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_NodeCollectionIsReadOnly()
         {
-            throw NotSupportedException_NodeCollectionIsReadOnly();
+            throw GetNotSupportedException_NodeCollectionIsReadOnly();
         }
 
-        public static NotSupportedException NotSupportedException_NodeCollectionIsReadOnly()
+        public static NotSupportedException GetNotSupportedException_NodeCollectionIsReadOnly()
         {
             return new NotSupportedException(SR.NodeCollectionIsReadOnly);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -14,91 +14,78 @@ namespace System.Text.Json
     internal static partial class ThrowHelper
     {
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_DeserializeWrongType(Type type, object value)
         {
             throw new ArgumentException(SR.Format(SR.DeserializeWrongType, type, value.GetType()));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_SerializationNotSupported(Type propertyType)
         {
             throw new NotSupportedException(SR.Format(SR.SerializationNotSupportedType, propertyType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_TypeRequiresAsyncSerialization(Type propertyType)
         {
             throw new NotSupportedException(SR.Format(SR.TypeRequiresAsyncSerialization, propertyType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_ConstructorMaxOf64Parameters(Type type)
         {
             throw new NotSupportedException(SR.Format(SR.ConstructorMaxOf64Parameters, type));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_DictionaryKeyTypeNotSupported(Type keyType, JsonConverter converter)
         {
             throw new NotSupportedException(SR.Format(SR.DictionaryKeyTypeNotSupported, keyType, converter.GetType()));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType)
         {
             throw new JsonException(SR.Format(SR.DeserializeUnableToConvertValue, propertyType)) { AppendPathInformation = true };
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidCastException_DeserializeUnableToAssignValue(Type typeOfValue, Type declaredType)
         {
             throw new InvalidCastException(SR.Format(SR.DeserializeUnableToAssignValue, typeOfValue, declaredType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_DeserializeUnableToAssignNull(Type declaredType)
         {
             throw new InvalidOperationException(SR.Format(SR.DeserializeUnableToAssignNull, declaredType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_SerializationConverterRead(JsonConverter? converter)
         {
             throw new JsonException(SR.Format(SR.SerializationConverterRead, converter)) { AppendPathInformation = true };
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_SerializationConverterWrite(JsonConverter? converter)
         {
             throw new JsonException(SR.Format(SR.SerializationConverterWrite, converter)) { AppendPathInformation = true };
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_SerializerCycleDetected(int maxDepth)
         {
             throw new JsonException(SR.Format(SR.SerializerCycleDetected, maxDepth)) { AppendPathInformation = true };
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException(string? message = null)
         {
             throw new JsonException(message) { AppendPathInformation = true };
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_CannotSerializeInvalidType(Type type, Type? parentClassType, MemberInfo? memberInfo)
         {
             if (parentClassType == null)
@@ -112,14 +99,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializationConverterNotCompatible(Type converterType, Type type)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializationConverterNotCompatible, converterType, type));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializationConverterOnAttributeInvalid(Type classType, MemberInfo? memberInfo)
         {
             string location = classType.ToString();
@@ -132,7 +117,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(Type classTypeAttributeIsOn, MemberInfo? memberInfo, Type typeToConvert)
         {
             string location = classTypeAttributeIsOn.ToString();
@@ -146,7 +130,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializerOptionsImmutable(JsonSerializerContext? context)
         {
             string message = context == null
@@ -157,21 +140,18 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializerPropertyNameConflict(Type type, JsonPropertyInfo jsonPropertyInfo)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNameConflict, type, jsonPropertyInfo.ClrName));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializerPropertyNameNull(Type parentType, JsonPropertyInfo jsonPropertyInfo)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializerPropertyNameNull, parentType, jsonPropertyInfo.MemberInfo?.Name));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NamingPolicyReturnNull(JsonNamingPolicy namingPolicy)
         {
             throw new InvalidOperationException(SR.Format(SR.NamingPolicyReturnNull, namingPolicy));
@@ -190,7 +170,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_MultiplePropertiesBindToConstructorParameters(
             Type parentType,
             string parameterName,
@@ -207,35 +186,30 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ConstructorParameterIncompleteBinding(Type parentType)
         {
             throw new InvalidOperationException(SR.Format(SR.ConstructorParamIncompleteBinding, parentType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ExtensionDataCannotBindToCtorParam(JsonPropertyInfo jsonPropertyInfo)
         {
             throw new InvalidOperationException(SR.Format(SR.ExtensionDataCannotBindToCtorParam, jsonPropertyInfo.ClrName, jsonPropertyInfo.DeclaringType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_JsonIncludeOnNonPublicInvalid(string memberName, Type declaringType)
         {
             throw new InvalidOperationException(SR.Format(SR.JsonIncludeOnNonPublicInvalid, memberName, declaringType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_IgnoreConditionOnValueTypeInvalid(string clrPropertyName, Type propertyDeclaringType)
         {
             throw new InvalidOperationException(SR.Format(SR.IgnoreConditionOnValueTypeInvalid, clrPropertyName, propertyDeclaringType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(JsonPropertyInfo jsonPropertyInfo)
         {
             MemberInfo? memberInfo = jsonPropertyInfo.MemberInfo;
@@ -246,14 +220,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ConverterCanConvertMultipleTypes(Type runtimePropertyType, JsonConverter jsonConverter)
         {
             throw new InvalidOperationException(SR.Format(SR.ConverterCanConvertMultipleTypes, jsonConverter.GetType(), jsonConverter.TypeToConvert, runtimePropertyType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotHonored(
             ReadOnlySpan<byte> propertyName,
             ref Utf8JsonReader reader,
@@ -267,7 +239,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ReThrowWithPath(ref ReadStack state, JsonReaderException ex)
         {
             Debug.Assert(ex.Path == null);
@@ -294,7 +265,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ReThrowWithPath(ref ReadStack state, in Utf8JsonReader reader, Exception ex)
         {
             JsonException jsonException = new JsonException(null, ex);
@@ -338,7 +308,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ReThrowWithPath(ref WriteStack state, Exception ex)
         {
             JsonException jsonException = new JsonException(null, ex);
@@ -369,7 +338,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializationDuplicateAttribute(Type attribute, Type classType, MemberInfo? memberInfo)
         {
             string location = classType.ToString();
@@ -382,21 +350,18 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializationDuplicateTypeAttribute(Type classType, Type attribute)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializationDuplicateTypeAttribute, classType, attribute));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializationDuplicateTypeAttribute<TAttribute>(Type classType)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializationDuplicateTypeAttribute, classType, typeof(TAttribute)));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_SerializationDataExtensionPropertyInvalid(Type type, JsonPropertyInfo jsonPropertyInfo)
         {
             throw new InvalidOperationException(SR.Format(SR.SerializationDataExtensionPropertyInvalid, type, jsonPropertyInfo.MemberInfo?.Name));
@@ -465,7 +430,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_DeserializeNoConstructor(Type type, ref Utf8JsonReader reader, ref ReadStack state)
         {
             string message;
@@ -483,42 +447,36 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_CannotPopulateCollection(Type type, ref Utf8JsonReader reader, ref ReadStack state)
         {
             ThrowNotSupportedException(ref state, reader, new NotSupportedException(SR.Format(SR.CannotPopulateCollection, type)));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataValuesInvalidToken(JsonTokenType tokenType)
         {
             ThrowJsonException(SR.Format(SR.MetadataInvalidTokenAfterValues, tokenType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataReferenceNotFound(string id)
         {
             ThrowJsonException(SR.Format(SR.MetadataReferenceNotFound, id));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataValueWasNotString(JsonTokenType tokenType)
         {
             ThrowJsonException(SR.Format(SR.MetadataValueWasNotString, tokenType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataValueWasNotString(JsonValueKind valueKind)
         {
             ThrowJsonException(SR.Format(SR.MetadataValueWasNotString, valueKind));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties(ReadOnlySpan<byte> propertyName, ref ReadStack state)
         {
             state.Current.JsonPropertyName = propertyName.ToArray();
@@ -526,14 +484,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties()
         {
             ThrowJsonException(SR.MetadataReferenceCannotContainOtherProperties);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataIdIsNotFirstProperty(ReadOnlySpan<byte> propertyName, ref ReadStack state)
         {
             state.Current.JsonPropertyName = propertyName.ToArray();
@@ -541,7 +497,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataMissingIdBeforeValues(ref ReadStack state, ReadOnlySpan<byte> propertyName)
         {
             state.Current.JsonPropertyName = propertyName.ToArray();
@@ -549,7 +504,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataInvalidPropertyWithLeadingDollarSign(ReadOnlySpan<byte> propertyName, ref ReadStack state, in Utf8JsonReader reader)
         {
             // Set PropertyInfo or KeyName to write down the conflicting property name in JsonException.Path
@@ -566,21 +520,18 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataDuplicateIdFound(string id)
         {
             ThrowJsonException(SR.Format(SR.MetadataDuplicateIdFound, id));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataInvalidReferenceToValueType(Type propertyType)
         {
             ThrowJsonException(SR.Format(SR.MetadataInvalidReferenceToValueType, propertyType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataPreservedArrayInvalidProperty(ref ReadStack state, Type propertyType, in Utf8JsonReader reader)
         {
             state.Current.JsonPropertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan.ToArray();
@@ -592,7 +543,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataPreservedArrayValuesNotFound(ref ReadStack state, Type propertyType)
         {
             // Missing $values, JSON path should point to the property's object.
@@ -604,14 +554,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataCannotParsePreservedObjectIntoImmutable(Type propertyType)
         {
             ThrowJsonException(SR.Format(SR.MetadataCannotParsePreservedObjectToImmutable, propertyType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_MetadataReferenceOfTypeCannotBeAssignedToType(string referenceId, Type currentType, Type typeToConvert)
         {
             throw new InvalidOperationException(SR.Format(SR.MetadataReferenceOfTypeCannotBeAssignedToType, referenceId, currentType, typeToConvert));
@@ -644,35 +592,30 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_JsonSerializerOptionsAlreadyBoundToContext()
         {
             throw new InvalidOperationException(SR.Format(SR.OptionsAlreadyBoundToContext));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_BuiltInConvertersNotRooted(Type type)
         {
             throw new NotSupportedException(SR.Format(SR.BuiltInConvertersNotRooted, type));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_NoMetadataForType(Type type)
         {
             throw new NotSupportedException(SR.Format(SR.NoMetadataForType, type));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NoMetadataForType(Type type)
         {
             throw new InvalidOperationException(SR.Format(SR.NoMetadataForType, type));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_MetadatInitFuncsNull()
         {
             throw new InvalidOperationException(SR.Format(SR.MetadataInitFuncsNull));
@@ -694,7 +637,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowMissingMemberException_MissingFSharpCoreMember(string missingFsharpCoreMember)
         {
             throw new MissingMemberException(SR.Format(SR.MissingFSharpCoreMember, missingFsharpCoreMember));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -12,9 +12,11 @@ namespace System.Text.Json
         // If the exception source is this value, the serializer will re-throw as JsonException.
         public const string ExceptionSourceValueToRethrowAsJsonException = "System.Text.Json.Rethrowable";
 
-        public static ArgumentOutOfRangeException GetArgumentOutOfRangeException_MaxDepthMustBePositive(string parameterName)
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentOutOfRangeException_MaxDepthMustBePositive(string parameterName)
         {
-            return GetArgumentOutOfRangeException(parameterName, SR.MaxDepthMustBePositive);
+            throw GetArgumentOutOfRangeException(parameterName, SR.MaxDepthMustBePositive);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -23,9 +25,11 @@ namespace System.Text.Json
             return new ArgumentOutOfRangeException(parameterName, message);
         }
 
-        public static ArgumentOutOfRangeException GetArgumentOutOfRangeException_CommentEnumMustBeInRange(string parameterName)
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowArgumentOutOfRangeException_CommentEnumMustBeInRange(string parameterName)
         {
-            return GetArgumentOutOfRangeException(parameterName, SR.CommentHandlingMustBeValid);
+            throw GetArgumentOutOfRangeException(parameterName, SR.CommentHandlingMustBeValid);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -35,6 +39,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(string message)
         {
             throw GetArgumentException(message);
@@ -46,30 +51,35 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_PropertyNameTooLarge(int tokenLength)
         {
             throw GetArgumentException(SR.Format(SR.PropertyNameTooLarge, tokenLength));
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_ValueTooLarge(int tokenLength)
         {
             throw GetArgumentException(SR.Format(SR.ValueTooLarge, tokenLength));
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_ValueNotSupported()
         {
             throw GetArgumentException(SR.SpecialNumberValuesNotSupported);
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NeedLargerSpan()
         {
             throw GetInvalidOperationException(SR.FailedToGetLargerSpan);
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<byte> propertyName, ReadOnlySpan<byte> value)
         {
             if (propertyName.Length > JsonConstants.MaxUnescapedTokenSize)
@@ -84,6 +94,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<byte> propertyName, ReadOnlySpan<char> value)
         {
             if (propertyName.Length > JsonConstants.MaxUnescapedTokenSize)
@@ -98,6 +109,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> value)
         {
             if (propertyName.Length > JsonConstants.MaxCharacterTokenSize)
@@ -112,6 +124,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> value)
         {
             if (propertyName.Length > JsonConstants.MaxCharacterTokenSize)
@@ -149,6 +162,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException(string message)
         {
             throw GetInvalidOperationException(message);
@@ -163,6 +177,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_DepthNonZeroOrEmptyJson(int currentDepth)
         {
             throw GetInvalidOperationException(currentDepth);
@@ -207,35 +222,46 @@ namespace System.Text.Json
             return GetInvalidOperationException("object", tokenType);
         }
 
-        public static InvalidOperationException GetInvalidOperationException_ExpectedNumber(JsonTokenType tokenType)
-        {
-            return GetInvalidOperationException("number", tokenType);
-        }
-
-        public static InvalidOperationException GetInvalidOperationException_ExpectedBoolean(JsonTokenType tokenType)
-        {
-            return GetInvalidOperationException("boolean", tokenType);
-        }
-
-        public static InvalidOperationException GetInvalidOperationException_ExpectedString(JsonTokenType tokenType)
-        {
-            return GetInvalidOperationException("string", tokenType);
-        }
-
-        public static InvalidOperationException GetInvalidOperationException_ExpectedStringComparison(JsonTokenType tokenType)
-        {
-            return GetInvalidOperationException(tokenType);
-        }
-
-        public static InvalidOperationException GetInvalidOperationException_ExpectedComment(JsonTokenType tokenType)
-        {
-            return GetInvalidOperationException("comment", tokenType);
-        }
-
+        [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static InvalidOperationException GetInvalidOperationException_CannotSkipOnPartial()
+        public static void ThrowInvalidOperationException_ExpectedNumber(JsonTokenType tokenType)
         {
-            return GetInvalidOperationException(SR.CannotSkip);
+            throw GetInvalidOperationException("number", tokenType);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_ExpectedBoolean(JsonTokenType tokenType)
+        {
+            throw GetInvalidOperationException("boolean", tokenType);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_ExpectedString(JsonTokenType tokenType)
+        {
+            throw GetInvalidOperationException("string", tokenType);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_ExpectedStringComparison(JsonTokenType tokenType)
+        {
+            throw GetInvalidOperationException(tokenType);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_ExpectedComment(JsonTokenType tokenType)
+        {
+            throw GetInvalidOperationException("comment", tokenType);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_CannotSkipOnPartial()
+        {
+            throw GetInvalidOperationException(SR.CannotSkip);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -250,20 +276,13 @@ namespace System.Text.Json
             return GetInvalidOperationException(SR.Format(SR.InvalidComparison, tokenType));
         }
 
+        [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static InvalidOperationException GetJsonElementWrongTypeException(
+        internal static void ThrowJsonElementWrongTypeException(
             JsonTokenType expectedType,
             JsonTokenType actualType)
         {
-            return GetJsonElementWrongTypeException(expectedType.ToValueKind(), actualType.ToValueKind());
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static InvalidOperationException GetJsonElementWrongTypeException(
-            string expectedTypeName,
-            JsonTokenType actualType)
-        {
-            return GetJsonElementWrongTypeException(expectedTypeName, actualType.ToValueKind());
+            throw GetJsonElementWrongTypeException(expectedType.ToValueKind(), actualType.ToValueKind());
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -285,6 +304,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonReaderException(ref Utf8JsonReader json, ExceptionResource resource, byte nextByte = default, ReadOnlySpan<byte> bytes = default)
         {
             throw GetJsonReaderException(ref json, resource, nextByte, bytes);
@@ -439,12 +459,14 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_InvalidCommentValue()
         {
             throw new ArgumentException(SR.CannotWriteCommentWithEmbeddedDelimiter);
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_InvalidUTF8(ReadOnlySpan<byte> value)
         {
             var builder = new StringBuilder();
@@ -473,18 +495,21 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_InvalidUTF16(int charAsInt)
         {
             throw new ArgumentException(SR.Format(SR.CannotEncodeInvalidUTF16, $"0x{charAsInt:X2}"));
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ReadInvalidUTF16(int charAsInt)
         {
             throw GetInvalidOperationException(SR.Format(SR.CannotReadInvalidUTF16, $"0x{charAsInt:X2}"));
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ReadInvalidUTF16()
         {
             throw GetInvalidOperationException(SR.CannotReadIncompleteUTF16);
@@ -517,6 +542,7 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowOutOfMemoryException(uint capacity)
         {
             throw new OutOfMemoryException(SR.Format(SR.BufferMaximumSizeExceeded, capacity));
@@ -563,15 +589,15 @@ namespace System.Text.Json
             return message;
         }
 
-        public static FormatException GetFormatException()
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowFormatException()
         {
-            var ex = new FormatException();
-            ex.Source = ExceptionSourceValueToRethrowAsJsonException;
-            return ex;
+            throw new FormatException { Source = ExceptionSourceValueToRethrowAsJsonException };
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static FormatException GetFormatException(NumericType numericType)
+        public static void ThrowFormatException(NumericType numericType)
         {
             string message = "";
 
@@ -615,13 +641,12 @@ namespace System.Text.Json
                     break;
             }
 
-            var ex = new FormatException(message);
-            ex.Source = ExceptionSourceValueToRethrowAsJsonException;
-            return ex;
+            throw new FormatException(message) { Source = ExceptionSourceValueToRethrowAsJsonException };
         }
 
+        [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static FormatException GetFormatException(DataType dateType)
+        public static void ThrowFormatException(DataType dateType)
         {
             string message = "";
 
@@ -653,14 +678,14 @@ namespace System.Text.Json
                     break;
             }
 
-            var ex = new FormatException(message);
-            ex.Source = ExceptionSourceValueToRethrowAsJsonException;
-            return ex;
+            throw new FormatException(message) { Source = ExceptionSourceValueToRethrowAsJsonException };
         }
 
-        public static InvalidOperationException GetInvalidOperationException_ExpectedChar(JsonTokenType tokenType)
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_ExpectedChar(JsonTokenType tokenType)
         {
-            return GetInvalidOperationException("char", tokenType);
+            throw GetInvalidOperationException("char", tokenType);
         }
     }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -13,33 +13,28 @@ namespace System.Text.Json
         public const string ExceptionSourceValueToRethrowAsJsonException = "System.Text.Json.Rethrowable";
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentOutOfRangeException_MaxDepthMustBePositive(string parameterName)
         {
             throw GetArgumentOutOfRangeException(parameterName, SR.MaxDepthMustBePositive);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(string parameterName, string message)
         {
             return new ArgumentOutOfRangeException(parameterName, message);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentOutOfRangeException_CommentEnumMustBeInRange(string parameterName)
         {
             throw GetArgumentOutOfRangeException(parameterName, SR.CommentHandlingMustBeValid);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArgumentException GetArgumentException(string message)
         {
             return new ArgumentException(message);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(string message)
         {
             throw GetArgumentException(message);
@@ -51,35 +46,30 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_PropertyNameTooLarge(int tokenLength)
         {
             throw GetArgumentException(SR.Format(SR.PropertyNameTooLarge, tokenLength));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_ValueTooLarge(int tokenLength)
         {
             throw GetArgumentException(SR.Format(SR.ValueTooLarge, tokenLength));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_ValueNotSupported()
         {
             throw GetArgumentException(SR.SpecialNumberValuesNotSupported);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_NeedLargerSpan()
         {
             throw GetInvalidOperationException(SR.FailedToGetLargerSpan);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<byte> propertyName, ReadOnlySpan<byte> value)
         {
             if (propertyName.Length > JsonConstants.MaxUnescapedTokenSize)
@@ -94,7 +84,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<byte> propertyName, ReadOnlySpan<char> value)
         {
             if (propertyName.Length > JsonConstants.MaxUnescapedTokenSize)
@@ -109,7 +98,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> value)
         {
             if (propertyName.Length > JsonConstants.MaxCharacterTokenSize)
@@ -124,7 +112,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> value)
         {
             if (propertyName.Length > JsonConstants.MaxCharacterTokenSize)
@@ -162,28 +149,22 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException(string message)
         {
             throw GetInvalidOperationException(message);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static InvalidOperationException GetInvalidOperationException(string message)
         {
-            var ex = new InvalidOperationException(message);
-            ex.Source = ExceptionSourceValueToRethrowAsJsonException;
-            return ex;
+            return new InvalidOperationException(message) { Source = ExceptionSourceValueToRethrowAsJsonException };
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_DepthNonZeroOrEmptyJson(int currentDepth)
         {
             throw GetInvalidOperationException(currentDepth);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static InvalidOperationException GetInvalidOperationException(int currentDepth)
         {
             currentDepth &= JsonConstants.RemoveFlagsBitMask;
@@ -223,61 +204,52 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ExpectedNumber(JsonTokenType tokenType)
         {
             throw GetInvalidOperationException("number", tokenType);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ExpectedBoolean(JsonTokenType tokenType)
         {
             throw GetInvalidOperationException("boolean", tokenType);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ExpectedString(JsonTokenType tokenType)
         {
             throw GetInvalidOperationException("string", tokenType);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ExpectedStringComparison(JsonTokenType tokenType)
         {
             throw GetInvalidOperationException(tokenType);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ExpectedComment(JsonTokenType tokenType)
         {
             throw GetInvalidOperationException("comment", tokenType);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_CannotSkipOnPartial()
         {
             throw GetInvalidOperationException(SR.CannotSkip);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static InvalidOperationException GetInvalidOperationException(string message, JsonTokenType tokenType)
         {
             return GetInvalidOperationException(SR.Format(SR.InvalidCast, tokenType, message));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static InvalidOperationException GetInvalidOperationException(JsonTokenType tokenType)
         {
             return GetInvalidOperationException(SR.Format(SR.InvalidComparison, tokenType));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void ThrowJsonElementWrongTypeException(
             JsonTokenType expectedType,
             JsonTokenType actualType)
@@ -285,7 +257,6 @@ namespace System.Text.Json
             throw GetJsonElementWrongTypeException(expectedType.ToValueKind(), actualType.ToValueKind());
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static InvalidOperationException GetJsonElementWrongTypeException(
             JsonValueKind expectedType,
             JsonValueKind actualType)
@@ -294,7 +265,6 @@ namespace System.Text.Json
                 SR.Format(SR.JsonElementHasWrongType, expectedType, actualType));
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static InvalidOperationException GetJsonElementWrongTypeException(
             string expectedTypeName,
             JsonValueKind actualType)
@@ -304,7 +274,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonReaderException(ref Utf8JsonReader json, ExceptionResource resource, byte nextByte = default, ReadOnlySpan<byte> bytes = default)
         {
             throw GetJsonReaderException(ref json, resource, nextByte, bytes);
@@ -459,14 +428,12 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_InvalidCommentValue()
         {
             throw new ArgumentException(SR.CannotWriteCommentWithEmbeddedDelimiter);
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_InvalidUTF8(ReadOnlySpan<byte> value)
         {
             var builder = new StringBuilder();
@@ -495,21 +462,18 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowArgumentException_InvalidUTF16(int charAsInt)
         {
             throw new ArgumentException(SR.Format(SR.CannotEncodeInvalidUTF16, $"0x{charAsInt:X2}"));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ReadInvalidUTF16(int charAsInt)
         {
             throw GetInvalidOperationException(SR.Format(SR.CannotReadInvalidUTF16, $"0x{charAsInt:X2}"));
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ReadInvalidUTF16()
         {
             throw GetInvalidOperationException(SR.CannotReadIncompleteUTF16);
@@ -542,7 +506,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowOutOfMemoryException(uint capacity)
         {
             throw new OutOfMemoryException(SR.Format(SR.BufferMaximumSizeExceeded, capacity));
@@ -590,13 +553,11 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowFormatException()
         {
             throw new FormatException { Source = ExceptionSourceValueToRethrowAsJsonException };
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowFormatException(NumericType numericType)
         {
             string message = "";
@@ -645,7 +606,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowFormatException(DataType dateType)
         {
             string message = "";
@@ -682,7 +642,6 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_ExpectedChar(JsonTokenType tokenType)
         {
             throw GetInvalidOperationException("char", tokenType);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterOptions.cs
@@ -58,7 +58,9 @@ namespace System.Text.Json
             set
             {
                 if (value < 0)
-                    throw ThrowHelper.GetArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                }
 
                 _maxDepth = value;
             }


### PR DESCRIPTION
Replaces a number of occurrences of `throw ThrowHelper.GetException();` statements found in System.Text.Json with `ThrowHelper.ThrowException();` method calls. 

While .NET 6 codegen around exception throwing appears to have improved, I'm still seeing modest performance improvements in microbenchmarks, particularly around the `Utf8JsonReader.Get*()` methods, which are relatively small methods that inline `throw` statements.

Fix #59378.