### PR TITLE
Type memory maps with placeholders

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5477,6 +5477,8 @@ public:
     // For a store to an address-exposed local at curTree, record the new curMemoryVN and update curTree's MemorySsaMap.
     void recordAddressExposedLocalStore(GenTree* curTree, ValueNum memoryVN DEBUGARG(const char* msg));
 
+    void fgSetCurrentMemoryVN(MemoryKind memoryKind, ValueNum newMemoryVN);
+
     // Tree caused an update in the current memory VN.  If "tree" has an associated heap SSA #, record that
     // value in that SSA #.
     void fgValueNumberRecordMemorySsa(MemoryKind memoryKind, GenTree* tree);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2217,7 +2217,7 @@ ValueNum ValueNumStore::VNForMapStore(ValueNum map, ValueNum index, ValueNum val
     if (m_pComp->verbose)
     {
         printf("    VNForMapStore(" FMT_VN ", " FMT_VN ", " FMT_VN "):%s in " FMT_BB " returns ", map, index, value,
-               varTypeName(TypeOfVN(result)), bb->bbNum);
+               VNMapTypeName(TypeOfVN(result)), bb->bbNum);
         m_pComp->vnPrint(result, 1);
         printf("\n");
     }
@@ -2255,7 +2255,7 @@ ValueNum ValueNumStore::VNForMapSelect(ValueNumKind vnk, var_types type, ValueNu
 #ifdef DEBUG
     if (m_pComp->verbose)
     {
-        printf("    VNForMapSelect(" FMT_VN ", " FMT_VN "):%s returns ", map, index, varTypeName(type));
+        printf("    VNForMapSelect(" FMT_VN ", " FMT_VN "):%s returns ", map, index, VNMapTypeName(type));
         m_pComp->vnPrint(result, 1);
         printf("\n");
     }
@@ -4265,8 +4265,8 @@ ValueNum Compiler::fgValueNumberArrIndexAssign(CORINFO_CLASS_HANDLE elemTypeEq,
     bool      invalidateArray      = false;
     ValueNum  elemTypeEqVN         = vnStore->VNForHandle(ssize_t(elemTypeEq), GTF_ICON_CLASS_HDL);
     var_types arrElemType          = DecodeElemType(elemTypeEq);
-    ValueNum  hAtArrType           = vnStore->VNForMapSelect(VNK_Liberal, TYP_REF, fgCurMemoryVN[GcHeap], elemTypeEqVN);
-    ValueNum  hAtArrTypeAtArr      = vnStore->VNForMapSelect(VNK_Liberal, TYP_REF, hAtArrType, arrVN);
+    ValueNum  hAtArrType           = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap], elemTypeEqVN);
+    ValueNum  hAtArrTypeAtArr      = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, hAtArrType, arrVN);
     ValueNum  hAtArrTypeAtArrAtInx = vnStore->VNForMapSelect(VNK_Liberal, arrElemType, hAtArrTypeAtArr, inxVN);
 
     ValueNum newValAtInx     = ValueNumStore::NoVN;
@@ -4279,7 +4279,7 @@ ValueNum Compiler::fgValueNumberArrIndexAssign(CORINFO_CLASS_HANDLE elemTypeEq,
         JITDUMP("    *** NotAField sequence encountered in fgValueNumberArrIndexAssign\n");
 
         // Store a new unique value for newValAtArrType
-        newValAtArrType = vnStore->VNForExpr(compCurBB, TYP_REF);
+        newValAtArrType = vnStore->VNForExpr(compCurBB, TYP_MEM);
         invalidateArray = true;
     }
     else
@@ -4301,7 +4301,7 @@ ValueNum Compiler::fgValueNumberArrIndexAssign(CORINFO_CLASS_HANDLE elemTypeEq,
             JITDUMP("    *** Mismatched types in fgValueNumberArrIndexAssign\n");
 
             // Store a new unique value for newValAtArrType
-            newValAtArrType = vnStore->VNForExpr(compCurBB, TYP_REF);
+            newValAtArrType = vnStore->VNForExpr(compCurBB, TYP_MEM);
             invalidateArray = true;
         }
     }
