### PR TITLE
Add CancellationToken to TextReader.ReadXAsync

### DIFF
--- a/src/libraries/System.Console/src/System/IO/SyncTextReader.cs
+++ b/src/libraries/System.Console/src/System/IO/SyncTextReader.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.IO
@@ -95,9 +96,19 @@ namespace System.IO
             return Task.FromResult(ReadLine());
         }
 
+        public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<string?>(cancellationToken) : new ValueTask<string?>(ReadLine());
+        }
+
         public override Task<string> ReadToEndAsync()
         {
             return Task.FromResult(ReadToEnd());
+        }
+
+        public override Task<string> ReadToEndAsync(CancellationToken cancellationToken)
+        {
+            return cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult(ReadToEnd());
         }
 
         public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)

--- a/src/libraries/System.Console/src/System/IO/SyncTextReader.cs
+++ b/src/libraries/System.Console/src/System/IO/SyncTextReader.cs
@@ -98,7 +98,9 @@ namespace System.IO
 
         public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken)
         {
-            return cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<string?>(cancellationToken) : new ValueTask<string?>(ReadLine());
+            return cancellationToken.IsCancellationRequested ?
+                ValueTask.FromCanceled<string?>(cancellationToken) :
+                new ValueTask<string?>(ReadLine());
         }
 
         public override Task<string> ReadToEndAsync()
@@ -108,7 +110,9 @@ namespace System.IO
 
         public override Task<string> ReadToEndAsync(CancellationToken cancellationToken)
         {
-            return cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult(ReadToEnd());
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled<string>(cancellationToken) :
+                Task.FromResult(ReadToEnd());
         }
 
         public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)

--- a/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -132,6 +132,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public async Task ReadToEndAsync_WithCancellation()
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -131,30 +131,15 @@ namespace System.IO.Tests
         [Fact]
         public async Task ReadToEndAsync_WithCancellation()
         {
-            var path = Path.GetTempFileName();
-            try
-            {
-                // create large (~100MB) file
-                using (var writer = new StreamWriter(path))
-                {
-                    for (var i = 0; i < 1_000_000; i++)
-                        writer.WriteLine("A very large file used for testing StreamReader cancellation. 0123456789012345678901234567890123456789.");
-                }
+            string path = GetTestFilePath();
+            
+            // create large (~100MB) file
+            File.WriteAllLines(path, Enumerable.Repeat("A very large file used for testing StreamReader cancellation. 0123456789012345678901234567890123456789.", 1_000_000));
 
-                using var reader = File.OpenText(path);
-                using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
-                await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await reader.ReadToEndAsync(cts.Token));
-            }
-            finally
-            {
-                try
-                {
-                    File.Delete(path);
-                }
-                catch (Exception)
-                {
-                }
-            }
+            using StreamReader reader = File.OpenText(path);
+            using CancellationTokenSource cts = new (TimeSpan.FromMilliseconds(50));
+            
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await reader.ReadToEndAsync(cts.Token));
         }
 
         [Fact]

--- a/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -125,7 +125,10 @@ namespace System.IO.Tests
             using var sw = new StreamReader(GetLargeStream());
             using var cts = new CancellationTokenSource();
             cts.Cancel();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sw.ReadToEndAsync(cts.Token));
+            var token = cts.Token;
+
+            var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sw.ReadToEndAsync(token));
+            Assert.Equal(token, ex.CancellationToken);
         }
 
         [Fact]
@@ -138,8 +141,10 @@ namespace System.IO.Tests
 
             using StreamReader reader = File.OpenText(path);
             using CancellationTokenSource cts = new (TimeSpan.FromMilliseconds(50));
-            
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await reader.ReadToEndAsync(cts.Token));
+            var token = cts.Token;
+
+            var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await reader.ReadToEndAsync(token));
+            Assert.Equal(token, ex.CancellationToken);
         }
 
         [Fact]

