### PR TITLE
Use correct VN relation kind for redundant relop opts

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -847,11 +847,11 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
     //  * makes the current relop redundant;
     //  * can safely and profitably forward substituted to the jump.
     //
-    Statement*                      prevStmt        = stmt;
-    GenTree*                        candidateTree   = nullptr;
-    Statement*                      candidateStmt   = nullptr;
-    ValueNumStore::VN_RELATION_KIND vnRelationMatch = ValueNumStore::VN_RELATION_KIND::VRK_Same;
-    bool                            sideEffect      = false;
+    Statement*                      prevStmt            = stmt;
+    GenTree*                        candidateTree       = nullptr;
+    Statement*                      candidateStmt       = nullptr;
+    ValueNumStore::VN_RELATION_KIND candidateVnRelation = ValueNumStore::VN_RELATION_KIND::VRK_Same;
+    bool                            sideEffect          = false;
 
     const ValueNumStore::VN_RELATION_KIND vnRelations[] = {ValueNumStore::VN_RELATION_KIND::VRK_Same,
                                                            ValueNumStore::VN_RELATION_KIND::VRK_Reverse,
@@ -984,8 +984,9 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
         // If the normal liberal VN of RHS is the normal liberal VN of the current tree, or is "related",
         // consider forward sub.
         //
-        const ValueNum domCmpVN = vnStore->VNNormalValue(prevTreeRHS->GetVN(VNK_Liberal));
-        bool           matched  = false;
+        const ValueNum                  domCmpVN        = vnStore->VNNormalValue(prevTreeRHS->GetVN(VNK_Liberal));
+        bool                            matched         = false;
+        ValueNumStore::VN_RELATION_KIND vnRelationMatch = ValueNumStore::VN_RELATION_KIND::VRK_Same;
 
         for (auto vnRelation : vnRelations)
         {
@@ -1058,8 +1059,9 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
         }
 
         JITDUMP(" -- prev tree is viable candidate for relop fwd sub!\n");
-        candidateTree = prevTreeRHS;
-        candidateStmt = prevStmt;
+        candidateTree       = prevTreeRHS;
+        candidateStmt       = prevStmt;
+        candidateVnRelation = vnRelationMatch;
     }
 
     if (candidateTree == nullptr)
@@ -1088,8 +1090,8 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
     // If we need the reverse compare, make it so.
     // We also need to set a proper VN.
     //
-    if ((vnRelationMatch == ValueNumStore::VN_RELATION_KIND::VRK_Reverse) ||
-        (vnRelationMatch == ValueNumStore::VN_RELATION_KIND::VRK_SwapReverse))
+    if ((candidateVnRelation == ValueNumStore::VN_RELATION_KIND::VRK_Reverse) ||
+        (candidateVnRelation == ValueNumStore::VN_RELATION_KIND::VRK_SwapReverse))
     {
         // Copy the vn info as it will be trashed when we change the oper.
         //

--- a/src/tests/JIT/Regression/JitBlue/Runtime_61908/Runtime_61908.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_61908/Runtime_61908.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public class Runtime_61908
+{
+    public static bool s_3;
+    public static int Main()
+    {
+        var vr6 = M3(s_3);
+        if (M3(vr6))
+        {
+            return -1;
+        }
+
+        return 100;
+    }
+
+    public static bool M3(bool arg0)
+    {
+        arg0 = !arg0;
+        return arg0;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_61908/Runtime_61908.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_61908/Runtime_61908.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We could overwrite the candidate VN relation kind with one from an
earlier tree that did not necessarily end up as a candidate.

Fix #61908

cc @AndyAyersMS 