@@ -4328,7 +4328,7 @@ ValueNum Compiler::fgValueNumberArrIndexAssign(CORINFO_CLASS_HANDLE elemTypeEq,
         printf("  hAtArrTypeAtArr " FMT_VN " is MapSelect(hAtArrType(" FMT_VN "), arr=" FMT_VN ")\n", hAtArrTypeAtArr,
                hAtArrType, arrVN);
         printf("  hAtArrTypeAtArrAtInx " FMT_VN " is MapSelect(hAtArrTypeAtArr(" FMT_VN "), inx=" FMT_VN "):%s\n",
-               hAtArrTypeAtArrAtInx, hAtArrTypeAtArr, inxVN, varTypeName(arrElemType));
+               hAtArrTypeAtArrAtInx, hAtArrTypeAtArr, inxVN, ValueNumStore::VNMapTypeName(arrElemType));
 
         if (!invalidateArray)
         {
@@ -4401,8 +4401,8 @@ ValueNum Compiler::fgValueNumberArrIndexVal(GenTree*             tree,
     else
     {
         ValueNum elemTypeEqVN    = vnStore->VNForHandle(ssize_t(elemTypeEq), GTF_ICON_CLASS_HDL);
-        ValueNum hAtArrType      = vnStore->VNForMapSelect(VNK_Liberal, TYP_REF, fgCurMemoryVN[GcHeap], elemTypeEqVN);
-        ValueNum hAtArrTypeAtArr = vnStore->VNForMapSelect(VNK_Liberal, TYP_REF, hAtArrType, arrVN);
+        ValueNum hAtArrType      = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap], elemTypeEqVN);
+        ValueNum hAtArrTypeAtArr = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, hAtArrType, arrVN);
         ValueNum wholeElem       = vnStore->VNForMapSelect(VNK_Liberal, elemTyp, hAtArrTypeAtArr, inxVN);
 
 #ifdef DEBUG
@@ -6291,8 +6291,7 @@ const char* ValueNumStore::VNFuncNameArr[] = {
 #undef ValueNumFuncDef
 };
 
-// static
-const char* ValueNumStore::VNFuncName(VNFunc vnf)
+/* static */ const char* ValueNumStore::VNFuncName(VNFunc vnf)
 {
     if (vnf < VNF_Boundary)
     {
@@ -6301,6 +6300,19 @@ const char* ValueNumStore::VNFuncName(VNFunc vnf)
     else
     {
         return VNFuncNameArr[vnf - (VNF_Boundary + 1)];
+    }
+}
+
+/* static */ const char* ValueNumStore::VNMapTypeName(var_types type)
+{
+    switch (type)
+    {
+        case TYP_HEAP:
+            return "heap";
+        case TYP_MEM:
+            return "mem";
+        default:
+            return varTypeName(type);
     }
 }
 
@@ -6757,7 +6769,7 @@ void Compiler::fgValueNumber()
         }
     }
     // Give memory an initial value number (about which we know nothing).
-    ValueNum memoryInitVal = vnStore->VNForFunc(TYP_REF, VNF_InitVal, vnStore->VNForIntCon(-1)); // Use -1 for memory.
+    ValueNum memoryInitVal = vnStore->VNForFunc(TYP_HEAP, VNF_InitVal, vnStore->VNForIntCon(-1)); // Use -1 for memory.
     GetMemoryPerSsaData(SsaConfig::FIRST_SSA_NUM)->m_vnPair.SetBoth(memoryInitVal);
 #ifdef DEBUG
     if (verbose)
