### PR TITLE
Mono hot reload reorg and beginning (disabled) add method support

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class AddLambdaCapturingThis
+    {
+	public AddLambdaCapturingThis () {
+	    field = "abcd";
+	}
+
+	public string GetField => field;
+
+	private string field;
+
+	public string TestMethod () {
+	    // capture 'this' but no locals
+	    Func<string,string> fn = s => field;
+	    return "123";
+	}
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis_v1.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class AddLambdaCapturingThis
+    {
+	public AddLambdaCapturingThis () {
+	    field = "abcd";
+	}
+
+	public string GetField => field;
+
+	private string field;
+
+	public string TestMethod () {
+	    // capture 'this' but no locals
+	    Func<string,string> fn = s => NewMethod (s + field, 42);
+	    return fn ("123");
+	}
+
+	private string NewMethod (string s, int i) {
+	    return i.ToString() + s;
+	}
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AddLambdaCapturingThis.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "AddLambdaCapturingThis.cs", "update": "AddLambdaCapturingThis_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -263,6 +263,7 @@ namespace System.Reflection.Metadata
             });
         }
 
+	[ActiveIssue ("https://github.com/dotnet/runtime/issues/50249", TestRuntimes.Mono)]
 	[ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
 	public static void TestAddLambdaCapturingThis()
 	{

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -263,6 +263,25 @@ namespace System.Reflection.Metadata
             });
         }
 
+	[ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
+	public static void TestAddLambdaCapturingThis()
+	{
+	    ApplyUpdateUtil.TestCase(static () =>
+	    {
+		var assm = typeof(System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis).Assembly;
+
+		var x = new System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis();
+
+		Assert.Equal("123", x.TestMethod());
+
+		ApplyUpdateUtil.ApplyUpdate(assm);
+
+		string result = x.TestMethod();
+		Assert.Equal("42123abcd", result);
+	    });
+	}
+
+
         class NonRuntimeAssembly : Assembly
         {
         }

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.LambdaBodyChange\System.Reflection.Metadata.ApplyUpdate.Test.LambdaBodyChange.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.LambdaCapturesThis\System.Reflection.Metadata.ApplyUpdate.Test.LambdaCapturesThis.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate\System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis\System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.csproj" />
 
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
@@ -60,6 +61,7 @@
       <TrimmerRootAssembly Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.LambdaBodyChange.dll'))" Include="%(ResolvedFileToPublish.FullPath)" />
       <TrimmerRootAssembly Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.LambdaCapturesThis.dll'))" Include="%(ResolvedFileToPublish.FullPath)" />
       <TrimmerRootAssembly Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.FirstCallAfterUpdate.dll'))" Include="%(ResolvedFileToPublish.FullPath)" />
+      <TrimmerRootAssembly Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.dll'))" Include="%(ResolvedFileToPublish.FullPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -41,9 +41,6 @@ hot_reload_stub_cleanup_on_close (MonoImage *image);
 static void
 hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int idx);
 
-static int
-hot_reload_stub_relative_delta_index (MonoImage *image_dmeta, int token);
-
 static void
 hot_reload_stub_close_except_pools_all (MonoImage *base_image);
 
@@ -83,7 +80,6 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_thread_generation,
 	&hot_reload_stub_cleanup_on_close,
 	&hot_reload_stub_effective_table_slow,
-	&hot_reload_stub_relative_delta_index,
 	&hot_reload_stub_apply_changes,
 	&hot_reload_stub_close_except_pools_all,
 	&hot_reload_stub_close_all,
@@ -148,12 +144,6 @@ hot_reload_stub_cleanup_on_close (MonoImage *image)
 
 void
 hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int idx)
-{
-	g_assert_not_reached ();
-}
-
-static int
-hot_reload_stub_relative_delta_index (MonoImage *image_dmeta, int token)
 {
 	g_assert_not_reached ();
 }

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -39,7 +39,7 @@ static void
 hot_reload_stub_cleanup_on_close (MonoImage *image);
 
 static void
-hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int *idx);
+hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int idx);
 
 static int
 hot_reload_stub_relative_delta_index (MonoImage *image_dmeta, int token);
@@ -147,7 +147,7 @@ hot_reload_stub_cleanup_on_close (MonoImage *image)
 }
 
 void
-hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int *idx)
+hot_reload_stub_effective_table_slow (const MonoTableInfo **t, int idx)
 {
 	g_assert_not_reached ();
 }

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -68,6 +68,12 @@ hot_reload_stub_has_modified_rows (const MonoTableInfo *table);
 static int
 hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index);
 
+static GArray*
+hot_reload_stub_get_added_methods (MonoClass *klass);
+
+static uint32_t
+hot_reload_stub_method_parent (MonoImage *image, uint32_t method_index);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -87,6 +93,8 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_updated_method_ppdb,
 	&hot_reload_stub_has_modified_rows,
 	&hot_reload_stub_table_num_rows_slow,
+	&hot_reload_stub_get_added_methods,
+	&hot_reload_stub_method_parent,
 };
 
 static bool
@@ -200,6 +208,18 @@ static int
 hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index)
 {
 	g_assert_not_reached (); /* should always take the fast path */
+}
+
+static GArray*
+hot_reload_stub_get_added_methods (MonoClass *klass)
+{
+	return NULL;
+}
+
+static uint32_t
+hot_reload_stub_method_parent (MonoImage *image, uint32_t method_index)
+{
+	return 0;
 }
 
 

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -65,6 +65,9 @@ hot_reload_stub_get_updated_method_ppdb (MonoImage *base_image, uint32_t idx);
 static gboolean
 hot_reload_stub_has_modified_rows (const MonoTableInfo *table);
 
+static int
+hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -83,6 +86,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_delta_heap_lookup,
 	&hot_reload_stub_get_updated_method_ppdb,
 	&hot_reload_stub_has_modified_rows,
+	&hot_reload_stub_table_num_rows_slow,
 };
 
 static bool
@@ -191,6 +195,13 @@ hot_reload_stub_has_modified_rows (const MonoTableInfo *table)
 {
 	return FALSE;
 }
+
+static int
+hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index)
+{
+	g_assert_not_reached (); /* should always take the fast path */
+}
+
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentHotReload *

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1407,7 +1407,6 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 
 		case ENC_FUNC_ADD_PARAM: {
 			g_assert (token_table == MONO_TABLE_METHOD);
-			/* assert that the token_index is equal to the number of rows in the table.  We only allow adding a param to the newest method def */
 			add_param_method_index = token_index;
 			break;
 		}
@@ -1511,6 +1510,25 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 		case MONO_TABLE_PARAM: {
 			/* ok, pass1 checked for disallowed modifications */
 			/* ALLOW_METHOD_ADD: FIXME: here we would really like to update the method's paramlist column to point to the new params. */
+			/* if there were multiple added methods, this comes in as several method
+			 * additions, followed by the parameter additions.
+			 *
+			 * 10: 0x02000002 (TypeDef)          0x00000001 (AddMethod)
+			 * 11: 0x06000006 (MethodDef)        0
+			 * 12: 0x02000002 (TypeDef)          0x00000001 (AddMethod)
+			 * 13: 0x06000007 (MethodDef)        0
+			 * 14: 0x06000006 (MethodDef)        0x00000003 (AddParameter)
+			 * 15: 0x08000003 (Param)            0
+			 * 16: 0x06000006 (MethodDef)        0x00000003 (AddParameter)
+			 * 17: 0x08000004 (Param)            0
+			 * 18: 0x06000007 (MethodDef)        0x00000003 (AddParameter)
+			 * 19: 0x08000005 (Param)            0
+			 *
+			 * So by the time we see the param additions, the methods are already in.
+			 *
+			 * FIXME: we need a lookaside table (like method_parent) for every place
+			 * that looks at MONO_METHOD_PARAMLIST
+			 */
 			break;
 		}
 		default: {

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -28,7 +28,7 @@
 
 #include <mono/utils/mono-compiler.h>
 
-#define ALLOW_METHOD_ADD
+#undef ALLOW_METHOD_ADD
 
 typedef struct _DeltaInfo DeltaInfo;
 
@@ -1546,7 +1546,9 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 
 
 	MonoClass *add_method_klass = NULL;
+#ifdef ALLOW_METHOD_ADD
 	uint32_t add_param_method_index = 0;
+#endif
 
 	gboolean assemblyref_updated = FALSE;
 	for (int i = 0; i < rows ; ++i) {

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -109,7 +109,6 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_get_thread_generation,
 	&hot_reload_cleanup_on_close,
 	&hot_reload_effective_table_slow,
-	&hot_reload_relative_delta_index,
 	&hot_reload_apply_changes,
 	&hot_reload_close_except_pools_all,
 	&hot_reload_close_all,

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1092,11 +1092,20 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 			continue;
 
 #ifndef ALLOW_METHOD_ADD
+
 		if (token_index > table_info_get_rows (&image_base->tables [token_table])) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "\tcannot add new method with token 0x%08x", log_token);
 			mono_error_set_type_load_name (error, NULL, image_base->name, "EnC: cannot add new method with token 0x%08x", log_token);
 			unsupported_edits = TRUE;
 		}
