### PR TITLE
Let argument check run before aborting check.

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
@@ -31,8 +31,8 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpDigestCurrent")]
         internal static partial int EvpDigestCurrent(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
 
-        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpDigestOneShot")]
-        internal static unsafe partial int EvpDigestOneShot(IntPtr type, byte* source, int sourceSize, byte* md, uint* mdSize);
+        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpDigestOneShot")]
+        internal static unsafe extern int EvpDigestOneShot(IntPtr type, byte* source, int sourceSize, byte* md, uint* mdSize);
 
         [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_EvpMdSize")]
         internal static partial int EvpMdSize(IntPtr md);

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Hmac.cs
@@ -22,8 +22,8 @@ internal static partial class Interop
         internal static int HmacUpdate(SafeHmacCtxHandle ctx, ReadOnlySpan<byte> data, int len) =>
             HmacUpdate(ctx, ref MemoryMarshal.GetReference(data), len);
 
-        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
-        private static partial int HmacUpdate(SafeHmacCtxHandle ctx, ref byte data, int len);
+        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
+        private static extern int HmacUpdate(SafeHmacCtxHandle ctx, ref byte data, int len);
 
         [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
         internal static partial int HmacFinal(SafeHmacCtxHandle ctx, ref byte data, ref int len);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
@@ -50,10 +50,10 @@ static jobject GetMessageDigestInstance(JNIEnv* env, intptr_t type)
 
 int32_t CryptoNative_EvpDigestOneShot(intptr_t type, void* source, int32_t sourceSize, uint8_t* md, uint32_t* mdSize)
 {
-    abort_if_invalid_pointer_argument (source);
-
     if (!type || !md || !mdSize || sourceSize < 0)
         return FAIL;
+
+    abort_if_invalid_pointer_argument (source);
 
     JNIEnv* env = GetJNIEnv();
 


### PR DESCRIPTION
Move abort check after the invalid arg check.

Fixes https://github.com/dotnet/runtime/issues/61783