@@ -6894,8 +6906,8 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
         // Is there a phi for this block?
         if (blk->bbMemorySsaPhiFunc[memoryKind] == nullptr)
         {
-            fgCurMemoryVN[memoryKind] = GetMemoryPerSsaData(blk->bbMemorySsaNumIn[memoryKind])->m_vnPair.GetLiberal();
-            assert(fgCurMemoryVN[memoryKind] != ValueNumStore::NoVN);
+            ValueNum newMemoryVN = GetMemoryPerSsaData(blk->bbMemorySsaNumIn[memoryKind])->m_vnPair.GetLiberal();
+            fgSetCurrentMemoryVN(memoryKind, newMemoryVN);
         }
         else
         {
@@ -6943,7 +6955,7 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
                     unsigned phiArgSSANum   = phiArgs->GetSsaNum();
                     ValueNum phiArgSSANumVN = vnStore->VNForIntCon(phiArgSSANum);
                     JITDUMP("  Building phi application: $%x = SSA# %d.\n", phiArgSSANumVN, phiArgSSANum);
-                    phiAppVN = vnStore->VNForFunc(TYP_REF, VNF_Phi, phiArgSSANumVN, phiAppVN);
+                    phiAppVN = vnStore->VNForFunc(TYP_HEAP, VNF_Phi, phiArgSSANumVN, phiAppVN);
                     JITDUMP("  Building phi application: $%x = phi($%x, $%x).\n", phiAppVN, phiArgSSANumVN,
                             oldPhiAppVN);
                     phiArgs = phiArgs->m_nextArg;
@@ -6954,16 +6966,16 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
                 }
                 else
                 {
-                    newMemoryVN = vnStore->VNForFunc(TYP_REF, VNF_PhiMemoryDef,
+                    newMemoryVN = vnStore->VNForFunc(TYP_HEAP, VNF_PhiMemoryDef,
                                                      vnStore->VNForHandle(ssize_t(blk), GTF_EMPTY), phiAppVN);
                 }
             }
             GetMemoryPerSsaData(blk->bbMemorySsaNumIn[memoryKind])->m_vnPair.SetLiberal(newMemoryVN);
-            fgCurMemoryVN[memoryKind] = newMemoryVN;
+            fgSetCurrentMemoryVN(memoryKind, newMemoryVN);
             if ((memoryKind == GcHeap) && byrefStatesMatchGcHeapStates)
             {
                 // Keep the CurMemoryVNs in sync
-                fgCurMemoryVN[ByrefExposed] = newMemoryVN;
+                fgSetCurrentMemoryVN(ByrefExposed, newMemoryVN);
             }
         }
 #ifdef DEBUG
@@ -7061,7 +7073,7 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
     // If this loop has memory havoc effects, just use a new, unique VN.
     if (optLoopTable[loopNum].lpLoopHasMemoryHavoc[memoryKind])
     {
-        ValueNum res = vnStore->VNForExpr(entryBlock, TYP_REF);
+        ValueNum res = vnStore->VNForExpr(entryBlock, TYP_HEAP);
 #ifdef DEBUG
         if (verbose)
         {
@@ -7101,7 +7113,7 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
     }
     if (multipleNonLoopPreds)
     {
-        ValueNum res = vnStore->VNForExpr(entryBlock, TYP_REF);
+        ValueNum res = vnStore->VNForExpr(entryBlock, TYP_HEAP);
 #ifdef DEBUG
         if (verbose)
         {
@@ -7146,9 +7158,9 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
                 }
 #endif // DEBUG
 
-                // Instance field maps get the placeholder TYP_REF - they do not represent "singular"
+                // Instance field maps get a placeholder type - they do not represent "singular"
                 // values. Static field maps, on the other hand, do, and so must be given proper types.
-                var_types fldMapType = eeIsFieldStatic(fldHnd) ? eeGetFieldType(fldHnd) : TYP_REF;
+                var_types fldMapType = eeIsFieldStatic(fldHnd) ? eeGetFieldType(fldHnd) : TYP_MEM;
 
                 newMemoryVN = vnStore->VNForMapStore(newMemoryVN, fldHndVN, vnStore->VNForExpr(entryBlock, fldMapType));
             }
@@ -7181,7 +7193,7 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
 #endif // DEBUG
 
                 ValueNum elemTypeVN = vnStore->VNForHandle(ssize_t(elemClsHnd), GTF_ICON_CLASS_HDL);
-                ValueNum uniqueVN   = vnStore->VNForExpr(entryBlock, TYP_REF);
+                ValueNum uniqueVN   = vnStore->VNForExpr(entryBlock, TYP_MEM);
                 newMemoryVN         = vnStore->VNForMapStore(newMemoryVN, elemTypeVN, uniqueVN);
             }
         }
