### PR TITLE
[TODO-List-Cleanup] Delete dead code from `InferStructOpSizeAlign`

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1211,44 +1211,6 @@ unsigned CodeGenInterface::InferStructOpSizeAlign(GenTree* op, unsigned* alignme
             alignment = TARGET_POINTER_SIZE;
         }
     }
-    else if (op->OperIsCopyBlkOp())
-    {
-        GenTree* op2 = op->AsOp()->gtOp2;
-
-        if (op2->OperGet() == GT_CNS_INT)
-        {
-            if (op2->IsIconHandle(GTF_ICON_CLASS_HDL))
-            {
-                CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE)op2->AsIntCon()->gtIconVal;
-                opSize = roundUp(compiler->info.compCompHnd->getClassSize(clsHnd), TARGET_POINTER_SIZE);
-                alignment =
-                    roundUp(compiler->info.compCompHnd->getClassAlignmentRequirement(clsHnd), TARGET_POINTER_SIZE);
-            }
-            else
-            {
-                opSize       = (unsigned)op2->AsIntCon()->gtIconVal;
-                GenTree* op1 = op->AsOp()->gtOp1;
-                // TODO-List-Cleanup: this looks like some really old dead code.
-                // assert(op1->OperGet() == GT_LIST);
-                GenTree* dstAddr = op1->AsOp()->gtOp1;
-                if (dstAddr->OperGet() == GT_ADDR)
-                {
-                    InferStructOpSizeAlign(dstAddr->AsOp()->gtOp1, &alignment);
-                }
-                else
-                {
-                    assert(!"Unhandle dstAddr node");
-                    alignment = TARGET_POINTER_SIZE;
-                }
-            }
-        }
-        else
-        {
-            noway_assert(!"Variable sized COPYBLK register arg!");
-            opSize    = 0;
-            alignment = TARGET_POINTER_SIZE;
-        }
-    }
     else if (op->gtOper == GT_MKREFANY)
     {
         opSize    = TARGET_POINTER_SIZE * 2;


### PR DESCRIPTION
The method's only caller is `InferOpSizeAlign`.

That is in turn only used in `LCL_FLD` stress, [which only looks at locals with non-struct types](https://github.com/dotnet/runtime/blob/69b5d67d9418d672609aa6e2c418a3d4ae00ad18/src/coreclr/jit/lclvars.cpp#L7978).

And [`fgInitArgInfo`](https://github.com/dotnet/runtime/blob/69b5d67d9418d672609aa6e2c418a3d4ae00ad18/src/coreclr/jit/morph.cpp#L2801-L2802), which only allows 3 nodes with `TYP_STRUCT`: [`OBJ`, `LCL_VAR` and `MKREFANY`](https://github.com/dotnet/runtime/blob/69b5d67d9418d672609aa6e2c418a3d4ae00ad18/src/coreclr/jit/morph.cpp#L2871-L2886).

Thus, this code is dead. Not surprising, considering it was looking for the old `GT_COPYBLK` representation.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1479561&view=ms.vss-build-web.run-extensions-tab).