### PR TITLE
Support zero-byte reads on HTTP response streams

### DIFF
--- a/src/libraries/Common/src/System/Net/StreamBuffer.cs
+++ b/src/libraries/Common/src/System/Net/StreamBuffer.cs
@@ -192,8 +192,6 @@ namespace System.IO
 
         private (bool wait, int bytesRead) TryReadFromBuffer(Span<byte> buffer)
         {
-            Debug.Assert(buffer.Length > 0);
-
             Debug.Assert(!Monitor.IsEntered(SyncObject));
             lock (SyncObject)
             {
@@ -225,11 +223,6 @@ namespace System.IO
 
         public int Read(Span<byte> buffer)
         {
-            if (buffer.Length == 0)
-            {
-                return 0;
-            }
-
             (bool wait, int bytesRead) = TryReadFromBuffer(buffer);
             if (wait)
             {
@@ -245,11 +238,6 @@ namespace System.IO
         public async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            if (buffer.Length == 0)
-            {
-                return 0;
-            }
 
             (bool wait, int bytesRead) = TryReadFromBuffer(buffer.Span);
             if (wait)

--- a/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
@@ -114,7 +114,7 @@ namespace System.IO.Tests
             from mode in Enum.GetValues<SeekMode>()
             select new object[] { mode, value };
 
-        protected async Task<int> ReadAsync(ReadWriteMode mode, Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+        public static async Task<int> ReadAsync(ReadWriteMode mode, Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
         {
             if (mode == ReadWriteMode.SyncByte)
             {

--- a/src/libraries/Common/tests/Tests/System/IO/ConnectedStreamsTests.cs
+++ b/src/libraries/Common/tests/Tests/System/IO/ConnectedStreamsTests.cs
@@ -9,6 +9,7 @@ namespace System.IO.Tests
     {
         protected override int BufferedSize => StreamBuffer.DefaultMaxBufferSize;
         protected override bool FlushRequiredToWriteData => false;
+        protected override bool BlocksOnZeroByteReads => true;
 
         protected override Task<StreamPair> CreateConnectedStreamsAsync() =>
             Task.FromResult<StreamPair>(ConnectedStreams.CreateUnidirectional());
@@ -18,6 +19,7 @@ namespace System.IO.Tests
     {
         protected override int BufferedSize => StreamBuffer.DefaultMaxBufferSize;
         protected override bool FlushRequiredToWriteData => false;
+        protected override bool BlocksOnZeroByteReads => true;
 
         protected override Task<StreamPair> CreateConnectedStreamsAsync() =>
             Task.FromResult<StreamPair>(ConnectedStreams.CreateBidirectional());

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -97,8 +97,8 @@ namespace System.Net.Http
                         // User requested a zero-byte read, and we have no data available in the buffer for processing.
                         // This zero-byte read indicates their desire to trade off the extra cost of a zero-byte read
                         // for reduced memory consumption when data is not immediately available.
-                        // So, we will issue our own zero-byte read against the underlying stream and defer buffer allocation
-                        // until data is actually available from the underlying stream.
+                        // So, we will issue our own zero-byte read against the underlying stream to allow it to make use of
+                        // optimizations, such as deferring buffer allocation until data is actually available.
                         _connection.Read(buffer);
                     }
 
@@ -213,8 +213,8 @@ namespace System.Net.Http
                             // User requested a zero-byte read, and we have no data available in the buffer for processing.
                             // This zero-byte read indicates their desire to trade off the extra cost of a zero-byte read
                             // for reduced memory consumption when data is not immediately available.
-                            // So, we will issue our own zero-byte read against the underlying stream and defer buffer allocation
-                            // until data is actually available from the underlying stream.
+                            // So, we will issue our own zero-byte read against the underlying stream to allow it to make use of
+                            // optimizations, such as deferring buffer allocation until data is actually available.
                             await _connection.ReadAsync(buffer).ConfigureAwait(false);
                         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -94,6 +94,11 @@ namespace System.Net.Http
 
                     if (buffer.Length == 0)
                     {
+                        // User requested a zero-byte read, and we have no data available in the buffer for processing.
+                        // This zero-byte read indicates their desire to trade off the extra cost of a zero-byte read
+                        // for reduced memory consumption when data is not immediately available.
+                        // So, we will issue our own zero-byte read against the underlying stream and defer buffer allocation
+                        // until data is actually available from the underlying stream.
                         _connection.Read(buffer);
                     }
 
@@ -205,6 +210,11 @@ namespace System.Net.Http
 
                         if (buffer.Length == 0)
                         {
+                            // User requested a zero-byte read, and we have no data available in the buffer for processing.
+                            // This zero-byte read indicates their desire to trade off the extra cost of a zero-byte read
+                            // for reduced memory consumption when data is not immediately available.
+                            // So, we will issue our own zero-byte read against the underlying stream and defer buffer allocation
+                            // until data is actually available from the underlying stream.
                             await _connection.ReadAsync(buffer).ConfigureAwait(false);
                         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -18,14 +18,14 @@ namespace System.Net.Http
             public override int Read(Span<byte> buffer)
             {
                 HttpConnection? connection = _connection;
-                if (connection == null || buffer.Length == 0)
+                if (connection == null)
                 {
-                    // Response body fully consumed or the caller didn't ask for any data
+                    // Response body fully consumed
                     return 0;
                 }
 
                 int bytesRead = connection.Read(buffer);
-                if (bytesRead == 0)
+                if (bytesRead == 0 && buffer.Length != 0)
                 {
                     // We cannot reuse this connection, so close it.
                     _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -40,9 +40,9 @@ namespace System.Net.Http
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 HttpConnection? connection = _connection;
-                if (connection == null || buffer.Length == 0)
+                if (connection == null)
                 {
-                    // Response body fully consumed or the caller didn't ask for any data
+                    // Response body fully consumed
                     return 0;
                 }
 
@@ -69,7 +69,7 @@ namespace System.Net.Http
                     }
                 }
 
-                if (bytesRead == 0)
+                if (bytesRead == 0 && buffer.Length != 0)
                 {
                     // If cancellation is requested and tears down the connection, it could cause the read
                     // to return 0, which would otherwise signal the end of the data, but that would lead

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -22,9 +22,9 @@ namespace System.Net.Http
 
             public override int Read(Span<byte> buffer)
             {
-                if (_connection == null || buffer.Length == 0)
+                if (_connection == null)
                 {
-                    // Response body fully consumed or the caller didn't ask for any data.
+                    // Response body fully consumed
                     return 0;
                 }
 
@@ -35,7 +35,7 @@ namespace System.Net.Http
                 }
 
                 int bytesRead = _connection.Read(buffer);
-                if (bytesRead <= 0)
+                if (bytesRead <= 0 && buffer.Length != 0)
                 {
                     // Unexpected end of response stream.
                     throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _contentBytesRemaining));

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -58,9 +58,9 @@ namespace System.Net.Http
             {
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
-                if (_connection == null || buffer.Length == 0)
+                if (_connection == null)
                 {
-                    // Response body fully consumed or the caller didn't ask for any data
+                    // Response body fully consumed
                     return 0;
                 }
 
@@ -94,7 +94,7 @@ namespace System.Net.Http
                     }
                 }
 
-                if (bytesRead <= 0)
+                if (bytesRead == 0 && buffer.Length != 0)
                 {
                     // A cancellation request may have caused the EOF.
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1071,11 +1071,6 @@ namespace System.Net.Http
 
             public int ReadData(Span<byte> buffer, HttpResponseMessage responseMessage)
             {
-                if (buffer.Length == 0)
-                {
-                    return 0;
-                }
-
                 (bool wait, int bytesRead) = TryReadFromBuffer(buffer, partOfSyncRead: true);
                 if (wait)
                 {
@@ -1090,7 +1085,7 @@ namespace System.Net.Http
                 {
                     _windowManager.AdjustWindow(bytesRead, this);
                 }
-                else
+                else if (buffer.Length != 0)
                 {
                     // We've hit EOF.  Pull in from the Http2Stream any trailers that were temporarily stored there.
                     MoveTrailersToResponseMessage(responseMessage);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1040,8 +1040,6 @@ namespace System.Net.Http
 
             private (bool wait, int bytesRead) TryReadFromBuffer(Span<byte> buffer, bool partOfSyncRead = false)
             {
-                Debug.Assert(buffer.Length > 0);
-
                 Debug.Assert(!Monitor.IsEntered(SyncObject));
                 lock (SyncObject)
                 {
@@ -1103,11 +1101,6 @@ namespace System.Net.Http
 
             public async ValueTask<int> ReadDataAsync(Memory<byte> buffer, HttpResponseMessage responseMessage, CancellationToken cancellationToken)
             {
-                if (buffer.Length == 0)
-                {
-                    return 0;
-                }
-
                 (bool wait, int bytesRead) = TryReadFromBuffer(buffer.Span);
                 if (wait)
                 {
@@ -1121,7 +1114,7 @@ namespace System.Net.Http
                 {
                     _windowManager.AdjustWindow(bytesRead, this);
                 }
-                else
+                else if (buffer.Length != 0)
                 {
                     // We've hit EOF.  Pull in from the Http2Stream any trailers that were temporarily stored there.
                     MoveTrailersToResponseMessage(responseMessage);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1120,7 +1120,7 @@ namespace System.Net.Http
             {
                 int totalBytesRead = 0;
 
-                while (buffer.Length != 0)
+                do
                 {
                     if (_responseDataPayloadRemaining <= 0 && !await ReadNextDataFrameAsync(response, cancellationToken).ConfigureAwait(false))
                     {
@@ -1155,7 +1155,7 @@ namespace System.Net.Http
                         int copyLen = (int)Math.Min(buffer.Length, _responseDataPayloadRemaining);
                         int bytesRead = await _stream.ReadAsync(buffer.Slice(0, copyLen), cancellationToken).ConfigureAwait(false);
 
-                        if (bytesRead == 0)
+                        if (bytesRead == 0 && buffer.Length != 0)
                         {
                             throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
                         }
@@ -1169,6 +1169,7 @@ namespace System.Net.Http
                         break;
                     }
                 }
+                while (buffer.Length != 0);
 
                 return totalBytesRead;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1050,7 +1050,7 @@ namespace System.Net.Http
             {
                 int totalBytesRead = 0;
 
-                while (buffer.Length != 0)
+                do
                 {
                     // Sync over async here -- QUIC implementation does it per-I/O already; this is at least more coarse-grained.
                     if (_responseDataPayloadRemaining <= 0 && !ReadNextDataFrameAsync(response, CancellationToken.None).AsTask().GetAwaiter().GetResult())
@@ -1086,7 +1086,7 @@ namespace System.Net.Http
                         int copyLen = (int)Math.Min(buffer.Length, _responseDataPayloadRemaining);
                         int bytesRead = _stream.Read(buffer.Slice(0, copyLen));
 
-                        if (bytesRead == 0)
+                        if (bytesRead == 0 && buffer.Length != 0)
                         {
                             throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _responseDataPayloadRemaining));
                         }
@@ -1100,6 +1100,7 @@ namespace System.Net.Http
                         break;
                     }
                 }
+                while (buffer.Length != 0);
 
                 return totalBytesRead;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1708,8 +1708,6 @@ namespace System.Net.Http
         private int ReadBuffered(Span<byte> destination)
         {
             // This is called when reading the response body.
-            Debug.Assert(destination.Length != 0);
-
             int remaining = _readLength - _readOffset;
             if (remaining > 0)
             {
@@ -1731,7 +1729,7 @@ namespace System.Net.Http
 
             // Do a buffered read directly against the underlying stream.
             Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
-            int bytesRead = _stream.Read(_readBuffer, 0, _readBuffer.Length);
+            int bytesRead = _stream.Read(_readBuffer, 0, destination.Length == 0 ? 0 : _readBuffer.Length);
             if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
             _readLength = bytesRead;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1745,7 +1745,9 @@ namespace System.Net.Http
             // If the caller provided buffer, and thus the amount of data desired to be read,
             // is larger than the internal buffer, there's no point going through the internal
             // buffer, so just do an unbuffered read.
-            return destination.Length == 0 || destination.Length >= _readBuffer.Length ?
+            // Also avoid avoid using the internal buffer if the user requested a zero-byte read to allow
+            // underlying streams to efficiently handle such a read (e.g. SslStream defering buffer allocation).
+            return destination.Length >= _readBuffer.Length || destination.Length == 0 ?
                 ReadAsync(destination) :
                 ReadBufferedAsyncCore(destination);
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1747,7 +1747,7 @@ namespace System.Net.Http
             // If the caller provided buffer, and thus the amount of data desired to be read,
             // is larger than the internal buffer, there's no point going through the internal
             // buffer, so just do an unbuffered read.
-            return destination.Length >= _readBuffer.Length ?
+            return destination.Length == 0 || destination.Length >= _readBuffer.Length ?
                 ReadAsync(destination) :
                 ReadBufferedAsyncCore(destination);
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -23,14 +23,14 @@ namespace System.Net.Http
             public override int Read(Span<byte> buffer)
             {
                 HttpConnection? connection = _connection;
-                if (connection == null || buffer.Length == 0)
+                if (connection == null)
                 {
                     // Response body fully consumed or the caller didn't ask for any data
                     return 0;
                 }
 
                 int bytesRead = connection.ReadBuffered(buffer);
-                if (bytesRead == 0)
+                if (bytesRead == 0 && buffer.Length != 0)
                 {
                     // We cannot reuse this connection, so close it.
                     _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -45,9 +45,9 @@ namespace System.Net.Http
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                 HttpConnection? connection = _connection;
-                if (connection == null || buffer.Length == 0)
+                if (connection == null)
                 {
-                    // Response body fully consumed or the caller didn't ask for any data
+                    // Response body fully consumed
                     return 0;
                 }
 
@@ -74,7 +74,7 @@ namespace System.Net.Http
                     }
                 }
 
-                if (bytesRead == 0)
+                if (bytesRead == 0 && buffer.Length != 0)
                 {
                     // A cancellation request may have caused the EOF.
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
@@ -80,6 +80,7 @@ namespace System.Net.Http.Functional.Tests
     {
         protected override Type UnsupportedConcurrentExceptionType => null;
         protected override bool UsableAfterCanceledReads => false;
+        protected override bool BlocksOnZeroByteReads => true;
 
         protected abstract string GetResponseHeaders();
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
@@ -1,0 +1,191 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Tests;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public sealed class Http1CloseResponseStreamZeroByteReadTest : ResponseStreamZeroByteReadTest
+    {
+        protected override string GetResponseHeaders() => "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n";
+
+        protected override async Task WriteAsync(Stream stream, byte[] data) => await stream.WriteAsync(data);
+    }
+
+    public sealed class Http1RawResponseStreamZeroByteReadTest : ResponseStreamZeroByteReadTest
+    {
+        protected override string GetResponseHeaders() => "HTTP/1.1 101 Switching Protocols\r\n\r\n";
+
+        protected override async Task WriteAsync(Stream stream, byte[] data) => await stream.WriteAsync(data);
+    }
+
+    public sealed class Http1ContentLengthResponseStreamZeroByteReadTest : ResponseStreamZeroByteReadTest
+    {
+        protected override string GetResponseHeaders() => "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n";
+
+        protected override async Task WriteAsync(Stream stream, byte[] data) => await stream.WriteAsync(data);
+    }
+
+    public sealed class Http1SingleChunkResponseStreamZeroByteReadTest : ResponseStreamZeroByteReadTest
+    {
+        protected override string GetResponseHeaders() => "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+
+        protected override async Task WriteAsync(Stream stream, byte[] data)
+        {
+            await stream.WriteAsync(Encoding.ASCII.GetBytes($"{data.Length:X}\r\n"));
+            await stream.WriteAsync(data);
+            await stream.WriteAsync(Encoding.ASCII.GetBytes("\r\n"));
+        }
+    }
+
+    public sealed class Http1MultiChunkResponseStreamZeroByteReadTest : ResponseStreamZeroByteReadTest
+    {
+        protected override string GetResponseHeaders() => "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+
+        protected override async Task WriteAsync(Stream stream, byte[] data)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                await stream.WriteAsync(Encoding.ASCII.GetBytes($"1\r\n"));
+                await stream.WriteAsync(data.AsMemory(i, 1));
+                await stream.WriteAsync(Encoding.ASCII.GetBytes("\r\n"));
+            }
+        }
+    }
+
+    public abstract class ResponseStreamZeroByteReadTest
+    {
+        protected abstract string GetResponseHeaders();
+
+        protected abstract Task WriteAsync(Stream stream, byte[] data);
+
+        public static IEnumerable<object[]> ZeroByteRead_IssuesZeroByteReadOnUnderlyingStream_MemberData() =>
+            from readMode in Enum.GetValues<StreamConformanceTests.ReadWriteMode>()
+                .Where(mode => mode != StreamConformanceTests.ReadWriteMode.SyncByte) // Can't test zero-byte reads with ReadByte
+            from useSsl in new[] { true, false }
+            select new object[] { readMode, useSsl };
+
+        [Theory]
+        [MemberData(nameof(ZeroByteRead_IssuesZeroByteReadOnUnderlyingStream_MemberData))]
+        public async Task ZeroByteRead_IssuesZeroByteReadOnUnderlyingStream(StreamConformanceTests.ReadWriteMode readMode, bool useSsl)
+        {
+            (Stream httpConnection, Stream server) = ConnectedStreams.CreateBidirectional(4096, int.MaxValue);
+            try
+            {
+                var sawZeroByteRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                httpConnection = new ReadInterceptStream(httpConnection, read =>
+                {
+                    if (read == 0)
+                    {
+                        sawZeroByteRead.TrySetResult();
+                    }
+                });
+
+                using var handler = new SocketsHttpHandler
+                {
+                    ConnectCallback = delegate { return ValueTask.FromResult(httpConnection); }
+                };
+                handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
+
+                using var client = new HttpClient(handler);
+
+                Task<HttpResponseMessage> clientTask = client.GetAsync($"http{(useSsl ? "s" : "")}://doesntmatter", HttpCompletionOption.ResponseHeadersRead);
+
+                if (useSsl)
+                {
+                    var sslStream = new SslStream(server, false, delegate { return true; });
+                    server = sslStream;
+
+                    using (X509Certificate2 cert = Test.Common.Configuration.Certificates.GetServerCertificate())
+                    {
+                        await ((SslStream)server).AuthenticateAsServerAsync(
+                            cert,
+                            clientCertificateRequired: true,
+                            enabledSslProtocols: SslProtocols.Tls12,
+                            checkCertificateRevocation: false).WaitAsync(TimeSpan.FromSeconds(10));
+                    }
+                }
+
+                await ResponseConnectedStreamConformanceTests.ReadHeadersAsync(server).WaitAsync(TimeSpan.FromSeconds(10));
+                await server.WriteAsync(Encoding.ASCII.GetBytes(GetResponseHeaders()));
+
+                using HttpResponseMessage response = await clientTask.WaitAsync(TimeSpan.FromSeconds(10));
+                using Stream clientStream = response.Content.ReadAsStream();
+                Assert.False(sawZeroByteRead.Task.IsCompleted);
+
+                Task<int> zeroByteReadTask = Task.Run(() => StreamConformanceTests.ReadAsync(readMode, clientStream, Array.Empty<byte>(), 0, 0, CancellationToken.None) );
+                Assert.False(zeroByteReadTask.IsCompleted);
+
+                // The zero-byte read should block until data is actually available
+                await sawZeroByteRead.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.False(zeroByteReadTask.IsCompleted);
+
+                byte[] data = Encoding.UTF8.GetBytes("Hello");
+                await WriteAsync(server, data);
+                await server.FlushAsync();
+
+                Assert.Equal(0, await zeroByteReadTask.WaitAsync(TimeSpan.FromSeconds(10)));
+
+                // Now that data is available, a zero-byte read should complete synchronously
+                zeroByteReadTask = StreamConformanceTests.ReadAsync(readMode, clientStream, Array.Empty<byte>(), 0, 0, CancellationToken.None);
+                Assert.True(zeroByteReadTask.IsCompleted);
+                Assert.Equal(0, await zeroByteReadTask);
+
+                var readBuffer = new byte[10];
+                int read = 0;
+                while (read < data.Length)
+                {
+                    read += await StreamConformanceTests.ReadAsync(readMode, clientStream, readBuffer, read, readBuffer.Length - read, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+                }
+
+                Assert.Equal(data.Length, read);
+                Assert.Equal(data, readBuffer.AsSpan(0, read).ToArray());
+            }
+            finally
+            {
+                httpConnection.Dispose();
+                server.Dispose();
+            }
+        }
+
+        private sealed class ReadInterceptStream : DelegatingStream
+        {
+            private readonly Action<int> _readCallback;
+
+            public ReadInterceptStream(Stream innerStream, Action<int> readCallback)
+                : base(innerStream)
+            {
+                _readCallback = readCallback;
+            }
+
+            public override int Read(Span<byte> buffer)
+            {
+                _readCallback(buffer.Length);
+                return base.Read(buffer);
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                _readCallback(count);
+                return base.Read(buffer, offset, count);
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                _readCallback(buffer.Length);
+                return base.ReadAsync(buffer, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamZeroByteReadTests.cs
@@ -67,6 +67,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
     public abstract class Http1ResponseStreamZeroByteReadTestBase
     {
         protected abstract string GetResponseHeaders();
@@ -228,6 +229,7 @@ namespace System.Net.Http.Functional.Tests
         protected override QuicImplementationProvider UseQuicImplementationProvider => QuicImplementationProviders.Mock;
     }
 
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
     public abstract class ResponseStreamZeroByteReadTestBase : HttpClientHandlerTestBase
     {
         public ResponseStreamZeroByteReadTestBase(ITestOutputHelper output) : base(output) { }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="StreamContentTest.cs" />
     <Compile Include="StringContentTest.cs" />
     <Compile Include="ResponseStreamConformanceTests.cs" />
+    <Compile Include="ResponseStreamZeroByteReadTests.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\SyncBlockingContent.cs"
              Link="Common\System\Net\Http\SyncBlockingContent.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Http\DefaultCredentialsTest.cs"

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
@@ -84,7 +84,7 @@ namespace System.Net.Quic.Implementations.Mock
             }
 
             int bytesRead = await streamBuffer.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-            if (bytesRead == 0)
+            if (bytesRead == 0 && buffer.Length != 0)
             {
                 if (_connection.ConnectionError is long connectonError)
                 {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
@@ -84,7 +84,7 @@ namespace System.Net.Quic.Implementations.Mock
             }
 
             int bytesRead = await streamBuffer.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-            if (bytesRead == 0 && buffer.Length != 0)
+            if (bytesRead == 0)
             {
                 if (_connection.ConnectionError is long connectonError)
                 {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -18,6 +18,7 @@ namespace System.Net.Quic.Tests
     public sealed class MockQuicStreamConformanceTests : QuicStreamConformanceTests
     {
         protected override QuicImplementationProvider Provider => QuicImplementationProviders.Mock;
+        protected override bool BlocksOnZeroByteReads => true;
     }
 
     [ConditionalClass(typeof(QuicTestBase<MsQuicProviderFactory>), nameof(QuicTestBase<MsQuicProviderFactory>.IsSupported))]


### PR DESCRIPTION
Fixes #61475

This PR does the plumbing to get zero-byte reads working but doesn't change the buffer management of underlying connections.
On HTTP/1.1: The 4k receive buffer remains
On HTTP/2: We don't issue zero-byte reads to the underlying connection at all, but that is unrelated to whether we support zero-byte reads on the response streams

The minimal change to get WebSockets working on HTTP/1.1 is just 25029a768caa064eb3dd8ebc31dd030a38bb2813

