### PR TITLE
Improve superpmi-asmdiffs AzDO pipeline robustness

### DIFF
--- a/src/coreclr/scripts/jitrollingbuild.py
+++ b/src/coreclr/scripts/jitrollingbuild.py
@@ -750,7 +750,6 @@ def main(args):
         return 1
 
     coreclr_args = setup_args(args)
-    success = True
 
     if coreclr_args.mode == "upload":
         upload_command(coreclr_args)
@@ -764,7 +763,8 @@ def main(args):
     else:
         raise NotImplementedError(coreclr_args.mode)
 
-    return 0 if success else 1
+    # Note that if there is any failure, an exception is raised and the process exit code is then `1`
+    return 0
 
 ################################################################################
 # __main__


### PR DESCRIPTION
1. When git fetching origin/main, use `--depth=500` to try to ensure
there is enough context to allow finding a JIT change in the history.
2. Add some error checking in pipeline setup so failures in setting
up the pipeline should fail the jobs early.