--- a/src/libraries/System.IO/tests/StringReader/StringReader.CtorTests.cs
+++ b/src/libraries/System.IO/tests/StringReader/StringReader.CtorTests.cs
@@ -69,6 +69,23 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        public static async Task ReadLineAsync()
+        {
+            string str1 = "Hello\0\t\v   \\ World";
+            string str2 = str1 + Environment.NewLine + str1;
+
+            using (StringReader sr = new StringReader(str1))
+            {
+                Assert.Equal(str1, await sr.ReadLineAsync());
+            }
+            using (StringReader sr = new StringReader(str2))
+            {
+                Assert.Equal(str1, await sr.ReadLineAsync(default));
+                Assert.Equal(str1, await sr.ReadLineAsync(default));
+            }
+        }
+
+        [Fact]
         public static void ReadPseudoRandomString()
         {
             string str1 = string.Empty;
@@ -153,6 +170,14 @@ namespace System.IO.Tests
 
             StringReader sr = new StringReader(str1);
             Assert.Equal(str1, sr.ReadToEnd());
+        }
+
+        [Fact]
+        public static async Task ReadToEndAsyncString()
+        {
+            string str1 = "Hello\0\t\v   \\ World";
+            StringReader sr = new StringReader(str1);
+            Assert.Equal(str1, await sr.ReadToEndAsync(default));
         }
 
         [Fact]
@@ -278,6 +303,8 @@ namespace System.IO.Tests
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => reader.ReadAsync(Memory<char>.Empty, new CancellationToken(true)).AsTask());
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => reader.ReadBlockAsync(Memory<char>.Empty, new CancellationToken(true)).AsTask());
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => reader.ReadLineAsync(new CancellationToken(true)).AsTask());
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => reader.ReadToEndAsync(new CancellationToken(true)));
         }
 
         private static void ValidateDisposedExceptions(StringReader sr)

--- a/src/libraries/System.IO/tests/TextReader/TextReaderTests.cs
+++ b/src/libraries/System.IO/tests/TextReader/TextReaderTests.cs
@@ -69,7 +69,10 @@ namespace System.IO.Tests
             using var tr = new CharArrayTextReader(TestDataProvider.LargeData);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await tr.ReadToEndAsync(cts.Token));
+            CancellationToken token = cts.Token;
+
+            TaskCanceledException ex = await Assert.ThrowsAsync<OperationCanceledException>(async () => await tr.ReadToEndAsync(token));
+            Assert.Equal(token, ex.CancellationToken);
         }
 
         [Fact]

--- a/src/libraries/System.IO/tests/TextReader/TextReaderTests.cs
+++ b/src/libraries/System.IO/tests/TextReader/TextReaderTests.cs
@@ -69,9 +69,9 @@ namespace System.IO.Tests
             using var tr = new CharArrayTextReader(TestDataProvider.LargeData);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
-            CancellationToken token = cts.Token;
+            var token = cts.Token;
 
-            TaskCanceledException ex = await Assert.ThrowsAsync<OperationCanceledException>(async () => await tr.ReadToEndAsync(token));
+            var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await tr.ReadToEndAsync(token));
             Assert.Equal(token, ex.CancellationToken);
         }
 

--- a/src/libraries/System.IO/tests/TextReader/TextReaderTests.cs
+++ b/src/libraries/System.IO/tests/TextReader/TextReaderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -52,6 +53,23 @@ namespace System.IO.Tests
 
                 Assert.Equal(5000, result.Length);
             }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public async Task ReadToEndAsync_WithCancellationToken()
