### PR TITLE
Do not explicitly pass type to `VNForMapStore`

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4289,16 +4289,10 @@ ValueNum Compiler::fgValueNumberArrIndexAssign(CORINFO_CLASS_HANDLE elemTypeEq,
         // This is the value that should be stored at "arr[inx]".
         newValAtInx = vnStore->VNApplySelectorsAssign(VNK_Liberal, hAtArrTypeAtArrAtInx, fldSeq, rhsVN, indType);
 
-        var_types arrElemFldType = arrElemType; // Uses arrElemType unless we has a non-null fldSeq
-        if (vnStore->IsVNFunc(newValAtInx))
-        {
-            VNFuncApp funcApp;
-            vnStore->GetVNFunc(newValAtInx, &funcApp);
-            if (funcApp.m_func == VNF_MapStore)
-            {
-                arrElemFldType = vnStore->TypeOfVN(newValAtInx);
-            }
-        }
+        // TODO-VNTypes: the validation below is a workaround for logic in ApplySelectorsAssignTypeCoerce
+        // not handling some cases correctly. Remove once ApplySelectorsAssignTypeCoerce has been fixed.
+        var_types arrElemFldType =
+            (fldSeq != nullptr) ? eeGetFieldType(fldSeq->GetTail()->GetFieldHandle()) : arrElemType;
 
         if (indType != arrElemFldType)
         {

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -589,7 +589,7 @@ public:
         ValueNumKind vnk, var_types type, ValueNum map, ValueNum index, int* pBudget, bool* pUsedRecursiveVN);
 
     // A specialized version of VNForFunc that is used for VNF_MapStore and provides some logging when verbose is set
-    ValueNum VNForMapStore(var_types type, ValueNum map, ValueNum index, ValueNum value);
+    ValueNum VNForMapStore(ValueNum map, ValueNum index, ValueNum value);
 
     ValueNum VNForFieldSelector(CORINFO_FIELD_HANDLE fieldHnd, var_types* pFieldType, size_t* pStructSize = nullptr);
 


### PR DESCRIPTION
Next prerequisite in preparation for typing maps with placeholder types. Separate as there are significant diffs.

First, there is a fix for how type mismatch was accounted for in `fgValueNumberArrIndexAssign` - we need to get the type of the last field. Note that at that point `fldSeq` only contains real fields. This fix is needed to minimize diffs for the second change.

Which is that we will no longer pass explicit types to `VNForMapStore` and instead derive them from `map`, as it reduces the possibility for mismatches and mistakes.

There are significant diffs from this, because this way we fix type mismatches arising in code such as the following:
```cs
private static int Problem(StructWithIndex a, StructWithIndex b)
{
    a.Index = 1;

    b = a;

    return b.Index;
}

struct StructWithIndex
{
    public int Index;
    public int Value;
}
```
(Struct promotion must be disabled for this sample code)

Previously, when we numbered `a.Index = 1`, we gave the whole struct a `MapStore` VN of `TYP_INT`:
```scala
***** BB01, STMT00000(before)
N003 (  5,  6) [000004] -A--G---R---              *  ASG       int   
N002 (  3,  4) [000003] U------N----              +--*  LCL_FLD   int    V00 arg0         ud:1->2[+0] Fseq[Index]
N001 (  1,  1) [000002] ------------              \--*  CNS_INT   int    1

N001 [000002]   CNS_INT   1 => $41 {IntCns 1}
  VNApplySelectors:
    VNForHandle(Index) is $100, fieldType is int
    VNForMapSelect($80, $100):int returns $140 {$80[$100]}
  VNApplySelectors:
    VNForHandle(Index) is $100, fieldType is int
    VNForMapSelect($80, $100):int returns $140 {$80[$100]}
N002 [000003]   LCL_FLD   V00 arg0         ud:1->2[+0] Fseq[Index] => $140 {$80[$100]}
  VNApplySelectorsAssign:
    VNForHandle(Index) is $100, fieldType is int
    VNForMapStore($80, $100, $41):int in BB01 returns $180 {$80[$100 := $41]}
  VNApplySelectorsAssign:
    VNForHandle(Index) is $100, fieldType is int
    VNForMapStore($80, $100, $41):int in BB01 returns $180 {$80[$100 := $41]}
N002 [000003]   LCL_FLD   V00 arg0         ud:1->2[+0] Fseq[Index] => $180 {$80[$100 := $41]}
N003 [000004]   ASG       => $41 {IntCns 1}
```
This is because `VNApplySelectorsAssign` gave the last map it returned a type of the field, which is not correct.

This lead to mismatch on copy:
```scala
***** BB01, STMT00001(before)
N003 (  7,  5) [000008] -A------R---              *  ASG       struct (copy)
N002 (  3,  2) [000006] D------N----              +--*  LCL_VAR   struct<StructWithIndex, 8> V01 arg1         d:2
N001 (  3,  2) [000005] ------------              \--*  LCL_VAR   struct<StructWithIndex, 8> V00 arg0         u:2 (last use)

N001 [000005]   LCL_VAR   V00 arg0         u:2 (last use) => $180 {$80[$100 := $41]}
    *** Mismatched types in VNApplySelectorsTypeCheck (indType is TYP_STRUCT)
    *** Mismatched types in VNApplySelectorsTypeCheck (indType is TYP_STRUCT)
    *** Mismatched types in VNApplySelectorsAssignTypeCoerce (indType is TYP_STRUCT)
    *** Mismatched types in VNApplySelectorsAssignTypeCoerce (indType is TYP_STRUCT)
Tree [000008] assigned VN to local var V01/2: <l:$1c3 {MemOpaque:NotInLoop}, c:$1c2 {MemOpaque:NotInLoop}>
N003 [000008]   ASG       => $VN.Void
```
And we lost track of the value. After this change, we no longer do, and this enables some nice improvements.

<details>
<summary>Win-x64 diffs</summary>

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 7065605 (overridden on cmd)
Total bytes of diff: 7065549 (overridden on cmd)
Total bytes of delta: -56 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          11 : 17517.dasm (1.18% of base)
          10 : 20447.dasm (1.48% of base)

Top file improvements (bytes):
         -77 : 19024.dasm (-4.51% of base)

3 total files with Code Size differences (1 improved, 2 regressed), 0 unchanged.

Top method regressions (bytes):
          11 ( 1.18% of base) : 17517.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ModifierUtils:ToDeclarationModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag):int
          10 ( 1.48% of base) : 20447.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ParameterHelpers:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):ubyte