@@ -7209,13 +7221,13 @@ ValueNum Compiler::fgMemoryVNForLoopSideEffects(MemoryKind  memoryKind,
 void Compiler::fgMutateGcHeap(GenTree* tree DEBUGARG(const char* msg))
 {
     // Update the current memory VN, and if we're tracking the heap SSA # caused by this node, record it.
-    recordGcHeapStore(tree, vnStore->VNForExpr(compCurBB, TYP_REF) DEBUGARG(msg));
+    recordGcHeapStore(tree, vnStore->VNForExpr(compCurBB, TYP_HEAP) DEBUGARG(msg));
 }
 
 void Compiler::fgMutateAddressExposedLocal(GenTree* tree DEBUGARG(const char* msg))
 {
     // Update the current ByrefExposed VN, and if we're tracking the heap SSA # caused by this node, record it.
-    recordAddressExposedLocalStore(tree, vnStore->VNForExpr(compCurBB) DEBUGARG(msg));
+    recordAddressExposedLocalStore(tree, vnStore->VNForExpr(compCurBB, TYP_HEAP) DEBUGARG(msg));
 }
 
 void Compiler::recordGcHeapStore(GenTree* curTree, ValueNum gcHeapVN DEBUGARG(const char* msg))
@@ -7223,13 +7235,13 @@ void Compiler::recordGcHeapStore(GenTree* curTree, ValueNum gcHeapVN DEBUGARG(co
     // bbMemoryDef must include GcHeap for any block that mutates the GC Heap
     // and GC Heap mutations are also ByrefExposed mutations
     assert((compCurBB->bbMemoryDef & memoryKindSet(GcHeap, ByrefExposed)) == memoryKindSet(GcHeap, ByrefExposed));
-    fgCurMemoryVN[GcHeap] = gcHeapVN;
+    fgSetCurrentMemoryVN(GcHeap, gcHeapVN);
 
     if (byrefStatesMatchGcHeapStates)
     {
         // Since GcHeap and ByrefExposed share SSA nodes, they need to share
         // value numbers too.
-        fgCurMemoryVN[ByrefExposed] = gcHeapVN;
+        fgSetCurrentMemoryVN(ByrefExposed, gcHeapVN);
     }
     else
     {
@@ -7237,7 +7249,7 @@ void Compiler::recordGcHeapStore(GenTree* curTree, ValueNum gcHeapVN DEBUGARG(co
         // assume that this GcHeap store may alias any byref load/store, so don't
         // bother trying to record the map/select stuff, and instead just an opaque VN
         // for ByrefExposed
-        fgCurMemoryVN[ByrefExposed] = vnStore->VNForExpr(compCurBB);
+        fgSetCurrentMemoryVN(ByrefExposed, vnStore->VNForExpr(compCurBB, TYP_HEAP));
     }
 
 #ifdef DEBUG
@@ -7262,7 +7274,7 @@ void Compiler::recordAddressExposedLocalStore(GenTree* curTree, ValueNum memoryV
 
     // bbMemoryDef must include ByrefExposed for any block that mutates an address-exposed local
     assert((compCurBB->bbMemoryDef & memoryKindSet(ByrefExposed)) != 0);
-    fgCurMemoryVN[ByrefExposed] = memoryVN;
+    fgSetCurrentMemoryVN(ByrefExposed, memoryVN);
 
 #ifdef DEBUG
     if (verbose)
@@ -7274,6 +7286,13 @@ void Compiler::recordAddressExposedLocalStore(GenTree* curTree, ValueNum memoryV
 #endif // DEBUG
 
     fgValueNumberRecordMemorySsa(ByrefExposed, curTree);
+}
+
+void Compiler::fgSetCurrentMemoryVN(MemoryKind memoryKind, ValueNum newMemoryVN)
+{
+    assert(vnStore->VNIsValid(newMemoryVN));
+    assert(vnStore->TypeOfVN(newMemoryVN) == TYP_HEAP);
+    fgCurMemoryVN[memoryKind] = newMemoryVN;
 }
 
 void Compiler::fgValueNumberRecordMemorySsa(MemoryKind memoryKind, GenTree* tree)
@@ -7516,7 +7535,7 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
                 // through address-taken locals in regions of code with no calls or byref
                 // writes.
                 // For now, just use a new opaque VN.
-                ValueNum heapVN = vnStore->VNForExpr(compCurBB);
+                ValueNum heapVN = vnStore->VNForExpr(compCurBB, TYP_HEAP);
                 recordAddressExposedLocalStore(tree, heapVN DEBUGARG("local assign"));
             }
 #ifdef DEBUG
@@ -7599,7 +7618,7 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
                 // As with GT_LCL_VAR, we could probably use MapStore here and MapSelect at corresponding
                 // loads, but to do so would have to identify the subset of address-exposed locals
                 // whose fields can be disambiguated.
-                ValueNum heapVN = vnStore->VNForExpr(compCurBB);
+                ValueNum heapVN = vnStore->VNForExpr(compCurBB, TYP_HEAP);
                 recordAddressExposedLocalStore(tree, heapVN DEBUGARG("local field assign"));
             }
         }
@@ -7725,7 +7744,7 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
                         // through address-taken locals in regions of code with no calls or byref
                         // writes.
                         // For now, just use a new opaque VN.
-                        ValueNum heapVN = vnStore->VNForExpr(compCurBB);
+                        ValueNum heapVN = vnStore->VNForExpr(compCurBB, TYP_HEAP);
                         recordAddressExposedLocalStore(tree, heapVN DEBUGARG("PtrToLoc indir"));
                     }
                 }
@@ -7841,8 +7860,8 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
 
                             // Construct the "field map" VN. It represents memory state of the first field
                             // of all objects on the heap. This is our primary map.
-                            ValueNum fldMapVN = vnStore->VNForMapSelect(VNK_Liberal, firstFieldType,
-                                                                        fgCurMemoryVN[GcHeap], firstFieldSelectorVN);
+                            ValueNum fldMapVN = vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap],
+                                                                        firstFieldSelectorVN);
 
                             ValueNum firstFieldValueSelectorVN = ValueNumStore::NoVN;
                             if (obj != nullptr)
