### PR TITLE
Fix Android crypto asserts

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherOneShotTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RC2/RC2CipherOneShotTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace System.Security.Cryptography.Encryption.RC2.Tests
 {
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    [ConditionalClass(typeof(RC2Factory), nameof(RC2Factory.IsSupported))]
     public class RC2CipherOneShotTests : SymmetricOneShotBase
     {
         protected override byte[] Key => new byte[]

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_evp.c
@@ -50,9 +50,7 @@ static jobject GetMessageDigestInstance(JNIEnv* env, intptr_t type)
 
 int32_t CryptoNative_EvpDigestOneShot(intptr_t type, void* source, int32_t sourceSize, uint8_t* md, uint32_t* mdSize)
 {
-    abort_if_invalid_pointer_argument (source);
-
-    if (!type || !md || !mdSize || sourceSize < 0)
+    if (!type || !md || !mdSize || sourceSize < 0 || (sourceSize > 0 && !source))
         return FAIL;
 
     JNIEnv* env = GetJNIEnv();

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_hmac.c
@@ -82,10 +82,10 @@ int32_t CryptoNative_HmacReset(jobject ctx)
 
 int32_t CryptoNative_HmacUpdate(jobject ctx, uint8_t* data, int32_t len)
 {
-    if (!ctx)
+    // Callers are expected to skip update calls with no data.
+    if (!ctx || !data || len <= 0)
         return FAIL;
 
-    abort_if_invalid_pointer_argument (data);
     JNIEnv* env = GetJNIEnv();
     jbyteArray dataBytes = make_java_byte_array(env, len);
     (*env)->SetByteArrayRegion(env, dataBytes, 0, len, (jbyte*)data);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_rsa.c
@@ -44,9 +44,11 @@ PALEXPORT void AndroidCryptoNative_RsaDestroy(RSA* rsa)
 
 PALEXPORT int32_t AndroidCryptoNative_RsaPublicEncrypt(int32_t flen, uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
 {
-    abort_if_invalid_pointer_argument (from);
     abort_if_invalid_pointer_argument (to);
     abort_if_invalid_pointer_argument (rsa);
+
+    if ((flen > 0 && !from) || flen < 0)
+        return RSA_FAIL;
 
     JNIEnv* env = GetJNIEnv();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.OpenSsl.cs
@@ -94,6 +94,11 @@ namespace Internal.Cryptography
 
             public override void AppendHashData(ReadOnlySpan<byte> data)
             {
+                if (data.IsEmpty)
+                {
+                    return;
+                }
+
                 _running = true;
                 Check(Interop.Crypto.EvpDigestUpdate(_ctx, data, data.Length));
             }
@@ -166,6 +171,11 @@ namespace Internal.Cryptography
 
             public override void AppendHashData(ReadOnlySpan<byte> data)
             {
+                if (data.IsEmpty)
+                {
+                    return;
+                }
+
                 _running = true;
                 Check(Interop.Crypto.HmacUpdate(_hmacCtx, data, data.Length));
             }

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -6,6 +6,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDllImportGenerator>true</EnableDllImportGenerator>
   </PropertyGroup>
+  <PropertyGroup>
+    <UseAndroidCrypto Condition="'$(TargetsAndroid)' == 'true'">true</UseAndroidCrypto>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\ConnectedStreams.cs"
              Link="Common\System\IO\ConnectedStreams.cs" />


### PR DESCRIPTION
This fixes three asserts that were started occurring in the native Android cryptographic primitives.

* One shot hashing now tolerates empty/null input.
* Hashing and HMAC will now no-op if the append is empty.
* RSA encryption now tolerates empty/null input.

/cc @AaronRobinsonMSFT.

Closes #61783