### PR TITLE
Reduce allocations for CreateDirectory

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
@@ -14,9 +14,8 @@ internal static partial class Interop
 
         internal static int MkDir(ReadOnlySpan<char> path, int mode)
         {
-            var converter = new ValueUtf8Converter(stackalloc byte[DefaultPathBufferSize]);
+            using ValueUtf8Converter converter = new(stackalloc byte[DefaultPathBufferSize]);
             int result = MkDir(ref MemoryMarshal.GetReference(converter.ConvertAndTerminateString(path)), mode);
-            converter.Dispose();
             return result;
         }
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
@@ -3,12 +3,21 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MkDir", CharSet = CharSet.Ansi, SetLastError = true)]
-        internal static partial int MkDir(string path, int mode);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MkDir", SetLastError = true)]
+        private static partial int MkDir(ref byte path, int mode);
+
+        internal static int MkDir(ReadOnlySpan<char> path, int mode)
+        {
+            var converter = new ValueUtf8Converter(stackalloc byte[DefaultPathBufferSize]);
+            int result = MkDir(ref MemoryMarshal.GetReference(converter.ConvertAndTerminateString(path)), mode);
+            converter.Dispose();
+            return result;
+        }
     }
 }

--- a/src/libraries/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/libraries/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -137,8 +137,6 @@
              Link="Common\Interop\Unix\Interop.GetHostName.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPeerUserName.cs"
              Link="Common\Interop\Unix\Interop.GetPeerUserName.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MkDir.cs"
-             Link="Common\Interop\Unix\Interop.MkDir.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Open.cs"
              Link="Common\Interop\Unix\Interop.Open.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.OpenFlags.cs"
@@ -166,7 +164,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj" />  
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -434,23 +434,6 @@ namespace System.IO.Pipes
             return LazyInitializer.EnsureInitialized(ref _asyncActiveSemaphore, () => new SemaphoreSlim(1, 1));
         }
 
-        private static void CreateDirectory(string directoryPath)
-        {
-            int result = Interop.Sys.MkDir(directoryPath, (int)Interop.Sys.Permissions.Mask);
-
-            // If successful created, we're done.
-            if (result >= 0)
-                return;
-
-            // If the directory already exists, consider it a success.
-            Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
-            if (errorInfo.Error == Interop.Error.EEXIST)
-                return;
-
-            // Otherwise, fail.
-            throw Interop.GetExceptionForIoErrno(errorInfo, directoryPath, isDirectory: true);
-        }
-
         /// <summary>Creates an anonymous pipe.</summary>
         /// <param name="reader">The resulting reader end of the pipe.</param>
         /// <param name="writer">The resulting writer end of the pipe.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -305,7 +305,7 @@ namespace System.IO
                 ValueListBuilder<int> stackDir = new(stackalloc int[32]); // 32 arbitrarily chosen
                 try
                 {
-                    CreateParentsAndDirectory(fullPath, stackDir);
+                    CreateParentsAndDirectory(fullPath, ref stackDir);
                 }
                 finally
                 {
@@ -318,7 +318,7 @@ namespace System.IO
             }
         }
 
-        private static void CreateParentsAndDirectory(string fullPath, ValueListBuilder<int> stackDir)
+        private static void CreateParentsAndDirectory(string fullPath, ref ValueListBuilder<int> stackDir)
         {
             stackDir.Append(fullPath.Length);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -300,17 +300,7 @@ namespace System.IO
             }
             else if (errorInfo.Error == Interop.Error.ENOENT) // Some parts of the path don't exist yet.
             {
-                // Try create parents bottom to top and track those that could not
-                // be created due to missing parents. Then create them top to bottom.
-                ValueListBuilder<int> stackDir = new(stackalloc int[32]); // 32 arbitrarily chosen
-                try
-                {
-                    CreateParentsAndDirectory(fullPath, ref stackDir);
-                }
-                finally
-                {
-                    stackDir.Dispose();
-                }
+                CreateParentsAndDirectory(fullPath);
             }
             else
             {
@@ -318,8 +308,11 @@ namespace System.IO
             }
         }
 
-        private static void CreateParentsAndDirectory(string fullPath, ref ValueListBuilder<int> stackDir)
+        private static void CreateParentsAndDirectory(string fullPath)
         {
+            // Try create parents bottom to top and track those that could not
+            // be created due to missing parents. Then create them top to bottom.
+            using ValueListBuilder<int> stackDir = new(stackalloc int[32]); // 32 arbitrarily chosen
             stackDir.Append(fullPath.Length);
 
             int i = fullPath.Length - 1;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -318,16 +318,16 @@ namespace System.IO
             }
         }
 
-        public static void CreateParentsAndDirectory(string fullPath, ValueListBuilder<int> stackDir)
+        private static void CreateParentsAndDirectory(string fullPath, ValueListBuilder<int> stackDir)
         {
             stackDir.Append(fullPath.Length);
 
             int i = fullPath.Length - 1;
-            // Trim trailing separator.
             if (PathInternal.IsDirectorySeparator(fullPath[i]))
             {
-                i--;
+                i--; // Trim trailing separator.
             }
+
             do
             {
                 // Find the end of the parent directory.
@@ -337,13 +337,11 @@ namespace System.IO
                     i--;
                 }
 
-                // Try create it.
                 ReadOnlySpan<char> mkdirPath = fullPath.AsSpan(0, i);
                 int result = Interop.Sys.MkDir(mkdirPath, (int)Interop.Sys.Permissions.Mask);
                 if (result == 0)
                 {
-                    // Created parent.
-                    break;
+                    break; // Created parent.
                 }
 
                 Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();


### PR DESCRIPTION
I wanted to see what would it take to have a sys-call that accepts a `ROS<char>` instead of `string` and after that I've discovered the existence of `ValueListBuilder<int>` which allowed me to get rid of `List<int>` allocation.

```ini
BenchmarkDotNet=v0.13.1.1616-nightly, OS=ubuntu 18.04
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=7.0.100-alpha.1.21566.20
```
|                         Method |       Toolchain | depth |       Mean | Ratio | Allocated |
|------------------------------- |---------------- |------ |-----------:|------:|----------:|
| RecursiveCreateDeleteDirectory | /before/corerun |    10 |   314.9 us |  1.00 |      8 KB |
| RecursiveCreateDeleteDirectory |  /after/corerun |    10 |   296.1 us |  0.95 |      7 KB |
|                                |                 |       |            |       |           |
| RecursiveCreateDeleteDirectory | /before/corerun |   100 | 3,565.2 us |  1.00 |    140 KB |
| RecursiveCreateDeleteDirectory |  /after/corerun |   100 | 3,559.1 us |  1.00 |    113 KB |