+        {
+            using var tr = new CharArrayTextReader(TestDataProvider.LargeData);
+            var result = await tr.ReadToEndAsync(default);
+            Assert.Equal(5000, result.Length);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public async Task ReadToEndAsync_WithCanceledCancellationToken()
+        {
+            using var tr = new CharArrayTextReader(TestDataProvider.LargeData);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await tr.ReadToEndAsync(cts.Token));
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -649,7 +649,7 @@ namespace System.IO
                 cancellationToken.ThrowIfCancellationRequested();
                 string? line;
                 List<string> lines = new List<string>();
-                while ((line = await sr.ReadLineAsync().ConfigureAwait(false)) != null)
+                while ((line = await sr.ReadLineAsync(cancellationToken).ConfigureAwait(false)) != null)
                 {
                     lines.Add(line);
                     cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -853,25 +853,27 @@ namespace System.IO
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A value task that represents the asynchronous read operation. The value of the <c>TResult</c>
-        /// parameter contains the next line from the stream, or is <c>null</c> if all of the characters have been read.</returns>
+        /// parameter contains the next line from the stream, or is <see langword="null" /> if all of the characters have been read.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The number of characters in the next line is larger than <see cref="int.MaxValue"/>.</exception>
         /// <exception cref="ObjectDisposedException">The stream reader has been disposed.</exception>
         /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
         /// <example>
-        /// The following example shows how to read the first line of a file by using the <see cref="ReadLineAsync(CancellationToken)"/> method.
+        /// The following example shows how to read and print all lines from the file until the end of the file is reached or the operation timed out.
         /// <code lang="C#">
-        /// using var tokenSource = new CancellationTokenSource();
-        /// using var reader = File.OpenText("existingfile.txt");
-        /// Console.WriteLine("Opened file.");
-        ///
-        /// var result = await reader.ReadLineAsync(tokenSource.Token);
-        /// Console.WriteLine("First line contains: " + result);
+        /// using CancellationTokenSource tokenSource = new (TimeSpan.FromSeconds(1));
+        /// using StreamReader reader = File.OpenText("existingfile.txt");
+        /// 
+        /// string line;
+        /// while ((line = await reader.ReadLineAsync(tokenSource.Token)) is not null)
+        /// {
+        ///     Console.WriteLine(line);
+        /// }
         /// </code>
         /// </example>
         /// <remarks>
-        /// <para>If this method is canceled via <paramref name="cancellationToken"/>, some data
+        /// If this method is canceled via <paramref name="cancellationToken"/>, some data
         /// that has been read from the current <see cref="Stream"/> but not stored (by the
-        /// <see cref="StreamReader"/>) or returned (to the caller) may be lost.</para>
+        /// <see cref="StreamReader"/>) or returned (to the caller) may be lost.
         /// </remarks>
         public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken)
         {
@@ -968,18 +970,16 @@ namespace System.IO
         /// <example>
         /// The following example shows how to read the contents of a file by using the <see cref="ReadToEndAsync(CancellationToken)"/> method.
         /// <code lang="C#">
-        /// using var tokenSource = new CancellationTokenSource();
-        /// using var reader = File.OpenText("existingfile.txt");
-        /// Console.WriteLine("Opened file.");
+        /// using CancellationTokenSource tokenSource = new (TimeSpan.FromSeconds(1));
+        /// using StreamReader reader = File.OpenText("existingfile.txt");
         ///
-        /// var result = await reader.ReadToEndAsync(tokenSource.Token);
-        /// Console.WriteLine("Contains: " + result);
+        /// Console.WriteLine(await reader.ReadToEndAsync(tokenSource.Token));
         /// </code>
         /// </example>
         /// <remarks>
-        /// <para>If this method is canceled via <paramref name="cancellationToken"/>, some data
+        /// If this method is canceled via <paramref name="cancellationToken"/>, some data
         /// that has been read from the current <see cref="Stream"/> but not stored (by the
-        /// <see cref="StreamReader"/>) or returned (to the caller) may be lost.</para>
+        /// <see cref="StreamReader"/>) or returned (to the caller) may be lost.
         /// </remarks>
         public override Task<string> ReadToEndAsync(CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -862,13 +862,13 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            Task<string?> task = ReadLineAsyncInternal(cancellationToken).AsTask();
+            Task<string?> task = ReadLineAsyncInternal(cancellationToken);
             _asyncReadTask = task;
 
             return new ValueTask<string?>(task);
         }
 
-        private async ValueTask<string?> ReadLineAsyncInternal(CancellationToken cancellationToken)
+        private async Task<string?> ReadLineAsyncInternal(CancellationToken cancellationToken)
         {
             if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -862,13 +862,13 @@ namespace System.IO
             ThrowIfDisposed();
             CheckAsyncTaskInProgress();
 
-            Task<string?> task = ReadLineAsyncInternal(cancellationToken);
+            Task<string?> task = ReadLineAsyncInternal(cancellationToken).AsTask();
             _asyncReadTask = task;
 
             return new ValueTask<string?>(task);
         }
 
-        private async Task<string?> ReadLineAsyncInternal(CancellationToken cancellationToken)
+        private async ValueTask<string?> ReadLineAsyncInternal(CancellationToken cancellationToken)
         {
             if (_charPos == _charLen && (await ReadBufferAsync(cancellationToken).ConfigureAwait(false)) == 0)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -862,7 +862,7 @@ namespace System.IO
         /// <code lang="C#">
         /// using CancellationTokenSource tokenSource = new (TimeSpan.FromSeconds(1));
         /// using StreamReader reader = File.OpenText("existingfile.txt");
-        /// 
+        ///
         /// string line;
         /// while ((line = await reader.ReadLineAsync(tokenSource.Token)) is not null)
         /// {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -929,8 +929,7 @@ namespace System.IO
             return sb.ToString();
         }
 
-        public override Task<string> ReadToEndAsync() =>
-            ReadToEndAsync(default);
+        public override Task<string> ReadToEndAsync() => ReadToEndAsync(default);
 
         public override Task<string> ReadToEndAsync(CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -848,6 +848,31 @@ namespace System.IO
         public override Task<string?> ReadLineAsync() =>
             ReadLineAsync(default).AsTask();
 
+        /// <summary>
+        /// Reads a line of characters asynchronously from the current stream and returns the data as a string.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A value task that represents the asynchronous read operation. The value of the <c>TResult</c>
+        /// parameter contains the next line from the stream, or is <c>null</c> if all of the characters have been read.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The number of characters in the next line is larger than <see cref="int.MaxValue"/>.</exception>
+        /// <exception cref="ObjectDisposedException">The stream reader has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
+        /// <example>
+        /// The following example shows how to read the first line of a file by using the <see cref="ReadLineAsync(CancellationToken)"/> method.
+        /// <code lang="C#">
+        /// using var tokenSource = new CancellationTokenSource();
+        /// using var reader = File.OpenText("existingfile.txt");
+        /// Console.WriteLine("Opened file.");
+        ///
+        /// var result = await reader.ReadLineAsync(tokenSource.Token);
+        /// Console.WriteLine("First line contains: " + result);
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// <para>If this method is canceled via <paramref name="cancellationToken"/>, some data
+        /// that has been read from the current <see cref="Stream"/> but not stored (by the
+        /// <see cref="StreamReader"/>) or returned (to the caller) may be lost.</para>
+        /// </remarks>
         public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken)
         {
             // If we have been inherited into a subclass, the following implementation could be incorrect
@@ -931,6 +956,31 @@ namespace System.IO
 
         public override Task<string> ReadToEndAsync() => ReadToEndAsync(default);
 
+        /// <summary>
+        /// Reads all characters from the current position to the end of the stream asynchronously and returns them as one string.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the <c>TResult</c> parameter contains
+        /// a string with the characters from the current position to the end of the stream.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The number of characters is larger than <see cref="int.MaxValue"/>.</exception>
+        /// <exception cref="ObjectDisposedException">The stream reader has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
+        /// <example>
+        /// The following example shows how to read the contents of a file by using the <see cref="ReadToEndAsync(CancellationToken)"/> method.
+        /// <code lang="C#">
+        /// using var tokenSource = new CancellationTokenSource();
+        /// using var reader = File.OpenText("existingfile.txt");
+        /// Console.WriteLine("Opened file.");
+        ///
+        /// var result = await reader.ReadToEndAsync(tokenSource.Token);
+        /// Console.WriteLine("Contains: " + result);
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// <para>If this method is canceled via <paramref name="cancellationToken"/>, some data
+        /// that has been read from the current <see cref="Stream"/> but not stored (by the
+        /// <see cref="StreamReader"/>) or returned (to the caller) may be lost.</para>
+        /// </remarks>
         public override Task<string> ReadToEndAsync(CancellationToken cancellationToken)
         {
             // If we have been inherited into a subclass, the following implementation could be incorrect

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -224,10 +224,20 @@ namespace System.IO
             return Task.FromResult(ReadLine());
         }
 
+        public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>
+            cancellationToken.IsCancellationRequested
+                ? ValueTask.FromCanceled<string?>(cancellationToken)
+                : new ValueTask<string?>(ReadLine());
+
         public override Task<string> ReadToEndAsync()
         {
             return Task.FromResult(ReadToEnd());
         }
+
+        public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
+            cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled<string>(cancellationToken)
+                : Task.FromResult(ReadToEnd());
 
         public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -229,7 +229,7 @@ namespace System.IO
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A value task that represents the asynchronous read operation. The value of the <c>TResult</c>
-        /// parameter contains the next line from the string reader, or is <c>null</c> if all of the characters have been read.</returns>
+        /// parameter contains the next line from the string reader, or is <see langword="null" /> if all of the characters have been read.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The number of characters in the next line is larger than <see cref="int.MaxValue"/>.</exception>
         /// <exception cref="ObjectDisposedException">The string reader has been disposed.</exception>
         /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
@@ -244,8 +244,8 @@ namespace System.IO
         /// stringToRead.AppendLine("and the end");
         ///
         /// string readText;
-        /// using var tokenSource = new CancellationTokenSource();
-        /// using var reader = new StringReader(stringToRead.ToString());
+        /// using CancellationTokenSource tokenSource = new (TimeSpan.FromSeconds(1));
+        /// using StringReader reader = new (stringToRead.ToString());
         /// while ((readText = await reader.ReadLineAsync(tokenSource.Token)) is not null)
         /// {
         ///     Console.WriteLine(readText);
@@ -281,8 +281,8 @@ namespace System.IO
         /// stringToRead.AppendLine("and 2nd line");
         /// stringToRead.AppendLine("and the end");
         ///
-        /// using var tokenSource = new CancellationTokenSource();
-        /// using var reader = new StringReader(stringToRead.ToString());
+        /// using CancellationTokenSource tokenSource = new (TimeSpan.FromSeconds(1));
+        /// using StringReader reader = new (stringToRead.ToString());
         /// var readText = await reader.ReadToEndAsync(tokenSource.Token);
         /// Console.WriteLine(readText);
         /// </code>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StringReader.cs
@@ -224,6 +224,34 @@ namespace System.IO
             return Task.FromResult(ReadLine());
         }
 
+        /// <summary>
+        /// Reads a line of characters asynchronously from the current string and returns the data as a string.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A value task that represents the asynchronous read operation. The value of the <c>TResult</c>
+        /// parameter contains the next line from the string reader, or is <c>null</c> if all of the characters have been read.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The number of characters in the next line is larger than <see cref="int.MaxValue"/>.</exception>
+        /// <exception cref="ObjectDisposedException">The string reader has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
+        /// <example>
+        /// The following example shows how to read one line at a time from a string asynchronously.
+        /// <code lang="C#">
+        /// using System.Text;
+        ///
+        /// StringBuilder stringToRead = new();
+        /// stringToRead.AppendLine("Characters in 1st line to read");
+        /// stringToRead.AppendLine("and 2nd line");
+        /// stringToRead.AppendLine("and the end");
+        ///
+        /// string readText;
+        /// using var tokenSource = new CancellationTokenSource();
+        /// using var reader = new StringReader(stringToRead.ToString());
+        /// while ((readText = await reader.ReadLineAsync(tokenSource.Token)) is not null)
+        /// {
+        ///     Console.WriteLine(readText);
+        /// }
+        /// </code>
+        /// </example>
         public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>
             cancellationToken.IsCancellationRequested
                 ? ValueTask.FromCanceled<string?>(cancellationToken)
@@ -234,6 +262,31 @@ namespace System.IO
             return Task.FromResult(ReadToEnd());
         }
 
+        /// <summary>
+        /// Reads all characters from the current position to the end of the string asynchronously and returns them as a single string.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the <c>TResult</c> parameter contains
+        /// a string with the characters from the current position to the end of the string.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The number of characters is larger than <see cref="int.MaxValue"/>.</exception>
+        /// <exception cref="ObjectDisposedException">The string reader has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
+        /// <example>
+        /// The following example shows how to read an entire string asynchronously.
+        /// <code lang="C#">
+        /// using System.Text;
+        ///
+        /// StringBuilder stringToRead = new();
+        /// stringToRead.AppendLine("Characters in 1st line to read");
+        /// stringToRead.AppendLine("and 2nd line");
+        /// stringToRead.AppendLine("and the end");
+        ///
+        /// using var tokenSource = new CancellationTokenSource();
+        /// using var reader = new StringReader(stringToRead.ToString());
+        /// var readText = await reader.ReadToEndAsync(tokenSource.Token);
+        /// Console.WriteLine(readText);
+        /// </code>
+        /// </example>
         public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
             cancellationToken.IsCancellationRequested
                 ? Task.FromCanceled<string>(cancellationToken)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -210,7 +210,7 @@ namespace System.IO
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A value task that represents the asynchronous read operation. The value of the <c>TResult</c>
-        /// parameter contains the next line from the text reader, or is <c>null</c> if all of the characters have been read.</returns>
+        /// parameter contains the next line from the text reader, or is <see langword="null" /> if all of the characters have been read.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The number of characters in the next line is larger than <see cref="int.MaxValue"/>.</exception>
         /// <exception cref="ObjectDisposedException">The text reader has been disposed.</exception>
         /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
@@ -219,7 +219,7 @@ namespace System.IO
         /// your code. For an example of using the <see cref="ReadLineAsync(CancellationToken)"/> method, see the
         /// <see cref="StreamReader.ReadLineAsync(CancellationToken)"/> method.</para>
         /// <para>If the current <see cref="TextReader"/> represents the standard input stream returned by
-        /// the <c>Console.In</c> property, the <see cref="ReadLineAsync(CancellationToken)"/> method
+        /// the <see cref="Console.In" /> property, the <see cref="ReadLineAsync(CancellationToken)"/> method
         /// executes synchronously rather than asynchronously.</para>
         /// </remarks>
         public virtual ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -212,8 +212,7 @@ namespace System.IO
             Task<string?>.Factory.StartNew(static state => ((TextReader)state!).ReadLine(), this,
                 cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
-        public virtual Task<string> ReadToEndAsync() =>
-            ReadToEndAsync(default);
+        public virtual Task<string> ReadToEndAsync() => ReadToEndAsync(default);
 
         public virtual async Task<string> ReadToEndAsync(CancellationToken cancellationToken)
         {
@@ -377,13 +376,15 @@ namespace System.IO
             public override Task<string?> ReadLineAsync() => Task.FromResult(ReadLine());
 
             [MethodImpl(MethodImplOptions.Synchronized)]
-            public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) => cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<string?>(cancellationToken) : new ValueTask<string?>(ReadLine());
+            public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken)
+                => cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<string?>(cancellationToken) : new ValueTask<string?>(ReadLine());
 
             [MethodImpl(MethodImplOptions.Synchronized)]
             public override Task<string> ReadToEndAsync() => Task.FromResult(ReadToEnd());
 
             [MethodImpl(MethodImplOptions.Synchronized)]
-            public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) => cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult(ReadToEnd());
+            public override Task<string> ReadToEndAsync(CancellationToken cancellationToken)
+                => cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult(ReadToEnd());
 
             [MethodImpl(MethodImplOptions.Synchronized)]
             public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -219,7 +219,7 @@ namespace System.IO
         /// your code. For an example of using the <see cref="ReadLineAsync(CancellationToken)"/> method, see the
         /// <see cref="StreamReader.ReadLineAsync(CancellationToken)"/> method.</para>
         /// <para>If the current <see cref="TextReader"/> represents the standard input stream returned by
