### PR TITLE
[iOS] Skip System.Diagnostics.TextWriterTraceListenerTests.XmlWriterTraceListenerTests on iOS/tvOS

### DIFF
--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace System.Diagnostics.TextWriterTraceListenerTests
 {
+    [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "libproc is not supported on iOS/tvOS")]
     public class XmlWriterTraceListenerTests : FileCleanupTestBase
     {
         private readonly string _processName;


### PR DESCRIPTION
This marks `System.Diagnostics.TextWriterTraceListenerTests.XmlWriterTraceListenerTests` with`SkipOnPlatform` attribute for iOS/tvOS as those tests try to create a process info, which throws PNSE after S.D.Process API's around `libproc` have been excluded in https://github.com/dotnet/runtime/pull/61590.