### PR TITLE
Fix XXHash for stripe size

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash32.cs
@@ -215,7 +215,7 @@ namespace System.IO.Hashing
             int totalLength = source.Length;
             State state = new State((uint)seed);
 
-            while (source.Length > StripeSize)
+            while (source.Length >= StripeSize)
             {
                 state.ProcessStripe(source);
                 source = source.Slice(StripeSize);

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -215,7 +215,7 @@ namespace System.IO.Hashing
             int totalLength = source.Length;
             State state = new State((ulong)seed);
 
-            while (source.Length > StripeSize)
+            while (source.Length >= StripeSize)
             {
                 state.ProcessStripe(source);
                 source = source.Slice(StripeSize);

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
@@ -36,6 +36,8 @@ namespace System.IO.Hashing.Tests
         private const string DotNetHashesThis3 = DotNetHashesThis + DotNetHashesThis + DotNetHashesThis;
         private const string DotNetNCHashing = ".NET now has non-crypto hashing";
         private const string DotNetNCHashing3 = DotNetNCHashing + DotNetNCHashing + DotNetNCHashing;
+        private const string SixteenBytes = ".NET Hashes This";
+        private const string SixteenBytes3 = SixteenBytes + SixteenBytes + SixteenBytes;
 
         protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
             new[]
@@ -77,6 +79,11 @@ namespace System.IO.Hashing.Tests
                     $"{DotNetNCHashing} (x3)",
                     Encoding.ASCII.GetBytes(DotNetNCHashing3),
                     "CABC8ABD"),
+                // stripe size
+                new TestCase(
+                    $"{SixteenBytes} (x3)",
+                    Encoding.ASCII.GetBytes(SixteenBytes3),
+                    "AD98EBD3")
             };
 
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32(Seed);

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
@@ -34,6 +34,8 @@ namespace System.IO.Hashing.Tests
         private const string DotNetHashesThis3 = DotNetHashesThis + DotNetHashesThis + DotNetHashesThis;
         private const string DotNetNCHashing = ".NET now has non-crypto hashing";
         private const string DotNetNCHashing3 = DotNetNCHashing + DotNetNCHashing + DotNetNCHashing;
+        private const string SixteenBytes = ".NET Hashes This";
+        private const string SixteenBytes3 = SixteenBytes + SixteenBytes + SixteenBytes;
 
         protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
             new[]
@@ -90,6 +92,11 @@ namespace System.IO.Hashing.Tests
                     $"{DotNetNCHashing} (x3)",
                     Encoding.ASCII.GetBytes(DotNetNCHashing3),
                     "65242024"),
+                // stripe size
+                new TestCase(
+                    $"{SixteenBytes} (x3)",
+                    Encoding.ASCII.GetBytes(SixteenBytes3),
+                    "29DA7472")
             };
 
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32();

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
@@ -36,6 +36,8 @@ namespace System.IO.Hashing.Tests
         private const string DotNetHashesThis3 = DotNetHashesThis + DotNetHashesThis + DotNetHashesThis;
         private const string DotNetNCHashing = ".NET now has non-crypto hashing";
         private const string DotNetNCHashing3 = DotNetNCHashing + DotNetNCHashing + DotNetNCHashing;
+        private const string SixteenBytes = ".NET Hashes This";
+        private const string SixteenBytes3 = SixteenBytes + SixteenBytes + SixteenBytes;
 
         protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
             new[]
@@ -77,6 +79,11 @@ namespace System.IO.Hashing.Tests
                     $"{DotNetNCHashing} (x3)",
                     Encoding.ASCII.GetBytes(DotNetNCHashing3),
                     "5A513E6D"),
+                // stripe size
+                new TestCase(
+                    $"{SixteenBytes} (x3)",
+                    Encoding.ASCII.GetBytes(SixteenBytes3),
+                    "B38A9A45")
             };
 
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash32(Seed);

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
@@ -38,6 +38,8 @@ namespace System.IO.Hashing.Tests
         private const string DotNetNCHashing = ".NET now has non-crypto hashing";
         private const string SixtyThreeBytes = "A sixty-three byte test input requires substantial forethought!";
         private const string SixtyThreeBytes3 = SixtyThreeBytes + SixtyThreeBytes + SixtyThreeBytes;
+        private const string ThirtyTwoBytes = "This string has 32 ASCII bytes..";
+        private const string ThirtyTwoBytes3 = ThirtyTwoBytes + ThirtyTwoBytes + ThirtyTwoBytes;
 
         protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
             new[]
@@ -87,6 +89,11 @@ namespace System.IO.Hashing.Tests
                     $"{SixtyThreeBytes} (x3)",
                     Encoding.ASCII.GetBytes(SixtyThreeBytes3),
                     "D6095B93EB10BEDA"),
+                // stripe size
+                new TestCase(
+                    $"{ThirtyTwoBytes} (x3)",
+                    Encoding.ASCII.GetBytes(ThirtyTwoBytes3),
+                    "45116421CF932B1F")
             };
 
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64(Seed);

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
@@ -36,6 +36,8 @@ namespace System.IO.Hashing.Tests
         private const string DotNetNCHashing = ".NET now has non-crypto hashing";
         private const string SixtyThreeBytes = "A sixty-three byte test input requires substantial forethought!";
         private const string SixtyThreeBytes3 = SixtyThreeBytes + SixtyThreeBytes + SixtyThreeBytes;
+        private const string ThirtyTwoBytes = "This string has 32 ASCII bytes..";
+        private const string ThirtyTwoBytes3 = ThirtyTwoBytes + ThirtyTwoBytes + ThirtyTwoBytes;
 
         protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
             new[]
@@ -103,6 +105,11 @@ namespace System.IO.Hashing.Tests
                     $"{SixtyThreeBytes} (x3)",
                     Encoding.ASCII.GetBytes(SixtyThreeBytes3),
                     "239C7B3A85BD22B3"),
+                // stripe size
+                new TestCase(
+                    $"{ThirtyTwoBytes} (x3)",
+                    Encoding.ASCII.GetBytes(ThirtyTwoBytes3),
+                    "975E3E6FE7E67FBC")
             };
 
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64();

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
@@ -38,6 +38,8 @@ namespace System.IO.Hashing.Tests
         private const string DotNetNCHashing = ".NET now has non-crypto hashing";
         private const string SixtyThreeBytes = "A sixty-three byte test input requires substantial forethought!";
         private const string SixtyThreeBytes3 = SixtyThreeBytes + SixtyThreeBytes + SixtyThreeBytes;
+        private const string ThirtyTwoBytes = "This string has 32 ASCII bytes..";
+        private const string ThirtyTwoBytes3 = ThirtyTwoBytes + ThirtyTwoBytes + ThirtyTwoBytes;
 
         protected static IEnumerable<TestCase> TestCaseDefinitions { get; } =
             new[]
@@ -87,6 +89,11 @@ namespace System.IO.Hashing.Tests
                     $"{SixtyThreeBytes} (x3)",
                     Encoding.ASCII.GetBytes(SixtyThreeBytes3),
                     "6F1C62EB48EA2FEC"),
+                // stripe size
+                new TestCase(
+                    $"{ThirtyTwoBytes} (x3)",
+                    Encoding.ASCII.GetBytes(ThirtyTwoBytes3),
+                    "B358EB96B8E3E7AD")
             };
 
         protected override NonCryptographicHashAlgorithm CreateInstance() => new XxHash64(Seed);


### PR DESCRIPTION
Closes #61878

Fixes the (multiple of) stripe size case and adds explicit tests for this specific case.