+
+#endif
+
+#ifdef ALLOW_METHOD_ADD
+		/* adding a new parameter to a new method is ok */
+		/* FIXME: total rows, not just the baseline rows */
+		if (func_code == ENC_FUNC_ADD_PARAM && token_index > table_info_get_rows (&image_base->tables [token_table]))
+			continue;
 #endif
 
 		g_assert (func_code == 0); /* anything else doesn't make sense here */
@@ -1117,6 +1126,10 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 			/* okay, supported */
 			break;
 		case MONO_TABLE_METHOD:
+#ifdef ALLOW_METHOD_ADD
+			if (func_code == ENC_FUNC_ADD_PARAM)
+				continue; /* ok, allowed */
+#endif
 			/* handled above */
 			break;
 		case MONO_TABLE_PROPERTY: {
@@ -1343,6 +1356,7 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 	 */
 
 	MonoClass *add_method_klass = NULL;
+	uint32_t add_param_method_index = 0;
 
 	gboolean assemblyref_updated = FALSE;
 	for (int i = 0; i < rows ; ++i) {
@@ -1372,6 +1386,13 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 				return FALSE;
 			}
 			add_method_klass = klass;
+			break;
+		}
+
+		case ENC_FUNC_ADD_PARAM: {
+			g_assert (token_table == MONO_TABLE_METHOD);
+			/* assert that the token_index is equal to the number of rows in the table.  We only allow adding a param to the newest method def */
+			add_param_method_index = token_index;
 			break;
 		}
 #endif
@@ -1416,12 +1437,19 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 			break;
 		}
 		case MONO_TABLE_METHOD: {
+#ifdef ALLOW_METHOD_ADD
+			/* if adding a param, handle it with the next record */
+			if (func_code == ENC_FUNC_ADD_PARAM)
+				break;
+
 			if (token_index > table_info_get_rows (&image_base->tables [token_table])) {
 				if (!add_method_klass)
 					g_error ("EnC: new method added but I don't know the class, should be caught by pass1");
 				g_assert (add_method_klass);
 				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Adding new method 0x%08x to class %s.%s", token_index, m_class_get_name_space (add_method_klass), m_class_get_name (add_method_klass));
+				add_method_klass = NULL;
 			}
+#endif
 
 			if (!base_info->method_table_update)
 				base_info->method_table_update = g_hash_table_new (g_direct_hash, g_direct_equal);
@@ -1465,6 +1493,7 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 		}
 		case MONO_TABLE_PARAM: {
 			/* ok, pass1 checked for disallowed modifications */
+			/* ALLOW_METHOD_ADD: FIXME: here we would really like to update the method's paramlist column to point to the new params. */
 			break;
 		}
 		default: {

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1908,7 +1908,7 @@ hot_reload_get_updated_method_ppdb (MonoImage *base_image, uint32_t idx)
 			loc = get_method_update_rva (base_image, info, idx, TRUE);
 		}
 		/* Check the method_parent table as a way of checking if the method was added by a later generation. If so, still look for its PPDB info in our update tables */
