### PR TITLE
[wasm] debug with modularized runtime(s)

### DIFF
--- a/src/mono/mono/component/mini-wasm-debugger.c
+++ b/src/mono/mono/component/mini-wasm-debugger.c
@@ -54,6 +54,8 @@ static gboolean has_pending_lazy_loaded_assemblies;
 
 #define THREAD_TO_INTERNAL(thread) (thread)->internal_thread
 
+extern void mono_wasm_debugger_log (int level, char *message);
+
 void wasm_debugger_log (int level, const gchar *format, ...)
 {
 	va_list args;
@@ -62,19 +64,7 @@ void wasm_debugger_log (int level, const gchar *format, ...)
 	va_start (args, format);
 	mesg = g_strdup_vprintf (format, args);
 	va_end (args);
-
-	EM_ASM ({
-		var level = $0;
-		var message = Module.UTF8ToString ($1);
-		var namespace = "Debugger.Debug";
-
-		if (INTERNAL["logging"] && INTERNAL.logging["debugger"]) {
-			INTERNAL.logging.debugger (level, message);
-			return;
-		}
-
-		console.debug("%s: %s", namespace, message);
-	}, level, mesg);
+	mono_wasm_debugger_log(level, mesg);
 	g_free (mesg);
 }
 
@@ -367,6 +357,8 @@ mono_wasm_set_is_debugger_attached (gboolean is_attached)
 	}
 }
 
