### PR TITLE
Include arch specific headers in standalone JITs

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -28,14 +28,19 @@ function(create_standalone_jit)
 
   if(TARGETDETAILS_ARCH STREQUAL "x64")
     set(JIT_ARCH_SOURCES ${JIT_AMD64_SOURCES})
+    set(JIT_ARCH_HEADERS ${JIT_AMD64_HEADERS})
   elseif((TARGETDETAILS_ARCH STREQUAL "arm") OR (TARGETDETAILS_ARCH STREQUAL "armel"))
     set(JIT_ARCH_SOURCES ${JIT_ARM_SOURCES})
+    set(JIT_ARCH_HEADERS ${JIT_ARM_HEADERS})
   elseif(TARGETDETAILS_ARCH STREQUAL "x86")
     set(JIT_ARCH_SOURCES ${JIT_I386_SOURCES})
+    set(JIT_ARCH_HEADERS ${JIT_I386_HEADERS})
   elseif(TARGETDETAILS_ARCH STREQUAL "arm64")
     set(JIT_ARCH_SOURCES ${JIT_ARM64_SOURCES})
+    set(JIT_ARCH_HEADERS ${JIT_ARM64_HEADERS})
   elseif(TARGETDETAILS_ARCH STREQUAL "s390x")
     set(JIT_ARCH_SOURCES ${JIT_S390X_SOURCES})
+    set(JIT_ARCH_HEADERS ${JIT_S390X_HEADERS})
   else()
     clr_unknown_arch()
   endif()
@@ -150,144 +155,10 @@ set( JIT_SOURCES
   valuenum.cpp
 )
 
-# Add header files to Visual Studio vcxproj, not required for unixes
-# change has effect on editor experience and has no impact on build
 if (CLR_CMAKE_TARGET_WIN32)
-  set( JIT_HEADERS
-    ../inc/corinfo.h
-    ../inc/corjit.h
-    ../inc/corjitflags.h
-    ../inc/corjithost.h
-    _typeinfo.h
-    alloc.h
-    arraystack.h
-    bitset.h
-    layout.h
-    bitsetasshortlong.h
-    bitsetasuint64.h
-    bitsetasuint64inclass.h
-    bitsetops.h
-    bitvec.h
-    block.h
-    blockset.h
-    codegen.h
-    codegeninterface.h
-    compiler.h
-    compiler.hpp
-    compilerbitsettraits.h
-    compilerbitsettraits.hpp
-    compmemkind.h
-    compphases.h
-    dataflow.h
-    debuginfo.h
-    decomposelongs.h
-    disasm.h
-    emit.h
-    emitdef.h
-    emitfmts.h
-    emitinl.h
-    emitjmps.h
-    emitpub.h
-    error.h
-    gentree.h
-    gtlist.h
-    gtstructs.h
-    hashbv.h
-    host.h
-    hostallocator.h
-    hwintrinsic.h
-    ICorJitInfo_API_names.h
-    ICorJitInfo_API_wrapper.hpp
-    inline.h
-    inlinepolicy.h
-    instr.h
-    instrs.h
-    jit.h
-    jitconfig.h
-    jitconfigvalues.h
-    jitee.h
-    jiteh.h
-    jitexpandarray.h
-    jitgcinfo.h
-    jithashtable.h
-    jitpch.h
-    jitstd.h
-    jittelemetry.h
-    lir.h
-    loopcloning.h
-    loopcloningopts.h
-    lower.h
-    lsra_reftypes.h
-    lsra_stats.h
-    lsra_score.h
-    lsra.h
-    namedintrinsiclist.h
-    objectalloc.h
-    opcode.h
-    phase.h
-    rangecheck.h
-    rationalize.h
-    regalloc.h
-    register_arg_convention.h
-    register.h
-    regset.h
-    sideeffects.h
-    simd.h
-    simdashwintrinsic.h
-    simdintrinsiclist.h
-    sm.h
-    smallhash.h
-    smcommon.h
-    smopenum.h
-    ssabuilder.h
-    ssaconfig.h
-    ssarenamestate.h
-    stacklevelsetter.h
-    target.h
-    targetx86.h
-    targetamd64.h
-    targetarm.h
-    targetarm64.h
-    tinyarray.h
-    titypes.h
-    treelifeupdater.h
-    typelist.h
-    unwind.h
-    utils.h
-    valuenum.h
-    valuenumfuncs.h
-    valuenumtype.h
-    varset.h
-    vartype.h
-    vartypesdef.h
-  )
-
   # Append clrjit.natvis file
   list (APPEND JIT_SOURCES
     clrjit.natvis)