@@ -7911,7 +7930,7 @@ void Compiler::fgValueNumberAssignment(GenTreeOp* tree)
                         // through address-taken locals in regions of code with no calls or byref
                         // writes.
                         // For now, just use a new opaque VN.
-                        ValueNum memoryVN = vnStore->VNForExpr(compCurBB);
+                        ValueNum memoryVN = vnStore->VNForExpr(compCurBB, TYP_HEAP);
                         recordAddressExposedLocalStore(tree, memoryVN DEBUGARG("PtrToLoc indir"));
                     }
                     else if (!isLocal)
@@ -9028,8 +9047,8 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         ValueNum  firstFieldSelectorVN =
                             vnStore->VNForFieldSelector(fldSeq2->GetFieldHandle(), &firstFieldType, &structSize);
 
-                        ValueNum fldMapVN = vnStore->VNForMapSelect(VNK_Liberal, firstFieldType, fgCurMemoryVN[GcHeap],
-                                                                    firstFieldSelectorVN);
+                        ValueNum fldMapVN =
+                            vnStore->VNForMapSelect(VNK_Liberal, TYP_MEM, fgCurMemoryVN[GcHeap], firstFieldSelectorVN);
 
                         ValueNum firstFieldValueSelectorVN;
                         if (obj != nullptr)

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -57,17 +57,9 @@
 //    taken from another map at a given index. As such, it must have a type that corresponds
 //    to the "index/selector", in practical terms - the field's type.
 //
-// Note that the above constraints on the types for maps are not followed currently to the
-// letter by the implementation - "opaque" maps can and do have TYP_REF assigned to them
-// in various situations such as when initializing the "primary" VNs for loop entries.
-//
-// Note as well that the meaning of "the type" for a map is overloaded, because maps are used
-// both to represent memory "of all fields B of all objects that have this field in the heap"
-// and "the field B of this particular object on the heap". Only the latter maps can be used
-// as VNs for actual nodes, while the former are used for "the first field" maps and "array
-// equivalence type" maps, and, of course, for the heap VNs, which always have the placeholder
-// types of TYP_REF or TYP_UNKNOWN. In principle, placeholder types could be given to all the
-// maps of the former type.
+// Note that we give "placeholder" types (TYP_UNDEF and TYP_UNKNOWN as TYP_MEM and TYP_HEAP)
+// to maps that do not represent values found in IR. This is just to avoid confusion and
+// facilitate more precise validating checks.
 //
 // Let's review the following snippet to demonstrate how the MapSelect/MapStore machinery works
 // together to deliver the results that it does. Say we have this snippet of (C#) code:
