### PR TITLE
Fix the only ilproj test that uses multiple command-line variants

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/GitHub_26491/GitHub_26491.il
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_26491/GitHub_26491.il
@@ -20,6 +20,10 @@
 //      During the merge gtNewTempAssign does not expect the source value of TYP_SIMD16
 //      and the destination value of TYP_STRUCT.
 
+.assembly extern System.Console
+{
+}
+
 .assembly extern System.Runtime
 {
 }
@@ -96,37 +100,68 @@
     IL_0009:  ret
   }
 
-  .method public hidebysig static int32 Main(string[] args) cil managed
+  .method public hidebysig static int32 MultipleReturns() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
-    .entrypoint
-    .maxstack  8
-    IL_0000:  ldarg.0
-    IL_0001:  ldstr      "MultipleReturns"
-    IL_0006:  call       int32 [System.Runtime]System.Array::IndexOf<string>(!!0[], !!0)
-    IL_000b:  ldc.i4.m1
-    IL_000c:  beq.s      IL_001b
-
     IL_000e:  ldc.i4     0x677b
     IL_0013:  call       valuetype GitHub_26491/ReturnType GitHub_26491::MultipleReturns(int32)
     IL_0018:  pop
-    IL_0019:  br.s       IL_0037
+    IL_0037:  ldc.i4.s   100
+    IL_0039:  ret
+  }
 
-    IL_001b:  ldarg.0
-    IL_001c:  ldstr      "SingleReturnSynchronized"
-    IL_0021:  call       int32 [System.Runtime]System.Array::IndexOf<string>(!!0[], !!0)
-    IL_0026:  ldc.i4.m1
-    IL_0027:  beq.s      IL_0031
-
+  .method public hidebysig static int32 SingleReturnSynchronized() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
     IL_0029:  call       valuetype GitHub_26491/ReturnType GitHub_26491::SingleReturnSynchronized()
     IL_002e:  pop
-    IL_002f:  br.s       IL_0037
+    IL_0037:  ldc.i4.s   100
+    IL_0039:  ret
+  }
 
+  .method public hidebysig static int32 SingleReturn() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
     IL_0031:  call       valuetype GitHub_26491/ReturnType GitHub_26491::SingleReturn()
     IL_0036:  pop
     IL_0037:  ldc.i4.s   100
     IL_0039:  ret
+  }
+
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .entrypoint
+    .maxstack  8
+
+    ldstr "MultipleReturns"
+    call void [System.Console]System.Console::WriteLine(string)
+    call int32 GitHub_26491::MultipleReturns()
+    ldc.i4 100
+    bne.un FAIL
+
+    ldstr "SingleReturnSynchronized"
+    call void [System.Console]System.Console::WriteLine(string)
+    call int32 GitHub_26491::SingleReturnSynchronized()
+    ldc.i4 100
+    bne.un FAIL
+
+    ldstr "SingleReturn"
+    call void [System.Console]System.Console::WriteLine(string)
+    call int32 GitHub_26491::SingleReturn()
+    ldc.i4 100
+    bne.un FAIL
+
+    ldc.i4 100
+    ret
+
+  FAIL:
+    ldc.i4 101
+    ret
   }
 }

--- a/src/tests/JIT/Regression/JitBlue/GitHub_26491/GitHub_26491.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_26491/GitHub_26491.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestExecutionArguments>MultipleReturns</CLRTestExecutionArguments>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GitHub_26491.il" />

--- a/src/tests/JIT/Regression/JitBlue/GitHub_26491/GitHub_26491_SingleReturnSynchronized.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_26491/GitHub_26491_SingleReturnSynchronized.ilproj
@@ -1,9 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestProjectToRun>GitHub_26491_MultipleReturns.ilproj</CLRTestProjectToRun>
-    <CLRTestExecutionArguments>SingleReturnSynchronized</CLRTestExecutionArguments>
-    <!-- Generated shell script has no corresponding assembly -->
-    <CLRTestTargetUnsupported Condition="'$(TargetOS)' == 'Android'">true</CLRTestTargetUnsupported>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
I believe that despite its singular nature this is worth a separate
review to make sure we're in agreement regarding the conversion
principles. There are several things worth noting here:

1) According to the current plan we're continuously documenting in
https://github.com/dotnet/runtime/issues/54512 we want to remove
command-line parameters from all test entrypoints. Variant tests
driven by command-line parameters should be turned into multiple
test cases marked with separate [Fact] attributes.

2) For ilproj tests, to facilitate local debugging, our current plan
is to keep them runnable as standalone executables. This implies that
ilproj tests comprising several [Fact] test entrypoints require a
new entrypoint that just calls into the individual test cases.

3) The Roslyn-generated merged wrapper for the tests won't care about
the "composite" main (that is for local debugging only), it will
directly identify and use the individual test cases marked with
[Fact] attributes.

4) In accordance with this scheme, such composite ILPROJ tests are
specific in not having their entrypoint method itself marked with
the [Fact] attribute.

5) Funnily enough this example nicely demonstrates the implied
cleanup - the entire command-line machinery is only used for a
handwritten switch to choose one of the three variants; moreover
we only exercised two out of the three variants, possibly due to
an authoring bug when creating the variant test, potentially caused
by previous complexity of such endeavor.

Thanks

Tomas