### PR TITLE
[wasm][debugger] Protecting send message to debugger if it's disabled

### DIFF
--- a/src/mono/mono/component/mini-wasm-debugger.c
+++ b/src/mono/mono/component/mini-wasm-debugger.c
@@ -370,6 +370,12 @@ mono_wasm_set_is_debugger_attached (gboolean is_attached)
 EMSCRIPTEN_KEEPALIVE gboolean 
 mono_wasm_send_dbg_command_with_parms (int id, MdbgProtCommandSet command_set, int command, guint8* data, unsigned int size, int valtype, char* newvalue)
 {
+	if (!debugger_enabled) {
+		EM_ASM ({
+			MONO.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
+		}, 0, id, 0, 0);
+		return TRUE;
+	}
 	MdbgProtBuffer bufWithParms;
 	buffer_init (&bufWithParms, 128);
 	m_dbgprot_buffer_add_data (&bufWithParms, data, size);
@@ -387,6 +393,12 @@ mono_wasm_send_dbg_command_with_parms (int id, MdbgProtCommandSet command_set, i
 EMSCRIPTEN_KEEPALIVE gboolean 
 mono_wasm_send_dbg_command (int id, MdbgProtCommandSet command_set, int command, guint8* data, unsigned int size)
 {
+	if (!debugger_enabled) {
+		EM_ASM ({
+			MONO.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
+		}, 0, id, 0, 0);
+		return TRUE;
+	}
 	ss_calculate_framecount (NULL, NULL, TRUE, NULL, NULL);
 	MdbgProtBuffer buf;
 	buffer_init (&buf, 128);


### PR DESCRIPTION
This PR fixes this issue: https://github.com/dotnet/runtime/issues/61917

Avoid sending messages to debugger if the debugger is not enabled because it's a release app.