### PR TITLE
Skip Linq tests, which are not supported in interpreter only build (without FEATURE_COMPILE)

### DIFF
--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -779,6 +779,7 @@ namespace System.Linq.Expressions.Tests
             Assert.DoesNotContain(Expression.Parameter(typeof(int)), parameters);
         }
 
+#if FEATURE_COMPILE
         [Theory, ClassData(typeof(CompilationTypes))]
         public void AboveByteMaxArityArg(bool useInterpreter)
         {
@@ -790,7 +791,6 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(23, result);
         }
 
-#if FEATURE_COMPILE
         [Fact]
         public void AboveByteMaxArityArgIL()
         {
@@ -903,7 +903,6 @@ namespace System.Linq.Expressions.Tests
 }
 ");
         }
-#endif
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void ExcessiveArity(bool useInterpreter)
@@ -912,6 +911,7 @@ namespace System.Linq.Expressions.Tests
             LambdaExpression lambda = Expression.Lambda(pars.Last(), pars);
             Assert.Throws<InvalidProgramException>(() => lambda.Compile(useInterpreter));
         }
+#endif
 
         private static int Add(ref int var, int val)
         {


### PR DESCRIPTION
These tests require MakeNewCustomDelegate, which throws PlatformNotSupportedException without FEATURE_COMPILE

To enable interpreter only build:
```patch
diff --git a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
index 0a9d7eba08b..aac8ca704da 100644
--- a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -3,8 +3,8 @@
     <FeatureInterpret>true</FeatureInterpret>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-MacCatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <IsInterpreting>false</IsInterpreting>
-    <IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting>
+    <IsInterpreting>true</IsInterpreting>
+    <!-- IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting -->
     <DefineConstants> $(DefineConstants);FEATURE_DLG_INVOKE;FEATURE_FAST_CREATE</DefineConstants>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
diff --git a/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj b/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
index c2efe998ee9..8e3031fb8d3 100644
--- a/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <FeatureInterpret>true</FeatureInterpret>
-    <IsInterpreting>false</IsInterpreting>
-    <IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting>
+    <IsInterpreting>true</IsInterpreting>
+    <!-- IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting -->
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-MacCatalyst</TargetFrameworks>
```

Without this change exception is thrown:
```
Discovered:  System.Linq.Expressions.Tests (found 5505 of 5514 test cases)
Starting:    System.Linq.Expressions.Tests (parallel test collections = on, max threads = 2)
        System.Linq.Expressions.Tests.LambdaTests.AboveByteMaxArityArg(useInterpreter: True) [FAIL]
            System.PlatformNotSupportedException : Operation is not supported on this platform.
            Stack Trace:
                at System.Linq.Expressions.Compiler.DelegateHelpers.MakeNewCustomDelegate(Type[] types) in System.Linq.Expressions.dll:token 0x6000dd5+0x5
                at System.Linq.Expressions.Compiler.DelegateHelpers.MakeNewDelegate(Type[] types) in System.Linq.Expressions.dll:token 0x6000ddb+0x7c
                at System.Linq.Expressions.Compiler.DelegateHelpers.MakeDelegateType(Type[] types) in System.Linq.Expressions.dll:token 0x6000dd6+0x2e
                at System.Linq.Expressions.Expression.Lambda(Expression body, String name, Boolean tailCall, IEnumerable`1 parameters) in System.Linq.Expressions.dll:token 0x600025f+0x98
                at System.Linq.Expressions.Expression.Lambda(Expression body, Boolean tailCall, IEnumerable`1 parameters) in System.Linq.Expressions.dll:token 0x6000259+0x0
                at System.Linq.Expressions.Expression.Lambda(Expression body, ParameterExpression[] parameters) in System.Linq.Expressions.dll:token 0x6000256+0x0
            /home/abuild/rpmbuild/BUILD/coreclr-6.0.0/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs(786,0): at System.Linq.Expressions.Tests.LambdaTests.AboveByteMaxArityArg(Boolean useInterpreter)
        System.Linq.Expressions.Tests.LambdaTests.ExcessiveArity(useInterpreter: True) [FAIL]
            System.PlatformNotSupportedException : Operation is not supported on this platform.
            Stack Trace:
                at System.Linq.Expressions.Compiler.DelegateHelpers.MakeNewCustomDelegate(Type[] types) in System.Linq.Expressions.dll:token 0x6000dd5+0x5
                at System.Linq.Expressions.Compiler.DelegateHelpers.MakeNewDelegate(Type[] types) in System.Linq.Expressions.dll:token 0x6000ddb+0x7c
                at System.Linq.Expressions.Compiler.DelegateHelpers.MakeDelegateType(Type[] types) in System.Linq.Expressions.dll:token 0x6000dd6+0x2e
                at System.Linq.Expressions.Expression.Lambda(Expression body, String name, Boolean tailCall, IEnumerable`1 parameters) in System.Linq.Expressions.dll:token 0x600025f+0x98
                at System.Linq.Expressions.Expression.Lambda(Expression body, Boolean tailCall, IEnumerable`1 parameters) in System.Linq.Expressions.dll:token 0x6000259+0x0
                at System.Linq.Expressions.Expression.Lambda(Expression body, ParameterExpression[] parameters) in System.Linq.Expressions.dll:token 0x6000256+0x0
            /home/abuild/rpmbuild/BUILD/coreclr-6.0.0/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs(912,0): at System.Linq.Expressions.Tests.LambdaTests.ExcessiveArity(Boolean useInterpreter)
Finished:    System.Linq.Expressions.Tests
```

cc @alpencolt 