### PR TITLE
Disable several GenericMath tests on iOS/tvOS

### DIFF
--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -449,6 +449,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateSaturatingFromInt16Test()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<short>(0x0000));
@@ -500,6 +501,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateSaturatingFromSByteTest()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<sbyte>(0x00));
@@ -581,6 +583,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateTruncatingFromInt16Test()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<short>(0x0000));
@@ -632,6 +635,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateTruncatingFromSByteTest()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<sbyte>(0x00));
@@ -775,6 +779,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void TryCreateFromInt16Test()
         {
             byte result;
@@ -879,6 +884,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void TryCreateFromSByteTest()
         {
             byte result;

--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -449,7 +449,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateSaturatingFromInt16Test()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<short>(0x0000));
@@ -501,7 +500,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateSaturatingFromSByteTest()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateSaturating<sbyte>(0x00));
@@ -583,7 +581,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateTruncatingFromInt16Test()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<short>(0x0000));
@@ -635,7 +632,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateTruncatingFromSByteTest()
         {
             Assert.Equal((byte)0x00, NumberHelper<byte>.CreateTruncating<sbyte>(0x00));
@@ -779,7 +775,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void TryCreateFromInt16Test()
         {
             byte result;
@@ -884,7 +879,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void TryCreateFromSByteTest()
         {
             byte result;

--- a/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/IntPtrTests.GenericMath.cs
@@ -784,6 +784,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateSaturatingFromInt16Test()
         {
             Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<short>(0x0000));
@@ -846,6 +847,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateSaturatingFromSByteTest()
         {
             Assert.Equal((nint)0x00000000, NumberHelper<nint>.CreateSaturating<sbyte>(0x00));
@@ -949,6 +951,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateTruncatingFromInt16Test()
         {
             if (Environment.Is64BitProcess)
@@ -1022,6 +1025,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void CreateTruncatingFromSByteTest()
         {
             if (Environment.Is64BitProcess)
@@ -1231,6 +1235,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void TryCreateFromInt16Test()
         {
             nint result;
@@ -1355,6 +1360,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/61920", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void TryCreateFromSByteTest()
         {
             nint result;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -181,7 +181,7 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'iOSSimulator' and '$(TargetArchitecture)' == 'arm64' and '$(RunDisablediOSTests)' != 'true'">
     <!-- Functional tests on arm64 simulator have problems with return codes from mlaunch -->
-    <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\$(TargetOS)\Simulator\**\*.Test.csproj" />
+    <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\**\*.Test.csproj" />
   </ItemGroup>
 
   <!-- Excluding all tests for devices until building on helix works properly -->


### PR DESCRIPTION
The tests were failing on iOS/tvOS device runs.  https://github.com/dotnet/runtime/issues/61920 was created to track them.