+extern void mono_wasm_add_dbg_command_received(mono_bool res_ok, int id, void* buffer, int buffer_len);
+
 EMSCRIPTEN_KEEPALIVE gboolean 
 mono_wasm_send_dbg_command_with_parms (int id, MdbgProtCommandSet command_set, int command, guint8* data, unsigned int size, int valtype, char* newvalue)
 {
@@ -374,9 +366,7 @@ mono_wasm_send_dbg_command_with_parms (int id, MdbgProtCommandSet command_set, i
 	buffer_init (&bufWithParms, 128);
 	m_dbgprot_buffer_add_data (&bufWithParms, data, size);
 	if (!write_value_to_buffer(&bufWithParms, valtype, newvalue)) {
-		EM_ASM ({
-			INTERNAL.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
-		}, 0, id, 0, 0);
+		mono_wasm_add_dbg_command_received(0, id, 0, 0);
 		return TRUE;
 	}
 	mono_wasm_send_dbg_command(id, command_set, command, bufWithParms.buf, m_dbgprot_buffer_len(&bufWithParms));
@@ -402,10 +392,9 @@ mono_wasm_send_dbg_command (int id, MdbgProtCommandSet command_set, int command,
 	}
 	else
 		error = mono_process_dbg_packet (id, command_set, command, &no_reply, data, data + size, &buf);
-	EM_ASM ({
-		INTERNAL.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
-	}, error == MDBGPROT_ERR_NONE, id, buf.buf, buf.p-buf.buf);
-	
+
+	mono_wasm_add_dbg_command_received(error == MDBGPROT_ERR_NONE, id, buf.buf, buf.p-buf.buf);
+
 	buffer_free (&buf);
 	return TRUE;
 }
@@ -413,9 +402,7 @@ mono_wasm_send_dbg_command (int id, MdbgProtCommandSet command_set, int command,
 static gboolean 
 receive_debugger_agent_message (void *data, int len)
 {
-	EM_ASM ({
-		INTERNAL.mono_wasm_add_dbg_command_received (1, -1, $0, $1);
-	}, data, len);
+	mono_wasm_add_dbg_command_received(1, -1, data, len);
 	mono_wasm_save_thread_context();
 	mono_wasm_fire_debugger_agent_message ();	
 	return FALSE;

--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -151,6 +151,12 @@ namespace Microsoft.WebAssembly.Diagnostics
                     }
 
                     var endpoint = new Uri($"ws://{devToolsHost.Authority}{context.Request.Path}");
+                    int runtimeId = 0;
+                    if (context.Request.Query.TryGetValue("RuntimeId", out var runtimeIdValue))
+                    {
+                        int.TryParse(runtimeIdValue.First(), out runtimeId);
+                    }
+
                     try
                     {
                         using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
@@ -159,7 +165,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         );
 
                         context.Request.Query.TryGetValue("urlSymbolServer", out StringValues urlSymbolServerList);
-                        var proxy = new DebuggerProxy(loggerFactory, urlSymbolServerList.ToList());
+                        var proxy = new DebuggerProxy(loggerFactory, urlSymbolServerList.ToList(), runtimeId);
 
                         System.Net.WebSockets.WebSocket ideSocket = await context.WebSockets.AcceptWebSocketAsync();
 

--- a/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
+++ b/src/mono/wasm/debugger/BrowserDebugHost/Startup.cs
@@ -152,11 +152,11 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                     var endpoint = new Uri($"ws://{devToolsHost.Authority}{context.Request.Path}");
                     int runtimeId = 0;
-                    if (context.Request.Query.TryGetValue("RuntimeId", out var runtimeIdValue))
+                    if (context.Request.Query.TryGetValue("RuntimeId", out StringValues runtimeIdValue) &&
+                                            int.TryParse(runtimeIdValue.FirstOrDefault(), out int parsedId))
                     {
-                        int.TryParse(runtimeIdValue.First(), out runtimeId);
+                        runtimeId = parsedId;
                     }
-
                     try
                     {
                         using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebuggerProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebuggerProxy.cs
@@ -17,9 +17,9 @@ namespace Microsoft.WebAssembly.Diagnostics
     {
         private readonly MonoProxy proxy;
 
-        public DebuggerProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList)
+        public DebuggerProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList, int runtimeId = 0)
         {
-            proxy = new MonoProxy(loggerFactory, urlSymbolServerList);
+            proxy = new MonoProxy(loggerFactory, urlSymbolServerList, runtimeId);
         }
 
         public Task Run(Uri browserUri, WebSocket ideSocket)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -172,31 +172,31 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public MonoCommands(string expression) => this.expression = expression;
 
-        public static MonoCommands GetDebuggerAgentBufferReceived() => new MonoCommands("INTERNAL.mono_wasm_get_dbg_command_info()");
+        public static MonoCommands GetDebuggerAgentBufferReceived(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_dbg_command_info()");
 
-        public static MonoCommands IsRuntimeReady() => new MonoCommands("INTERNAL.mono_wasm_runtime_is_ready");
+        public static MonoCommands IsRuntimeReady(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_runtime_is_ready");
 
-        public static MonoCommands GetLoadedFiles() => new MonoCommands("INTERNAL.mono_wasm_get_loaded_files()");
+        public static MonoCommands GetLoadedFiles(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_loaded_files()");
 
-        public static MonoCommands SendDebuggerAgentCommand(int id, int command_set, int command, string command_parameters)
+        public static MonoCommands SendDebuggerAgentCommand(int runtimeId, int id, int command_set, int command, string command_parameters)
         {
-            return new MonoCommands($"INTERNAL.mono_wasm_send_dbg_command ({id}, {command_set}, {command},'{command_parameters}')");
+            return new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_send_dbg_command ({id}, {command_set}, {command},'{command_parameters}')");
         }
 
-        public static MonoCommands SendDebuggerAgentCommandWithParms(int id, int command_set, int command, string command_parameters, int len, int type, string parm)
+        public static MonoCommands SendDebuggerAgentCommandWithParms(int runtimeId, int id, int command_set, int command, string command_parameters, int len, int type, string parm)
         {
-            return new MonoCommands($"INTERNAL.mono_wasm_send_dbg_command_with_parms ({id}, {command_set}, {command},'{command_parameters}', {len}, {type}, '{parm}')");
+            return new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_send_dbg_command_with_parms ({id}, {command_set}, {command},'{command_parameters}', {len}, {type}, '{parm}')");
         }
 
-        public static MonoCommands CallFunctionOn(JToken args) => new MonoCommands($"INTERNAL.mono_wasm_call_function_on ({args})");
+        public static MonoCommands CallFunctionOn(int runtimeId, JToken args) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_call_function_on ({args})");
 
-        public static MonoCommands GetDetails(int objectId, JToken args = null) => new MonoCommands($"INTERNAL.mono_wasm_get_details ({objectId}, {(args ?? "{ }")})");
+        public static MonoCommands GetDetails(int runtimeId, int objectId, JToken args = null) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_details ({objectId}, {(args ?? "{ }")})");
 
-        public static MonoCommands Resume() => new MonoCommands($"INTERNAL.mono_wasm_debugger_resume ()");
+        public static MonoCommands Resume(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_debugger_resume ()");
 
-        public static MonoCommands DetachDebugger() => new MonoCommands($"INTERNAL.mono_wasm_detach_debugger()");
+        public static MonoCommands DetachDebugger(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_detach_debugger()");
 
-        public static MonoCommands ReleaseObject(DotnetObjectId objectId) => new MonoCommands($"INTERNAL.mono_wasm_release_object('{objectId}')");
+        public static MonoCommands ReleaseObject(int runtimeId, DotnetObjectId objectId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_release_object('{objectId}')");
     }
 
     internal enum MonoErrorCodes

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -25,7 +25,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         private const string sPauseOnUncaught = "pause_on_uncaught";
         private const string sPauseOnCaught = "pause_on_caught";
         // index of the runtime in a same JS page/process
-        public int RuntimeId { get; private set; }
+        public int RuntimeId { get; private init; }
 
         public MonoProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList, int runtimeId = 0) : base(loggerFactory)
         {

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -24,10 +24,13 @@ namespace Microsoft.WebAssembly.Diagnostics
         private Dictionary<SessionId, ExecutionContext> contexts = new Dictionary<SessionId, ExecutionContext>();
         private const string sPauseOnUncaught = "pause_on_uncaught";
         private const string sPauseOnCaught = "pause_on_caught";
+        // index of the runtime in a same JS page/process
+        public int RuntimeId { get; private set; }
 
-        public MonoProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList) : base(loggerFactory)
+        public MonoProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList, int runtimeId = 0) : base(loggerFactory)
         {
             this.urlSymbolServerList = urlSymbolServerList ?? new List<string>();
+            RuntimeId = runtimeId;
         }
 
         internal ExecutionContext GetContext(SessionId sessionId)
@@ -223,7 +226,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                 case "Target.targetDestroyed":
                     {
-                        await SendMonoCommand(sessionId, MonoCommands.DetachDebugger(), token);
+                        await SendMonoCommand(sessionId, MonoCommands.DetachDebugger(RuntimeId), token);
                         break;
                     }
             }
@@ -236,7 +239,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (contexts.TryGetValue(sessionId, out ExecutionContext context) && context.IsRuntimeReady)
                 return true;
 
-            Result res = await SendMonoCommand(sessionId, MonoCommands.IsRuntimeReady(), token);
+            Result res = await SendMonoCommand(sessionId, MonoCommands.IsRuntimeReady(RuntimeId), token);
             return res.Value?["result"]?["value"]?.Value<bool>() ?? false;
         }
 
@@ -434,7 +437,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         if (!(DotnetObjectId.TryParse(args["objectId"], out DotnetObjectId objectId) && objectId.Scheme == "cfo_res"))
                             break;
 
-                        await SendMonoCommand(id, MonoCommands.ReleaseObject(objectId), token);
+                        await SendMonoCommand(id, MonoCommands.ReleaseObject(RuntimeId, objectId), token);
                         SendResponse(id, Result.OkFromObject(new { }), token);
                         return true;
                     }
@@ -558,7 +561,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     break;
                 case "cfo_res":
                 {
-                    Result cfo_res = await SendMonoCommand(id, MonoCommands.CallFunctionOn(args), token);
+                    Result cfo_res = await SendMonoCommand(id, MonoCommands.CallFunctionOn(RuntimeId, args), token);
                     cfo_res = Result.OkFromObject(new { result = cfo_res.Value?["result"]?["value"]});
                     SendResponse(id, cfo_res, token);
                     return true;
@@ -574,7 +577,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 default:
                     return false;
             }
-            Result res = await SendMonoCommand(id, MonoCommands.CallFunctionOn(args), token);
+            Result res = await SendMonoCommand(id, MonoCommands.CallFunctionOn(RuntimeId, args), token);
             if (res.IsErr)
             {
                 SendResponse(id, res, token);
@@ -652,7 +655,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         return new JArray{await context.SdbAgent.GetPointerContent(int.Parse(objectId.Value), token)};
                     case "cfo_res":
                     {
-                        Result res = await SendMonoCommand(id, MonoCommands.GetDetails(int.Parse(objectId.Value), args), token);
+                        Result res = await SendMonoCommand(id, MonoCommands.GetDetails(RuntimeId, int.Parse(objectId.Value), args), token);
                         string value_json_str = res.Value["result"]?["value"]?["__value_as_json_string__"]?.Value<string>();
                         return value_json_str != null ? JArray.Parse(value_json_str) : null;
                     }
@@ -831,7 +834,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
         private async Task<bool> OnReceiveDebuggerAgentEvent(SessionId sessionId, JObject args, CancellationToken token)
         {
-            Result res = await SendMonoCommand(sessionId, MonoCommands.GetDebuggerAgentBufferReceived(), token);
+            Result res = await SendMonoCommand(sessionId, MonoCommands.GetDebuggerAgentBufferReceived(RuntimeId), token);
             if (res.IsErr)
                 return false;
 
@@ -966,11 +969,11 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         private async Task OnResume(MessageId msg_id, CancellationToken token)
         {
-            ExecutionContext ctx = GetContext(msg_id);
-            if (ctx.CallStack != null)
+            ExecutionContext context = GetContext(msg_id);
+            if (context.CallStack != null)
             {
                 // Stopped on managed code
-                await SendMonoCommand(msg_id, MonoCommands.Resume(), token);
+                await SendMonoCommand(msg_id, MonoCommands.Resume(RuntimeId), token);
             }
 
             //discard managed frames
@@ -1187,7 +1190,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
                 if (loaded_files == null)
                 {
-                    Result loaded = await SendMonoCommand(sessionId, MonoCommands.GetLoadedFiles(), token);
+                    Result loaded = await SendMonoCommand(sessionId, MonoCommands.GetLoadedFiles(RuntimeId), token);
                     loaded_files = loaded.Value?["result"]?["value"]?.ToObject<string[]>();
                 }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -859,7 +859,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
 
         internal async Task<MonoBinaryReader> SendDebuggerAgentCommand<T>(T command, MonoBinaryWriter arguments, CancellationToken token) =>
-            MonoBinaryReader.From (await proxy.SendMonoCommand(sessionId, MonoCommands.SendDebuggerAgentCommand(GetId(), (int)GetCommandSetForCommand(command), (int)(object)command, arguments?.ToBase64().data ?? string.Empty), token));
+            MonoBinaryReader.From (await proxy.SendMonoCommand(sessionId, MonoCommands.SendDebuggerAgentCommand(proxy.RuntimeId, GetId(), (int)GetCommandSetForCommand(command), (int)(object)command, arguments?.ToBase64().data ?? string.Empty), token));
 
         internal CommandSet GetCommandSetForCommand<T>(T command) =>
             command switch {
@@ -882,7 +882,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             };
 
         internal async Task<MonoBinaryReader> SendDebuggerAgentCommandWithParms<T>(T command, (string data, int length) encoded, int type, string extraParm, CancellationToken token) =>
-            MonoBinaryReader.From(await proxy.SendMonoCommand(sessionId, MonoCommands.SendDebuggerAgentCommandWithParms(GetId(), (int)GetCommandSetForCommand(command), (int)(object)command, encoded.data, encoded.length, type, extraParm), token));
+            MonoBinaryReader.From(await proxy.SendMonoCommand(sessionId, MonoCommands.SendDebuggerAgentCommandWithParms(proxy.RuntimeId, GetId(), (int)GetCommandSetForCommand(command), (int)(object)command, encoded.data, encoded.length, type, extraParm), token));
 
         public async Task<int> CreateString(string value, CancellationToken token)
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -36,7 +36,7 @@ namespace DebuggerTests
         {
             // Test that js breakpoints get set correctly
             // 13 24
-            // 13 33
+            // 13 53
             var bp1_res = await SetBreakpoint("/debugger-driver.html", 13, 24);
 
             Assert.EndsWith("debugger-driver.html", bp1_res.Value["breakpointId"].ToString());
@@ -48,7 +48,7 @@ namespace DebuggerTests
             Assert.Equal(13, (int)loc["lineNumber"]);
             Assert.Equal(24, (int)loc["columnNumber"]);
 
-            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 33);
+            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 53);
 
             Assert.EndsWith("debugger-driver.html", bp2_res.Value["breakpointId"].ToString());
             Assert.Equal(1, bp2_res.Value["locations"]?.Value<JArray>()?.Count);
@@ -57,14 +57,14 @@ namespace DebuggerTests
 
             Assert.NotNull(loc2["scriptId"]);
             Assert.Equal(13, (int)loc2["lineNumber"]);
-            Assert.Equal(33, (int)loc2["columnNumber"]);
+            Assert.Equal(53, (int)loc2["columnNumber"]);
         }
 
         [Fact]
         public async Task CreateJS0Breakpoint()
         {
             // 13 24
-            // 13 33
+            // 13 53
             var bp1_res = await SetBreakpoint("/debugger-driver.html", 13, 0);
 
             Assert.EndsWith("debugger-driver.html", bp1_res.Value["breakpointId"].ToString());
@@ -74,9 +74,9 @@ namespace DebuggerTests
 
             Assert.NotNull(loc["scriptId"]);
             Assert.Equal(13, (int)loc["lineNumber"]);
-            Assert.Equal(24, (int)loc["columnNumber"]);
+            Assert.Equal(4, (int)loc["columnNumber"]);
 
-            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 33);
+            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 53);
 
             Assert.EndsWith("debugger-driver.html", bp2_res.Value["breakpointId"].ToString());
             Assert.Equal(1, bp2_res.Value["locations"]?.Value<JArray>()?.Count);
@@ -85,7 +85,7 @@ namespace DebuggerTests
 
             Assert.NotNull(loc2["scriptId"]);
             Assert.Equal(13, (int)loc2["lineNumber"]);
-            Assert.Equal(33, (int)loc2["columnNumber"]);
+            Assert.Equal(53, (int)loc2["columnNumber"]);
         }
 
         [Theory]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
@@ -18,12 +18,12 @@ namespace DebuggerTests
         {
             var bad_expressions = new[]
             {
-                    "INTERNAL.mono_wasm_raise_debug_event('')",
-                    "INTERNAL.mono_wasm_raise_debug_event(undefined)",
-                    "INTERNAL.mono_wasm_raise_debug_event({})",
+                    "getDotnetRuntime(0).INTERNAL.mono_wasm_raise_debug_event('')",
+                    "getDotnetRuntime(0).INTERNAL.mono_wasm_raise_debug_event(undefined)",
+                    "getDotnetRuntime(0).INTERNAL.mono_wasm_raise_debug_event({})",
 
-                    "INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, '')",
-                    "INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, 12)"
+                    "getDotnetRuntime(0).INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, '')",
+                    "getDotnetRuntime(0).INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, 12)"
                 };
 
             foreach (var expression in bad_expressions)
@@ -58,7 +58,7 @@ namespace DebuggerTests
             });
 
             var trace_str = trace.HasValue ? $"trace: {trace.ToString().ToLower()}" : String.Empty;
