### PR TITLE
Fix MemoryPool<byte>.Shared.MaxBufferSize seems incorrect

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ArrayMemoryPool.cs
@@ -7,15 +7,13 @@ namespace System.Buffers
 {
     internal sealed partial class ArrayMemoryPool<T> : MemoryPool<T>
     {
-        private const int MaximumBufferSize = int.MaxValue;
-
-        public sealed override int MaxBufferSize => MaximumBufferSize;
+        public sealed override int MaxBufferSize => Array.MaxLength;
 
         public sealed override IMemoryOwner<T> Rent(int minimumBufferSize = -1)
         {
             if (minimumBufferSize == -1)
                 minimumBufferSize = 1 + (4095 / Unsafe.SizeOf<T>());
-            else if (((uint)minimumBufferSize) > MaximumBufferSize)
+            else if (((uint)minimumBufferSize) > Array.MaxLength)
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumBufferSize);
 
             return new ArrayMemoryPoolBuffer(minimumBufferSize);


### PR DESCRIPTION
`ArrayMemoryPool.MaxBufferSize`'s value was changed to `Array.MaxLength`.

Fixes #61560