@@ -195,6 +187,12 @@ struct VNFuncApp
 // We use a unique prefix character when printing value numbers in dumps:  i.e.  $1c0
 // This define is used with string concatenation to put this in printf format strings
 #define FMT_VN "$%x"
+
+// We will use this placeholder type for memory maps that do not represent IR values ("field maps", etc).
+static const var_types TYP_MEM = TYP_UNDEF;
+
+// We will use this placeholder type for memory maps representing "the heap" (GcHeap/ByrefExposed).
+static const var_types TYP_HEAP = TYP_UNKNOWN;
 
 class ValueNumStore
 {
@@ -1037,9 +1035,11 @@ public:
     // Used in the implementation of the above.
     static const char* VNFuncNameArr[];
 
+    // Returns a type name used for "maps", i. e. displays TYP_UNDEF and TYP_UNKNOWN as TYP_MEM and TYP_HEAP.
+    static const char* VNMapTypeName(var_types type);
+
     // Returns the string name of "vn" when it is a reserved value number, nullptr otherwise
     static const char* reservedName(ValueNum vn);
-
 #endif // DEBUG
 
     // Returns true if "vn" is a reserved value number


### PR DESCRIPTION
Use `TYP_UNDEF` (as `TYP_MEM`) for "first field"-like maps and `TYP_UNKNOWN` (as `TYP_HEAP`) for the heaps themselves.

This will enable the type validation logic to be more precise. For now though, just assert that the heap is always updated with the properly typed VNs.

Sample from the new dump showcasing the now-more-apparent hierarchy of maps:
```scala
***** BB01, STMT00000(before)
N006 (  6,  6) [000010] -A-XG-------              *  ASG       long  
N004 (  4,  4) [000009] *--XG--N----              +--*  IND       long  
N003 (  2,  2) [000016] -------N----              |  \--*  ADD       byref 
N001 (  1,  1) [000000] ------------              |     +--*  LCL_VAR   ref    V00 arg0         u:1 (last use)
N002 (  1,  1) [000015] ------------              |     \--*  CNS_INT   long   56 field offset Fseq[LargeStruct, SmallerStruct1, MultiRegStruct2, FirstLngValue]
N005 (  1,  1) [000008] ------------              \--*  CNS_INT   long   2

N001 [000000]   LCL_VAR   V00 arg0         u:1 (last use) => $80 {InitVal($40)}
N002 [000015]   CNS_INT   56 field offset Fseq[LargeStruct, SmallerStruct1, MultiRegStruct2, FirstLngValue] => $100 {LngCns:  56}
N003 [000016]   ADD       => $140 {ADD($80, $100)}
N005 [000008]   CNS_INT   2 => $101 {LngCns:  2}
    VNForHandle(LargeStruct) is $180, fieldType is struct, size = 96
    VNForMapSelect($c0, $180):mem returns $1c0 {$c0[$180]}
    VNForMapSelect($1c0, $80):struct returns $200 {$1c0[$80]}
    VNForHandle(SmallerStruct1) is $181, fieldType is struct, size = 48
    VNForMapSelect($200, $181):struct returns $201 {$200[$181]}
    VNForHandle(MultiRegStruct2) is $182, fieldType is struct, size = 16
    VNForMapSelect($201, $182):struct returns $202 {$201[$182]}
  VNApplySelectorsAssign:
    VNForHandle(FirstLngValue) is $183, fieldType is long
    VNForMapStore($202, $183, $101):struct in BB01 returns $240 {$202[$183 := $101]}
    VNForMapStore($201, $182, $240):struct in BB01 returns $241 {$201[$182 := $240]}
    VNForMapStore($200, $181, $241):struct in BB01 returns $242 {$200[$181 := $241]}
    VNForMapStore($1c0, $80, $242):mem in BB01 returns $280 {$1c0[$80 := $242]}
    VNForMapStore($c0, $180, $280):heap in BB01 returns $2c0 {$c0[$180 := $280]}
  fgCurMemoryVN[GcHeap] assigned for StoreField at [000010] to VN: $2c0.
N006 [000010]   ASG       => $VN.Void
```

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1488682&view=ms.vss-build-web.run-extensions-tab).

Part of #58312.