### PR TITLE
Switch IP mapping lists to use jitstd::list

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -10616,9 +10616,7 @@ void CodeGen::genIPmappingGen()
     for (jitstd::list<IPmappingDsc>::iterator it = compiler->genIPmappings.begin();
          it != compiler->genIPmappings.end();)
     {
-        const IPmappingDsc& dsc = *it;
-
-        UNATIVE_OFFSET dscNativeOfs = dsc.ipmdNativeLoc.CodeOffset(GetEmitter());
+        UNATIVE_OFFSET dscNativeOfs = it->ipmdNativeLoc.CodeOffset(GetEmitter());
         if (dscNativeOfs != prevNativeOfs)
         {
             prevNativeOfs = dscNativeOfs;
@@ -10631,18 +10629,16 @@ void CodeGen::genIPmappingGen()
         jitstd::list<IPmappingDsc>::iterator prev = it;
         --prev;
 
-        const IPmappingDsc& prevDsc = *prev;
-
         // Prev and current mappings have same native offset.
         // If one does not map to IL then remove that one.
-        if (prevDsc.ipmdKind == IPmappingDscKind::NoMapping)
+        if (prev->ipmdKind == IPmappingDscKind::NoMapping)
         {
             compiler->genIPmappings.erase(prev);
             ++it;
             continue;
         }
 
-        if (dsc.ipmdKind == IPmappingDscKind::NoMapping)
+        if (it->ipmdKind == IPmappingDscKind::NoMapping)
         {
             it = compiler->genIPmappings.erase(it);
             continue;
@@ -10652,8 +10648,8 @@ void CodeGen::genIPmappingGen()
         // If previous is the prolog, keep both if this one is at IL offset 0.
         // (TODO: Why? Debugger has no problem breaking on the prolog mapping
         // it seems.)
-        if ((prevDsc.ipmdKind == IPmappingDscKind::Prolog) && (dsc.ipmdKind == IPmappingDscKind::Normal) &&
-            (dsc.ipmdLoc.GetOffset() == 0))
+        if ((prev->ipmdKind == IPmappingDscKind::Prolog) && (it->ipmdKind == IPmappingDscKind::Normal) &&
+            (it->ipmdLoc.GetOffset() == 0))
         {
             ++it;
             continue;
@@ -10665,7 +10661,7 @@ void CodeGen::genIPmappingGen()
         // statement if the user tries to put a breakpoint there, and then have
         // the option of seeing the epilog or not based on SetUnmappedStopMask
         // for the stepper.
-        if (dsc.ipmdKind == IPmappingDscKind::Epilog)
+        if (it->ipmdKind == IPmappingDscKind::Epilog)
         {
             ++it;
             continue;
@@ -10673,8 +10669,8 @@ void CodeGen::genIPmappingGen()
 
         // For managed return values we store all calls. Keep both in this case
         // too.
-        if (((prevDsc.ipmdKind == IPmappingDscKind::Normal) && (prevDsc.ipmdLoc.IsCall())) ||
-            ((dsc.ipmdKind == IPmappingDscKind::Normal) && (dsc.ipmdLoc.IsCall())))
+        if (((prev->ipmdKind == IPmappingDscKind::Normal) && (prev->ipmdLoc.IsCall())) ||
+            ((it->ipmdKind == IPmappingDscKind::Normal) && (it->ipmdLoc.IsCall())))
         {
             ++it;
             continue;
@@ -10682,7 +10678,7 @@ void CodeGen::genIPmappingGen()
 
         // Otherwise report the higher offset unless the previous mapping is a
         // label.
-        if (prevDsc.ipmdIsLabel)
+        if (prev->ipmdIsLabel)
         {
             it = compiler->genIPmappings.erase(it);
         }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -122,13 +122,7 @@ CodeGen::CodeGen(Compiler* theCompiler) : CodeGenInterface(theCompiler)
     compiler->compVSQuirkStackPaddingNeeded = 0;
 #endif // TARGET_AMD64
 
-    //  Initialize the IP-mapping logic.
-    compiler->genIPmappingList         = nullptr;
-    compiler->genIPmappingLast         = nullptr;
     compiler->genCallSite2DebugInfoMap = nullptr;
-
-    compiler->genPreciseIPMappingsHead = nullptr;
-    compiler->genPreciseIPMappingsTail = nullptr;
 
     /* Assume that we not fully interruptible */
 
@@ -10456,12 +10450,11 @@ void CodeGen::genIPmappingDisp(unsigned mappingNum, IPmappingDsc* ipMapping)
 
 void CodeGen::genIPmappingListDisp()
 {
-    unsigned      mappingNum = 0;
-    IPmappingDsc* ipMapping;
+    unsigned mappingNum = 0;
 
-    for (ipMapping = compiler->genIPmappingList; ipMapping != nullptr; ipMapping = ipMapping->ipmdNext)
+    for (IPmappingDsc& dsc : compiler->genIPmappings)
     {
-        genIPmappingDisp(mappingNum, ipMapping);
+        genIPmappingDisp(mappingNum, &dsc);
         ++mappingNum;
     }
 }
@@ -10500,8 +10493,8 @@ void CodeGen::genIPmappingAdd(IPmappingDscKind kind, const DebugInfo& di, bool i
             // Ignore this one if it's the same IL location as the last one we saw.
             // Note that we'll let through two identical IL offsets if the flag bits
             // differ, or two identical "special" mappings (e.g., PROLOG).
-            if ((compiler->genIPmappingLast != nullptr) && (kind == compiler->genIPmappingLast->ipmdKind) &&
-                (di.GetLocation() == compiler->genIPmappingLast->ipmdLoc))
+            if ((compiler->genIPmappings.size() > 0) && (kind == compiler->genIPmappings.back().ipmdKind) &&
+                (di.GetLocation() == compiler->genIPmappings.back().ipmdLoc))
             {
                 JITDUMP("genIPmappingAdd: ignoring duplicate IL offset 0x%x\n", di.GetLocation().GetOffset());
                 return;
@@ -10509,36 +10502,20 @@ void CodeGen::genIPmappingAdd(IPmappingDscKind kind, const DebugInfo& di, bool i
             break;
     }
 
-    /* Create a mapping entry and append it to the list */
+    IPmappingDsc addMapping;
+    addMapping.ipmdNativeLoc.CaptureLocation(GetEmitter());
+    addMapping.ipmdKind    = kind;
+    addMapping.ipmdLoc     = di.GetLocation();
+    addMapping.ipmdIsLabel = isLabel;
 
-    IPmappingDsc* addMapping = compiler->getAllocator(CMK_DebugInfo).allocate<IPmappingDsc>(1);
-    addMapping->ipmdNativeLoc.CaptureLocation(GetEmitter());
-    addMapping->ipmdKind    = kind;
-    addMapping->ipmdLoc     = di.GetLocation();
-    addMapping->ipmdIsLabel = isLabel;
-    addMapping->ipmdNext    = nullptr;
-
-    assert((kind == IPmappingDscKind::Normal) == addMapping->ipmdLoc.IsValid());
-
-    if (compiler->genIPmappingList != nullptr)
-    {
-        assert(compiler->genIPmappingLast != nullptr);
-        assert(compiler->genIPmappingLast->ipmdNext == nullptr);
-        compiler->genIPmappingLast->ipmdNext = addMapping;
-    }
-    else
-    {
-        assert(compiler->genIPmappingLast == nullptr);
-        compiler->genIPmappingList = addMapping;
-    }
-
-    compiler->genIPmappingLast = addMapping;
+    assert((kind == IPmappingDscKind::Normal) == addMapping.ipmdLoc.IsValid());
+    compiler->genIPmappings.push_back(addMapping);
 
 #ifdef DEBUG
     if (verbose)
     {
         printf("Added IP mapping: ");
-        genIPmappingDisp(unsigned(-1), addMapping);
+        genIPmappingDisp(unsigned(-1), &addMapping);
     }
 #endif // DEBUG
 }
@@ -10560,25 +10537,18 @@ void CodeGen::genIPmappingAddToFront(IPmappingDscKind kind, const DebugInfo& di,
 
     /* Create a mapping entry and prepend it to the list */
 
-    IPmappingDsc* addMapping = compiler->getAllocator(CMK_DebugInfo).allocate<IPmappingDsc>(1);
-    addMapping->ipmdNativeLoc.CaptureLocation(GetEmitter());
-    addMapping->ipmdKind    = kind;
-    addMapping->ipmdLoc     = di.GetLocation();
-    addMapping->ipmdIsLabel = isLabel;
-
-    addMapping->ipmdNext       = compiler->genIPmappingList;
-    compiler->genIPmappingList = addMapping;
-
-    if (compiler->genIPmappingLast == nullptr)
-    {
-        compiler->genIPmappingLast = addMapping;
-    }
+    IPmappingDsc addMapping;
+    addMapping.ipmdNativeLoc.CaptureLocation(GetEmitter());
+    addMapping.ipmdKind    = kind;
+    addMapping.ipmdLoc     = di.GetLocation();
+    addMapping.ipmdIsLabel = isLabel;
+    compiler->genIPmappings.push_front(addMapping);
 
 #ifdef DEBUG
     if (verbose)
     {
         printf("Added IP mapping to front: ");
-        genIPmappingDisp(unsigned(-1), addMapping);
+        genIPmappingDisp(unsigned(-1), &addMapping);
     }
 #endif // DEBUG
 }
@@ -10597,31 +10567,30 @@ void CodeGen::genEnsureCodeEmitted(const DebugInfo& di)
         return;
     }
 
-    /* If other IL were offsets reported, skip */
+    // If other IL were offsets reported, skip
 
-    if (compiler->genIPmappingLast == nullptr)
+    if (compiler->genIPmappings.size() <= 0)
     {
         return;
     }
 
-    if (compiler->genIPmappingLast->ipmdLoc != di.GetLocation())
+    const IPmappingDsc& prev = compiler->genIPmappings.back();
+    if (prev.ipmdLoc != di.GetLocation())
     {
         return;
     }
 
-    /* offsx was the last reported offset. Make sure that we generated native code */
+    // di represents the last reported offset. Make sure that we generated native code
 
-    if (compiler->genIPmappingLast->ipmdNativeLoc.IsCurrentLocation(GetEmitter()))
+    if (prev.ipmdNativeLoc.IsCurrentLocation(GetEmitter()))
     {
         instGen(INS_nop);
     }
 }
 
-/*****************************************************************************
- *
- *  Shut down the IP-mapping logic, report the info to the EE.
- */
-
+//------------------------------------------------------------------------
+// genIPmappingGen: Shut down the IP-mapping logic, report the info to the EE.
+//
 void CodeGen::genIPmappingGen()
 {
     if (!compiler->opts.compDbgInfo)
@@ -10636,133 +10605,103 @@ void CodeGen::genIPmappingGen()
     }
 #endif
 
-    if (compiler->genIPmappingList == nullptr)
+    if (compiler->genIPmappings.size() <= 0)
     {
         compiler->eeSetLIcount(0);
         compiler->eeSetLIdone();
         return;
     }
 
-    IPmappingDsc*  tmpMapping;
-    IPmappingDsc*  prevMapping;
-    unsigned       mappingCnt;
-    UNATIVE_OFFSET lastNativeOfs;
-
-    /* First count the number of distinct mapping records */
-
-    mappingCnt    = 0;
-    lastNativeOfs = UNATIVE_OFFSET(~0);
-
-    for (prevMapping = nullptr, tmpMapping = compiler->genIPmappingList; tmpMapping != nullptr;
-         tmpMapping = tmpMapping->ipmdNext)
+    UNATIVE_OFFSET prevNativeOfs = UNATIVE_OFFSET(~0);
+    for (jitstd::list<IPmappingDsc>::iterator it = compiler->genIPmappings.begin();
+         it != compiler->genIPmappings.end();)
     {
-        // Managed RetVal - since new sequence points are emitted to identify IL calls,
-        // make sure that those are not filtered and do not interfere with filtering of
-        // other sequence points.
-        if (tmpMapping->ipmdKind == IPmappingDscKind::Normal && tmpMapping->ipmdLoc.IsCall())
+        const IPmappingDsc& dsc = *it;
+
+        UNATIVE_OFFSET dscNativeOfs = dsc.ipmdNativeLoc.CodeOffset(GetEmitter());
+        if (dscNativeOfs != prevNativeOfs)
         {
-            mappingCnt++;
+            prevNativeOfs = dscNativeOfs;
+            ++it;
             continue;
         }
 
-        UNATIVE_OFFSET nextNativeOfs = tmpMapping->ipmdNativeLoc.CodeOffset(GetEmitter());
+        // If we have a previous offset we should have a previous mapping.
+        assert(it != compiler->genIPmappings.begin());
+        jitstd::list<IPmappingDsc>::iterator prev = it;
+        --prev;
 
-        if (nextNativeOfs != lastNativeOfs)
+        const IPmappingDsc& prevDsc = *prev;
+
+        // Prev and current mappings have same native offset.
+        // If one does not map to IL then remove that one.
+        if (prevDsc.ipmdKind == IPmappingDscKind::NoMapping)
         {
-            mappingCnt++;
-            lastNativeOfs = nextNativeOfs;
-            prevMapping   = tmpMapping;
+            compiler->genIPmappings.erase(prev);
+            ++it;
             continue;
         }
 
-        /* If there are mappings with the same native offset, then:
-           o If one of them is NO_MAPPING, ignore it
-           o If one of them is a label, report that and ignore the other one
-           o Else report the higher IL offset
-         */
+        if (dsc.ipmdKind == IPmappingDscKind::NoMapping)
+        {
+            it = compiler->genIPmappings.erase(it);
+            continue;
+        }
 
-        PREFIX_ASSUME(prevMapping != nullptr); // We would exit before if this was true
-        if (prevMapping->ipmdKind == IPmappingDscKind::NoMapping)
+        // Both have mappings.
+        // If previous is the prolog, keep both if this one is at IL offset 0.
+        // (TODO: Why? Debugger has no problem breaking on the prolog mapping
+        // it seems.)
+        if ((prevDsc.ipmdKind == IPmappingDscKind::Prolog) && (dsc.ipmdKind == IPmappingDscKind::Normal) &&
+            (dsc.ipmdLoc.GetOffset() == 0))
         {
-            // If the previous entry was NO_MAPPING, ignore it
-            prevMapping->ipmdNativeLoc.Init();
-            prevMapping = tmpMapping;
+            ++it;
+            continue;
         }
-        else if (tmpMapping->ipmdKind == IPmappingDscKind::NoMapping)
+
+        // For the special case of an IL instruction with no body followed by
+        // the epilog (say ret void immediately preceding the method end), we
+        // leave both entries in, so that we'll stop at the (empty) ret
+        // statement if the user tries to put a breakpoint there, and then have
+        // the option of seeing the epilog or not based on SetUnmappedStopMask
+        // for the stepper.
+        if (dsc.ipmdKind == IPmappingDscKind::Epilog)
         {
-            // If the current entry is NO_MAPPING, ignore it
-            // Leave prevMapping unchanged as tmpMapping is no longer valid
-            tmpMapping->ipmdNativeLoc.Init();
+            ++it;
+            continue;
         }
-        else if ((tmpMapping->ipmdKind == IPmappingDscKind::Epilog) ||
-                 (tmpMapping->ipmdKind == IPmappingDscKind::Normal && tmpMapping->ipmdLoc.GetOffset() == 0))
+
+        // For managed return values we store all calls. Keep both in this case
+        // too.
+        if (((prevDsc.ipmdKind == IPmappingDscKind::Normal) && (prevDsc.ipmdLoc.IsCall())) ||
+            ((dsc.ipmdKind == IPmappingDscKind::Normal) && (dsc.ipmdLoc.IsCall())))
         {
-            // counting for special cases: see below
-            mappingCnt++;
-            prevMapping = tmpMapping;
+            ++it;
+            continue;
+        }
+
+        // Otherwise report the higher offset unless the previous mapping is a
+        // label.
+        if (prevDsc.ipmdIsLabel)
+        {
+            it = compiler->genIPmappings.erase(it);
         }
         else
         {
-            noway_assert(prevMapping != nullptr);
-            noway_assert(!prevMapping->ipmdNativeLoc.Valid() ||
-                         lastNativeOfs == prevMapping->ipmdNativeLoc.CodeOffset(GetEmitter()));
-
-            /* The previous block had the same native offset. We have to
-               discard one of the mappings. Simply reinitialize ipmdNativeLoc
-               and prevMapping will be ignored later. */
-
-            if (prevMapping->ipmdIsLabel)
-            {
-                // Leave prevMapping unchanged as tmpMapping is no longer valid
-                tmpMapping->ipmdNativeLoc.Init();
-            }
-            else
-            {
-                prevMapping->ipmdNativeLoc.Init();
-                prevMapping = tmpMapping;
-            }
+            compiler->genIPmappings.erase(prev);
+            ++it;
         }
     }
 
-    /* Tell them how many mapping records we've got */
+    // Tell them how many mapping records we've got
 
-    compiler->eeSetLIcount(mappingCnt);
+    compiler->eeSetLIcount(static_cast<unsigned int>(compiler->genIPmappings.size()));
 
-    /* Now tell them about the mappings */
-
-    mappingCnt    = 0;
-    lastNativeOfs = UNATIVE_OFFSET(~0);
-
-    for (tmpMapping = compiler->genIPmappingList; tmpMapping != nullptr; tmpMapping = tmpMapping->ipmdNext)
+    // Now tell them about the mappings
+    unsigned int mappingIdx = 0;
+    for (const IPmappingDsc& dsc : compiler->genIPmappings)
     {
-        // Do we have to skip this record ?
-        if (!tmpMapping->ipmdNativeLoc.Valid())
-        {
-            continue;
-        }
-
-        UNATIVE_OFFSET nextNativeOfs = tmpMapping->ipmdNativeLoc.CodeOffset(GetEmitter());
-
-        if (tmpMapping->ipmdKind == IPmappingDscKind::Normal && tmpMapping->ipmdLoc.IsCall())
-        {
-            compiler->eeSetLIinfo(mappingCnt++, nextNativeOfs, IPmappingDscKind::Normal, tmpMapping->ipmdLoc);
-        }
-        else if (nextNativeOfs != lastNativeOfs)
-        {
-            compiler->eeSetLIinfo(mappingCnt++, nextNativeOfs, tmpMapping->ipmdKind, tmpMapping->ipmdLoc);
-            lastNativeOfs = nextNativeOfs;
-        }
-        else if (tmpMapping->ipmdKind == IPmappingDscKind::Epilog ||
-                 (tmpMapping->ipmdKind == IPmappingDscKind::Normal && tmpMapping->ipmdLoc.GetOffset() == 0))
-        {
-            // For the special case of an IL instruction with no body
-            // followed by the epilog (say ret void immediately preceding
-            // the method end), we put two entries in, so that we'll stop
-            // at the (empty) ret statement if the user tries to put a
-            // breakpoint there, and then have the option of seeing the
-            // epilog or not based on SetUnmappedStopMask for the stepper.
-            compiler->eeSetLIinfo(mappingCnt++, nextNativeOfs, tmpMapping->ipmdKind, tmpMapping->ipmdLoc);
-        }
+        compiler->eeSetLIinfo(mappingIdx++, dsc.ipmdNativeLoc.CodeOffset(GetEmitter()), dsc.ipmdKind, dsc.ipmdLoc);
     }
 
 #if 0
@@ -10859,7 +10798,7 @@ void CodeGen::genDumpPreciseDebugInfo()
     genDumpPreciseDebugInfoInlineTree(file, compiler->compInlineContext, &first);
     fprintf(file, ",\"Mappings\":[");
     first = true;
-    for (PreciseIPMapping* mapping = compiler->genPreciseIPMappingsHead; mapping != nullptr; mapping = mapping->next)
+    for (PreciseIPMapping& mapping : compiler->genPreciseIPmappings)
     {
         if (!first)
         {
@@ -10869,8 +10808,8 @@ void CodeGen::genDumpPreciseDebugInfo()
         first = false;
 
         fprintf(file, "{\"NativeOffset\":%u,\"InlineContext\":%u,\"ILOffset\":%u}",
-                mapping->nativeLoc.CodeOffset(GetEmitter()), mapping->debugInfo.GetInlineContext()->GetOrdinal(),
-                mapping->debugInfo.GetLocation().GetOffset());
+                mapping.nativeLoc.CodeOffset(GetEmitter()), mapping.debugInfo.GetInlineContext()->GetOrdinal(),
+                mapping.debugInfo.GetLocation().GetOffset());
     }
 
     fprintf(file, "]}\n");
@@ -10880,21 +10819,10 @@ void CodeGen::genDumpPreciseDebugInfo()
 
 void CodeGen::genAddPreciseIPMappingHere(const DebugInfo& di)
 {
-    PreciseIPMapping* mapping = new (compiler, CMK_DebugInfo) PreciseIPMapping;
-    mapping->next             = nullptr;
-    mapping->nativeLoc.CaptureLocation(GetEmitter());
-    mapping->debugInfo = di;
-
-    if (compiler->genPreciseIPMappingsTail != nullptr)
-    {
-        compiler->genPreciseIPMappingsTail->next = mapping;
-    }
-    else
-    {
-        compiler->genPreciseIPMappingsHead = mapping;
-    }
-
-    compiler->genPreciseIPMappingsTail = mapping;
+    PreciseIPMapping mapping;
+    mapping.nativeLoc.CaptureLocation(GetEmitter());
+    mapping.debugInfo = di;
+    compiler->genPreciseIPmappings.push_back(mapping);
 }
 #endif
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1847,6 +1847,11 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
         impSpillCliquePredMembers = JitExpandArray<BYTE>(getAllocator());
         impSpillCliqueSuccMembers = JitExpandArray<BYTE>(getAllocator());
 
+        new (&genIPmappings, jitstd::placement_t()) jitstd::list<IPmappingDsc>(getAllocator(CMK_DebugInfo));
+#ifdef DEBUG
+        new (&genPreciseIPmappings, jitstd::placement_t()) jitstd::list<PreciseIPMapping>(getAllocator(CMK_DebugInfo));
+#endif
+
         lvMemoryPerSsaData = SsaDefArray<SsaMemDef>();
 
         //

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1849,7 +1849,7 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
 
         new (&genIPmappings, jitstd::placement_t()) jitstd::list<IPmappingDsc>(getAllocator(CMK_DebugInfo));
 #ifdef DEBUG
-        new (&genPreciseIPmappings, jitstd::placement_t()) jitstd::list<PreciseIPMapping>(getAllocator(CMK_DebugInfo));
+        new (&genPreciseIPmappings, jitstd::placement_t()) jitstd::list<PreciseIPMapping>(getAllocator(CMK_DebugOnly));
 #endif
 
         lvMemoryPerSsaData = SsaDefArray<SsaMemDef>();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2527,7 +2527,6 @@ enum class IPmappingDscKind
 
 struct IPmappingDsc
 {
-    IPmappingDsc*    ipmdNext;      // next line# record
     emitLocation     ipmdNativeLoc; // the emitter location of the native code corresponding to the IL offset
     IPmappingDscKind ipmdKind;      // The kind of mapping
     ILLocation       ipmdLoc;       // The location for normal mappings
@@ -2536,9 +2535,8 @@ struct IPmappingDsc
 
 struct PreciseIPMapping
 {
-    PreciseIPMapping* next;
-    emitLocation      nativeLoc;
-    DebugInfo         debugInfo;
+    emitLocation nativeLoc;
+    DebugInfo    debugInfo;
 };
 
 /*
@@ -8273,11 +8271,11 @@ public:
 
     // Record the instr offset mapping to the generated code
 
-    IPmappingDsc* genIPmappingList;
-    IPmappingDsc* genIPmappingLast;
+    jitstd::list<IPmappingDsc> genIPmappings;
 
-    PreciseIPMapping* genPreciseIPMappingsHead;
-    PreciseIPMapping* genPreciseIPMappingsTail;
+#ifdef DEBUG
+    jitstd::list<PreciseIPMapping> genPreciseIPmappings;
+#endif
 
     // Managed RetVal - A side hash table meant to record the mapping from a
     // GT_CALL node to its debug info.  This info is used to emit sequence points

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6242,8 +6242,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #define DEFAULT_CODE_BUFFER_INIT 0xcc
 
 #ifdef DEBUG
-    *instrCount                   = 0;
-    PreciseIPMapping* nextMapping = emitComp->genPreciseIPMappingsHead;
+    *instrCount                                          = 0;
+    jitstd::list<PreciseIPMapping>::iterator nextMapping = emitComp->genPreciseIPmappings.begin();
 #endif
     for (insGroup* ig = emitIGlist; ig != nullptr; ig = ig->igNext)
     {
@@ -6416,7 +6416,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             if ((emitComp->opts.disAsm || emitComp->verbose) && (JitConfig.JitDisasmWithDebugInfo() != 0))
             {
                 UNATIVE_OFFSET curCodeOffs = emitCurCodeOffs(cp);
-                while (nextMapping != nullptr)
+                while (nextMapping != emitComp->genPreciseIPmappings.end())
                 {
                     UNATIVE_OFFSET mappingOffs = nextMapping->nativeLoc.CodeOffset(this);
 
@@ -6435,7 +6435,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                         printf("\n");
                     }
 
-                    nextMapping = nextMapping->next;
+                    ++nextMapping;
                 }
             }
 


### PR DESCRIPTION
We may want to change the logic around how IP mappings are reported to
the EE, and the manually maintained singly-linked lists made it hard to
understand the logic that goes on here. Switch to jitstd::list which
allows us to simplify the logic by directly removing the mappings we do
not want to emit.

There are two small behavior changes here:
1. The previous logic would record superfluous IL offset 0 mappings
   under the assumption that the previous mapping was the prolog; this
   is not always the case, so check this explicitly
2. The previous logic would record _all_ CALL_INSTRUCTION mappings and
   would not use these to check whether to remove NO_MAP mappings.  This
   is superfluous as well, if we have a regular mapping at a native
   offset it does not give any information to add a NO_MAP mapping at
   the same native offset.

All diffs I looked at therefore look like the following. In case 1 above:
```diff
-IP mapping count : 7
+IP mapping count : 6
 IL offs PROLOG : 0x00000000 ( STACK_EMPTY )
 IL offs 0x0000 : 0x00000009 ( STACK_EMPTY )
 IL offs 0x0000 : 0x000000F4 ( STACK_EMPTY )
-IL offs 0x0000 : 0x000000F4 ( STACK_EMPTY )
 IL offs NO_MAP : 0x00000114 ( STACK_EMPTY )
 IL offs EPILOG : 0x0000011D ( STACK_EMPTY )
 IL offs 0x0000 : 0x00000124 ( STACK_EMPTY )
```

And in case 2:
```diff
 IL offs 0x0000 : 0x000000D7 ( STACK_EMPTY )
 IL offs 0x0001 : 0x000000DE ( CALL_INSTRUCTION )
-IL offs NO_MAP : 0x000000E9 ( STACK_EMPTY )
 IL offs 0x000B : 0x000000E9 ( CALL_INSTRUCTION )
 IL offs NO_MAP : 0x000000F7 ( STACK_EMPTY )
```