Top method improvements (bytes):
         -77 (-4.51% of base) : 19024.dasm - Microsoft.CodeAnalysis.CSharp.SourceDocumentationCommentUtils:GetDocumentationCommentTriviaFromSyntaxNode(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Syntax.DocumentationCommentTriviaSyntax, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]

Top method regressions (percentages):
          10 ( 1.48% of base) : 20447.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ParameterHelpers:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):ubyte
          11 ( 1.18% of base) : 17517.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ModifierUtils:ToDeclarationModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag):int

Top method improvements (percentages):
         -77 (-4.51% of base) : 19024.dasm - Microsoft.CodeAnalysis.CSharp.SourceDocumentationCommentUtils:GetDocumentationCommentTriviaFromSyntaxNode(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode,Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Syntax.DocumentationCommentTriviaSyntax, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]

3 total methods with Code Size differences (1 improved, 2 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 124577271 (overridden on cmd)
Total bytes of diff: 124523009 (overridden on cmd)
Total bytes of delta: -54262 (-0.04 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
           4 : 246343.dasm (0.13% of base)

Top file improvements (bytes):
       -4254 : 218538.dasm (-33.60% of base)
       -4223 : 218510.dasm (-33.18% of base)
       -2993 : 217937.dasm (-25.73% of base)
       -2962 : 217838.dasm (-25.88% of base)
       -2715 : 218579.dasm (-23.92% of base)
       -2703 : 218551.dasm (-24.17% of base)
       -2635 : 218496.dasm (-23.63% of base)
       -2604 : 218468.dasm (-23.72% of base)
       -2600 : 218450.dasm (-24.23% of base)
       -2271 : 218351.dasm (-21.54% of base)
       -2160 : 226089.dasm (-21.76% of base)
       -2158 : 226255.dasm (-21.95% of base)
       -2124 : 226156.dasm (-22.10% of base)
       -2122 : 226188.dasm (-21.99% of base)
       -1897 : 227260.dasm (-20.50% of base)
       -1761 : 227230.dasm (-18.65% of base)
       -1725 : 227211.dasm (-18.90% of base)
       -1666 : 227241.dasm (-18.37% of base)
        -854 : 167523.dasm (-27.01% of base)
        -854 : 168746.dasm (-26.82% of base)

137 total files with Code Size differences (136 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
           4 ( 0.13% of base) : 246343.dasm - X:SetDirect(System.String,bool):bool

Top method improvements (bytes):
       -4254 (-33.60% of base) : 218538.dasm - TestApp:Main():int
       -4223 (-33.18% of base) : 218510.dasm - TestApp:Main():int
       -2993 (-25.73% of base) : 217937.dasm - TestApp:Main():int
       -2962 (-25.88% of base) : 217838.dasm - TestApp:Main():int
       -2715 (-23.92% of base) : 218579.dasm - TestApp:Main():int
       -2703 (-24.17% of base) : 218551.dasm - TestApp:Main():int
       -2635 (-23.63% of base) : 218496.dasm - TestApp:Main():int
       -2604 (-23.72% of base) : 218468.dasm - TestApp:Main():int
       -2600 (-24.23% of base) : 218450.dasm - TestApp:Main():int
       -2271 (-21.54% of base) : 218351.dasm - TestApp:Main():int
       -2160 (-21.76% of base) : 226089.dasm - TestApp:Main():int
       -2158 (-21.95% of base) : 226255.dasm - TestApp:Main():int
       -2124 (-22.10% of base) : 226156.dasm - TestApp:Main():int
       -2122 (-21.99% of base) : 226188.dasm - TestApp:Main():int
       -1897 (-20.50% of base) : 227260.dasm - TestApp:Main():int
       -1761 (-18.65% of base) : 227230.dasm - TestApp:Main():int
       -1725 (-18.90% of base) : 227211.dasm - TestApp:Main():int
       -1666 (-18.37% of base) : 227241.dasm - TestApp:Main():int
        -854 (-27.01% of base) : 167523.dasm - NullableTest34:Run()
        -854 (-26.82% of base) : 168746.dasm - NullableTest34:Run()

Top method regressions (percentages):
           4 ( 0.13% of base) : 246343.dasm - X:SetDirect(System.String,bool):bool

Top method improvements (percentages):
        -114 (-43.35% of base) : 230553.dasm - NullableTest:BoxUnboxToQ(System.__Canon):bool
        -114 (-43.35% of base) : 229892.dasm - NullableTest:BoxUnboxToQ(System.Object):bool
        -114 (-43.35% of base) : 167506.dasm - NullableTest34:BoxUnboxToQ(System.Object):bool
        -114 (-43.35% of base) : 167514.dasm - NullableTest34:BoxUnboxToQGen(System.__Canon):bool
        -120 (-41.24% of base) : 230556.dasm - NullableTest:BoxUnboxToQ(int):bool
        -120 (-41.24% of base) : 167517.dasm - NullableTest34:BoxUnboxToQGen(int):bool
        -120 (-41.24% of base) : 170391.dasm - NullableTest34:BoxUnboxToQGen(int):bool
        -120 (-41.10% of base) : 230555.dasm - NullableTest:BoxUnboxToQ(short):bool
        -120 (-41.10% of base) : 230554.dasm - NullableTest:BoxUnboxToQ(ubyte):bool
        -120 (-41.10% of base) : 167516.dasm - NullableTest34:BoxUnboxToQGen(short):bool
        -120 (-41.10% of base) : 170390.dasm - NullableTest34:BoxUnboxToQGen(short):bool
        -120 (-41.10% of base) : 167515.dasm - NullableTest34:BoxUnboxToQGen(ubyte):bool
        -120 (-41.10% of base) : 170389.dasm - NullableTest34:BoxUnboxToQGen(ubyte):bool
        -120 (-40.96% of base) : 231198.dasm - NullableTest:BoxUnboxToQ(int):bool
        -120 (-40.96% of base) : 230559.dasm - NullableTest:BoxUnboxToQ(long):bool
        -120 (-40.96% of base) : 170394.dasm - NullableTest34:BoxUnboxToQGen(long):bool
        -120 (-40.96% of base) : 167520.dasm - NullableTest34:BoxUnboxToQGen(long):bool
        -120 (-40.82% of base) : 231197.dasm - NullableTest:BoxUnboxToQ(short):bool
        -120 (-40.82% of base) : 231196.dasm - NullableTest:BoxUnboxToQ(ubyte):bool
        -120 (-40.68% of base) : 231201.dasm - NullableTest:BoxUnboxToQ(long):bool

137 total methods with Code Size differences (136 improved, 1 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 45295203 (overridden on cmd)
Total bytes of diff: 45252520 (overridden on cmd)
Total bytes of delta: -42683 (-0.09 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         265 : 50558.dasm (2.88% of base)
         115 : 50661.dasm (2.20% of base)
          82 : 71035.dasm (6.58% of base)
          58 : 43649.dasm (8.72% of base)
          47 : 30754.dasm (3.41% of base)
          45 : 79676.dasm (3.61% of base)
          35 : 79675.dasm (3.13% of base)
          31 : 30755.dasm (2.22% of base)
          25 : 71037.dasm (1.70% of base)
          21 : 43641.dasm (2.53% of base)
          13 : 50555.dasm (2.31% of base)
          13 : 44069.dasm (3.00% of base)
          13 : 55122.dasm (2.46% of base)
          12 : 113645.dasm (3.85% of base)
          10 : 51684.dasm (0.99% of base)
           2 : 50504.dasm (0.29% of base)

Top file improvements (bytes):
       -1569 : 54250.dasm (-39.12% of base)
       -1250 : 50748.dasm (-37.99% of base)
       -1198 : 50786.dasm (-18.68% of base)
       -1107 : 50881.dasm (-24.29% of base)
       -1072 : 50768.dasm (-20.29% of base)
        -916 : 50543.dasm (-37.62% of base)
        -832 : 50760.dasm (-36.11% of base)
        -810 : 54646.dasm (-15.58% of base)
        -795 : 50496.dasm (-20.72% of base)
        -774 : 50635.dasm (-17.40% of base)
        -770 : 50781.dasm (-13.20% of base)
        -763 : 51012.dasm (-8.35% of base)
        -728 : 50753.dasm (-15.54% of base)
        -683 : 50510.dasm (-16.34% of base)
        -661 : 50481.dasm (-40.06% of base)
        -639 : 50534.dasm (-29.78% of base)
        -630 : 50857.dasm (-26.66% of base)
        -582 : 50616.dasm (-17.39% of base)
        -572 : 50499.dasm (-23.77% of base)
        -570 : 50761.dasm (-14.65% of base)

146 total files with Code Size differences (130 improved, 16 regressed), 0 unchanged.

Top method regressions (bytes):
         265 ( 2.88% of base) : 50558.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:DecodeModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,int,int,int,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.MemberModifiers:this
         115 ( 2.20% of base) : 50661.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:DecodeLocalModifiersAndReportErrors(Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag):this
          82 ( 6.58% of base) : 71035.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTokenList):Microsoft.CodeAnalysis.SyntaxTokenList:this
          58 ( 8.72% of base) : 43649.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ParameterHelpers:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref,byref):ubyte
          47 ( 3.41% of base) : 30754.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTokenList):Microsoft.CodeAnalysis.SyntaxTokenList:this
          45 ( 3.61% of base) : 79676.dasm - Microsoft.CodeAnalysis.AbstractSyntaxNavigator:GetPreviousToken(Microsoft.CodeAnalysis.SyntaxTrivia,Microsoft.CodeAnalysis.SyntaxTriviaList,System.Func`2[SyntaxToken,Boolean],System.Func`2[SyntaxTrivia,Boolean],byref):Microsoft.CodeAnalysis.SyntaxToken:this
          35 ( 3.13% of base) : 79675.dasm - Microsoft.CodeAnalysis.AbstractSyntaxNavigator:GetNextToken(Microsoft.CodeAnalysis.SyntaxTrivia,Microsoft.CodeAnalysis.SyntaxTriviaList,System.Func`2[SyntaxToken,Boolean],System.Func`2[SyntaxTrivia,Boolean],byref):Microsoft.CodeAnalysis.SyntaxToken:this
          31 ( 2.22% of base) : 30755.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTriviaList):Microsoft.CodeAnalysis.SyntaxTriviaList:this
          25 ( 1.70% of base) : 71037.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTriviaList):Microsoft.CodeAnalysis.SyntaxTriviaList:this
          21 ( 2.53% of base) : 43641.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ModifierUtils:ToDeclarationModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,bool):int
          13 ( 3.00% of base) : 44069.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:ContainsModifier(Microsoft.CodeAnalysis.SyntaxTokenList,ushort):bool
          13 ( 2.31% of base) : 50555.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:FindFirstKeyword(Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.VisualBasic.SyntaxKind[]):Microsoft.CodeAnalysis.SyntaxToken
          13 ( 2.46% of base) : 55122.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.UnboundLambdaParameterSymbol:GetModifierToken(Microsoft.CodeAnalysis.SyntaxTokenList,ushort):Microsoft.CodeAnalysis.SyntaxToken
          12 ( 3.85% of base) : 113645.dasm - System.Data.RBTree`1[Vector`1][System.Numerics.Vector`1[System.Single]]:GetNewNode(System.Numerics.Vector`1[Single]):int:this
          10 ( 0.99% of base) : 51684.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.DeclarationTreeBuilder:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList):int
           2 ( 0.29% of base) : 50504.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:GetXmlString(Microsoft.CodeAnalysis.SyntaxTokenList):System.String

