### PR TITLE
fix for excessive gen0 in high memory load situation

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -17183,10 +17183,8 @@ allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size
                 check_for_full_gc (gen_number, size);
             }
 
-            bool recheck_p = false;
-
 #ifdef BACKGROUND_GC
-            recheck_p = wait_for_bgc_high_memory (awr_gen0_alloc, loh_p);
+            bool recheck_p = wait_for_bgc_high_memory (awr_gen0_alloc, loh_p);
 #endif //BACKGROUND_GC
 
 #ifdef SYNCHRONIZATION_STATS
@@ -17195,7 +17193,11 @@ allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size
             dprintf (2, ("h%d running out of budget on gen%d, gc", heap_number, gen_number));
 
 #ifdef BACKGROUND_GC
-            if (!recheck_p || !(new_allocation_allowed (gen_number)))
+            bool trigger_gc_p = true;
+            if (recheck_p)
+                trigger_gc_p = !(new_allocation_allowed (gen_number));
+
+            if (trigger_gc_p)
 #endif //BACKGROUND_GC
             {
                 if (!settings.concurrent || (gen_number == 0))

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -7151,7 +7151,6 @@ void gc_mechanisms::init_mechanisms()
     found_finalizers = FALSE;
 #ifdef BACKGROUND_GC
     background_p = gc_heap::background_running_p() != FALSE;
-    allocations_allowed = TRUE;
 #endif //BACKGROUND_GC
 
     entry_memory_load = 0;
@@ -7444,15 +7443,6 @@ void gc_heap::reset_allocation_pointers (generation* gen, uint8_t* start)
 
 bool gc_heap::new_allocation_allowed (int gen_number)
 {
-#ifdef BACKGROUND_GC
-    //TODO BACKGROUND_GC this is for test only
-    if (!settings.allocations_allowed)
-    {
-        dprintf (2, ("new allocation not allowed"));
-        return FALSE;
-    }
-#endif //BACKGROUND_GC
-
     if (dd_new_allocation (dynamic_data_of (gen_number)) < 0)
     {
         if (gen_number != 0)
@@ -16071,18 +16061,22 @@ void gc_heap::wait_for_background (alloc_wait_reason awr, bool loh_p)
     add_saved_spinlock_info (loh_p, me_acquire, mt_wait_bgc);
 }
 
-void gc_heap::wait_for_bgc_high_memory (alloc_wait_reason awr, bool loh_p)
+bool gc_heap::wait_for_bgc_high_memory (alloc_wait_reason awr, bool loh_p)
 {
+    bool wait_p = false;
     if (gc_heap::background_running_p())
     {
         uint32_t memory_load;
         get_memory_info (&memory_load);
         if (memory_load >= m_high_memory_load_th)
         {
+            wait_p = true;
             dprintf (GTC_LOG, ("high mem - wait for BGC to finish, wait reason: %d", awr));
             wait_for_background (awr, loh_p);
         }
     }
+
+    return wait_p;
 }
 
 #endif //BACKGROUND_GC
@@ -17189,8 +17183,10 @@ allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size
                 check_for_full_gc (gen_number, size);
             }
 
+            bool recheck_p = false;
+
 #ifdef BACKGROUND_GC
-            wait_for_bgc_high_memory (awr_gen0_alloc, loh_p);
+            recheck_p = wait_for_bgc_high_memory (awr_gen0_alloc, loh_p);
 #endif //BACKGROUND_GC
 
 #ifdef SYNCHRONIZATION_STATS
@@ -17198,10 +17194,15 @@ allocation_state gc_heap::try_allocate_more_space (alloc_context* acontext, size
 #endif //SYNCHRONIZATION_STATS
             dprintf (2, ("h%d running out of budget on gen%d, gc", heap_number, gen_number));
 
-            if (!settings.concurrent || (gen_number == 0))
+#ifdef BACKGROUND_GC
+            if (!recheck_p || !(new_allocation_allowed (gen_number)))
+#endif //BACKGROUND_GC
             {
-                trigger_gc_for_alloc (0, ((gen_number == 0) ? reason_alloc_soh : reason_alloc_loh),
-                                    msl, loh_p, mt_try_budget);
+                if (!settings.concurrent || (gen_number == 0))
+                {
+                    trigger_gc_for_alloc (0, ((gen_number == 0) ? reason_alloc_soh : reason_alloc_loh),
+                                        msl, loh_p, mt_try_budget);
+                }
             }
         }
     }

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -504,7 +504,6 @@ public:
 #ifdef BACKGROUND_GC
     BOOL background_p;
     bgc_state b_state;
-    BOOL allocations_allowed;
 #endif //BACKGROUND_GC
 
 #ifdef STRESS_HEAP
@@ -1791,7 +1790,7 @@ protected:
     void wait_for_background (alloc_wait_reason awr, bool loh_p);
 
     PER_HEAP
