### PR TITLE
[JIT] [Issue: 61620] Optimizing ARM64 for *x = dblCns;

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6800,9 +6800,9 @@ void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
             ssize_t   intCns = 0;
             var_types type   = TYP_UNKNOWN;
 
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH) || defined(TARGET_ARM)
             bool shouldSwitchToInteger = true;
-#else // TARGET_ARMARCH
+#else // TARGET_ARM64
             bool shouldSwitchToInteger = !data->IsCnsNonZeroFltOrDbl();
 #endif
             

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6794,7 +6794,7 @@ void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
     {
         if (varTypeIsFloating(ind) && ind->Data()->IsCnsFltOrDbl())
         {
-            // Optimize *x = DCON to *x = ICON which is slightly faster on xarch
+            // Optimize *x = DCON to *x = ICON which can be slightly faster and/or smaller.
             GenTree*  data   = ind->Data();
             double    dblCns = data->AsDblCon()->gtDconVal;
             ssize_t   intCns = 0;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6799,6 +6799,12 @@ void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
             double    dblCns = data->AsDblCon()->gtDconVal;
             ssize_t   intCns = 0;
             var_types type   = TYP_UNKNOWN;
+            // XARCH: we can always contain the immediates.
+            // ARM64: zero can always be contained, other cases will use immediates from the data
+            //        section and it is not a clear win to switch them to inline integers.
+            // ARM:   FP constants are assembled from integral ones, so it is always profitable
+            //        to directly use the integers as it avoids the int -> float conversion.
+            CLANG_FORMAT_COMMENT_ANCHOR;
 
 #if defined(TARGET_XARCH) || defined(TARGET_ARM)
             bool shouldSwitchToInteger = true;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6809,7 +6809,6 @@ void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
                 float fltCns = static_cast<float>(dblCns); // should be a safe round-trip
                 intCns       = static_cast<ssize_t>(*reinterpret_cast<INT32*>(&fltCns));
                 type         = TYP_INT;
-                printf("qwe");
             }
 #ifdef TARGET_AMD64
             else

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6794,7 +6794,6 @@ void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
     {
         LowerStoreIndir(ind);
 
-        // Moved from lowerxarch.cpp. Issue: #61620
         if (varTypeIsFloating(ind) && ind->Data()->IsCnsFltOrDbl())
         {
             // Optimize *x = DCON to *x = ICON which is slightly faster on xarch

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6805,7 +6805,7 @@ void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
 #else // TARGET_ARM64
             bool shouldSwitchToInteger = !data->IsCnsNonZeroFltOrDbl();
 #endif
-            
+
             if (shouldSwitchToInteger)
             {
                 if (ind->TypeIs(TYP_FLOAT))
@@ -6900,7 +6900,7 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
 #ifdef TARGET_ARM64
     bool useNullCheck = true;
 #elif TARGET_ARM
-    bool useNullCheck = false;
+    bool         useNullCheck          = false;
 #else  // TARGET_XARCH
     bool useNullCheck = !ind->Addr()->isContained();
 #endif // !TARGET_XARCH

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -130,37 +130,7 @@ void Lowering::LowerStoreIndir(GenTreeStoreInd* node)
             return;
         }
     }
-    else if (node->Data()->IsCnsFltOrDbl())
-    {
-        // Optimize *x = DCON to *x = ICON which is slightly faster on xarch
-        GenTree*  data   = node->Data();
-        double    dblCns = data->AsDblCon()->gtDconVal;
-        ssize_t   intCns = 0;
-        var_types type   = TYP_UNKNOWN;
-
-        if (node->TypeIs(TYP_FLOAT))
-        {
-            float fltCns = static_cast<float>(dblCns); // should be a safe round-trip
-            intCns       = static_cast<ssize_t>(*reinterpret_cast<INT32*>(&fltCns));
-            type         = TYP_INT;
-        }
-#ifdef TARGET_AMD64
-        else
-        {
-            assert(node->TypeIs(TYP_DOUBLE));
-            intCns = static_cast<ssize_t>(*reinterpret_cast<INT64*>(&dblCns));
-            type   = TYP_LONG;
-        }
-#endif
-
-        if (type != TYP_UNKNOWN)
-        {
-            data->SetContained();
-            data->BashToConst(intCns, type);
-            node->ChangeType(type);
-        }
-    }
-
+    
     // Optimization: do not unnecessarily zero-extend the result of setcc.
     if (varTypeIsByte(node) && (node->Data()->OperIsCompare() || node->Data()->OperIs(GT_SETCC)))
     {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -130,7 +130,7 @@ void Lowering::LowerStoreIndir(GenTreeStoreInd* node)
             return;
         }
     }
-    
+
     // Optimization: do not unnecessarily zero-extend the result of setcc.
     if (varTypeIsByte(node) && (node->Data()->OperIsCompare() || node->Data()->OperIs(GT_SETCC)))
     {


### PR DESCRIPTION
Issue: #61620 
old assembly code for ARM64:
```assembly
            movi    v16.16b, #0x00
            str     s16, [x1]
```
new assembly code for ARM64:
```assembly
            str     wzr, [x0]
```

![image](https://user-images.githubusercontent.com/52250045/142672367-7d7e46c6-267a-4c3f-9029-8638892ab35e.png)

Other changes:

- The code was moved from lowerxarch.cpp in lower.cpp
- Calling data->SetContained() for ARM64 only.

Previously, the code was like this:
```c++
    data->SetContained();
    data->BashToConst(intCns, type);
```
Now:
```c++
    data->BashToConst(intCns, type);
#if defined(TARGET_ARM64)
    data->SetContained();
#endif
```
BashToConst zeroes the node flags and SetContained didn't work.


I checked the output of the assembler code for x64-x86, arm and it remained the same as before the change. The change is applied only for ARM64
