### PR TITLE
Do not devirtualize when optimizations disabled

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -21325,6 +21325,12 @@ void Compiler::impDevirtualizeCall(GenTreeCall*            call,
         return;
     }
 
+    // Bail if optimizations are disabled.
+    if (opts.OptimizationDisabled())
+    {
+        return;
+    }
+
 #if defined(DEBUG)
     // Bail if devirt is disabled.
     if (JitConfig.JitEnableDevirtualization() == 0)


### PR DESCRIPTION
We started doing devir in unoptimized builds. I assume that was an unintended consequence of #61453.