-    void wait_for_bgc_high_memory (alloc_wait_reason awr, bool loh_p);
+    bool wait_for_bgc_high_memory (alloc_wait_reason awr, bool loh_p);
 
     PER_HEAP
     void bgc_uoh_alloc_clr (uint8_t* alloc_start,


### PR DESCRIPTION
in high memory load situations, when we had to wait for a BGC to finish, we switched to preemptive mode which means GCs could have occurred and replenished the budget. but when we come back from the wait, we use the previous decision on whether the budget was exceeded or not. this causes us to trigger GC incorrect and you would see GCs triggered when the allocated bytes are tiny. 

repro -

```
set complus_GCHeapCount=8
set complus_gcServer=1

corerun \saved\GCPerfSim.dll -tc 32 -tagb 3000 -tlgb 3 -lohar 0 -sohsi 50 -lohsi 100 -pohsi 0 -sohpi 30 -lohpi 0 -sohfi 0 -lohfi 0 -pohfi 0 -allocType reference -testKind time -printEveryNthIter 300000
```
when memory load is high (I made it 97%), using [GC realmon](https://github.com/maoni0/realmon) this is the output - the `gen0 alloc (mb)` column shows some gen0 GCs triggered when it's < 1mb or just a few mb instead of hundreds of mb -

```
C:\realmon\src\GCRealTimeMon\bin\Release\net6.0>C:\realmon\src\GCRealTimeMon\bin\Release\net6.0\GCRealTimeMon.exe -p 13508
------- press s for current stats or any other key to exit -------

Monitoring process with name: corerun and pid: 13508
GC#     index |            type |   gen | pause (ms) |                reason | gen0 alloc (mb) | LOH size (mb) | peak/after | gen2 size (mb) |
----------------------------------------------------------------------------------------------------------------------------------------------
GC#       401 | NonConcurrentGC |     0 |      16.15 |            AllocSmall |           0.000 |        12.895 |       1.00 |      7,254.638 |
GC#       402 | NonConcurrentGC |     1 |      25.09 |            AllocSmall |         393.777 |        12.895 |       1.00 |      7,254.638 |
GC#      2278 | NonConcurrentGC |     0 |      26.29 |            AllocSmall |         378.853 |        12.895 |       1.00 |      3,219.551 |
GC#      2279 | NonConcurrentGC |     0 |      24.52 |            AllocSmall |         422.564 |        12.895 |       1.00 |      3,219.551 |
GC#      2280 | NonConcurrentGC |     0 |      24.40 |            AllocSmall |         420.125 |        12.895 |       1.00 |      3,219.551 |
GC#      2281 | NonConcurrentGC |     0 |      24.86 |            AllocSmall |         429.455 |        12.895 |       1.00 |      3,219.551 |
GC#      2283 | NonConcurrentGC |     0 |      26.49 |            AllocSmall |         581.462 |        12.895 |       1.00 |      3,219.551 |
GC#      2282 |    BackgroundGC |     2 |      14.90 |            AllocSmall |           0.000 |        12.895 |       1.00 |      3,219.542 |
GC#      2284 | NonConcurrentGC |     2 |     333.70 |            AllocSmall |          14.501 |        12.895 |       1.04 |      3,045.020 |
GC#      2285 | NonConcurrentGC |     0 |      34.91 |            AllocSmall |           0.000 |        12.895 |       1.00 |      3,045.020 |
GC#      2286 | NonConcurrentGC |     0 |      17.15 |            AllocSmall |           0.013 |        12.895 |       1.00 |      3,045.020 |
GC#      2287 | NonConcurrentGC |     0 |      17.03 |            AllocSmall |           0.090 |        12.895 |       1.00 |      3,045.020 |
GC#      2288 | NonConcurrentGC |     0 |      16.98 |            AllocSmall |           0.087 |        12.895 |       1.00 |      3,045.020 |
GC#      2289 | NonConcurrentGC |     0 |      17.04 |            AllocSmall |           0.346 |        12.895 |       1.00 |      3,045.020 |
GC#      2290 | NonConcurrentGC |     0 |      16.91 |            AllocSmall |           0.228 |        12.895 |       1.00 |      3,045.020 |
GC#      2291 | NonConcurrentGC |     0 |      17.26 |            AllocSmall |           0.991 |        12.895 |       1.00 |      3,045.020 |
GC#      2292 | NonConcurrentGC |     0 |      17.10 |            AllocSmall |           0.189 |        12.895 |       1.00 |      3,045.020 |
GC#      2293 | NonConcurrentGC |     0 |      16.97 |            AllocSmall |           0.581 |        12.895 |       1.00 |      3,045.020 |
GC#      2294 | NonConcurrentGC |     0 |      17.26 |            AllocSmall |           0.474 |        12.895 |       1.00 |      3,045.020 |
GC#      2295 | NonConcurrentGC |     0 |      18.22 |            AllocSmall |           7.915 |        12.895 |       1.00 |      3,045.020 |
GC#      2296 | NonConcurrentGC |     0 |      23.71 |            AllocSmall |         440.564 |        12.895 |       1.00 |      3,045.020 |
GC#      2297 | NonConcurrentGC |     0 |      23.86 |            AllocSmall |         433.488 |        12.895 |       1.00 |      3,045.020 |
GC#      2298 | NonConcurrentGC |     0 |      24.30 |            AllocSmall |         437.295 |        12.895 |       1.00 |      3,045.020 |
GC#      2299 | NonConcurrentGC |     0 |      24.17 |            AllocSmall |         422.302 |        12.895 |       1.00 |      3,045.020 |
GC#      2300 | NonConcurrentGC |     1 |      39.35 |            AllocSmall |         423.940 |        12.895 |       0.98 |      3,126.880 |
GC#      2301 | NonConcurrentGC |     0 |      24.23 |            AllocSmall |         413.198 |        12.895 |       1.00 |      3,126.880 |
GC#      2302 | NonConcurrentGC |     0 |      26.61 |            AllocSmall |         439.262 |        12.895 |       1.00 |      3,126.880 |
GC#      2303 | NonConcurrentGC |     0 |      25.65 |            AllocSmall |         416.549 |        12.895 |       1.00 |      3,126.880 |
GC#      2304 | NonConcurrentGC |     0 |      25.17 |            AllocSmall |         405.923 |        12.895 |       1.00 |      3,126.880 |
GC#      2305 | NonConcurrentGC |     0 |      24.96 |            AllocSmall |         438.479 |        12.895 |       1.00 |      3,126.880 |
GC#      2306 | NonConcurrentGC |     1 |      42.12 |            AllocSmall |         438.927 |        12.895 |       0.98 |      3,221.068 |
GC#      2307 | NonConcurrentGC |     0 |      24.27 |            AllocSmall |         425.704 |        12.895 |       1.00 |      3,221.068 |
GC#      2308 | NonConcurrentGC |     0 |      24.17 |            AllocSmall |         439.244 |        12.895 |       1.00 |      3,221.068 |
GC#      2309 | NonConcurrentGC |     0 |      24.67 |            AllocSmall |         416.837 |        12.895 |       1.00 |      3,221.068 |
GC#      2310 | NonConcurrentGC |     0 |      25.06 |            AllocSmall |         425.330 |        12.895 |       1.00 |      3,221.068 |
GC#      2311 | NonConcurrentGC |     0 |      26.25 |            AllocSmall |         448.383 |        12.895 |       1.00 |      3,221.068 |
GC#      2313 | NonConcurrentGC |     0 |      26.85 |            AllocSmall |         571.748 |        12.895 |       1.00 |      3,221.068 |
GC#      2312 |    BackgroundGC |     2 |      12.65 |            AllocSmall |           0.000 |        12.895 |       1.00 |      3,221.062 |
GC#      2314 | NonConcurrentGC |     2 |     358.62 |            AllocSmall |          14.904 |        12.895 |       1.04 |      3,044.236 |
GC#      2315 | NonConcurrentGC |     0 |      35.18 |            AllocSmall |           0.000 |        12.895 |       1.00 |      3,044.236 |
GC#      2316 | NonConcurrentGC |     0 |      18.83 |            AllocSmall |           0.022 |        12.895 |       1.00 |      3,044.236 |
GC#      2317 | NonConcurrentGC |     0 |      17.50 |            AllocSmall |           0.019 |        12.895 |       1.00 |      3,044.236 |
GC#      2318 | NonConcurrentGC |     0 |      17.01 |            AllocSmall |           0.000 |        12.895 |       1.00 |      3,044.236 |
GC#      2319 | NonConcurrentGC |     0 |      16.94 |            AllocSmall |           0.036 |        12.895 |       1.00 |      3,044.236 |
GC#      2320 | NonConcurrentGC |     0 |      17.61 |            AllocSmall |           0.309 |        12.895 |       1.00 |      3,044.236 |
GC#      2321 | NonConcurrentGC |     0 |      17.09 |            AllocSmall |           0.103 |        12.895 |       1.00 |      3,044.236 |
GC#      2322 | NonConcurrentGC |     0 |      17.32 |            AllocSmall |           4.160 |        12.895 |       1.00 |      3,044.236 |
GC#      2323 | NonConcurrentGC |     0 |      17.03 |            AllocSmall |           1.006 |        12.895 |       1.00 |      3,044.236 |
GC#      2324 | NonConcurrentGC |     0 |      23.48 |            AllocSmall |         442.973 |        12.895 |       1.00 |      3,044.236 |
```
with fix this no longer repros.

also got rid of the allocations_allowed check that's unused.

@PeterSolMS I did put in a bit more logic to detect whether I should do the check again. PTAL. 