-        /// the <see cref="Console.In" /> property, the <see cref="ReadLineAsync(CancellationToken)"/> method
+        /// the <c>Console.In</c> property, the <see cref="ReadLineAsync(CancellationToken)"/> method
         /// executes synchronously rather than asynchronously.</para>
         /// </remarks>
         public virtual ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -205,6 +205,23 @@ namespace System.IO
         #region Task based Async APIs
         public virtual Task<string?> ReadLineAsync() => ReadLineCoreAsync(default);
 
+        /// <summary>
+        /// Reads a line of characters asynchronously and returns the data as a string.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A value task that represents the asynchronous read operation. The value of the <c>TResult</c>
+        /// parameter contains the next line from the text reader, or is <c>null</c> if all of the characters have been read.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The number of characters in the next line is larger than <see cref="int.MaxValue"/>.</exception>
+        /// <exception cref="ObjectDisposedException">The text reader has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
+        /// <remarks>
+        /// <para>The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in
+        /// your code. For an example of using the <see cref="ReadLineAsync(CancellationToken)"/> method, see the
+        /// <see cref="StreamReader.ReadLineAsync(CancellationToken)"/> method.</para>
+        /// <para>If the current <see cref="TextReader"/> represents the standard input stream returned by
+        /// the <c>Console.In</c> property, the <see cref="ReadLineAsync(CancellationToken)"/> method
+        /// executes synchronously rather than asynchronously.</para>
+        /// </remarks>
         public virtual ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>
             new ValueTask<string?>(ReadLineCoreAsync(cancellationToken));
 
