### PR TITLE
Fix `optComputeLoopSideEffects` to account for HWI stores

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7539,6 +7539,15 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                         }
                         break;
 
+#ifdef FEATURE_HW_INTRINSICS
+                    case GT_HWINTRINSIC:
+                        if (tree->AsHWIntrinsic()->OperIsMemoryStore())
+                        {
+                            memoryHavoc |= memoryKindSet(GcHeap, ByrefExposed);
+                        }
+                        break;
+#endif // FEATURE_HW_INTRINSICS
+
                     case GT_LOCKADD:
                     case GT_XORR:
                     case GT_XAND:
@@ -7547,7 +7556,6 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
                     case GT_CMPXCHG:
                     case GT_MEMORYBARRIER:
                     {
-                        assert(!tree->OperIs(GT_LOCKADD) && "LOCKADD should not appear before lowering");
                         memoryHavoc |= memoryKindSet(GcHeap, ByrefExposed);
                     }
                     break;
@@ -7587,6 +7595,7 @@ bool Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
 
                     default:
                         // All other gtOper node kinds, leave 'memoryHavoc' unchanged (i.e. false)
+                        assert(!tree->OperRequiresAsgFlag());
                         break;
                 }
             }

--- a/src/tests/JIT/opt/Loops/LoopSideEffectsForHwiStores.cs
+++ b/src/tests/JIT/opt/Loops/LoopSideEffectsForHwiStores.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;

--- a/src/tests/JIT/opt/Loops/LoopSideEffectsForHwiStores.cs
+++ b/src/tests/JIT/opt/Loops/LoopSideEffectsForHwiStores.cs
@@ -1,0 +1,70 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using System.Runtime.Intrinsics.Arm;
+
+unsafe class LoopSideEffectsForHwiStores
+{
+    public static int Main()
+    {
+        static bool VerifyExpectedVtor(Vector128<int> a) => a.Equals(Vector128.Create(4));
+
+        var a = new ClassWithVtor();
+
+        fixed (Vector128<int>* p = &a.VtorField)
+        {
+            if (Sse2.IsSupported && !VerifyExpectedVtor(ProblemWithSse2(a, (byte*)p)))
+            {
+                System.Console.WriteLine("ProblemWithSse2 failed!");
+                return 101;
+            }
+
+            if (AdvSimd.IsSupported && !VerifyExpectedVtor(ProblemWithAdvSimd(a, (byte*)p)))
+            {
+                System.Console.WriteLine("ProblemWithAdvSimd failed!");
+                return 101;
+            }
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe Vector128<int> ProblemWithSse2(ClassWithVtor a, byte* p)
+    {
+        Vector128<int> vtor = Vector128<int>.Zero;
+
+        a.VtorField = Vector128.Create(1);
+        a.VtorField = Sse2.Add(a.VtorField, a.VtorField);
+
+        for (int i = 0; i < 10; i++)
+        {
+            vtor = Sse2.Add(vtor, Sse2.Add(a.VtorField, a.VtorField));
+            Sse2.Store(p, Vector128<byte>.Zero);
+        }
+
+        return vtor;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe Vector128<int> ProblemWithAdvSimd(ClassWithVtor a, byte* p)
+    {
+        Vector128<int> vtor = Vector128<int>.Zero;
+
+        a.VtorField = Vector128.Create(1);
+        a.VtorField = AdvSimd.Add(a.VtorField, a.VtorField);
+
+        for (int i = 0; i < 10; i++)
+        {
+            vtor = AdvSimd.Add(vtor, AdvSimd.Add(a.VtorField, a.VtorField));
+            AdvSimd.Store(p, Vector128<byte>.Zero);
+        }
+
+        return vtor;
+    }
+
+    class ClassWithVtor
+    {
+        public Vector128<int> VtorField;
+    }
+}

--- a/src/tests/JIT/opt/Loops/LoopSideEffectsForHwiStores.csproj
+++ b/src/tests/JIT/opt/Loops/LoopSideEffectsForHwiStores.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Otherwise we can end up not seeing the loop has memory havoc.

Also added an assert that will prevent this issue from arising in the future.

A few small diffs in methods where we had such loops.

<details>
<summary>Win-x64 diffs</summary>

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 7065605 (overridden on cmd)
Total bytes of diff: 7065604 (overridden on cmd)
Total bytes of delta: -1 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
          -1 : 21732.dasm (-0.07% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -1 (-0.07% of base) : 21732.dasm - System.Collections.BitArray:CopyTo(System.Array,int):this

Top method improvements (percentages):
          -1 (-0.07% of base) : 21732.dasm - System.Collections.BitArray:CopyTo(System.Array,int):this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 45295203 (overridden on cmd)
Total bytes of diff: 45295192 (overridden on cmd)
Total bytes of delta: -11 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -11 : 174250.dasm (-0.72% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -11 (-0.72% of base) : 174250.dasm - System.Collections.BitArray:CopyTo(System.Array,int):this

Top method improvements (percentages):
         -11 (-0.72% of base) : 174250.dasm - System.Collections.BitArray:CopyTo(System.Array,int):this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------
</details>

[Full diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1480717&view=ms.vss-build-web.run-extensions-tab).