-            var expression = $"INTERNAL.mono_wasm_raise_debug_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
+            var expression = $"getDotnetRuntime(0).INTERNAL.mono_wasm_raise_debug_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
             var res = await cli.SendCommand($"Runtime.evaluate", JObject.FromObject(new { expression }), token);
             Assert.True(res.IsOk, $"Expected to pass for {expression}");
 
@@ -139,7 +139,7 @@ namespace DebuggerTests
                 pdb_base64 = Convert.ToBase64String(bytes);
             }
 
-            var expression = $@"INTERNAL.mono_wasm_raise_debug_event({{
+            var expression = $@"getDotnetRuntime(0).INTERNAL.mono_wasm_raise_debug_event({{
                     eventName: 'AssemblyLoaded',
                     assembly_name: '{asm_name}',
                     assembly_b64: '{asm_base64}',

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
@@ -6,14 +6,14 @@
 	<script type='text/javascript'>
 		var App = {
 			init: function () {
-				this.int_add = INTERNAL.mono_bind_static_method ("[debugger-test] Math:IntAdd");
-				this.use_complex = INTERNAL.mono_bind_static_method ("[debugger-test] Math:UseComplex");
-				this.delegates_test = INTERNAL.mono_bind_static_method ("[debugger-test] Math:DelegatesTest");
-				this.generic_types_test = INTERNAL.mono_bind_static_method ("[debugger-test] Math:GenericTypesTest");
-				this.outer_method = INTERNAL.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
-				this.async_method = INTERNAL.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
-				this.method_with_structs = INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTests.ValueTypesTest:MethodWithLocalStructs");
-				this.run_all = INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTest:run_all");
+				this.int_add = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] Math:IntAdd");
+				this.use_complex = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] Math:UseComplex");
+				this.delegates_test = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] Math:DelegatesTest");
+				this.generic_types_test = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] Math:GenericTypesTest");
+				this.outer_method = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
+				this.async_method = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
+				this.method_with_structs = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTests.ValueTypesTest:MethodWithLocalStructs");
+				this.run_all = getDotnetRuntime(0).INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTest:run_all");
 				this.static_method_table = {};
 				console.log ("ready");
 			},