@@ -214,6 +231,20 @@ namespace System.IO
 
         public virtual Task<string> ReadToEndAsync() => ReadToEndAsync(default);
 
+        /// <summary>
+        /// Reads all characters from the current position to the end of the text reader asynchronously and returns them as one string.
+        /// </summary>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous read operation. The value of the <c>TResult</c> parameter contains
+        /// a string with the characters from the current position to the end of the text reader.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The number of characters is larger than <see cref="int.MaxValue"/>.</exception>
+        /// <exception cref="ObjectDisposedException">The text reader has been disposed.</exception>
+        /// <exception cref="InvalidOperationException">The reader is currently in use by a previous read operation.</exception>
+        /// <remarks>
+        /// <para>The <see cref="TextReader"/> class is an abstract class. Therefore, you do not instantiate it in
+        /// your code. For an example of using the <see cref="ReadToEndAsync(CancellationToken)"/> method, see the
+        /// <see cref="StreamReader.ReadToEndAsync(CancellationToken)"/> method.</para>
+        /// </remarks>
         public virtual async Task<string> ReadToEndAsync(CancellationToken cancellationToken)
         {
             var sb = new StringBuilder(4096);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10855,8 +10855,10 @@ namespace System.IO
         public override System.Threading.Tasks.ValueTask<int> ReadBlockAsync(System.Memory<char> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override string? ReadLine() { throw null; }
         public override System.Threading.Tasks.Task<string?> ReadLineAsync() { throw null; }
+        public override System.Threading.Tasks.ValueTask<string?> ReadLineAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override string ReadToEnd() { throw null; }
         public override System.Threading.Tasks.Task<string> ReadToEndAsync() { throw null; }
+        public override System.Threading.Tasks.Task<string> ReadToEndAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class StreamWriter : System.IO.TextWriter
     {
@@ -10920,8 +10922,10 @@ namespace System.IO
         public override System.Threading.Tasks.ValueTask<int> ReadBlockAsync(System.Memory<char> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override string? ReadLine() { throw null; }
         public override System.Threading.Tasks.Task<string?> ReadLineAsync() { throw null; }
+        public override System.Threading.Tasks.ValueTask<string?> ReadLineAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public override string ReadToEnd() { throw null; }
         public override System.Threading.Tasks.Task<string> ReadToEndAsync() { throw null; }
+        public override System.Threading.Tasks.Task<string> ReadToEndAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public partial class StringWriter : System.IO.TextWriter
     {
@@ -10972,8 +10976,10 @@ namespace System.IO
         public virtual System.Threading.Tasks.ValueTask<int> ReadBlockAsync(System.Memory<char> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual string? ReadLine() { throw null; }
         public virtual System.Threading.Tasks.Task<string?> ReadLineAsync() { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<string?> ReadLineAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual string ReadToEnd() { throw null; }
         public virtual System.Threading.Tasks.Task<string> ReadToEndAsync() { throw null; }
+        public virtual System.Threading.Tasks.Task<string> ReadToEndAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.IO.TextReader Synchronized(System.IO.TextReader reader) { throw null; }
     }
     public abstract partial class TextWriter : System.MarshalByRefObject, System.IAsyncDisposable, System.IDisposable


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/20824

Implements the API from https://github.com/dotnet/runtime/issues/20824#issuecomment-759281692 except that `token` has been changed to `cancellationToken` to match other public APIs on `TextReader`.