### PR TITLE
Default BuildTargetFramework to NetCoreAppCurrent for GenerateReferenceAssemblySource

### DIFF
--- a/eng/outerBuild.targets
+++ b/eng/outerBuild.targets
@@ -1,5 +1,11 @@
 <Project>
-  <Target Name="GenerateReferenceAssemblySource" DependsOnTargets="GetProjectWithBestTargetFrameworks">
+  <Target Name="SetBuildTargetFramework">
+    <PropertyGroup>
+      <BuildTargetFramework Condition="'$(BuildTargetFramework)' == ''">$(NetCoreAppCurrent)</BuildTargetFramework>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="GenerateReferenceAssemblySource" DependsOnTargets="SetBuildTargetFramework;GetProjectWithBestTargetFrameworks">
     <MSBuild Projects="@(InnerBuildProjectsWithBestTargetFramework)"
              Targets="GenerateReferenceAssemblySource"
              BuildInParallel="$(BuildInParallel)">


### PR DESCRIPTION
Currently we would run GenerateReferenceAssembly source for all tfms, leading to an ordering issue as the last tfm that is run for wins and that's not essentially what we want. Let's default the BuildTargetFramework on the outer target to netcoreappcurrent so that we by default generate the ref for that, and if someone wants another tfm, they can specify their `BuildTargetFramework`.

cc: @BrennanConroy 