### PR TITLE
Fix regression in IsPrefix / IsSuffix benchmarks

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Collation.cs
+++ b/src/libraries/Common/src/Interop/Interop.Collation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -25,10 +26,12 @@ internal static partial class Interop
         internal static unsafe partial int LastIndexOf(IntPtr sortHandle, char* target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options, int* matchLengthPtr);
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_StartsWith", CharSet = CharSet.Unicode)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool StartsWith(IntPtr sortHandle, char* target, int cwTargetLength, char* source, int cwSourceLength, CompareOptions options, int* matchedLength);
 
         [GeneratedDllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_EndsWith", CharSet = CharSet.Unicode)]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool EndsWith(IntPtr sortHandle, char* target, int cwTargetLength, char* source, int cwSourceLength, CompareOptions options, int* matchedLength);
 


### PR DESCRIPTION
The regressed scenarios actually did not call into any p/invokes - which is actually why they are the ones that regressed. With the switch to `GeneratedDllImport` in #61640, the generated stub and blittable p/invoke for `Interop.Globalization.EndsWith` and `Interop.Globalization.StartsWith` ended up inlined into their callers, resulting in a p/invoke frame being initialized even in the cases that did not use the p/invoke.

This PR marks those two functions as no inlining and gets us back to where it was before #61640. The issue was filed for arm64, but it is the same problem on x64 (just by less). Ran on Windows x64:
|                      Method |                 Toolchain |                           Options |          Mean |       Error |      StdDev |        Median |           Min |           Max | Ratio | MannWhitney(3%) | RatioSD | Allocated |
|------------------------ |-------------------------- |---------------------------------- |--------------:|------------:|------------:|--------------:|--------------:|--------------:|------:|---------------- |--------:|----------:|
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |             (, IgnoreCase, False) |     20.330 ns |   0.0381 ns |   0.0337 ns |     20.323 ns |     20.288 ns |     20.402 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |             (, IgnoreCase, False) |     14.640 ns |   0.0245 ns |   0.0229 ns |     14.631 ns |     14.612 ns |     14.680 ns |  0.72 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |                   (, None, False) |     20.900 ns |   0.0631 ns |   0.0590 ns |     20.923 ns |     20.815 ns |     20.974 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |                   (, None, False) |     14.654 ns |   0.0207 ns |   0.0193 ns |     14.656 ns |     14.627 ns |     14.688 ns |  0.70 |          Faster |    0.00 |         - |     - |

<details>
<summary>
Results for System.Globalization.Tests.StringSearch*
</summary>

|                      Method |                 Toolchain |                           Options |          Mean |       Error |      StdDev |        Median |           Min |           Max | Ratio | MannWhitney(3%) | RatioSD | Allocated |
|------------------------ |-------------------------- |---------------------------------- |--------------:|------------:|------------:|--------------:|--------------:|--------------:|------:|---------------- |--------:|----------:|
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |             (, IgnoreCase, False) |    194.393 ns |   1.3521 ns |   1.1986 ns |    194.433 ns |    192.894 ns |    196.665 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |             (, IgnoreCase, False) |    187.368 ns |   0.4431 ns |   0.4145 ns |    187.334 ns |    186.846 ns |    188.286 ns |  0.96 |          Faster |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |             (, IgnoreCase, False) |     20.330 ns |   0.0381 ns |   0.0337 ns |     20.323 ns |     20.288 ns |     20.402 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |             (, IgnoreCase, False) |     14.640 ns |   0.0245 ns |   0.0229 ns |     14.631 ns |     14.612 ns |     14.680 ns |  0.72 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |             (, IgnoreCase, False) |    212.495 ns |   0.5216 ns |   0.4624 ns |    212.342 ns |    211.539 ns |    213.235 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |             (, IgnoreCase, False) |    186.362 ns |   0.1782 ns |   0.1580 ns |    186.373 ns |    186.136 ns |    186.679 ns |  0.88 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |             (, IgnoreCase, False) |     20.855 ns |   0.1086 ns |   0.1016 ns |     20.872 ns |     20.712 ns |     20.993 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |             (, IgnoreCase, False) |     15.177 ns |   0.0142 ns |   0.0119 ns |     15.175 ns |     15.155 ns |     15.195 ns |  0.73 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |             (, IgnoreCase, False) |    683.095 ns |   6.6165 ns |   5.8653 ns |    683.481 ns |    675.406 ns |    692.925 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |             (, IgnoreCase, False) |    677.060 ns |   2.8404 ns |   2.6570 ns |    675.815 ns |    673.879 ns |    681.470 ns |  0.99 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |             (, IgnoreCase, False) |    676.341 ns |   1.3916 ns |   1.3017 ns |    675.693 ns |    674.882 ns |    679.335 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |             (, IgnoreCase, False) |    677.288 ns |   1.5849 ns |   1.4050 ns |    676.964 ns |    675.575 ns |    680.218 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |              (, IgnoreCase, True) |  3,574.746 ns |  11.8865 ns |  11.1187 ns |  3,572.241 ns |  3,561.510 ns |  3,592.023 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |              (, IgnoreCase, True) |  3,606.154 ns |  42.8753 ns |  38.0078 ns |  3,582.626 ns |  3,570.643 ns |  3,685.335 ns |  1.01 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |              (, IgnoreCase, True) |    831.642 ns |   5.8088 ns |   5.4335 ns |    832.867 ns |    825.062 ns |    843.031 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |              (, IgnoreCase, True) |    843.770 ns |   5.7553 ns |   5.1020 ns |    844.892 ns |    838.090 ns |    852.988 ns |  1.01 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |              (, IgnoreCase, True) |  7,316.780 ns | 139.9483 ns | 137.4480 ns |  7,347.592 ns |  7,165.856 ns |  7,600.568 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |              (, IgnoreCase, True) |  7,254.119 ns | 132.5820 ns | 117.5305 ns |  7,186.973 ns |  7,170.234 ns |  7,512.003 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |              (, IgnoreCase, True) |  1,283.598 ns |  16.2192 ns |  15.1715 ns |  1,282.635 ns |  1,266.832 ns |  1,314.400 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |              (, IgnoreCase, True) |  1,293.430 ns |  13.4541 ns |  12.5850 ns |  1,295.049 ns |  1,278.562 ns |  1,313.944 ns |  1.01 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |              (, IgnoreCase, True) |  8,773.427 ns | 279.7391 ns | 310.9293 ns |  8,638.881 ns |  8,434.559 ns |  9,548.658 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |              (, IgnoreCase, True) |  8,461.640 ns |  74.8071 ns |  62.4673 ns |  8,438.167 ns |  8,415.068 ns |  8,603.207 ns |  0.96 |            Same |    0.04 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |              (, IgnoreCase, True) | 15,207.016 ns | 179.3193 ns | 167.7354 ns | 15,227.226 ns | 15,029.975 ns | 15,596.782 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |              (, IgnoreCase, True) | 15,570.916 ns | 485.0580 ns | 558.5935 ns | 15,352.230 ns | 15,004.047 ns | 16,719.308 ns |  1.03 |            Same |    0.04 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |                   (, None, False) |    179.165 ns |   0.2829 ns |   0.2508 ns |    179.078 ns |    178.810 ns |    179.718 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |                   (, None, False) |    172.511 ns |   0.3044 ns |   0.2542 ns |    172.420 ns |    172.233 ns |    173.160 ns |  0.96 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |                   (, None, False) |     20.470 ns |   0.0406 ns |   0.0379 ns |     20.456 ns |     20.433 ns |     20.544 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |                   (, None, False) |     14.067 ns |   0.0302 ns |   0.0252 ns |     14.064 ns |     14.034 ns |     14.127 ns |  0.69 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |                   (, None, False) |    179.038 ns |   0.1133 ns |   0.1005 ns |    179.023 ns |    178.892 ns |    179.222 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |                   (, None, False) |    177.152 ns |   2.7482 ns |   2.4362 ns |    176.097 ns |    173.877 ns |    181.647 ns |  0.99 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |                   (, None, False) |     20.900 ns |   0.0631 ns |   0.0590 ns |     20.923 ns |     20.815 ns |     20.974 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |                   (, None, False) |     14.654 ns |   0.0207 ns |   0.0193 ns |     14.656 ns |     14.627 ns |     14.688 ns |  0.70 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |                   (, None, False) |    512.179 ns |   0.6999 ns |   0.6546 ns |    512.310 ns |    510.890 ns |    513.264 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |                   (, None, False) |    511.446 ns |   0.6401 ns |   0.5675 ns |    511.430 ns |    510.760 ns |    512.647 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |                   (, None, False) |    511.673 ns |   0.5447 ns |   0.4253 ns |    511.737 ns |    511.087 ns |    512.298 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |                   (, None, False) |    510.973 ns |   0.3723 ns |   0.3300 ns |    510.965 ns |    510.408 ns |    511.557 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |                    (, None, True) |  3,561.368 ns |  11.1167 ns |   8.6792 ns |  3,560.335 ns |  3,545.554 ns |  3,576.012 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |                    (, None, True) |  3,573.755 ns |  11.8553 ns |   9.8997 ns |  3,571.414 ns |  3,555.116 ns |  3,589.746 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |                    (, None, True) |    836.304 ns |  16.2111 ns |  16.6476 ns |    828.583 ns |    818.665 ns |    870.598 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |                    (, None, True) |    836.214 ns |   6.1372 ns |   5.7407 ns |    836.250 ns |    830.162 ns |    847.423 ns |  1.00 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |                    (, None, True) |  7,315.706 ns | 109.3084 ns |  96.8990 ns |  7,328.551 ns |  7,174.069 ns |  7,484.585 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |                    (, None, True) |  7,364.889 ns | 140.4755 ns | 156.1381 ns |  7,354.172 ns |  7,194.659 ns |  7,784.378 ns |  1.01 |            Same |    0.03 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |                    (, None, True) |  1,258.321 ns |   9.4250 ns |   8.3550 ns |  1,259.702 ns |  1,244.440 ns |  1,275.853 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |                    (, None, True) |  1,286.283 ns |  20.5681 ns |  19.2394 ns |  1,280.850 ns |  1,269.117 ns |  1,326.702 ns |  1.02 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |                    (, None, True) |  8,455.165 ns |  92.8074 ns |  86.8121 ns |  8,413.614 ns |  8,336.519 ns |  8,562.197 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |                    (, None, True) |  8,482.582 ns | 126.5231 ns | 118.3498 ns |  8,410.619 ns |  8,344.823 ns |  8,709.746 ns |  1.00 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |                    (, None, True) | 14,979.847 ns | 222.2341 ns | 207.8779 ns | 14,855.549 ns | 14,835.173 ns | 15,422.322 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |                    (, None, True) | 15,040.241 ns | 264.0188 ns | 246.9634 ns | 14,904.880 ns | 14,823.384 ns | 15,583.415 ns |  1.00 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |        (en-US, IgnoreCase, False) |    192.585 ns |   0.1521 ns |   0.1348 ns |    192.561 ns |    192.417 ns |    192.819 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |        (en-US, IgnoreCase, False) |    187.522 ns |   0.4867 ns |   0.4314 ns |    187.440 ns |    186.928 ns |    188.315 ns |  0.97 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |        (en-US, IgnoreCase, False) |     20.737 ns |   0.0201 ns |   0.0188 ns |     20.733 ns |     20.700 ns |     20.770 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |        (en-US, IgnoreCase, False) |     16.728 ns |   0.0171 ns |   0.0160 ns |     16.727 ns |     16.701 ns |     16.755 ns |  0.81 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |        (en-US, IgnoreCase, False) |    212.396 ns |   0.4381 ns |   0.4098 ns |    212.551 ns |    211.829 ns |    213.160 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |        (en-US, IgnoreCase, False) |    186.205 ns |   0.1774 ns |   0.1572 ns |    186.196 ns |    185.992 ns |    186.514 ns |  0.88 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |        (en-US, IgnoreCase, False) |     21.096 ns |   0.0295 ns |   0.0247 ns |     21.092 ns |     21.062 ns |     21.145 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |        (en-US, IgnoreCase, False) |     15.166 ns |   0.0207 ns |   0.0193 ns |     15.160 ns |     15.144 ns |     15.204 ns |  0.72 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |        (en-US, IgnoreCase, False) |    680.742 ns |   2.1943 ns |   1.8323 ns |    681.131 ns |    676.315 ns |    682.695 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |        (en-US, IgnoreCase, False) |    678.559 ns |   3.1456 ns |   2.9424 ns |    679.790 ns |    674.605 ns |    682.468 ns |  1.00 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |        (en-US, IgnoreCase, False) |    682.174 ns |  12.0477 ns |  11.2694 ns |    677.122 ns |    674.863 ns |    712.852 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |        (en-US, IgnoreCase, False) |    676.452 ns |   1.2954 ns |   1.1483 ns |    676.133 ns |    674.985 ns |    678.514 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |         (en-US, IgnoreCase, True) |  3,576.194 ns |  12.0959 ns |  10.7227 ns |  3,575.706 ns |  3,555.812 ns |  3,596.613 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |         (en-US, IgnoreCase, True) |  3,592.460 ns |  18.3768 ns |  17.1897 ns |  3,589.975 ns |  3,566.716 ns |  3,624.217 ns |  1.00 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |         (en-US, IgnoreCase, True) |    828.166 ns |   5.7399 ns |   5.0883 ns |    826.757 ns |    822.918 ns |    838.492 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |         (en-US, IgnoreCase, True) |    845.816 ns |   8.0837 ns |   7.5615 ns |    845.998 ns |    835.937 ns |    860.546 ns |  1.02 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |         (en-US, IgnoreCase, True) |  7,259.500 ns | 111.4437 ns | 104.2445 ns |  7,195.555 ns |  7,174.710 ns |  7,483.724 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |         (en-US, IgnoreCase, True) |  7,286.106 ns | 122.3634 ns | 114.4588 ns |  7,206.645 ns |  7,182.287 ns |  7,543.353 ns |  1.00 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |         (en-US, IgnoreCase, True) |  1,283.746 ns |  17.0649 ns |  15.1275 ns |  1,282.431 ns |  1,265.446 ns |  1,316.937 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |         (en-US, IgnoreCase, True) |  1,294.374 ns |  12.4748 ns |  10.4170 ns |  1,294.731 ns |  1,275.163 ns |  1,310.448 ns |  1.01 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |         (en-US, IgnoreCase, True) |  8,503.652 ns | 124.1596 ns | 116.1390 ns |  8,436.175 ns |  8,389.601 ns |  8,725.877 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |         (en-US, IgnoreCase, True) |  8,542.614 ns | 147.0320 ns | 137.5338 ns |  8,569.570 ns |  8,388.089 ns |  8,733.448 ns |  1.00 |            Same |    0.03 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |         (en-US, IgnoreCase, True) | 15,322.394 ns | 291.4048 ns | 286.1985 ns | 15,246.212 ns | 15,039.573 ns | 15,999.584 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |         (en-US, IgnoreCase, True) | 15,237.165 ns | 201.1182 ns | 188.1261 ns | 15,309.976 ns | 15,007.710 ns | 15,562.260 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |    (en-US, IgnoreNonSpace, False) |    179.540 ns |   0.4334 ns |   0.4054 ns |    179.514 ns |    178.844 ns |    180.104 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |    (en-US, IgnoreNonSpace, False) |    172.465 ns |   0.1713 ns |   0.1431 ns |    172.513 ns |    172.236 ns |    172.662 ns |  0.96 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |    (en-US, IgnoreNonSpace, False) |     21.164 ns |   0.0309 ns |   0.0258 ns |     21.161 ns |     21.127 ns |     21.224 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |    (en-US, IgnoreNonSpace, False) |     14.107 ns |   0.0112 ns |   0.0093 ns |     14.108 ns |     14.088 ns |     14.121 ns |  0.67 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |    (en-US, IgnoreNonSpace, False) |    179.054 ns |   0.1735 ns |   0.1355 ns |    179.047 ns |    178.856 ns |    179.258 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |    (en-US, IgnoreNonSpace, False) |    173.421 ns |   0.2946 ns |   0.2611 ns |    173.384 ns |    173.046 ns |    173.792 ns |  0.97 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |    (en-US, IgnoreNonSpace, False) |     21.016 ns |   0.0240 ns |   0.0224 ns |     21.015 ns |     20.978 ns |     21.054 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |    (en-US, IgnoreNonSpace, False) |     14.633 ns |   0.0144 ns |   0.0120 ns |     14.635 ns |     14.610 ns |     14.653 ns |  0.70 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |    (en-US, IgnoreNonSpace, False) |    511.326 ns |   0.5471 ns |   0.4568 ns |    511.221 ns |    510.841 ns |    512.187 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |    (en-US, IgnoreNonSpace, False) |    511.568 ns |   0.4104 ns |   0.3839 ns |    511.650 ns |    510.801 ns |    512.183 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |    (en-US, IgnoreNonSpace, False) |    510.292 ns |   0.5253 ns |   0.4657 ns |    510.307 ns |    509.613 ns |    511.210 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |    (en-US, IgnoreNonSpace, False) |    510.559 ns |   1.0415 ns |   0.9232 ns |    510.191 ns |    509.614 ns |    512.566 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |     (en-US, IgnoreSymbols, False) | 15,049.017 ns | 178.5435 ns | 139.3950 ns | 15,010.773 ns | 14,773.380 ns | 15,267.396 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |     (en-US, IgnoreSymbols, False) | 14,952.763 ns | 225.1827 ns | 188.0377 ns | 14,897.511 ns | 14,754.595 ns | 15,442.490 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |     (en-US, IgnoreSymbols, False) | 28,861.033 ns | 348.3812 ns | 308.8308 ns | 28,871.024 ns | 28,428.530 ns | 29,483.380 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |     (en-US, IgnoreSymbols, False) | 28,520.656 ns | 373.1350 ns | 330.7744 ns | 28,526.900 ns | 28,094.998 ns | 29,199.485 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |     (en-US, IgnoreSymbols, False) | 17,399.451 ns | 331.6047 ns | 325.6802 ns | 17,459.873 ns | 16,991.082 ns | 18,167.631 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |     (en-US, IgnoreSymbols, False) | 17,147.848 ns | 178.1021 ns | 166.5968 ns | 17,036.906 ns | 17,010.630 ns | 17,541.983 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |     (en-US, IgnoreSymbols, False) | 34,479.412 ns | 688.3063 ns | 643.8421 ns | 34,431.875 ns | 33,891.087 ns | 35,775.543 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |     (en-US, IgnoreSymbols, False) | 34,001.561 ns | 418.7672 ns | 391.7151 ns | 33,774.973 ns | 33,636.382 ns | 34,834.348 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |     (en-US, IgnoreSymbols, False) |  8,389.964 ns | 167.6830 ns | 164.6872 ns |  8,330.942 ns |  8,234.367 ns |  8,781.727 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |     (en-US, IgnoreSymbols, False) |  8,505.469 ns | 111.7649 ns | 104.5450 ns |  8,531.724 ns |  8,382.644 ns |  8,709.147 ns |  1.01 |            Same |    0.03 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |     (en-US, IgnoreSymbols, False) | 14,401.381 ns | 244.5161 ns | 228.7205 ns | 14,361.703 ns | 14,049.500 ns | 14,684.529 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |     (en-US, IgnoreSymbols, False) | 14,317.445 ns | 207.3344 ns | 193.9408 ns | 14,363.585 ns | 14,079.350 ns | 14,797.215 ns |  0.99 |            Same |    0.03 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |              (en-US, None, False) |    179.241 ns |   0.2914 ns |   0.2583 ns |    179.232 ns |    178.774 ns |    179.685 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |              (en-US, None, False) |    172.406 ns |   0.1697 ns |   0.1587 ns |    172.341 ns |    172.215 ns |    172.731 ns |  0.96 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |              (en-US, None, False) |     21.047 ns |   0.0326 ns |   0.0289 ns |     21.044 ns |     21.004 ns |     21.095 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |              (en-US, None, False) |     14.070 ns |   0.0148 ns |   0.0124 ns |     14.063 ns |     14.054 ns |     14.088 ns |  0.67 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |              (en-US, None, False) |    179.240 ns |   0.2008 ns |   0.1677 ns |    179.279 ns |    178.974 ns |    179.471 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |              (en-US, None, False) |    173.412 ns |   0.3247 ns |   0.3037 ns |    173.320 ns |    173.014 ns |    174.135 ns |  0.97 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |              (en-US, None, False) |     21.093 ns |   0.0224 ns |   0.0210 ns |     21.094 ns |     21.048 ns |     21.131 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |              (en-US, None, False) |     14.624 ns |   0.0083 ns |   0.0073 ns |     14.624 ns |     14.608 ns |     14.637 ns |  0.69 |          Faster |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |              (en-US, None, False) |    511.314 ns |   0.4328 ns |   0.3837 ns |    511.239 ns |    510.843 ns |    512.278 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |              (en-US, None, False) |    512.347 ns |   0.8399 ns |   0.7856 ns |    512.110 ns |    511.462 ns |    513.988 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |              (en-US, None, False) |    511.230 ns |   0.5743 ns |   0.4796 ns |    511.283 ns |    510.486 ns |    511.914 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |              (en-US, None, False) |    511.460 ns |   1.1063 ns |   0.8637 ns |    511.641 ns |    510.216 ns |    513.079 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |               (en-US, None, True) |  3,558.037 ns |   7.2155 ns |   6.7494 ns |  3,558.462 ns |  3,546.353 ns |  3,573.106 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |               (en-US, None, True) |  3,562.930 ns |  12.2524 ns |  11.4609 ns |  3,566.237 ns |  3,543.664 ns |  3,581.075 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |               (en-US, None, True) |    823.498 ns |   4.0542 ns |   3.7923 ns |    821.472 ns |    819.544 ns |    829.810 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |               (en-US, None, True) |    835.843 ns |   4.5527 ns |   3.8017 ns |    836.496 ns |    829.226 ns |    840.791 ns |  1.01 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |               (en-US, None, True) |  7,292.268 ns | 138.9155 ns | 148.6380 ns |  7,244.774 ns |  7,151.938 ns |  7,630.487 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |               (en-US, None, True) |  7,264.698 ns | 116.6418 ns |  97.4012 ns |  7,197.776 ns |  7,173.885 ns |  7,480.546 ns |  1.00 |            Same |    0.03 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |               (en-US, None, True) |  1,278.144 ns |  13.2719 ns |  12.4146 ns |  1,279.447 ns |  1,263.650 ns |  1,300.658 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |               (en-US, None, True) |  1,277.128 ns |  12.4016 ns |  10.3559 ns |  1,272.206 ns |  1,266.068 ns |  1,302.867 ns |  1.00 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |               (en-US, None, True) |  8,507.300 ns | 160.7743 ns | 150.3884 ns |  8,430.914 ns |  8,340.245 ns |  8,732.739 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |               (en-US, None, True) |  8,467.653 ns | 140.3933 ns | 124.4550 ns |  8,403.869 ns |  8,342.895 ns |  8,718.556 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |               (en-US, None, True) | 15,108.783 ns | 251.6039 ns | 235.3505 ns | 15,132.306 ns | 14,835.211 ns | 15,468.869 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |               (en-US, None, True) | 15,098.139 ns | 230.9072 ns | 215.9907 ns | 15,135.245 ns | 14,839.090 ns | 15,455.216 ns |  1.00 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |           (en-US, Ordinal, False) |      9.582 ns |   0.0096 ns |   0.0080 ns |      9.584 ns |      9.568 ns |      9.598 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |           (en-US, Ordinal, False) |      9.644 ns |   0.0116 ns |   0.0103 ns |      9.643 ns |      9.631 ns |      9.670 ns |  1.01 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |           (en-US, Ordinal, False) |      6.084 ns |   0.0077 ns |   0.0068 ns |      6.086 ns |      6.072 ns |      6.097 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |           (en-US, Ordinal, False) |      6.078 ns |   0.0055 ns |   0.0046 ns |      6.078 ns |      6.071 ns |      6.084 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |           (en-US, Ordinal, False) |     17.249 ns |   2.2067 ns |   2.5412 ns |     18.065 ns |      9.814 ns |     18.113 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |           (en-US, Ordinal, False) |     18.054 ns |   0.0372 ns |   0.0348 ns |     18.050 ns |     17.972 ns |     18.114 ns |  1.11 |            Same |    0.30 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |           (en-US, Ordinal, False) |     13.305 ns |   0.0195 ns |   0.0183 ns |     13.308 ns |     13.281 ns |     13.343 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |           (en-US, Ordinal, False) |     13.424 ns |   0.1992 ns |   0.1863 ns |     13.296 ns |     13.260 ns |     13.735 ns |  1.01 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |           (en-US, Ordinal, False) |     37.618 ns |   0.1202 ns |   0.0938 ns |     37.619 ns |     37.457 ns |     37.740 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |           (en-US, Ordinal, False) |     37.573 ns |   0.2010 ns |   0.1880 ns |     37.595 ns |     37.194 ns |     37.877 ns |  1.00 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |           (en-US, Ordinal, False) |     81.877 ns |   0.0999 ns |   0.0935 ns |     81.905 ns |     81.744 ns |     82.018 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |           (en-US, Ordinal, False) |     81.882 ns |   0.1464 ns |   0.1298 ns |     81.839 ns |     81.746 ns |     82.100 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe | (en-US, OrdinalIgnoreCase, False) |     72.843 ns |   1.2101 ns |   1.3451 ns |     72.285 ns |     71.624 ns |     75.902 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe | (en-US, OrdinalIgnoreCase, False) |     71.640 ns |   0.0566 ns |   0.0529 ns |     71.635 ns |     71.550 ns |     71.753 ns |  0.98 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe | (en-US, OrdinalIgnoreCase, False) |      7.175 ns |   0.0235 ns |   0.0219 ns |      7.170 ns |      7.134 ns |      7.216 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe | (en-US, OrdinalIgnoreCase, False) |      7.154 ns |   0.0095 ns |   0.0074 ns |      7.154 ns |      7.143 ns |      7.168 ns |  1.00 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe | (en-US, OrdinalIgnoreCase, False) |     72.566 ns |   0.4840 ns |   0.4527 ns |     72.474 ns |     72.005 ns |     73.403 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe | (en-US, OrdinalIgnoreCase, False) |     71.945 ns |   0.0950 ns |   0.0742 ns |     71.951 ns |     71.815 ns |     72.094 ns |  0.99 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe | (en-US, OrdinalIgnoreCase, False) |    125.910 ns |   0.1770 ns |   0.1478 ns |    125.962 ns |    125.625 ns |    126.143 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe | (en-US, OrdinalIgnoreCase, False) |    128.797 ns |   0.1568 ns |   0.1467 ns |    128.799 ns |    128.548 ns |    129.077 ns |  1.02 |            Same |    0.00 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe | (en-US, OrdinalIgnoreCase, False) |    592.862 ns |   2.8643 ns |   2.6793 ns |    592.444 ns |    587.524 ns |    596.828 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe | (en-US, OrdinalIgnoreCase, False) |    589.886 ns |   2.7130 ns |   2.2655 ns |    590.434 ns |    586.501 ns |    593.437 ns |  0.99 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe | (en-US, OrdinalIgnoreCase, False) |    709.160 ns |   5.2179 ns |   4.8808 ns |    706.741 ns |    703.768 ns |    720.306 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe | (en-US, OrdinalIgnoreCase, False) |    697.776 ns |   5.1470 ns |   4.8145 ns |    697.268 ns |    686.084 ns |    704.137 ns |  0.98 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|          IsPrefix_FirstHalf | \runtime-main\corerun.exe |              (pl-PL, None, False) |  5,819.969 ns |  63.6196 ns |  56.3971 ns |  5,794.798 ns |  5,749.032 ns |  5,952.656 ns |  1.00 |            Base |    0.00 |         - |
|          IsPrefix_FirstHalf |   \runtime-pr\corerun.exe |              (pl-PL, None, False) |  5,890.738 ns |  80.4689 ns |  71.3336 ns |  5,890.526 ns |  5,794.861 ns |  6,041.379 ns |  1.01 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
| IsPrefix_DifferentFirstChar | \runtime-main\corerun.exe |              (pl-PL, None, False) |    829.587 ns |   5.5416 ns |   5.1837 ns |    827.746 ns |    824.117 ns |    836.308 ns |  1.00 |            Base |    0.00 |         - |
| IsPrefix_DifferentFirstChar |   \runtime-pr\corerun.exe |              (pl-PL, None, False) |    835.576 ns |   6.6494 ns |   5.8945 ns |    832.525 ns |    830.824 ns |    851.214 ns |  1.01 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|         IsSuffix_SecondHalf | \runtime-main\corerun.exe |              (pl-PL, None, False) |  8,275.919 ns | 138.3208 ns | 129.3853 ns |  8,291.450 ns |  8,115.938 ns |  8,452.845 ns |  1.00 |            Base |    0.00 |         - |
|         IsSuffix_SecondHalf |   \runtime-pr\corerun.exe |              (pl-PL, None, False) |  8,263.575 ns | 115.9370 ns | 108.4475 ns |  8,286.026 ns |  8,108.706 ns |  8,444.095 ns |  1.00 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|  IsSuffix_DifferentLastChar | \runtime-main\corerun.exe |              (pl-PL, None, False) |  1,205.716 ns |  16.2325 ns |  15.1839 ns |  1,204.418 ns |  1,187.402 ns |  1,232.607 ns |  1.00 |            Base |    0.00 |         - |
|  IsSuffix_DifferentLastChar |   \runtime-pr\corerun.exe |              (pl-PL, None, False) |  1,188.148 ns |  11.7662 ns |  11.0061 ns |  1,191.183 ns |  1,176.049 ns |  1,208.433 ns |  0.99 |            Same |    0.02 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|       IndexOf_Word_NotFound | \runtime-main\corerun.exe |              (pl-PL, None, False) | 11,777.601 ns | 124.9907 ns | 110.8010 ns | 11,829.684 ns | 11,589.825 ns | 11,891.676 ns |  1.00 |            Base |    0.00 |         - |
|       IndexOf_Word_NotFound |   \runtime-pr\corerun.exe |              (pl-PL, None, False) | 11,623.384 ns | 188.3069 ns | 176.1424 ns | 11,641.224 ns | 11,397.813 ns | 12,049.652 ns |  0.98 |            Same |    0.01 |         - |
|                             |                           |                                   |               |             |             |               |               |               |       |                 |         |           |
|   LastIndexOf_Word_NotFound | \runtime-main\corerun.exe |              (pl-PL, None, False) | 16,668.686 ns | 223.1986 ns | 208.7801 ns | 16,725.532 ns | 16,434.023 ns | 17,046.911 ns |  1.00 |            Base |    0.00 |         - |
|   LastIndexOf_Word_NotFound |   \runtime-pr\corerun.exe |              (pl-PL, None, False) | 17,070.973 ns | 174.7257 ns | 154.8898 ns | 17,117.887 ns | 16,837.473 ns | 17,399.187 ns |  1.02 |            Same |    0.02 |         - |
</details>

Fixes https://github.com/dotnet/runtime/issues/61821

@AaronRobinsonMSFT @jkoritzinsky 