### PR TITLE
[TODO-List-Cleanup] Delete the quirks

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2519,13 +2519,6 @@ unsigned Compiler::gtSetMultiOpOrder(GenTreeMultiOp* multiOp)
                 bool canSwap = multiOp->IsReverseOp() ? gtCanSwapOrder(multiOp->Op(2), multiOp->Op(1))
                                                       : gtCanSwapOrder(multiOp->Op(1), multiOp->Op(2));
 
-                // The InitN intrinsic for two operands used to be not reversible, so preserve this.
-                // TODO-List-Cleanup: delete this only-needed-for-zero-diffs quirk.
-                if (multiOp->OperIs(GT_SIMD) && (multiOp->AsSIMD()->GetSIMDIntrinsicId() == SIMDIntrinsicInitN))
-                {
-                    canSwap = false;
-                }
-
                 if (canSwap)
                 {
                     if (multiOp->IsReverseOp())

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9464,9 +9464,7 @@ void Compiler::fgValueNumberSimd(GenTreeSIMD* tree)
         excSetPair = ValueNumStore::VNPForEmptyExcSet();
         normalPair = vnStore->VNPairForFunc(tree->TypeGet(), simdFunc);
     }
-    // TODO-List-Cleanup: the "tree->GetSIMDIntrinsicId() == SIMDIntrinsicInitN" case is a quirk
-    // to get zero diffs - Vector2(float, float) was imported with lists - remove it.
-    else if ((tree->GetOperandCount() > 2) || (tree->GetSIMDIntrinsicId() == SIMDIntrinsicInitN))
+    else if (tree->GetOperandCount() > 2)
     {
         // We have a SIMD node with 3 or more args. To retain the
         // previous behavior, we will generate a unique VN for this case.


### PR DESCRIPTION
These were left in only to get to a clean zero-diff change. Delete them.

Small [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1507114&view=ms.vss-build-web.run-extensions-tab), as expected, mostly improvements due to new CSEs. A few small regressions due to new copies being propagated, but not in a way that ultimately pays off.