@@ -21,7 +21,7 @@
 		function invoke_static_method (method_name, ...args) {
 			var method = App.static_method_table [method_name];
 			if (method == undefined)
-				method = App.static_method_table [method_name] = INTERNAL.mono_bind_static_method (method_name);
+				method = App.static_method_table [method_name] = getDotnetRuntime(0).INTERNAL.mono_bind_static_method (method_name);
 
 			return method (...args);
 		}
@@ -29,7 +29,7 @@
 		async function invoke_static_method_async (method_name, ...args) {
 			var method = App.static_method_table [method_name];
 			if (method == undefined) {
-				method = App.static_method_table [method_name] = INTERNAL.mono_bind_static_method (method_name);
+				method = App.static_method_table [method_name] = getDotnetRuntime(0).INTERNAL.mono_bind_static_method (method_name);
 			}
 
 			return await method (...args);

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -120,7 +120,7 @@ export function mono_wasm_get_loaded_files(): string[] {
 function _create_proxy_from_object_id(objectId: string, details: any) {
     if (objectId.startsWith("dotnet:array:")) {
         let ret: Array<any>;
-        if (details.dimensionsDetails == undefined || details.dimensionsDetails.length == 1) {
+        if (details.dimensionsDetails === undefined || details.dimensionsDetails.length === 1) {
             ret = details.items.map((p: any) => p.value);
             return ret;
         }
@@ -297,7 +297,7 @@ export function mono_wasm_release_object(objectId: string): void {
 export function mono_wasm_debugger_log(level: number, message_ptr: CharPtr): void {
     const message = Module.UTF8ToString(message_ptr);
 
-    if (INTERNAL["logging"] && INTERNAL.logging["debugger"]) {
+    if (INTERNAL["logging"] && typeof INTERNAL.logging["debugger"] === "function") {
         INTERNAL.logging.debugger(level, message);
         return;
     }
@@ -312,7 +312,7 @@ export function mono_wasm_trace_logger(log_domain_ptr: CharPtr, log_level_ptr: C
     const dataPtr = user_data;
     const log_level = Module.UTF8ToString(log_level_ptr);
 
-    if (INTERNAL["logging"] && INTERNAL.logging["trace"]) {
+    if (INTERNAL["logging"] && typeof INTERNAL.logging["trace"] === "function") {
         INTERNAL.logging.trace(domain, log_level, message, isFatal, dataPtr);
         return;
     }

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { Module, MONO, runtimeHelpers } from "./imports";
+import { INTERNAL, Module, MONO, runtimeHelpers } from "./imports";
 import { toBase64StringImpl } from "./base64";
 import cwraps from "./cwraps";
 import { VoidPtr } from "./types";
@@ -45,6 +45,7 @@ export function mono_wasm_add_dbg_command_received(res_ok: boolean, id: number, 
     };
     commands_received = buffer_obj;
 }
+
 function mono_wasm_malloc_and_set_debug_buffer(command_parameters: string) {
     if (command_parameters.length > _debugger_buffer_len) {
         if (_debugger_buffer)
@@ -118,9 +119,8 @@ export function mono_wasm_get_loaded_files(): string[] {
 
 function _create_proxy_from_object_id(objectId: string, details: any) {
     if (objectId.startsWith("dotnet:array:")) {
-        let ret : Array<any>;
-        if (details.dimensionsDetails == undefined || details.dimensionsDetails.length == 1)
-        {
+        let ret: Array<any>;
+        if (details.dimensionsDetails == undefined || details.dimensionsDetails.length == 1) {
             ret = details.items.map((p: any) => p.value);
             return ret;
         }
@@ -292,6 +292,55 @@ function _cache_call_function_res(obj: any) {
 export function mono_wasm_release_object(objectId: string): void {
     if (objectId in _call_function_res_cache)
         delete _call_function_res_cache[objectId];
+}
+
+export function mono_wasm_debugger_log(level: number, message_ptr: CharPtr): void {
+    const message = Module.UTF8ToString(message_ptr);
+
+    if (INTERNAL["logging"] && INTERNAL.logging["debugger"]) {
+        INTERNAL.logging.debugger(level, message);
+        return;
+    }
+
+    console.debug(`Debugger.Debug: ${message}`);
+}
+
+export function mono_wasm_trace_logger(log_domain_ptr: CharPtr, log_level_ptr: CharPtr, message_ptr: CharPtr, fatal: number, user_data: VoidPtr): void {
+    const message = Module.UTF8ToString(message_ptr);
+    const isFatal = !!fatal;
+    const domain = Module.UTF8ToString(log_domain_ptr); // is this always Mono?
+    const dataPtr = user_data;
+    const log_level = Module.UTF8ToString(log_level_ptr);
+
+    if (INTERNAL["logging"] && INTERNAL.logging["trace"]) {
+        INTERNAL.logging.trace(domain, log_level, message, isFatal, dataPtr);
+        return;
+    }
+
+    if (isFatal)
+        console.trace(message);
+
+    switch (log_level) {
+        case "critical":
+        case "error":
+            console.error(message);
+            break;
+        case "warning":
+            console.warn(message);
+            break;
+        case "message":
+            console.log(message);
+            break;
+        case "info":
+            console.info(message);
+            break;
+        case "debug":
+            console.debug(message);
+            break;
+        default:
+            console.log(message);
+            break;
+    }
 }
 
 type CallDetails = {

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -136,47 +136,12 @@ static MonoDomain *root_domain;
 
 #define RUNTIMECONFIG_BIN_FILE "runtimeconfig.bin"
 
+extern void mono_wasm_trace_logger (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
+
 static void
 wasm_trace_logger (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data)
 {
-	EM_ASM({
-		var log_level = $0;
-		var message = Module.UTF8ToString ($1);
-		var isFatal = $2;
-		var domain = Module.UTF8ToString ($3); // is this always Mono?
-		var dataPtr = $4;
-
-		if (INTERNAL["logging"] && INTERNAL.logging["trace"]) {
-			INTERNAL.logging.trace(domain, log_level, message, isFatal, dataPtr);
-			return;
-		}
-
-		if (isFatal)
-			console.trace (message);
-
-		switch (Module.UTF8ToString ($0)) {
-			case "critical":
-			case "error":
-				console.error (message);
-				break;
-			case "warning":
-				console.warn (message);
-				break;
-			case "message":
-				console.log (message);
-				break;
-			case "info":
-				console.info (message);
-				break;
-			case "debug":
-				console.debug (message);
-				break;
-			default:
-				console.log (message);
-				break;
-		}
-	}, log_level, message, fatal, log_domain, user_data);
-
+	mono_wasm_trace_logger(log_domain, log_level, message, fatal, user_data);
 	if (fatal)
 		exit (1);
 }

--- a/src/mono/wasm/runtime/export-types.ts
+++ b/src/mono/wasm/runtime/export-types.ts
@@ -1,7 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 import { DotNetPublicAPI } from "./exports";
 import { EmscriptenModuleConfig } from "./types";
 
-// this is the only public export from the dotnet.js module
+// this files has all public exports from the dotnet.js module
 declare function createDotnetRuntime(moduleFactory: (api: DotNetPublicAPI) => EmscriptenModuleConfig): Promise<DotNetPublicAPI>;
 export default createDotnetRuntime;
 
+export declare function getDotnetRuntime(runtimeId: number): DotNetPublicAPI | undefined;

--- a/src/mono/wasm/runtime/export-types.ts
+++ b/src/mono/wasm/runtime/export-types.ts
@@ -4,8 +4,15 @@
 import { DotNetPublicAPI } from "./exports";
 import { EmscriptenModuleConfig } from "./types";
 
+// -----------------------------------------------------------
 // this files has all public exports from the dotnet.js module
-declare function createDotnetRuntime(moduleFactory: (api: DotNetPublicAPI) => EmscriptenModuleConfig): Promise<DotNetPublicAPI>;
-export default createDotnetRuntime;
+// -----------------------------------------------------------
 
-export declare function getDotnetRuntime(runtimeId: number): DotNetPublicAPI | undefined;
+declare function createDotnetRuntime(moduleFactory: (api: DotNetPublicAPI) => EmscriptenModuleConfig): Promise<DotNetPublicAPI>;
+
+// Here, declare things that go in the global namespace, or augment existing declarations in the global namespace
+declare global {
+    function getDotnetRuntime(runtimeId: number): DotNetPublicAPI | undefined;
+}
+
+export default createDotnetRuntime;

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -143,8 +143,10 @@ function initializeImportsAndExports(
         BINDING: exports.binding,
         INTERNAL: exports.internal,
         Module: module,
-        productVersion,
-        configuration
+        RuntimeBuildInfo: {
+            productVersion,
+            configuration
+        }
     };
 
     if (module.configSrc) {
@@ -222,7 +224,7 @@ function initializeImportsAndExports(
     else {
         list = globalThisAny.getDotnetRuntime.list;
     }
-    api.runtimeId = globalThisAny.getDotnetRuntime.list.length;
+    api.RuntimeId = globalThisAny.getDotnetRuntime.list.length;
     list.push(create_weak_ref(api));
 
     return api;
@@ -371,7 +373,9 @@ export interface DotNetPublicAPI {
     MONO: MONO,
     BINDING: BINDING,
     Module: any,
-    runtimeId: number,
-    productVersion: string,
-    configuration: string,
+    RuntimeId: number,
+    RuntimeBuildInfo: {
+        productVersion: string,
+        configuration: string,
+    }
 }

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import productVersion from "consts:productVersion";
+import configuration from "consts:configuration";
 
 import {
     mono_wasm_new_root, mono_wasm_new_roots, mono_wasm_release_roots,
@@ -142,7 +143,8 @@ function initializeImportsAndExports(
         BINDING: exports.binding,
         INTERNAL: exports.internal,
         Module: module,
-        productVersion: productVersion
+        productVersion,
+        configuration
     };
 
     if (module.configSrc) {
@@ -371,4 +373,5 @@ export interface DotNetPublicAPI {
     Module: any,
     runtimeId: number,
     productVersion: string,
+    configuration: string,
 }

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import productVersion from "consts:productVersion";
-import configuration from "consts:configuration";
+import ProductVersion from "consts:productVersion";
+import Configuration from "consts:configuration";
 
 import {
     mono_wasm_new_root, mono_wasm_new_roots, mono_wasm_release_roots,
@@ -144,8 +144,8 @@ function initializeImportsAndExports(
         INTERNAL: exports.internal,
         Module: module,
         RuntimeBuildInfo: {
-            productVersion,
-            configuration
+            ProductVersion,
+            Configuration
         }
     };
 
@@ -369,8 +369,8 @@ export interface DotNetPublicAPI {
     Module: any,
     RuntimeId: number,
     RuntimeBuildInfo: {
-        productVersion: string,
-        configuration: string,
+        ProductVersion: string,
+        Configuration: string,
     }
 }
 

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -1,12 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import productVersion from "consts:productVersion";
+
 import {
     mono_wasm_new_root, mono_wasm_new_roots, mono_wasm_release_roots,
     mono_wasm_new_root_buffer, mono_wasm_new_root_buffer_from_pointer
 } from "./roots";
 import {
-    mono_wasm_add_dbg_command_received,
     mono_wasm_send_dbg_command_with_parms,
     mono_wasm_send_dbg_command,
     mono_wasm_get_dbg_command_info,
@@ -19,6 +20,9 @@ import {
     mono_wasm_get_loaded_files,
     mono_wasm_raise_debug_event,
     mono_wasm_fire_debugger_agent_message,
+    mono_wasm_debugger_log,
+    mono_wasm_trace_logger,
+    mono_wasm_add_dbg_command_received,
 } from "./debug";
 import { runtimeHelpers, setImportsAndExports } from "./imports";
 import { EmscriptenModuleMono, MonoArray, MonoConfig, MonoConfigError, MonoObject } from "./types";
@@ -32,7 +36,7 @@ import {
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
-import { conv_string, js_string_to_mono_string, mono_intern_string, string_decoder } from "./strings";
+import { conv_string, js_string_to_mono_string, mono_intern_string } from "./strings";
 import { js_to_mono_obj, js_typed_array_to_array, mono_wasm_typed_array_to_array } from "./js-to-cs";
 import {
     mono_array_to_js_array, mono_wasm_create_cs_owned_object, unbox_mono_obj,
@@ -62,6 +66,7 @@ import {
     getI8, getI16, getI32, getI64,
     getU8, getU16, getU32, getF32, getF64,
 } from "./memory";
+import { create_weak_ref } from "./weak-ref";
 
 const MONO: MONO = <any>{
     // current "public" MONO API
@@ -112,13 +117,15 @@ const BINDING: BINDING = <any>{
     _teardown_after_call,
 };
 
+let api: DotNetPublicAPI;
+
 // this is executed early during load of emscripten runtime
 // it exports methods to global objects MONO, BINDING and Module in backward compatible way
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function initializeImportsAndExports(
     imports: { isGlobal: boolean, isNode: boolean, isShell: boolean, isWeb: boolean, locateFile: Function },
     exports: { mono: any, binding: any, internal: any, module: any },
-): void {
+): DotNetPublicAPI {
     const module = exports.module as EmscriptenModuleMono;
     const globalThisAny = globalThis as any;
 
@@ -130,11 +137,12 @@ function initializeImportsAndExports(
     Object.assign(exports.binding, BINDING);
     Object.assign(exports.internal, INTERNAL);
 
-    const api: DotNetPublicAPI = <any>{
+    api = <any>{
         MONO: exports.mono,
         BINDING: exports.binding,
         INTERNAL: exports.internal,
-        Module: module
+        Module: module,
+        productVersion: productVersion
     };
 
     if (module.configSrc) {
@@ -199,7 +207,25 @@ function initializeImportsAndExports(
         warnWrap("addRunDependency", () => module.addRunDependency);
         warnWrap("removeRunDependency", () => module.removeRunDependency);
     }
+    let list: WeakRef<DotNetPublicAPI>[] = [];
+    if (!globalThisAny.getDotnetRuntime) {
+        globalThisAny.getDotnetRuntime = (runtimeId: number) => {
+            if (runtimeId < 0 || list.length < runtimeId) {
+                return undefined;
+            }
+            return list[runtimeId].deref();
+        };
+        globalThisAny.getDotnetRuntime.list = list;
+    }
+    else {
+        list = globalThisAny.getDotnetRuntime.list;
+    }
+    api.runtimeId = globalThisAny.getDotnetRuntime.list.length;
+    list.push(create_weak_ref(api));
+
+    return api;
 }
+
 export const __initializeImportsAndExports: any = initializeImportsAndExports; // don't want to export the type
 
 // the methods would be visible to EMCC linker
@@ -211,6 +237,8 @@ export const __linker_exports: any = {
     // mini-wasm-debugger.c
     mono_wasm_asm_loaded,
     mono_wasm_fire_debugger_agent_message,
+    mono_wasm_debugger_log,
+    mono_wasm_add_dbg_command_received,
 
     // mono-threads-wasm.c
     schedule_background_exec,
@@ -218,6 +246,7 @@ export const __linker_exports: any = {
     // also keep in sync with driver.c
     mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
+    mono_wasm_trace_logger,
 
     // also keep in sync with corebindings.c
     mono_wasm_invoke_js_with_args,
@@ -258,18 +287,13 @@ const INTERNAL: any = {
     mono_profiler_init_aot: cwraps.mono_profiler_init_aot,
     mono_wasm_set_runtime_options,
     mono_wasm_set_main_args: mono_wasm_set_main_args,
-    mono_wasm_strdup: cwraps.mono_wasm_strdup,
     mono_wasm_exec_regression: cwraps.mono_wasm_exec_regression,
     mono_method_resolve,//MarshalTests.cs
     mono_bind_static_method,// MarshalTests.cs
     mono_intern_string,// MarshalTests.cs
 
-    // EM_JS,EM_ASM,EM_ASM_INT macros
-    string_decoder,
+    // with mono_wasm_debugger_log and mono_wasm_trace_logger
     logging: undefined,
-
-    // used in EM_ASM macros in debugger
-    mono_wasm_add_dbg_command_received,
 
     // used in debugger DevToolsHelper.cs
     mono_wasm_get_loaded_files,
@@ -344,5 +368,7 @@ interface BINDING {
 export interface DotNetPublicAPI {
     MONO: MONO,
     BINDING: BINDING,
-    Module: any
+    Module: any,
+    runtimeId: number,
+    productVersion: string,
 }

--- a/src/mono/wasm/runtime/gc-handles.ts
+++ b/src/mono/wasm/runtime/gc-handles.ts
@@ -3,9 +3,9 @@
 
 import corebindings from "./corebindings";
 import { GCHandle, JSHandle, JSHandleDisposed, JSHandleNull, MonoObject, MonoObjectNull } from "./types";
+import { create_weak_ref } from "./weak-ref";
 
 export const _use_finalization_registry = typeof globalThis.FinalizationRegistry === "function";
-export const _use_weak_ref = typeof globalThis.WeakRef === "function";
 export let _js_owned_object_registry: FinalizationRegistry<any>;
 
 // this is array, not map. We maintain list of gaps in _js_handle_free_list so that it could be as compact as possible
@@ -78,18 +78,7 @@ export function _lookup_js_owned_object(gc_handle: GCHandle): any {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function _register_js_owned_object(gc_handle: GCHandle, js_obj: any): void {
-    let wr;
-    if (_use_weak_ref) {
-        wr = new WeakRef(js_obj);
-    }
-    else {
-        // this is trivial WeakRef replacement, which holds strong refrence, instead of weak one, when the browser doesn't support it
-        wr = {
-            deref: () => {
-                return js_obj;
-            }
-        };
-    }
+    const wr = create_weak_ref(js_obj);
     _js_owned_object_table.set(gc_handle, wr);
 }
 

--- a/src/mono/wasm/runtime/library-dotnet.js
+++ b/src/mono/wasm/runtime/library-dotnet.js
@@ -10,7 +10,7 @@ const DotNetSupportLib = {
     $BINDING: {},
     $INTERNAL: {},
     // this line will be executed early on runtime, passing import and export objects into __dotnet_runtime IFFE
-    $DOTNET__postset: "__dotnet_runtime.__initializeImportsAndExports({isGlobal:true, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile}, {mono:MONO, binding:BINDING, internal:INTERNAL, module:Module});",
+    $DOTNET__postset: "let api = __dotnet_runtime.__initializeImportsAndExports({isGlobal:true, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile}, {mono:MONO, binding:BINDING, internal:INTERNAL, module:Module});",
 };
 
 // the methods would be visible to EMCC linker
@@ -22,6 +22,8 @@ const linked_functions = [
     // mini-wasm-debugger.c
     "mono_wasm_asm_loaded",
     "mono_wasm_fire_debugger_agent_message",
+    "mono_wasm_debugger_log",
+    "mono_wasm_add_dbg_command_received",
 
     // mono-threads-wasm.c
     "schedule_background_exec",
@@ -29,6 +31,7 @@ const linked_functions = [
     // driver.c
     "mono_wasm_invoke_js",
     "mono_wasm_invoke_js_blazor",
+    "mono_wasm_trace_logger",
 
     // corebindings.c
     "mono_wasm_invoke_js_with_args",

--- a/src/mono/wasm/runtime/package-lock.json
+++ b/src/mono/wasm/runtime/package-lock.json
@@ -1194,6 +1194,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rollup-plugin-consts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-consts/-/rollup-plugin-consts-1.0.2.tgz",
+      "integrity": "sha512-vsy9uyIGTXHsVVlD6c2f43xgiQQYRWY29ycC3ezewxc9AHySjQh5Oi3NEX/9c4OnRnnxe+PMwOtvYBMyP0993Q==",
+      "dev": true
+    },
     "rollup-plugin-dts": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.0.0.tgz",

--- a/src/mono/wasm/runtime/package.json
+++ b/src/mono/wasm/runtime/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/parser": "4.31.2",
     "eslint": "7.32.0",
     "rollup": "2.56.3",
+    "rollup-plugin-consts": "1.0.2",
     "rollup-plugin-dts": "4.0.0",
     "rollup-plugin-terser": "7.0.2",
     "tslib": "2.3.1",

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -8,7 +8,8 @@ import dts from "rollup-plugin-dts";
 import consts from "rollup-plugin-consts";
 
 const outputFileName = "runtime.iffe.js";
-const isDebug = process.env.Configuration !== "Release";
+const configuration = process.env.Configuration;
+const isDebug = configuration !== "Release";
 const productVersion = process.env.ProductVersion || "7.0.0-dev";
 const nativeBinDir = process.env.NativeBinDir ? process.env.NativeBinDir.replace(/"/g, "") : "bin";
 const terserConfig = {
@@ -54,7 +55,7 @@ export default defineConfig([
             format,
             plugins,
         }],
-        plugins: [consts({ productVersion }), typescript()]
+        plugins: [consts({ productVersion, configuration }), typescript()]
     },
     {
         input: "./export-types.ts",

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -5,9 +5,11 @@ import { readFile, writeFile, mkdir } from "fs/promises";
 import * as fs from "fs";
 import { createHash } from "crypto";
 import dts from "rollup-plugin-dts";
+import consts from "rollup-plugin-consts";
 
 const outputFileName = "runtime.iffe.js";
 const isDebug = process.env.Configuration !== "Release";
+const productVersion = process.env.ProductVersion || "7.0.0-dev";
 const nativeBinDir = process.env.NativeBinDir ? process.env.NativeBinDir.replace(/"/g, "") : "bin";
 const terserConfig = {
     compress: {
@@ -52,7 +54,7 @@ export default defineConfig([
             format,
             plugins,
         }],
-        plugins: [typescript()]
+        plugins: [consts({ productVersion }), typescript()]
     },
     {
         input: "./export-types.ts",

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -536,10 +536,10 @@ export function mono_wasm_set_main_args(name: string, allRuntimeArguments: strin
     const main_argc = allRuntimeArguments.length + 1;
     const main_argv = <any>Module._malloc(main_argc * 4);
     let aindex = 0;
-    Module.setValue(main_argv + (aindex * 4), INTERNAL.mono_wasm_strdup(name), "i32");
+    Module.setValue(main_argv + (aindex * 4), cwraps.mono_wasm_strdup(name), "i32");
     aindex += 1;
     for (let i = 0; i < allRuntimeArguments.length; ++i) {
-        Module.setValue(main_argv + (aindex * 4), INTERNAL.mono_wasm_strdup(allRuntimeArguments[i]), "i32");
+        Module.setValue(main_argv + (aindex * 4), cwraps.mono_wasm_strdup(allRuntimeArguments[i]), "i32");
         aindex += 1;
     }
     cwraps.mono_wasm_set_main_args(main_argc, main_argv);

--- a/src/mono/wasm/runtime/types/consts.d.ts
+++ b/src/mono/wasm/runtime/types/consts.d.ts
@@ -1,0 +1,5 @@
+declare module "consts:*" {
+    //Constant that will be inlined by Rollup and rollup-plugin-consts.
+    const constant: any;
+    export default constant;
+}

--- a/src/mono/wasm/runtime/weak-ref.ts
+++ b/src/mono/wasm/runtime/weak-ref.ts
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+const _use_weak_ref = typeof globalThis.WeakRef === "function";
+
+export function create_weak_ref<T extends object>(js_obj: T): WeakRef<T> {
+    if (_use_weak_ref) {
+        return new WeakRef(js_obj);
+    }
+    else {
+        // this is trivial WeakRef replacement, which holds strong refrence, instead of weak one, when the browser doesn't support it
+        return <any>{
+            deref: () => {
+                return js_obj;
+            }
+        };
+    }
+}

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -176,7 +176,7 @@
     <RunWithEmSdkEnv Command="npm run lint" StandardOutputImportance="High" EmSdkPath="$(EMSDK_PATH)" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>
 
     <!-- compile typescript -->
-    <RunWithEmSdkEnv Command="npm run rollup -- --environment Configuration:$(Configuration),NativeBinDir:$(NativeBinDir)" EmSdkPath="$(EMSDK_PATH)" IgnoreStandardErrorWarningFormat="true" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>
+    <RunWithEmSdkEnv Command="npm run rollup -- --environment Configuration:$(Configuration),NativeBinDir:$(NativeBinDir),ProductVersion:$(ProductVersion)" EmSdkPath="$(EMSDK_PATH)" IgnoreStandardErrorWarningFormat="true" WorkingDirectory="$(MonoProjectRoot)wasm/runtime/"/>
 
     <Copy SourceFiles="runtime/driver.c;
                        runtime/pinvoke.c;


### PR DESCRIPTION
### Context
After we modularize the runtime, the APIs like `MONO` or `INTERNAL` would not be on globalThis anymore.
Also, there would be possibility to instantiate multiple runtimes in the same web page.

I don't think that multiple runtimes on same page nor multiple debuggers running on same page in parallel are very likely scenarios. This PR is just neat way how to allow that possibility in the future, while **solving the isolation that ES6 will bring**.

### Changes
- New `globalThis.getDotnetRuntime` method, which takes `runtimeId`, essentially index of the runtime on the page. It returns the `DotNetPublicAPI` object of the instance `{MONO, BINDING, Module, RuntimeId, RuntimeBuildInfo }`.
- Change the **debugger to use the getDotnetRuntime()** function when talking to the runtime on the page via CDP.
- Use `getDotnetRuntime()` in unit tests, with runtimeId is zero as there is only one runtime in tests.
- We add optional `&runtimeId=0` to the initial URL which opens DebuggerProxy, so that MonoProxy could be created for specific runtime on the page.
- Moved `mono_wasm_add_dbg_command_received`, `mono_wasm_debugger_log` and `mono_wasm_trace_logger` out of C macro into typescript
- Introduced `RuntimeBuildInfo: { ProductVersion, Configuration }` into `DotNetPublicAPI`