### PR TITLE
Fix a few special cases of projects with command line arguments

### DIFF
--- a/src/tests/Loader/regressions/polyrec/Polyrec.csproj
+++ b/src/tests/Loader/regressions/polyrec/Polyrec.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestExecutionArguments>4 50</CLRTestExecutionArguments>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- This test leaves threads running at exit -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Loader/regressions/polyrec/Polyrec.csproj
+++ b/src/tests/Loader/regressions/polyrec/Polyrec.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- This test leaves threads running at exit -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/tests/Loader/regressions/polyrec/polyrec.cs
+++ b/src/tests/Loader/regressions/polyrec/polyrec.cs
@@ -63,24 +63,24 @@ public class P
     genmeth2<string>(ninsts);
   }
 
-  public static int Main(String[] args)
+  public static int Test(int threads, int insts)
   {
-    if (args.Length < 2)
-    {
-      Console.WriteLine("Usage: polyrec <nthreads> <ninsts>");
-      return 99;
-    }
-
-    nthreads = Int32.Parse(args[0]);
-    ninsts = Int32.Parse(args[1]);
+    nthreads = threads;
+    ninsts = insts;
 
     for (int i = 0; i < nthreads; i++)
-    {	
+    {
       Thread t = new Thread(i % 2 == 0 ? new ThreadStart(Start) : new ThreadStart(Start2));
       t.Name = "Thread " + i;	
       t.Start();
     }
-      Console.WriteLine("Main thread exited");
+    
+    Console.WriteLine("Main thread exited");
     return 100;
+  }
+  
+  public static int Main()
+  {
+    return Test(4, 50);
   }
 }

--- a/src/tests/Loader/regressions/polyrec/polyrec.cs
+++ b/src/tests/Loader/regressions/polyrec/polyrec.cs
@@ -8,6 +8,7 @@
 // and niters it the number of type/method instantiations to create each thread
 using System;
 using System.Threading;
+using Xunit;
 
 // Spice things up a bit with some mutual recursion between instantiations
 class C<T>
@@ -63,7 +64,7 @@ public class P
     genmeth2<string>(ninsts);
   }
 
-  public static int Test(int threads, int insts)
+  public static void Test(int threads, int insts)
   {
     nthreads = threads;
     ninsts = insts;
@@ -74,13 +75,13 @@ public class P
       t.Name = "Thread " + i;	
       t.Start();
     }
-    
+
     Console.WriteLine("Main thread exited");
-    return 100;
   }
-  
-  public static int Main()
+
+  [Fact]
+  public static void Test_4_50()
   {
-    return Test(4, 50);
+    Test(4, 50);
   }
 }

--- a/src/tests/baseservices/exceptions/sharedexceptions/emptystacktrace/OOMException01.csproj
+++ b/src/tests/baseservices/exceptions/sharedexceptions/emptystacktrace/OOMException01.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestExecutionArguments>-trustedexe</CLRTestExecutionArguments>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="oomexception01.cs" />

--- a/src/tests/baseservices/threading/regressions/beta1/347011.csproj
+++ b/src/tests/baseservices/threading/regressions/beta1/347011.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
-    <CLRTestExecutionArguments>240</CLRTestExecutionArguments>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="347011.cs" />


### PR DESCRIPTION
This tackles the few special cases where command-line arguments are either ignored or used to run the test with a specific set of arguments; in the latter case I reworked the entry point to accept the parameters in its signature. This change doesn't address those cases where we run the same csproj test multiple times with different command-line combinations; that will require further design discussion with the GC team that owns most of the tests in this category.

Thanks

Tomas

Contributes to: https://github.com/dotnet/runtime/issues/54512