-
-  if (CLR_CMAKE_TARGET_ARCH_ARM64 OR CLR_CMAKE_TARGET_ARCH_ARM)
-    list (APPEND JIT_HEADERS
-      emitarm.h
-      emitarm64.h
-      emitfmtsarm.h
-      emitfmtsarm64.h
-      hwintrinsic.h
-      hwintrinsiclistarm64.h
-      instrsarm.h
-      instrsarm64.h
-      registerarm.h
-      registerarm64.h
-      simdashwintrinsiclistarm64.h)
-  elseif (CLR_CMAKE_TARGET_ARCH_AMD64 OR CLR_CMAKE_TARGET_ARCH_I386)
-    list (APPEND JIT_HEADERS
-      emitfmtsxarch.h
-      emitxarch.h
-      hwintrinsiclistxarch.h
-      hwintrinsic.h
-      instrsxarch.h
-      simdashwintrinsiclistxarch.h)
-  endif ()
 endif(CLR_CMAKE_TARGET_WIN32)
 
 # Define all the architecture-specific source files
@@ -353,35 +224,184 @@ set( JIT_S390X_SOURCES
   # Not supported as JIT target
 )
 
-if(CLR_CMAKE_TARGET_ARCH_AMD64)
-  set(JIT_ARCH_SOURCES ${JIT_AMD64_SOURCES})
-elseif(CLR_CMAKE_TARGET_ARCH_ARM)
-  set(JIT_ARCH_SOURCES ${JIT_ARM_SOURCES})
-elseif(CLR_CMAKE_TARGET_ARCH_I386)
-  set(JIT_ARCH_SOURCES ${JIT_I386_SOURCES})
-elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
-  set(JIT_ARCH_SOURCES ${JIT_ARM64_SOURCES})
-elseif(CLR_CMAKE_TARGET_ARCH_S390X)
-  set(JIT_ARCH_SOURCES ${JIT_S390X_SOURCES})
-else()
-  clr_unknown_arch()
-endif()
-
-set(JIT_CORE_SOURCES
-  ${JIT_SOURCES}
-  ${JIT_HEADERS}
+# We include the headers here for better experience in IDEs.
+set( JIT_HEADERS
+  ../inc/corinfo.h
+  ../inc/corjit.h
+  ../inc/corjitflags.h
+  ../inc/corjithost.h
+  _typeinfo.h
+  alloc.h
+  arraystack.h
+  bitset.h
+  layout.h
+  bitsetasshortlong.h
+  bitsetasuint64.h
+  bitsetasuint64inclass.h
+  bitsetops.h
+  bitvec.h
+  block.h
+  blockset.h
+  codegen.h
+  codegeninterface.h
+  compiler.h
+  compiler.hpp
+  compilerbitsettraits.h
+  compilerbitsettraits.hpp
+  compmemkind.h
+  compphases.h
+  dataflow.h
+  debuginfo.h
+  decomposelongs.h
+  disasm.h
+  emit.h
+  emitdef.h
+  emitfmts.h
+  emitinl.h
+  emitjmps.h
+  emitpub.h
+  error.h
+  gentree.h
+  gtlist.h
+  gtstructs.h
+  hashbv.h
+  host.h
+  hostallocator.h
+  hwintrinsic.h
+  ICorJitInfo_API_names.h
+  ICorJitInfo_API_wrapper.hpp
+  inline.h
+  inlinepolicy.h
+  instr.h
+  instrs.h
+  jit.h
+  jitconfig.h
+  jitconfigvalues.h
+  jitee.h
+  jiteh.h
+  jitexpandarray.h
+  jitgcinfo.h
+  jithashtable.h
+  jitpch.h
+  jitstd.h
+  jittelemetry.h
+  lir.h
+  loopcloning.h
+  loopcloningopts.h
+  lower.h
+  lsra_reftypes.h
+  lsra_stats.h
+  lsra_score.h
+  lsra.h
+  namedintrinsiclist.h
+  objectalloc.h
+  opcode.h
+  phase.h
+  rangecheck.h
+  rationalize.h
+  regalloc.h
+  register_arg_convention.h
+  register.h
+  regset.h
+  sideeffects.h
+  simd.h
+  simdashwintrinsic.h
+  simdintrinsiclist.h
+  sm.h
+  smallhash.h
+  smcommon.h
+  smopenum.h
+  ssabuilder.h
+  ssaconfig.h
+  ssarenamestate.h
+  stacklevelsetter.h
+  target.h
+  targetx86.h
+  targetamd64.h
+  targetarm.h
+  targetarm64.h
+  tinyarray.h
+  titypes.h
+  treelifeupdater.h
+  typelist.h
+  unwind.h
+  utils.h
+  valuenum.h
+  valuenumfuncs.h
+  valuenumtype.h
+  varset.h
+  vartype.h
+  vartypesdef.h
 )
 
-convert_to_absolute_path(JIT_CORE_SOURCES ${JIT_CORE_SOURCES})
-convert_to_absolute_path(JIT_ARCH_SOURCES ${JIT_ARCH_SOURCES})
+# Arch specific headers
+set( JIT_AMD64_HEADERS
+  emitfmtsxarch.h
+  emitxarch.h
+  hwintrinsiclistxarch.h
+  hwintrinsic.h
+  instrsxarch.h
+  simdashwintrinsiclistxarch.h
+)
+
+set( JIT_I386_HEADERS ${JIT_AMD64_HEADERS} )
+
+set( JIT_ARM64_HEADERS
+    emitarm64.h
+    emitfmtsarm64.h
+    hwintrinsiclistarm64.h
+    instrsarm64.h
+    registerarm64.h
+    simdashwintrinsiclistarm64.h
+)
+
+set( JIT_ARM_HEADERS
+  emitarm.h
+  emitfmtsarm.h
+  instrsarm.h
+  registerarm.h
+)
+
+set ( JIT_S390X_HEADERS
+  # Not supported as JIT target
+)
+
+convert_to_absolute_path(JIT_SOURCES ${JIT_SOURCES})
+convert_to_absolute_path(JIT_HEADERS ${JIT_HEADERS})
 convert_to_absolute_path(JIT_RESOURCES ${JIT_RESOURCES})
 
 # Also convert the per-architecture sources to absolute paths, if the subdirs want to use them.
 
 convert_to_absolute_path(JIT_AMD64_SOURCES ${JIT_AMD64_SOURCES})
+convert_to_absolute_path(JIT_AMD64_HEADERS ${JIT_AMD64_HEADERS})
 convert_to_absolute_path(JIT_ARM_SOURCES ${JIT_ARM_SOURCES})
+convert_to_absolute_path(JIT_ARM_HEADERS ${JIT_ARM_HEADERS})
 convert_to_absolute_path(JIT_I386_SOURCES ${JIT_I386_SOURCES})
+convert_to_absolute_path(JIT_I386_HEADERS ${JIT_I386_HEADERS})
 convert_to_absolute_path(JIT_ARM64_SOURCES ${JIT_ARM64_SOURCES})
+convert_to_absolute_path(JIT_ARM64_HEADERS ${JIT_ARM64_HEADERS})
+convert_to_absolute_path(JIT_S390X_SOURCES ${JIT_S390X_SOURCES})
+convert_to_absolute_path(JIT_S390X_HEADERS ${JIT_S390X_HEADERS})
+
+if(CLR_CMAKE_TARGET_ARCH_AMD64)
+  set(JIT_ARCH_SOURCES ${JIT_AMD64_SOURCES})
+  set(JIT_ARCH_HEADERS ${JIT_AMD64_HEADERS})
+elseif(CLR_CMAKE_TARGET_ARCH_ARM)
+  set(JIT_ARCH_SOURCES ${JIT_ARM_SOURCES})
+  set(JIT_ARCH_HEADERS ${JIT_ARM_HEADERS})
+elseif(CLR_CMAKE_TARGET_ARCH_I386)
+  set(JIT_ARCH_SOURCES ${JIT_I386_SOURCES})
+  set(JIT_ARCH_HEADERS ${JIT_I386_HEADERS})
+elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
+  set(JIT_ARCH_SOURCES ${JIT_ARM64_SOURCES})
+  set(JIT_ARCH_HEADERS ${JIT_ARM64_HEADERS})
+elseif(CLR_CMAKE_TARGET_ARCH_S390X)
+  set(JIT_ARCH_SOURCES ${JIT_S390X_SOURCES})
+  set(JIT_ARCH_HEADERS ${JIT_S390X_HEADERS})
+else()
+  clr_unknown_arch()
+endif()
+
 
 set(JIT_DLL_MAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/dllmain.cpp)
 
@@ -446,14 +466,29 @@ function(add_jit jitName)
 
     set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
 
-    add_library_clr(${jitName}
-        SHARED
-        ${JIT_CORE_SOURCES}
-        ${JIT_RESOURCES}
-        ${JIT_ARCH_SOURCES}
-        ${JIT_DEF_FILE}
-        ${JIT_DLL_MAIN_FILE}
-    )
+    if (CLR_CMAKE_TARGET_WIN32)
+      # If generating for Visual Studio then include headers for a better
+      # IDE experience.
+      add_library_clr(${jitName}
+          SHARED
+          ${JIT_SOURCES}
+          ${JIT_ARCH_SOURCES}
+          ${JIT_HEADERS}
+          ${JIT_ARCH_HEADERS}
+          ${JIT_RESOURCES}
+          ${JIT_DEF_FILE}
+          ${JIT_DLL_MAIN_FILE}
+      )
+    else()
+      add_library_clr(${jitName}
+          SHARED
+          ${JIT_SOURCES}
+          ${JIT_ARCH_SOURCES}
+          ${JIT_RESOURCES}
+          ${JIT_DEF_FILE}
+          ${JIT_DLL_MAIN_FILE}
+      )
+    endif(CLR_CMAKE_TARGET_WIN32)
 
     if(CLR_CMAKE_TARGET_WIN32)
         target_compile_definitions(${jitName} PRIVATE FX_VER_INTERNALNAME_STR=${jitName}.dll)

--- a/src/coreclr/jit/static/CMakeLists.txt
+++ b/src/coreclr/jit/static/CMakeLists.txt
@@ -4,7 +4,7 @@ set_source_files_properties(${JIT_EXPORTS_FILE} PROPERTIES GENERATED TRUE)
 
 add_library_clr(clrjit_obj
     OBJECT
-    ${JIT_CORE_SOURCES}
+    ${JIT_SOURCES}
     ${JIT_ARCH_SOURCES}
 )
 


### PR DESCRIPTION
Change CMake build for JIT to include headers and arch-specific headers
in the same way as sources. This makes arch-specific headers appear in
the correct standalone jit (clrjit_universel_arm64_x64 etc.) projects.