-		if (G_UNLIKELY (loc == 0 && GPOINTER_TO_UINT (g_hash_table_lookup (info->method_parent, GUINT_TO_POINTER (idx))) > 0)) {
+		if (G_UNLIKELY (loc == 0 && info->method_parent && GPOINTER_TO_UINT (g_hash_table_lookup (info->method_parent, GUINT_TO_POINTER (idx))) > 0)) {
 			loc = get_method_update_rva (base_image, info, idx, TRUE);
 		}
 	}

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -21,7 +21,7 @@ typedef struct _MonoComponentHotReload {
 	uint32_t (*thread_expose_published) (void);
 	uint32_t (*get_thread_generation) (void);
 	void (*cleanup_on_close) (MonoImage *image);
-	void (*effective_table_slow) (const MonoTableInfo **t, int *idx);
+	void (*effective_table_slow) (const MonoTableInfo **t, int idx);
 	int (*relative_delta_index) (MonoImage *image_dmeta, int token);
 	void (*apply_changes) (int origin, MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, gconstpointer dpdb_bytes_orig, uint32_t dpdb_length, MonoError *error);
 	void (*image_close_except_pools_all) (MonoImage *base_image);

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -22,7 +22,6 @@ typedef struct _MonoComponentHotReload {
 	uint32_t (*get_thread_generation) (void);
 	void (*cleanup_on_close) (MonoImage *image);
 	void (*effective_table_slow) (const MonoTableInfo **t, int idx);
-	int (*relative_delta_index) (MonoImage *image_dmeta, int token);
 	void (*apply_changes) (int origin, MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, gconstpointer dpdb_bytes_orig, uint32_t dpdb_length, MonoError *error);
 	void (*image_close_except_pools_all) (MonoImage *base_image);
 	void (*image_close_all) (MonoImage *base_image);

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -32,6 +32,8 @@ typedef struct _MonoComponentHotReload {
 	gpointer (*get_updated_method_ppdb) (MonoImage *base_image, uint32_t idx);
 	gboolean (*has_modified_rows) (const MonoTableInfo *table);
 	gboolean (*table_num_rows_slow) (MonoImage *base_image, int table_index);
+	GArray* (*get_added_methods) (MonoClass *klass);
+	uint32_t (*method_parent) (MonoImage *base_image, uint32_t method_index);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -31,6 +31,7 @@ typedef struct _MonoComponentHotReload {
 	gboolean (*delta_heap_lookup) (MonoImage *base_image, MetadataHeapGetterFunc get_heap, uint32_t orig_index, MonoImage **image_out, uint32_t *index_out);
 	gpointer (*get_updated_method_ppdb) (MonoImage *base_image, uint32_t idx);
 	gboolean (*has_modified_rows) (const MonoTableInfo *table);
+	gboolean (*table_num_rows_slow) (MonoImage *base_image, int table_index);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -470,6 +470,13 @@ mono_method_desc_match (MonoMethodDesc *desc, MonoMethod *method)
 	char *sig;
 	gboolean name_match;
 
+	if (desc->name_glob && !strcmp (desc->name, "*"))
+		return TRUE;
+#if 0
+	/* FIXME: implement g_pattern_match_simple in eglib */
+	if (desc->name_glob && g_pattern_match_simple (desc->name, method->name))
+		return TRUE;
+#endif
 	name_match = strcmp (desc->name, method->name) == 0;
 	if (!name_match)
 		return FALSE;

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -427,6 +427,8 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 {
  	int i;
 
+	/* FIXME: method refs from metadata-upate probably end up here */
+
 	/* Search directly in the metadata to avoid calling setup_methods () */
 	error_init (error);
 
@@ -1159,6 +1161,8 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 {
 	MonoMethod *result = NULL;
 	gboolean used_context = FALSE;
+
+	/* FIXME: method definition lookups for metadata-update probably end up here */
 
 	/* We do everything inside the lock to prevent creation races */
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -791,16 +791,16 @@ gboolean
 mono_metadata_has_updates_api (void);
 
 void
-mono_image_effective_table_slow (const MonoTableInfo **t, int *idx);
+mono_image_effective_table_slow (const MonoTableInfo **t, int idx);
 
 gboolean
 mono_metadata_update_has_modified_rows (const MonoTableInfo *t);
 
 static inline void
-mono_image_effective_table (const MonoTableInfo **t, int *idx)
+mono_image_effective_table (const MonoTableInfo **t, int idx)
 {
 	if (G_UNLIKELY (mono_metadata_has_updates ())) {
-		if (G_UNLIKELY (*idx >= table_info_get_rows ((*t)) || mono_metadata_update_has_modified_rows (*t))) {
+		if (G_UNLIKELY (idx >= table_info_get_rows ((*t)) || mono_metadata_update_has_modified_rows (*t))) {
 			mono_image_effective_table_slow (t, idx);
 		}
 	}

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -806,9 +806,6 @@ mono_image_effective_table (const MonoTableInfo **t, int idx)
 	}
 }
 
-int
-mono_image_relative_delta_index (MonoImage *image_dmeta, int token);
-
 enum MonoEnCDeltaOrigin {
         MONO_ENC_DELTA_API = 0,
         MONO_ENC_DELTA_DBG = 1,

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -848,6 +848,18 @@ mono_metadata_clean_generic_classes_for_image (MonoImage *image);
 gboolean
 mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int token_index);
 
+int
+mono_metadata_table_num_rows_slow (MonoImage *image, int table_index);
+
+static inline int
+mono_metadata_table_num_rows (MonoImage *image, int table_index)
+{
+	if (G_LIKELY (!image->has_updates))
+		return table_info_get_rows (&image->tables [table_index]);
+	else
+		return mono_metadata_table_num_rows_slow (image, table_index);
+}
+
 /* token_index is 1-based */
 static inline gboolean
 mono_metadata_table_bounds_check (MonoImage *image, int table_index, int token_index)

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1235,4 +1235,18 @@ mono_type_get_array_type_internal (MonoType *type)
 	return type->data.array;
 }
 
+static inline int
+mono_metadata_table_to_ptr_table (int table_num)
+{
+	switch (table_num) {
+	case MONO_TABLE_FIELD: return MONO_TABLE_FIELD_POINTER;
+	case MONO_TABLE_METHOD: return MONO_TABLE_METHOD_POINTER;
+	case MONO_TABLE_PARAM: return MONO_TABLE_PARAM_POINTER;
+	case MONO_TABLE_PROPERTY: return MONO_TABLE_PROPERTY_POINTER;
+	case MONO_TABLE_EVENT: return MONO_TABLE_EVENT_POINTER;
+	default:
+		g_assert_not_reached ();
+	}
+}
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -66,12 +66,6 @@ mono_image_effective_table_slow (const MonoTableInfo **t, int idx)
 	mono_component_hot_reload ()->effective_table_slow (t, idx);
 }
 
-int
-mono_image_relative_delta_index (MonoImage *image_dmeta, int token)
-{
-	return mono_component_hot_reload ()->relative_delta_index (image_dmeta, token);
-}
-
 void
 mono_image_load_enc_delta (int origin, MonoImage *base_image, gconstpointer dmeta, uint32_t dmeta_len, gconstpointer dil, uint32_t dil_len, gconstpointer dpdb, uint32_t dpdb_len, MonoError *error)
 {

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -141,3 +141,15 @@ mono_metadata_has_updates_api (void)
 {
         return mono_metadata_has_updates ();
 }
+
+/**
+ * mono_metadata_table_num_rows:
+ *
+ * Returns the number of rows from the specified table that the current thread can see.
+ * If there's a EnC metadata update, this number may change.
+ */
+int
+mono_metadata_table_num_rows_slow (MonoImage *base_image, int table_index)
+{
+	return mono_component_hot_reload()->table_num_rows_slow (base_image, table_index);
+}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -61,7 +61,7 @@ mono_metadata_update_cleanup_on_close (MonoImage *base_image)
 }
 
 void
-mono_image_effective_table_slow (const MonoTableInfo **t, int *idx)
+mono_image_effective_table_slow (const MonoTableInfo **t, int idx)
 {
 	mono_component_hot_reload ()->effective_table_slow (t, idx);
 }

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -4835,7 +4835,12 @@ mono_metadata_typedef_from_method (MonoImage *meta, guint32 index)
 	if (meta->uncompressed_metadata)
 		loc.idx = search_ptr_table (meta, MONO_TABLE_METHOD_POINTER, loc.idx);
 
-	/* FIXME: metadata-update */
+	/* if it's not in the base image, look in the hot reload table */
+	gboolean added = (loc.idx > table_info_get_rows (&meta->tables [MONO_TABLE_METHOD]));
+	if (added) {
+		uint32_t res = mono_component_hot_reload ()->method_parent (meta, loc.idx);
+		return res; /* 0 if not found, otherwise 1-based */
+	}
 
 	if (!mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, typedef_locator))
 		return 0;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1303,7 +1303,7 @@ mono_metadata_decode_row (const MonoTableInfo *t, int idx, guint32 *res, int res
 void
 mono_metadata_decode_row_slow (const MonoTableInfo *t, int idx, guint32 *res, int res_size)
 {
-	mono_image_effective_table (&t, &idx);
+	mono_image_effective_table (&t, idx);
 	mono_metadata_decode_row_raw (t, idx, res, res_size);
 }
 
@@ -1359,7 +1359,7 @@ mono_metadata_decode_row_checked (const MonoImage *image, const MonoTableInfo *t
 {
 	const char *image_name = image && image->name ? image->name : "unknown image";
 
-	mono_image_effective_table (&t, &idx);
+	mono_image_effective_table (&t, idx);
 
 	guint32 bitfield = t->size_bitfield;
 	int i, count = mono_metadata_table_count (bitfield);
@@ -1448,7 +1448,7 @@ mono_metadata_decode_row_col (const MonoTableInfo *t, int idx, guint col)
 guint32
 mono_metadata_decode_row_col_slow (const MonoTableInfo *t, int idx, guint col)
 {
-	mono_image_effective_table (&t, &idx);
+	mono_image_effective_table (&t, idx);
 	return mono_metadata_decode_row_col_raw (t, idx, col);
 }
 

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2313,8 +2313,12 @@ mono_metadata_get_param_attrs (MonoImage *m, int def, int param_count)
 	guint lastp, i, param_index = mono_metadata_decode_row_col (methodt, def - 1, MONO_METHOD_PARAMLIST);
 	int *pattrs = NULL;
 
+	/* hot reload deltas may specify 0 for the param table index */
+	if (param_index == 0)
+		return NULL;
+
 	/* FIXME: metadata-update */
-	int rows = table_info_get_rows (methodt);
+	int rows = mono_metadata_table_num_rows (m, MONO_TABLE_METHOD);
 	if (def < rows)
 		lastp = mono_metadata_decode_row_col (methodt, def, MONO_METHOD_PARAMLIST);
 	else

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3403,7 +3403,7 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 		for (i = 0; verbose_method_names [i] != NULL; i++){
 			const char *name = verbose_method_names [i];
 
-			if ((strchr (name, '.') > name) || strchr (name, ':')) {
+			if ((strchr (name, '.') > name) || strchr (name, ':') || strchr (name, '*')) {
 				MonoMethodDesc *desc;
 				
 				desc = mono_method_desc_new (name, TRUE);


### PR DESCRIPTION
This PR does two things:
1. Reorganizes how we keep track of deltas, and how we do metadata lookups after updates
2. Adds an ifdefed-out initial draft of support for adding methods.  (It worked for a simple test but it's not ready for general use yet).

Details of the delta changes.

* Previously Mono used a fully immutable model of metadata changes.  Logically each delta brings in modifications to existing table rows and addition of new rows.  Previously mono never formed the fully mutated tables - instead, each lookup was essentially responsible for playing all the changes forward every time it needed to lookup a row.  This was fine when we primarily supported only row additions (because we could just skip past all the updates that hadn't added the row we wanted yet, and just look in a single delta).  But as we started to support more and more modifications (of custom attributes, of property getters & setters, of parameters, etc) we now had to look through the whole list of deltas to make sure we found the latest modification of every row.
* The new approach is for each `DeltaInfo` (representing a summary of a particular update to a single assembly) to contain a collection of `mutants` - the fully modified tables with all the newly added rows and all the new modifications.  So lookups are fast now - we just go to the latest generation that is visible to a particular thread and look at its mutants tables.  The downside is increased memory use.  So we allocate the mutants from memory pools owned by each `DeltaInfo`.  Right now we never dealloc the pools, but in the future we could.  We already iterate over all the threads during our stop-the-world phase - we can record the earliest generation still needed by every thread and delete the pools for all earlier copies.  In practice this means we only keep 3 sets of tables: the mmaped baseline tables, the newest mutants, and the mutants from the prior generation for any still-executing methods.
* Additionally instead of storing a list of delta images in the `BaselineInfo`, we now store a list of `DeltaInfo` structs which each `DeltaInfo` pointing to a delta image.  This means that we can avoid repeated hash table lookups to map from a delta image to its `DeltaInfo` every time the runtime queries us for a table row or for a heap element.