Top method improvements (bytes):
       -1569 (-39.12% of base) : 54250.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceDelegateMethodSymbol:MakeDelegateMembers(Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Syntax.ParameterListSyntax,Microsoft.CodeAnalysis.VisualBasic.Binder,byref,byref,byref,byref,Microsoft.CodeAnalysis.DiagnosticBag)
       -1250 (-37.99% of base) : 50748.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:ValidateAndConvertIsExpressionArgument(Microsoft.CodeAnalysis.VisualBasic.BoundExpression,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,bool,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
       -1198 (-18.68% of base) : 50786.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindLateBoundInvocation(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.BoundMethodOrPropertyGroup,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.VisualBasic.BoundExpression, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],System.Collections.Immutable.ImmutableArray`1[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],Microsoft.CodeAnalysis.DiagnosticBag,bool):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
       -1107 (-24.29% of base) : 50881.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindDictionaryAccess(Microsoft.CodeAnalysis.VisualBasic.Syntax.MemberAccessExpressionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
       -1072 (-20.29% of base) : 50768.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:GetArgumentForParameterDefaultValue(Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.DiagnosticBag,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -916 (-37.62% of base) : 50543.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlnsAttribute(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax,System.String,System.String,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundXmlAttribute:this
        -832 (-36.11% of base) : 50760.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:ConvertNothingLiterals(int,byref,byref,Microsoft.CodeAnalysis.DiagnosticBag):this
        -810 (-15.58% of base) : 54646.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceNonPropertyAccessorMethodSymbol:GetReturnType(Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceModuleSymbol,byref,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol:this
        -795 (-20.72% of base) : 50496.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlName(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNameSyntax,bool,XmlElementRootInfo,byref,byref,byref,byref,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -774 (-17.40% of base) : 50635.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindForToBlockParts(Microsoft.CodeAnalysis.VisualBasic.Syntax.ForOrForEachBlockSyntax,Microsoft.CodeAnalysis.VisualBasic.Symbols.LocalSymbol,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,bool,bool,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundForStatement:this
        -770 (-13.20% of base) : 50781.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:InferFunctionLambdaReturnType(Microsoft.CodeAnalysis.VisualBasic.UnboundLambda,TargetSignature):System.Collections.Generic.KeyValuePair`2[[Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.Diagnostic, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], System.Collections.Immutable, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]:this
        -763 (-8.35% of base) : 51012.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:MakeVarianceConversionSuggestion(int,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.DiagnosticBag,bool):bool:this
        -728 (-15.54% of base) : 50753.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindUserDefinedShortCircuitingOperator(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,int,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,byref,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundUserDefinedShortCircuitingOperator:this
        -683 (-16.34% of base) : 50510.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlnsAttributes(Microsoft.CodeAnalysis.SyntaxList`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref,Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.VisualBasic.BoundXmlAttribute, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.ArrayBuilder`1[[System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]:this
        -661 (-40.06% of base) : 50481.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlnsName(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax,System.String,bool,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -639 (-29.78% of base) : 50534.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlProcessingInstruction(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlProcessingInstructionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -630 (-26.66% of base) : 50857.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindInterpolatedStringExpression(Microsoft.CodeAnalysis.VisualBasic.Syntax.InterpolatedStringExpressionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -582 (-17.39% of base) : 50616.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindMidAssignmentStatement(Microsoft.CodeAnalysis.VisualBasic.Syntax.AssignmentStatementSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpressionStatement:this
        -572 (-23.77% of base) : 50499.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindGetXmlNamespace(Microsoft.CodeAnalysis.VisualBasic.Syntax.GetXmlNamespaceExpressionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -570 (-14.65% of base) : 50761.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindUnaryOperator(Microsoft.CodeAnalysis.VisualBasic.Syntax.UnaryExpressionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this

Top method regressions (percentages):
          58 ( 8.72% of base) : 43649.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ParameterHelpers:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref,byref):ubyte
          82 ( 6.58% of base) : 71035.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTokenList):Microsoft.CodeAnalysis.SyntaxTokenList:this
          12 ( 3.85% of base) : 113645.dasm - System.Data.RBTree`1[Vector`1][System.Numerics.Vector`1[System.Single]]:GetNewNode(System.Numerics.Vector`1[Single]):int:this
          45 ( 3.61% of base) : 79676.dasm - Microsoft.CodeAnalysis.AbstractSyntaxNavigator:GetPreviousToken(Microsoft.CodeAnalysis.SyntaxTrivia,Microsoft.CodeAnalysis.SyntaxTriviaList,System.Func`2[SyntaxToken,Boolean],System.Func`2[SyntaxTrivia,Boolean],byref):Microsoft.CodeAnalysis.SyntaxToken:this
          47 ( 3.41% of base) : 30754.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTokenList):Microsoft.CodeAnalysis.SyntaxTokenList:this
          35 ( 3.13% of base) : 79675.dasm - Microsoft.CodeAnalysis.AbstractSyntaxNavigator:GetNextToken(Microsoft.CodeAnalysis.SyntaxTrivia,Microsoft.CodeAnalysis.SyntaxTriviaList,System.Func`2[SyntaxToken,Boolean],System.Func`2[SyntaxTrivia,Boolean],byref):Microsoft.CodeAnalysis.SyntaxToken:this
          13 ( 3.00% of base) : 44069.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:ContainsModifier(Microsoft.CodeAnalysis.SyntaxTokenList,ushort):bool
         265 ( 2.88% of base) : 50558.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:DecodeModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,int,int,int,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.MemberModifiers:this
          21 ( 2.53% of base) : 43641.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ModifierUtils:ToDeclarationModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,bool):int
          13 ( 2.46% of base) : 55122.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.UnboundLambdaParameterSymbol:GetModifierToken(Microsoft.CodeAnalysis.SyntaxTokenList,ushort):Microsoft.CodeAnalysis.SyntaxToken
          13 ( 2.31% of base) : 50555.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:FindFirstKeyword(Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.VisualBasic.SyntaxKind[]):Microsoft.CodeAnalysis.SyntaxToken
          31 ( 2.22% of base) : 30755.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTriviaList):Microsoft.CodeAnalysis.SyntaxTriviaList:this
         115 ( 2.20% of base) : 50661.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:DecodeLocalModifiersAndReportErrors(Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag):this
          25 ( 1.70% of base) : 71037.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxRewriter:VisitList(Microsoft.CodeAnalysis.SyntaxTriviaList):Microsoft.CodeAnalysis.SyntaxTriviaList:this
          10 ( 0.99% of base) : 51684.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.DeclarationTreeBuilder:GetModifiers(Microsoft.CodeAnalysis.SyntaxTokenList):int
           2 ( 0.29% of base) : 50504.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:GetXmlString(Microsoft.CodeAnalysis.SyntaxTokenList):System.String

Top method improvements (percentages):
        -240 (-44.86% of base) : 31289.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxFactory:HasUnterminatedMultiLineComment(Microsoft.CodeAnalysis.SyntaxTriviaList):bool
        -232 (-43.20% of base) : 50754.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:ReportBinaryOperatorOnObject(ushort,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,int,Microsoft.CodeAnalysis.DiagnosticBag):this
        -284 (-41.58% of base) : 50596.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindBooleanExpression(Microsoft.CodeAnalysis.VisualBasic.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -661 (-40.06% of base) : 50481.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlnsName(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax,System.String,bool,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
       -1569 (-39.12% of base) : 54250.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceDelegateMethodSymbol:MakeDelegateMembers(Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Syntax.ParameterListSyntax,Microsoft.CodeAnalysis.VisualBasic.Binder,byref,byref,byref,byref,Microsoft.CodeAnalysis.DiagnosticBag)
        -324 (-38.66% of base) : 50834.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindArrayInitializerList(Microsoft.CodeAnalysis.VisualBasic.Syntax.CollectionInitializerSyntax,Microsoft.CodeAnalysis.VisualBasic.Binder+DimensionSize[],byref,byref,byref,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundArrayInitialization:this
       -1250 (-37.99% of base) : 50748.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:ValidateAndConvertIsExpressionArgument(Microsoft.CodeAnalysis.VisualBasic.BoundExpression,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,bool,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
        -916 (-37.62% of base) : 50543.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlnsAttribute(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax,System.String,System.String,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundXmlAttribute:this
        -540 (-36.94% of base) : 50533.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlDeclarationOption(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlDeclarationSyntax,Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlDeclarationOptionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundLiteral:this
        -272 (-36.81% of base) : 50509.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:CreateStringLiteral(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,System.String,bool,Microsoft.CodeAnalysis.DiagnosticBag,bool):Microsoft.CodeAnalysis.VisualBasic.BoundLiteral:this
        -832 (-36.11% of base) : 50760.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:ConvertNothingLiterals(int,byref,byref,Microsoft.CodeAnalysis.DiagnosticBag):this
        -298 (-35.60% of base) : 50831.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:CreateArrayBounds(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Binder+DimensionSize[],Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.VisualBasic.BoundExpression, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
        -240 (-35.56% of base) : 55501.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SynthesizedConstructorBase:.ctor(Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol,bool,Microsoft.CodeAnalysis.VisualBasic.Binder,Microsoft.CodeAnalysis.DiagnosticBag):this
        -258 (-35.54% of base) : 50858.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindInterpolatedStringText(Microsoft.CodeAnalysis.VisualBasic.Syntax.InterpolatedStringTextSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundLiteral:this
        -236 (-35.49% of base) : 51629.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SynthesizedConstructorSymbol:.ctor(Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol,bool,bool,Microsoft.CodeAnalysis.VisualBasic.Binder,Microsoft.CodeAnalysis.DiagnosticBag):this
        -320 (-35.36% of base) : 50602.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindError(Microsoft.CodeAnalysis.VisualBasic.Syntax.ErrorStatementSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundStatement:this
        -276 (-35.20% of base) : 50503.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlText(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlTextSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundLiteral:this
        -374 (-34.69% of base) : 51327.dasm - Microsoft.CodeAnalysis.VisualBasic.ImplicitVariableBinder:DeclareImplicitLocalVariable(Microsoft.CodeAnalysis.VisualBasic.Syntax.IdentifierNameSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.Symbols.LocalSymbol:this
        -258 (-34.31% of base) : 50838.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindLiteralConstant(Microsoft.CodeAnalysis.VisualBasic.Syntax.LiteralExpressionSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundLiteral:this
        -298 (-32.93% of base) : 50747.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindIsExpression(Microsoft.CodeAnalysis.VisualBasic.BoundExpression,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,bool,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this

146 total methods with Code Size differences (130 improved, 16 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 114144210 (overridden on cmd)
Total bytes of diff: 114120412 (overridden on cmd)
Total bytes of delta: -23798 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          61 : 312404.dasm (2.32% of base)
          61 : 312402.dasm (2.32% of base)
          61 : 312403.dasm (2.32% of base)
          32 : 126120.dasm (4.83% of base)
          29 : 312277.dasm (2.26% of base)
          29 : 312275.dasm (2.26% of base)
          29 : 312276.dasm (2.26% of base)
          20 : 11538.dasm (1.15% of base)
          10 : 131458.dasm (2.03% of base)
           7 : 127264.dasm (0.56% of base)
           7 : 129578.dasm (0.97% of base)
           1 : 130115.dasm (0.11% of base)
           1 : 125305.dasm (0.12% of base)

Top file improvements (bytes):
       -4831 : 312202.dasm (-74.24% of base)
        -952 : 127722.dasm (-43.97% of base)
        -900 : 127718.dasm (-48.78% of base)
        -801 : 18582.dasm (-21.33% of base)
        -701 : 130989.dasm (-42.05% of base)
        -655 : 127222.dasm (-22.23% of base)
        -620 : 130994.dasm (-36.19% of base)
        -564 : 129482.dasm (-19.43% of base)
        -525 : 127734.dasm (-25.29% of base)
        -448 : 125682.dasm (-17.68% of base)
        -411 : 129472.dasm (-28.15% of base)
        -339 : 130548.dasm (-8.87% of base)
        -312 : 129435.dasm (-38.66% of base)
        -310 : 312221.dasm (-9.06% of base)
        -305 : 125282.dasm (-17.33% of base)
        -303 : 130159.dasm (-16.49% of base)
        -272 : 312220.dasm (-8.39% of base)
        -271 : 312197.dasm (-15.88% of base)
        -271 : 312198.dasm (-15.88% of base)
        -269 : 129374.dasm (-29.79% of base)

119 total files with Code Size differences (106 improved, 13 regressed), 0 unchanged.

Top method regressions (bytes):
          61 ( 2.32% of base) : 312402.dasm - System.Numerics.Tests.QuaternionTests:QuaternionFromRotationMatrixTest2():this
          61 ( 2.32% of base) : 312403.dasm - System.Numerics.Tests.QuaternionTests:QuaternionFromRotationMatrixTest3():this
          61 ( 2.32% of base) : 312404.dasm - System.Numerics.Tests.QuaternionTests:QuaternionFromRotationMatrixTest4():this
          32 ( 4.83% of base) : 126120.dasm - Microsoft.CodeAnalysis.CSharp.FindSymbols.CSharpDeclaredSymbolInfoFactoryService:GetAccessibility(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxTokenList):int
          29 ( 2.26% of base) : 312275.dasm - System.Numerics.Tests.Matrix4x4Tests:Matrix4x4FromQuaternionTest2():this
          29 ( 2.26% of base) : 312276.dasm - System.Numerics.Tests.Matrix4x4Tests:Matrix4x4FromQuaternionTest3():this
          29 ( 2.26% of base) : 312277.dasm - System.Numerics.Tests.Matrix4x4Tests:Matrix4x4FromQuaternionTest4():this
          20 ( 1.15% of base) : 11538.dasm - Microsoft.CodeAnalysis.CodeGeneration.AbstractCodeGenerationService:GetUpdatedDeclarationAccessibilityModifiers(Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[SyntaxToken],Microsoft.CodeAnalysis.SyntaxTokenList,System.Func`2[SyntaxToken,Boolean]):Microsoft.CodeAnalysis.SyntaxTokenList
          10 ( 2.03% of base) : 131458.dasm - Rewriter:AreModifiersInRightOrder(Microsoft.CodeAnalysis.SyntaxTokenList):bool
           7 ( 0.56% of base) : 127264.dasm - Microsoft.CodeAnalysis.CSharp.Classification.Worker:ClassifyXmlTextTokens(Microsoft.CodeAnalysis.SyntaxTokenList):this
           7 ( 0.97% of base) : 129578.dasm - Microsoft.CodeAnalysis.VisualBasic.FindSymbols.VisualBasicDeclaredSymbolInfoFactoryService:GetAccessibility(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Syntax.StatementSyntax,Microsoft.CodeAnalysis.SyntaxTokenList):int
           1 ( 0.12% of base) : 125305.dasm - Microsoft.CodeAnalysis.CSharp.LanguageServices.CSharpSyntaxFacts:GetAccessibilityAndModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):this
           1 ( 0.11% of base) : 130115.dasm - Microsoft.CodeAnalysis.VisualBasic.LanguageServices.VisualBasicSyntaxFacts:GetAccessibilityAndModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):this

Top method improvements (bytes):
       -4831 (-74.24% of base) : 312202.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2EqualsNanTest():this
        -952 (-43.97% of base) : 127722.dasm - CodeShapeAnalyzer:ShouldFormatSingleLine(Microsoft.CodeAnalysis.Formatting.TriviaList):bool
        -900 (-48.78% of base) : 127718.dasm - Analyzer:Analyze(Microsoft.CodeAnalysis.SyntaxTriviaList,byref)
        -801 (-21.33% of base) : 18582.dasm - System.Collections.Generic.Tests.EqualityComparerTests:NullableEquals(System.Numerics.Vector`1[Single],System.Numerics.Vector`1[Single],bool):this
        -701 (-42.05% of base) : 130989.dasm - Analyzer:Analyze(Microsoft.CodeAnalysis.SyntaxTriviaList,byref)
        -655 (-22.23% of base) : 127222.dasm - Microsoft.CodeAnalysis.CSharp.Classification.Worker:ClassifyDirectiveTrivia(Microsoft.CodeAnalysis.CSharp.Syntax.DirectiveTriviaSyntax,bool):this
        -620 (-36.19% of base) : 130994.dasm - CodeShapeAnalyzer:ShouldFormatSingleLine(Microsoft.CodeAnalysis.Formatting.TriviaList):bool
        -564 (-19.43% of base) : 129482.dasm - Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery.SyntaxTreeExtensions:IsQueryIntoClauseContext(Microsoft.CodeAnalysis.SyntaxTree,int,Microsoft.CodeAnalysis.SyntaxToken,System.Threading.CancellationToken):bool
        -525 (-25.29% of base) : 127734.dasm - CodeShapeAnalyzer:ShouldFormat():bool:this
        -448 (-17.68% of base) : 125682.dasm - Microsoft.CodeAnalysis.CSharp.Rename.CSharpRenameConflictLanguageService:GetExpansionTarget(Microsoft.CodeAnalysis.SyntaxToken):Microsoft.CodeAnalysis.SyntaxNode
        -411 (-28.15% of base) : 129472.dasm - Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery.SyntaxTreeExtensions:IsAttributeNameContext(Microsoft.CodeAnalysis.SyntaxTree,int,Microsoft.CodeAnalysis.SyntaxToken,System.Threading.CancellationToken):bool
        -339 (-8.87% of base) : 130548.dasm - DocumentationCommentClassifier:ClassifyXmlTextTokens(Microsoft.CodeAnalysis.SyntaxTokenList):this
        -312 (-38.66% of base) : 129435.dasm - Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery.SyntaxTokenExtensions:CheckTrivia(Microsoft.CodeAnalysis.SyntaxTriviaList,int,byref,byref):bool
        -310 (-9.06% of base) : 312221.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2CreateRotationRightAngleCenterTest():this
        -305 (-17.33% of base) : 125282.dasm - Microsoft.CodeAnalysis.CSharp.LanguageServices.CSharpSyntaxFacts:IsBetweenTypeMembers(Microsoft.CodeAnalysis.Text.SourceText,Microsoft.CodeAnalysis.SyntaxNode,int,byref):bool:this
        -303 (-16.49% of base) : 130159.dasm - Microsoft.CodeAnalysis.VisualBasic.LanguageServices.VisualBasicSyntaxFacts:IsBetweenTypeMembers(Microsoft.CodeAnalysis.Text.SourceText,Microsoft.CodeAnalysis.SyntaxNode,int,byref):bool:this
        -272 (-8.39% of base) : 312220.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2CreateRotationRightAngleTest():this
        -271 (-15.88% of base) : 312197.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2CreateSkewXTest():this
        -271 (-15.88% of base) : 312198.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2CreateSkewYTest():this
        -269 (-29.79% of base) : 129374.dasm - Microsoft.CodeAnalysis.VisualBasic.Extensions.SyntaxTreeExtensions:IsGlobalStatementContext(Microsoft.CodeAnalysis.SyntaxToken,int):bool

Top method regressions (percentages):
          32 ( 4.83% of base) : 126120.dasm - Microsoft.CodeAnalysis.CSharp.FindSymbols.CSharpDeclaredSymbolInfoFactoryService:GetAccessibility(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxTokenList):int
          61 ( 2.32% of base) : 312402.dasm - System.Numerics.Tests.QuaternionTests:QuaternionFromRotationMatrixTest2():this
          61 ( 2.32% of base) : 312403.dasm - System.Numerics.Tests.QuaternionTests:QuaternionFromRotationMatrixTest3():this
          61 ( 2.32% of base) : 312404.dasm - System.Numerics.Tests.QuaternionTests:QuaternionFromRotationMatrixTest4():this
          29 ( 2.26% of base) : 312275.dasm - System.Numerics.Tests.Matrix4x4Tests:Matrix4x4FromQuaternionTest2():this
          29 ( 2.26% of base) : 312276.dasm - System.Numerics.Tests.Matrix4x4Tests:Matrix4x4FromQuaternionTest3():this
          29 ( 2.26% of base) : 312277.dasm - System.Numerics.Tests.Matrix4x4Tests:Matrix4x4FromQuaternionTest4():this
          10 ( 2.03% of base) : 131458.dasm - Rewriter:AreModifiersInRightOrder(Microsoft.CodeAnalysis.SyntaxTokenList):bool
          20 ( 1.15% of base) : 11538.dasm - Microsoft.CodeAnalysis.CodeGeneration.AbstractCodeGenerationService:GetUpdatedDeclarationAccessibilityModifiers(Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[SyntaxToken],Microsoft.CodeAnalysis.SyntaxTokenList,System.Func`2[SyntaxToken,Boolean]):Microsoft.CodeAnalysis.SyntaxTokenList
           7 ( 0.97% of base) : 129578.dasm - Microsoft.CodeAnalysis.VisualBasic.FindSymbols.VisualBasicDeclaredSymbolInfoFactoryService:GetAccessibility(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Syntax.StatementSyntax,Microsoft.CodeAnalysis.SyntaxTokenList):int
           7 ( 0.56% of base) : 127264.dasm - Microsoft.CodeAnalysis.CSharp.Classification.Worker:ClassifyXmlTextTokens(Microsoft.CodeAnalysis.SyntaxTokenList):this
           1 ( 0.12% of base) : 125305.dasm - Microsoft.CodeAnalysis.CSharp.LanguageServices.CSharpSyntaxFacts:GetAccessibilityAndModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):this
           1 ( 0.11% of base) : 130115.dasm - Microsoft.CodeAnalysis.VisualBasic.LanguageServices.VisualBasicSyntaxFacts:GetAccessibilityAndModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,byref,byref,byref):this

Top method improvements (percentages):
        -146 (-82.95% of base) : 156031.dasm - <>c:<CultureInfo_InvalidLcid_Throws>b__8_0():System.Object:this
        -146 (-82.95% of base) : 156032.dasm - <>c:<CultureInfo_InvalidLcid_Throws>b__8_1():System.Object:this
        -146 (-82.95% of base) : 156033.dasm - <>c:<CultureInfo_InvalidLcid_Throws>b__8_2():System.Object:this
       -4831 (-74.24% of base) : 312202.dasm - System.Numerics.Tests.Matrix3x2Tests:Matrix3x2EqualsNanTest():this
        -900 (-48.78% of base) : 127718.dasm - Analyzer:Analyze(Microsoft.CodeAnalysis.SyntaxTriviaList,byref)
        -952 (-43.97% of base) : 127722.dasm - CodeShapeAnalyzer:ShouldFormatSingleLine(Microsoft.CodeAnalysis.Formatting.TriviaList):bool
        -701 (-42.05% of base) : 130989.dasm - Analyzer:Analyze(Microsoft.CodeAnalysis.SyntaxTriviaList,byref)
        -312 (-38.66% of base) : 129435.dasm - Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery.SyntaxTokenExtensions:CheckTrivia(Microsoft.CodeAnalysis.SyntaxTriviaList,int,byref,byref):bool
        -147 (-37.22% of base) : 237160.dasm - Humanizer.Bytes.ByteSize:AddGigabytes(double):Humanizer.Bytes.ByteSize:this
        -147 (-37.22% of base) : 237158.dasm - Humanizer.Bytes.ByteSize:AddKilobytes(double):Humanizer.Bytes.ByteSize:this
        -147 (-37.22% of base) : 237159.dasm - Humanizer.Bytes.ByteSize:AddMegabytes(double):Humanizer.Bytes.ByteSize:this
        -147 (-37.22% of base) : 237161.dasm - Humanizer.Bytes.ByteSize:AddTerabytes(double):Humanizer.Bytes.ByteSize:this
        -147 (-36.39% of base) : 237156.dasm - Humanizer.Bytes.ByteSize:AddBits(long):Humanizer.Bytes.ByteSize:this
        -223 (-36.38% of base) : 95627.dasm - System.Text.Json.Tests.JsonDocumentTests:DefaultArrayEnumeratorDoesNotThrow()
        -620 (-36.19% of base) : 130994.dasm - CodeShapeAnalyzer:ShouldFormatSingleLine(Microsoft.CodeAnalysis.Formatting.TriviaList):bool
         -90 (-34.62% of base) : 342687.dasm - System.Tests.ExtensionsTests:ConvertToRef6()
         -82 (-34.45% of base) : 342686.dasm - System.Tests.ExtensionsTests:ConvertToRef5()
        -154 (-33.85% of base) : 126415.dasm - Microsoft.CodeAnalysis.CSharp.Extensions.SyntaxTriviaListExtensions:Any(Microsoft.CodeAnalysis.SyntaxTriviaList,Microsoft.CodeAnalysis.CSharp.SyntaxKind[]):bool
        -144 (-31.79% of base) : 9224.dasm - Microsoft.CodeAnalysis.Formatting.FormattingExtensions:HasAnyWhitespaceElasticTrivia(Microsoft.CodeAnalysis.SyntaxTriviaList):bool
         -84 (-31.34% of base) : 342688.dasm - System.Tests.ExtensionsTests:ConvertToRef7()

119 total methods with Code Size differences (106 improved, 13 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------
</details>

All regressions I checked appear to be of the usual CSE-related flavor.

[Overall diffs]().

Part of #58312.