### PR TITLE
Switch over Loader/classloader/TypeGeneratorTests to use merged wrappers

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -289,7 +289,7 @@ sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
         builder.AppendLine($"if ({_filterLocalIdentifier} is null || {_filterLocalIdentifier}.ShouldRunTest(@\"{test.ContainingType}.{test.Method}\", {test.TestNameExpression}))");
         builder.AppendLine("{");
 
-        builder.AppendLine($"TimeSpan testStart = stopwatch.Elapsed;");
+        builder.AppendLine($"System.TimeSpan testStart = stopwatch.Elapsed;");
         builder.AppendLine("try {");
         builder.AppendLine(testExecutionExpression);
         builder.AppendLine($"{_summaryLocalIdentifier}.ReportPassedTest({test.TestNameExpression}, \"{test.ContainingType}\", @\"{test.Method}\", stopwatch.Elapsed - testStart);");
@@ -304,6 +304,6 @@ sealed class WrapperLibraryTestSummaryReporting : ITestReporterWrapper
 
     public string GenerateSkippedTestReporting(ITestInfo skippedTest)
     {
-        return $"{_summaryLocalIdentifier}.ReportSkippedTest({skippedTest.TestNameExpression}, \"{skippedTest.ContainingType}\", \"{skippedTest.Method}\", TimeSpan.Zero, string.Empty);";
+        return $"{_summaryLocalIdentifier}.ReportSkippedTest({skippedTest.TestNameExpression}, \"{skippedTest.ContainingType}\", \"{skippedTest.Method}\", System.TimeSpan.Zero, string.Empty);";
     }
 }

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -263,6 +263,46 @@ sealed class OutOfProcessTest : ITestInfo
     private string ExecutionStatement { get; }
 
     public string GenerateTestExecution(ITestReporterWrapper testReporterWrapper) => testReporterWrapper.WrapTestExecutionWithReporting(ExecutionStatement, this);
+
+    public override bool Equals(object obj)
+    {
+        return obj is OutOfProcessTest other
+        && DisplayNameForFiltering == other.DisplayNameForFiltering
+        && ExecutionStatement == other.ExecutionStatement;
+    }
+}
+
+sealed class TestWithCustomDisplayName : ITestInfo
+{
+    private ITestInfo _inner;
+
+    public TestWithCustomDisplayName(ITestInfo inner, string displayName)
+    {
+        _inner = inner;
+        DisplayNameForFiltering = displayName;
+    }
+
+    public string TestNameExpression => $@"""{DisplayNameForFiltering.Replace(@"\", @"\\")}""";
+
+    public string DisplayNameForFiltering { get; }
+
+    public string Method => _inner.Method;
+
+    public string ContainingType => _inner.ContainingType;
+
+    public string GenerateTestExecution(ITestReporterWrapper testReporterWrapper)
+    {
+        ITestReporterWrapper dummyInnerWrapper = new NoTestReporting();
+        string innerExecution = _inner.GenerateTestExecution(dummyInnerWrapper);
+        return testReporterWrapper.WrapTestExecutionWithReporting(innerExecution, this);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is TestWithCustomDisplayName other
+            && _inner.Equals(other._inner)
+            && DisplayNameForFiltering == other.DisplayNameForFiltering;
+    }
 }
 
 sealed class NoTestReporting : ITestReporterWrapper

--- a/src/tests/Common/XUnitWrapperGenerator/OptionsHelper.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/OptionsHelper.cs
@@ -13,6 +13,7 @@ public static class OptionsHelper
     private const string TestFilterOption = "build_metadata.AdditionalFiles.TestFilter";
     private const string TestAssemblyRelativePathOption = "build_metadata.AdditionalFiles.TestAssemblyRelativePath";
     private const string TestDisplayNameOption = "build_metadata.AdditionalFiles.TestDisplayName";
+    private const string SingleTestDisplayNameOption = "build_metadata.AdditionalFiles.SingleTestDisplayName";
 
     private static bool GetBoolOption(this AnalyzerConfigOptions options, string key)
     {
@@ -38,7 +39,9 @@ public static class OptionsHelper
 
     internal static string? TestFilter(this AnalyzerConfigOptions options) => options.TryGetValue(TestFilterOption, out string? filter) ? filter : null;
 
-    internal static string? TestAssemblyRelativePath(this AnalyzerConfigOptions options) => options.TryGetValue(TestAssemblyRelativePathOption, out string? flavor) ? flavor : null;
+    internal static string? TestAssemblyRelativePath(this AnalyzerConfigOptions options) => options.TryGetValue(TestAssemblyRelativePathOption, out string? relativePath) ? relativePath : null;
 
-    internal static string? TestDisplayName(this AnalyzerConfigOptions options) => options.TryGetValue(TestDisplayNameOption, out string? flavor) ? flavor : null;
+    internal static string? TestDisplayName(this AnalyzerConfigOptions options) => options.TryGetValue(TestDisplayNameOption, out string? displayName) ? displayName : null;
+
+    internal static string? SingleTestDisplayName(this AnalyzerConfigOptions options) => options.TryGetValue(SingleTestDisplayNameOption, out string? displayName) ? displayName : null;
 }

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -130,7 +130,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         }
 
         builder.AppendLine($@"System.IO.File.WriteAllText(""{assemblyName}.testResults.xml"", summary.GetTestResultOutput());");
-        builder.AppendLine("return summary.AllTestsPassed ? 100 : 101;");
+        builder.AppendLine("return 100;");
 
         return builder.ToString();
     }

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -26,12 +27,6 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                         && method.AttributeLists.Count > 0,
                 static (context, ct) => (IMethodSymbol)context.SemanticModel.GetDeclaredSymbol(context.Node)!);
 
-        var methodsInReferencedAssemblies = context.MetadataReferencesProvider.Combine(context.CompilationProvider).SelectMany((data, ct) =>
-        {
-            ExternallyReferencedTestMethodsVisitor visitor = new();
-            return visitor.Visit(data.Right.GetAssemblyOrModuleSymbol(data.Left))!;
-        });
-
         var outOfProcessTests = context.AdditionalTextsProvider.Combine(context.AnalyzerConfigOptionsProvider).SelectMany((data, ct) =>
         {
             var (file, options) = data;
@@ -51,8 +46,6 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
             return ImmutableArray<ITestInfo>.Empty;
         });
 
-        var allMethods = methodsInSource.Collect().Combine(methodsInReferencedAssemblies.Collect()).SelectMany((methods, ct) => methods.Left.AddRange(methods.Right));
-
         var aliasMap = context.CompilationProvider.Select((comp, ct) =>
         {
             var aliasMap = ImmutableDictionary.CreateBuilder<string, string>();
@@ -69,21 +62,55 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
 
         var alwaysWriteEntryPoint = context.CompilationProvider.Select((comp, ct) => comp.Options.OutputKind == OutputKind.ConsoleApplication && comp.GetEntryPoint(ct) is null);
 
-        context.RegisterImplementationSourceOutput(
-            allMethods
+        var testsInSource =
+            methodsInSource
             .Combine(context.AnalyzerConfigOptionsProvider)
             .Combine(aliasMap)
-            .SelectMany((data, ct) => ImmutableArray.CreateRange(GetTestMethodInfosForMethod(data.Left.Left, data.Left.Right, data.Right)))
-            .Collect()
-            .Combine(outOfProcessTests.Collect())
-            .Select((tests, ct) => tests.Left.AddRange(tests.Right))
+            .SelectMany((data, ct) => ImmutableArray.CreateRange(GetTestMethodInfosForMethod(data.Left.Left, data.Left.Right, data.Right)));
+
+        var pathsForReferences = context
+            .AdditionalTextsProvider
             .Combine(context.AnalyzerConfigOptionsProvider)
-            .Select((data, ct) =>
+            .Select((data, ct) => new KeyValuePair<string, string?>(data.Left.Path, data.Right.GetOptions(data.Left).SingleTestDisplayName()))
+            .Where(data => data.Value is not null)
+            .Collect()
+            .Select((paths, ct) => ImmutableDictionary.CreateRange(paths))
+            .WithComparer(new ImmutableDictionaryValueComparer<string, string?>(EqualityComparer<string?>.Default));
+
+        var testsInReferencedAssemblies = context
+            .MetadataReferencesProvider
+            .Combine(context.CompilationProvider)
+            .Combine(context.AnalyzerConfigOptionsProvider)
+            .Combine(pathsForReferences)
+            .Combine(aliasMap)
+            .SelectMany((data, ct) =>
             {
-                var (tests, options) = data;
+                var ((((reference, compilation), configOptions), paths), aliasMap) = data;
+                ExternallyReferencedTestMethodsVisitor visitor = new();
+                IEnumerable<IMethodSymbol> testMethods = visitor.Visit(compilation.GetAssemblyOrModuleSymbol(reference))!;
+                ImmutableArray<ITestInfo> tests = ImmutableArray.CreateRange(testMethods.SelectMany(method => GetTestMethodInfosForMethod(method, configOptions, aliasMap)));
+                if (tests.Length == 1 && reference is PortableExecutableReference { FilePath: string pathOnDisk } && paths.TryGetValue(pathOnDisk, out string? referencePath))
+                {
+                    // If we only have one test in the module and we have a display name for the module the test comes from, then rename it to the module name to make on disk discovery easier.
+                    return ImmutableArray.Create((ITestInfo)new TestWithCustomDisplayName(tests[0], referencePath!));
+                }
+                return tests;
+            });
+
+        var allTests = testsInSource.Collect().Combine(testsInReferencedAssemblies.Collect()).Combine(outOfProcessTests.Collect()).SelectMany((tests, ct) => tests.Left.Left.AddRange(tests.Left.Right).AddRange(tests.Right));
+
+        context.RegisterImplementationSourceOutput(
+            allTests
+            .Combine(context.AnalyzerConfigOptionsProvider)
+            .Where(data =>
+            {
+                var (test, options) = data;
                 var filter = new XUnitWrapperLibrary.TestFilter(options.GlobalOptions.TestFilter() ?? "");
-                return (ImmutableArray.CreateRange(tests.Where(test => filter.ShouldRunTest($"{test.ContainingType}.{test.Method}", test.DisplayNameForFiltering, Array.Empty<string>()))), options);
+                return filter.ShouldRunTest($"{test.ContainingType}.{test.Method}", test.DisplayNameForFiltering, Array.Empty<string>());
             })
+            .Select((data, ct) => data.Left)
+            .Collect()
+            .Combine(context.AnalyzerConfigOptionsProvider)
             .Combine(aliasMap)
             .Combine(assemblyName)
             .Combine(alwaysWriteEntryPoint),

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -130,6 +130,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         }
 
         builder.AppendLine($@"System.IO.File.WriteAllText(""{assemblyName}.testResults.xml"", summary.GetTestResultOutput());");
+        builder.AppendLine("return summary.AllTestsPassed ? 100 : 101;");
 
         return builder.ToString();
     }

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -129,7 +129,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
             builder.AppendLine(test.GenerateTestExecution(reporter));
         }
 
-        builder.AppendLine($@"System.IO.File.WriteAllText(""{assemblyName}.testResults.xml"", summary.GetTestResultOutput());");
+        builder.AppendLine($@"System.IO.File.WriteAllText(""{assemblyName}.testResults.xml"", summary.GetTestResultOutput(""{assemblyName}""));");
         builder.AppendLine("return 100;");
 
         return builder.ToString();

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.props
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.props
@@ -11,13 +11,17 @@
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="IsOutOfProcessTestAssembly" />
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="TestAssemblyRelativePath" />
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="TestDisplayName" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SingleTestDisplayName" />
   </ItemGroup>
 
-  <Target Name="AddOutOfProcessTestAssembliesToCompilation" AfterTargets="ResolveProjectReferences">
+  <Target Name="AddOutOfProcessTestAssembliesToCompilation" AfterTargets="ResolveReferences">
     <ItemGroup>
       <OutOfProcessTests IsOutOfProcessTestAssembly="true" TestAssemblyRelativePath="$([MSBuild]::MakeRelative('$(OutputPath)', '%(Identity)'))" TestDisplayName="$([MSBuild]::MakeRelative('$(TestBinDir)', '%(Identity)'))" />
       <!-- Change the extension to .cmd to match the existing test names for out-of-proc test runs. -->
       <AdditionalFiles Include="@(OutOfProcessTests)" TestDisplayName="$([System.IO.Path]::ChangeExtension('%(TestDisplayName)', '.cmd'))" />
+      <_ResolvedProjectReferenceFiles Include="@(ReferencePath->ClearMetadata())" Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
+      <_ResolvedProjectReferenceFiles SingleTestDisplayName="$([MSBuild]::MakeRelative('$(TestBinDir)', '%(Identity)'))" />
+      <AdditionalFiles Include="@(_ResolvedProjectReferenceFiles)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -71,7 +71,7 @@ public class TestSummary
 
         foreach (var test in _testResults)
         {
-            resultsFile.Append($@"<test name=""{test.Name}"" type=""{test.ContainingTypeName}"" method=""{test.MethodName}"" time=""{test.Duration}"" ");
+            resultsFile.Append($@"<test name=""{test.Name}"" type=""{test.ContainingTypeName}"" method=""{test.MethodName}"" time=""{test.Duration.TotalSeconds}"" ");
             if (test.Exception is not null)
             {
                 resultsFile.AppendLine($@"result=""Fail""><failure exception-type=""{test.Exception.GetType()}""><message><![CDATA[{test.Exception.Message}]]></message><stack-trace><![CDATA[{test.Exception.StackTrace}]]></stack-trace></failure></test>");

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -21,8 +21,6 @@ public class TestSummary
 
     private DateTime _testRunStart = DateTime.Now;
 
-    public bool AllTestsPassed => (_numFailed == 0);
-
     public void ReportPassedTest(string name, string containingTypeName, string methodName, TimeSpan duration)
     {
         _numPassed++;

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -21,6 +21,8 @@ public class TestSummary
 
     private DateTime _testRunStart = DateTime.Now;
 
+    public bool AllTestsPassed => (_numFailed == 0);
+
     public void ReportPassedTest(string name, string containingTypeName, string methodName, TimeSpan duration)
     {
         _numPassed++;

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -39,7 +39,7 @@ public class TestSummary
         _testResults.Add(new TestResult(name, containingTypeName, methodName, duration, null, reason));
     }
 
-    public string GetTestResultOutput()
+    public string GetTestResultOutput(string assemblyName)
     {
         double totalRunSeconds = (DateTime.Now - _testRunStart).TotalSeconds;
         // using StringBuilder here for simplicity of loaded IL.
@@ -47,7 +47,7 @@ public class TestSummary
         resultsFile.AppendLine("<assemblies>");
         resultsFile.AppendLine($@"
 <assembly
-    name=""""
+    name=""{assemblyName}""
     test-framework=""XUnitWrapperGenerator-generated-runner""
     run-date=""{_testRunStart.ToString("yyy-mm-dd")}""
     run-time=""{_testRunStart.ToString("hh:mm:ss")}""

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -280,8 +280,7 @@
 
   <Target Name="PrepareMergedTestPayloadDirectory"
       Outputs="%(_MergedWrapperRunScript.FileName)"
-      DependsOnTargets="DiscoverMergedTestWrappers"
-      Condition="'@(_MergedWrapperRunScript)' != ''">
+      DependsOnTargets="DiscoverMergedTestWrappers">
     <PropertyGroup>
       <_MergedWrapperDirectory>%(_MergedWrapperRunScript.RootDir)%(Directory)</_MergedWrapperDirectory>
       <_MergedWrapperName>%(_MergedWrapperRunScript.FileName)</_MergedWrapperName>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -158,7 +158,6 @@
   </Target>
 
   <Target Name="PrepareLegacyPayloadDirectory"
-      Condition="'@(_XUnitWrapperDll)' != ''"
       Outputs="%(_XUnitWrapperDll.FileName)%(PayloadGroup)"
       DependsOnTargets="DiscoverLegacyXUnitWrappers">
     <PropertyGroup>
@@ -223,10 +222,10 @@
 
     <ItemGroup>
       <_PayloadGroups Include="$(PayloadGroups)" />
-      <_ProjectsToBuild Include="testenvironment.proj">
+      <_ProjectsToBuild Include="testenvironment.proj" Condition="!$(IsMergedTestWrapper)">
         <Properties>Scenario=$(Scenario);TestEnvFileName=$(LegacyPayloadsRootDirectory)%(_PayloadGroups.Identity)\$(TestEnvFileName);TargetsWindows=$(TestWrapperTargetsWindows);RuntimeVariant=$(_RuntimeVariant)</Properties>
       </_ProjectsToBuild>
-      <_ProjectsToBuild Include="testenvironment.proj">
+      <_ProjectsToBuild Include="testenvironment.proj" Condition="$(IsMergedTestWrapper)">
         <Properties>Scenario=$(Scenario);TestEnvFileName=$(MergedPayloadsRootDirectory)%(_PayloadGroups.Identity)\$(TestEnvFileName);TargetsWindows=$(TestWrapperTargetsWindows);RuntimeVariant=$(_RuntimeVariant)</Properties>
       </_ProjectsToBuild>
     </ItemGroup>
@@ -244,13 +243,13 @@
 
   <Target Name="PrepareLegacyPayloadDirectories" DependsOnTargets="PrepareLegacyPayloadDirectory">
     <PropertyGroup>
-      <_PayloadGroups>@(_XUnitWrapperDll->Metadata('PayloadGroup')->DistinctWithCase())</_PayloadGroups>
+      <_LegacyPayloadGroups>@(_XUnitWrapperDll->Metadata('PayloadGroup')->DistinctWithCase())</_LegacyPayloadGroups>
     </PropertyGroup>
 
     <ItemGroup>
       <_Scenario Include="$(_Scenarios.Split(','))" />
       <_ProjectsToBuild Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=$(_PayloadGroups)</AdditionalProperties>
+        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=$(_LegacyPayloadGroups);IsMergedTestWrapper=false</AdditionalProperties>
       </_ProjectsToBuild>
     </ItemGroup>
 
@@ -258,10 +257,14 @@
   </Target>
 
   <Target Name="PrepareMergedTestPayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectory">
+    <PropertyGroup>
+      <_MergedPayloadGroups>@(_MergedWrapperName)</_MergedPayloadGroups>
+    </PropertyGroup>
+
     <ItemGroup>
       <_Scenario Include="$(_Scenarios.Split(','))" />
       <_ProjectsToBuild Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_MergedWrapperName)</AdditionalProperties>
+        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_MergedPayloadGroups);IsMergedTestWrapper=true</AdditionalProperties>
       </_ProjectsToBuild>
     </ItemGroup>
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -270,8 +270,6 @@
       <_MergedWrapperMarker Include="$(TestBinDir)**\*.MergedTestAssembly" />
       <_MergedWrapperRunScript Include="$([System.IO.Path]::ChangeExtension('%(_MergedWrapperMarker.Identity)', '.$(TestScriptExtension)'))" />
     </ItemGroup>
-
-    <Exec Command="chmod a+rwx %(_MergedWrapperRunScript.Identity)" Condition="'$(TargetOSSpec)' != 'windows'" />
   </Target>
 
   <Target Name="PrepareMergedTestPayloadDirectory"
@@ -443,6 +441,10 @@
       <MergedTestHelixCommand>$([System.IO.File]::ReadAllText('%(PayloadHelixCommandFile)'))</MergedTestHelixCommand>
       <PayloadGroup>$([System.IO.Path]::GetDirectoryName('%(MergedTestHelixCommand)').Replace('/', '-').Replace('\', '-'))</PayloadGroup>
       <PayloadZipFile>$(MergedPayloadsRootDirectory)%(PayloadGroup).zip</PayloadZipFile>
+    </MergedPayloads>
+
+    <MergedPayloads Update="@(MergedPayloads)" Condition="'$(TargetOSSpec)' != 'windows'">
+      <MergedTestHelixCommand>chmod +x %(MergedPayloads.MergedTestHelixCommand) && %(MergedPayloads.MergedTestHelixCommand)</MergedTestHelixCommand>
     </MergedPayloads>
 
     <HelixWorkItem Include="@(LegacyPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -278,9 +278,6 @@
       <!-- Remove the managed pdbs from our payloads.
            This is for performance reasons to reduce our helix payload size  -->
       <ReducedPayloadFiles Include="@(_PayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
-
-      <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.sh' and '$(TestWrapperTargetsWindows)' == 'true' "/>
-      <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.cmd' and '$(TestWrapperTargetsWindows)' != 'true' "/>
     </ItemGroup>
 
     <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -255,7 +255,6 @@
 
   <Target Name="PrepareMergedTestPayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectory">
     <ItemGroup>
-      <_MergedPayloadGroups Include="$(_MergedWrapperName)" />
       <_Scenario Include="$(_Scenarios.Split(','))" />
       <_ProjectsToBuild Include="$(MSBuildProjectFile)">
         <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_MergedPayloadGroups);IsMergedTestWrapper=true</AdditionalProperties>
@@ -282,6 +281,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <_MergedPayloadGroups Include="$(_MergedWrapperName)" />
       <_MergedPayloadFiles Include="$(_MergedWrapperDirectory)**" />
       <_MergedPayloadFiles Update="@(_MergedPayloadFiles)">
         <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -7,6 +7,14 @@
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props" Condition=" '$(UsesHelixSdk)' == 'true' " />
   <Import Sdk="Microsoft.Build.NoTargets" Project="Sdk.props" Condition=" '$(UsesHelixSdk)' != 'true' " />
 
+  <PropertyGroup>
+    <CoreRootDirectory>$(TestBinDir)Tests\Core_Root\</CoreRootDirectory>
+    <LegacyPayloadsRootDirectory>$(TestBinDir)LegacyPayloads\</LegacyPayloadsRootDirectory>
+    <LegacyPayloadsRootDirectory>$([MSBuild]::NormalizeDirectory($(LegacyPayloadsRootDirectory)))</LegacyPayloadsRootDirectory>
+    <MergedPayloadsRootDirectory>$(TestBinDir)MergedPayloads\</MergedPayloadsRootDirectory>
+    <MergedPayloadsRootDirectory>$([MSBuild]::NormalizeDirectory($(MergedPayloadsRootDirectory)))</MergedPayloadsRootDirectory>
+  </PropertyGroup>
+
   <!-- This target runs once and creates several instances of this project (one for each scenario)
        that will run in parallel. -->
 
@@ -40,7 +48,6 @@
         PALTestsDir=$(_PALTestsDir)
       </_PropertiesToPass>
 
-
       <_PropertiesToPass Condition="'$(TargetOS)' == 'Browser' Or '$(TargetOS)' == 'Android'">
         $(_PropertiesToPass);
         IncludeDotNetCli=$(IncludeDotNetCli);
@@ -53,6 +60,13 @@
     <Message Text="DotNetCliPackageType: $(DotNetCliPackageType)" Importance="High" />
     <Message Text="HelixRuntimeRid: $(HelixRuntimeRid)" Importance="High" />
     <Error Condition="'$(_Scenarios)' == ''" Text="_Scenarios not set" />
+
+    <ItemGroup>
+      <CleanPreexistingPayloads Include="$(LegacyPayloadsRootDirectory)**" />
+      <CleanPreexistingPayloads Include="$(MergedPayloadsRootDirectory)**" />
+    </ItemGroup>
+
+    <Delete Files="@(CleanPreexistingPayloads)" />
 
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="PrepareCorrelationPayloadDirectory" />
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePayloadDirectories" Properties="Scenarios=$(_Scenarios)" StopOnFirstFailure="true" />
@@ -88,9 +102,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <CoreRootDirectory>$(TestBinDir)Tests\Core_Root\</CoreRootDirectory>
-    <PayloadsRootDirectory>$(TestBinDir)Payloads\</PayloadsRootDirectory>
-    <PayloadsRootDirectory>$([MSBuild]::NormalizeDirectory($(PayloadsRootDirectory)))</PayloadsRootDirectory>
     <TestEnvFileName Condition=" '$(TestWrapperTargetsWindows)' == 'true' ">SetStressModes_$(Scenario).cmd</TestEnvFileName>
     <TestEnvFileName Condition=" '$(TestWrapperTargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
 
@@ -132,9 +143,9 @@
       <_XUnitWrapperDll Include="@(XUnitWrapperGrouping)" />
 
       <!-- This adds the remaining *.XUnitWrapper.dll files in TestBinDir unless
-           1) they are in PayloadsRootDirectory or
+           1) they are in LegacyPayloadsRootDirectory or
            2) they are grouped by XUnitWrapperGrouping. -->
-      <_XUnitWrapperDll Include="$(TestBinDir)**\*.XUnitWrapper.dll" Exclude="$(PayloadsRootDirectory)**\*.XUnitWrapper.dll;@(XUnitWrapperGrouping->Metadata('FullPath'))">
+      <_XUnitWrapperDll Include="$(TestBinDir)**\*.XUnitWrapper.dll" Exclude="$(LegacyPayloadsRootDirectory)**\*.XUnitWrapper.dll;@(XUnitWrapperGrouping->Metadata('FullPath'))">
          <!-- Set PayloadGroup to empty string, so we can update _XUnitWrapperDll items with no PayloadGroup to default value. Unfortunatelly, we can't do this right here. -->
          <PayloadGroup></PayloadGroup>
       </_XUnitWrapperDll>
@@ -146,14 +157,10 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="DiscoverMergedTestWrappers">
-    <ItemGroup>
-      <_MergedWrapperMarker Include="$(TestBinDir)**\*.MergedTestAssembly" />
-      <_MergedWrapperRunScript Include="$([System.IO.Path]::ChangeExtension('%(_MergedWrapperMarker.Identity)', '.$(TestScriptExtension)'))" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="PrepareLegacyPayloadDirectory" Outputs="%(_XUnitWrapperDll.FileName)%(PayloadGroup)" DependsOnTargets="DiscoverLegacyXUnitWrappers">
+  <Target Name="PrepareLegacyPayloadDirectory"
+      Condition="'@(_XUnitWrapperDll)' != ''"
+      Outputs="%(_XUnitWrapperDll.FileName)%(PayloadGroup)"
+      DependsOnTargets="DiscoverLegacyXUnitWrappers">
     <PropertyGroup>
       <_FileDirectory>%(_XUnitWrapperDll.RootDir)%(Directory)</_FileDirectory>
       <_PayloadGroup>%(_XUnitWrapperDll.PayloadGroup)</_PayloadGroup>
@@ -194,7 +201,7 @@
       <ReducedPayloadFilesFinal Remove="@(_MergedWrapperRunScript)" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
+    <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(LegacyPayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
   </Target>
 
   <Target Name="PrepareCorrelationPayloadDirectory">
@@ -217,7 +224,10 @@
     <ItemGroup>
       <_PayloadGroups Include="$(PayloadGroups)" />
       <_ProjectsToBuild Include="testenvironment.proj">
-        <Properties>Scenario=$(Scenario);TestEnvFileName=$(PayloadsRootDirectory)%(_PayloadGroups.Identity)\$(TestEnvFileName);TargetsWindows=$(TestWrapperTargetsWindows);RuntimeVariant=$(_RuntimeVariant)</Properties>
+        <Properties>Scenario=$(Scenario);TestEnvFileName=$(LegacyPayloadsRootDirectory)%(_PayloadGroups.Identity)\$(TestEnvFileName);TargetsWindows=$(TestWrapperTargetsWindows);RuntimeVariant=$(_RuntimeVariant)</Properties>
+      </_ProjectsToBuild>
+      <_ProjectsToBuild Include="testenvironment.proj">
+        <Properties>Scenario=$(Scenario);TestEnvFileName=$(MergedPayloadsRootDirectory)%(_PayloadGroups.Identity)\$(TestEnvFileName);TargetsWindows=$(TestWrapperTargetsWindows);RuntimeVariant=$(_RuntimeVariant)</Properties>
       </_ProjectsToBuild>
     </ItemGroup>
 
@@ -227,7 +237,7 @@
   <Target Name="PreparePALTestArchive">
     <Exec Condition="'$(PALTestsDir)' != '' and '$(TestWrapperTargetsWindows)' != 'true'"
           WorkingDirectory="$(PALTestsDir)"
-          Command="tar -czvf $(PayloadsRootDirectory)paltests.tar.gz `ls -A`"/>
+          Command="tar -czvf $(LegacyPayloadsRootDirectory)paltests.tar.gz `ls -A`"/>
   </Target>
 
   <Target Name="PreparePayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectories;PrepareLegacyPayloadDirectories" />
@@ -258,13 +268,21 @@
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
   </Target>
 
+  <Target Name="DiscoverMergedTestWrappers">
+    <ItemGroup>
+      <_MergedWrapperMarker Include="$(TestBinDir)**\*.MergedTestAssembly" />
+      <_MergedWrapperRunScript Include="$([System.IO.Path]::ChangeExtension('%(_MergedWrapperMarker.Identity)', '.$(TestScriptExtension)'))" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="PrepareMergedTestPayloadDirectory" Outputs="%(_MergedWrapperRunScript.FileName)" DependsOnTargets="DiscoverMergedTestWrappers">
     <PropertyGroup>
       <_MergedWrapperDirectory>%(_MergedWrapperRunScript.RootDir)%(Directory)</_MergedWrapperDirectory>
+      <_MergedWrapperName>%(_MergedWrapperRunScript.FileName)</_MergedWrapperName>
+      <_MergedWrapperRunScriptRelative>$([System.IO.Path]::GetRelativePath($(TestBinDir), %(_MergedWrapperRunScript.FullPath)))</_MergedWrapperRunScriptRelative>
     </PropertyGroup>
 
     <ItemGroup>
-      <_MergedWrapperName Include="%(_MergedWrapperRunScript.FileName)" />
       <_PayloadFiles Include="$(_MergedWrapperDirectory)**" />
       <_PayloadFiles Update="@(_PayloadFiles)">
         <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
@@ -279,8 +297,8 @@
       <ReducedPayloadFilesFinal Include="@(_PayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
     </ItemGroup>
 
-    <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
-    <WriteLinesToFile File="$(PayloadsRootDirectory)\%(_MergedWrapperRunScript.FileName)\Launch.txt" Lines="%(_MergedWrapperRunScript.Identity)" />
+    <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\%(FileRelativeToPayloadsRootDirectory)')" />
+    <WriteLinesToFile File="$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\Launch.txt" Lines="$(_MergedWrapperRunScriptRelative)" />
   </Target>
 
   <PropertyGroup>
@@ -288,16 +306,28 @@
     <IsRunningOnMobileTargets Condition="'$(TargetOS)' == 'Android' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator' ">true</IsRunningOnMobileTargets>
   </PropertyGroup>
 
-  <Target Name="ZipPayloadDirectory" AfterTargets="PrepareLegacyPayloadDirectories" Condition="'$(IsRunningOnMobileTargets)' == 'true'">
+  <Target Name="ZipLegacyPayloadDirectory" AfterTargets="PrepareLegacyPayloadDirectories" Condition="'$(IsRunningOnMobileTargets)' == 'true'">
     <ItemGroup>
-      <Payloads Include="$([System.IO.Directory]::GetDirectories($(PayloadsRootDirectory)))" Condition="Exists('$(PayloadsRootDirectory)')" />
-      <Payloads Update="@(Payloads)">
-        <PayloadGroup>$([MSBuild]::MakeRelative($(PayloadsRootDirectory), %(FullPath)))</PayloadGroup>
+      <LegacyPayloads Include="$([System.IO.Directory]::GetDirectories($(LegacyPayloadsRootDirectory)))" Condition="Exists('$(LegacyPayloadsRootDirectory)')" />
+      <LegacyPayloads Update="@(LegacyPayloads)">
+        <PayloadGroup>$([MSBuild]::MakeRelative($(LegacyPayloadsRootDirectory), %(FullPath)))</PayloadGroup>
         <PayloadDirectory>%(FullPath)</PayloadDirectory>
-      </Payloads>
+      </LegacyPayloads>
     </ItemGroup>
 
-    <ZipDirectory SourceDirectory="@(Payloads->Metadata('PayloadDirectory'))" DestinationFile="$(PayloadsRootDirectory)\%(Payloads.PayloadGroup).zip" />
+    <ZipDirectory SourceDirectory="@(LegacyPayloads->Metadata('PayloadDirectory'))" DestinationFile="$(LegacyPayloadsRootDirectory)\%(LegacyPayloads.PayloadGroup).zip" />
+  </Target>
+
+  <Target Name="ZipMergedPayloadDirectory" AfterTargets="PrepareMergedPayloadDirectories" Condition="'$(IsRunningOnMobileTargets)' == 'true'">
+    <ItemGroup>
+      <MergedPayloads Include="$([System.IO.Directory]::GetDirectories($(MergedPayloadsRootDirectory)))" Condition="Exists('$(MergedPayloadsRootDirectory)')" />
+      <MergedPayloads Update="@(MergedPayloads)">
+        <PayloadGroup>$([MSBuild]::MakeRelative($(MergedPayloadsRootDirectory), %(FullPath)))</PayloadGroup>
+        <PayloadDirectory>%(FullPath)</PayloadDirectory>
+      </MergedPayloads>
+    </ItemGroup>
+
+    <ZipDirectory SourceDirectory="@(MergedPayloads->Metadata('PayloadDirectory'))" DestinationFile="$(MergedPayloadsRootDirectory)\%(MergedPayloads.PayloadGroup).zip" />
   </Target>
 
   <PropertyGroup>
@@ -388,35 +418,57 @@
   <ItemGroup Condition=" '$(UsesHelixSdk)' == 'true' ">
     <HelixCorrelationPayload Include="$(CoreRootDirectory)" />
 
-    <Payloads Include="$([System.IO.Directory]::GetDirectories($(PayloadsRootDirectory)))" Condition="Exists('$(PayloadsRootDirectory)')" />
-    <Payloads Update="@(Payloads)">
-      <PayloadGroup>$([MSBuild]::MakeRelative($(PayloadsRootDirectory), %(FullPath)))</PayloadGroup>
+    <LegacyPayloads Include="$([System.IO.Directory]::GetDirectories($(LegacyPayloadsRootDirectory)))" Condition="Exists('$(LegacyPayloadsRootDirectory)')" />
+    <LegacyPayloads Update="@(LegacyPayloads)">
+      <PayloadGroup>$([MSBuild]::MakeRelative($(LegacyPayloadsRootDirectory), %(FullPath)))</PayloadGroup>
       <PayloadDirectory>%(FullPath)</PayloadDirectory>
       <XUnitWrapperDlls>$([System.String]::Join(' ', $([System.IO.Directory]::GetFiles(%(FullPath), '*.XUnitWrapper.dll', SearchOption.AllDirectories))).Replace($([MSBuild]::EnsureTrailingSlash(%(FullPath))),''))</XUnitWrapperDlls>
-      <IsMergedTestWrapper>false</IsMergedTestWrapper>
-    </Payloads>
-
-    <Payloads Update="@(Payloads)">
+    </LegacyPayloads>
+    <LegacyPayloads Update="@(LegacyPayloads)">
       <TestGroup>%(PayloadGroup)</TestGroup>
       <!-- When Payload contains more than one *.XUnitWrapper.dll TestGroup should not be specified. -->
       <TestGroup Condition=" $([MSBuild]::ValueOrDefault(%(XUnitWrapperDlls), '').IndexOf('.XUnitWrapper.dll')) != $([MSBuild]::ValueOrDefault(%(XUnitWrapperDlls), '').LastIndexOf('.XUnitWrapper.dll')) "></TestGroup>
-      <PayloadZipFile>$(PayloadsRootDirectory)\%(PayloadGroup).zip</PayloadZipFile>
-    </Payloads>
+      <PayloadZipFile>$(LegacyPayloadsRootDirectory)\%(PayloadGroup).zip</PayloadZipFile>
+    </LegacyPayloads>
 
-    <HelixWorkItem Include="@(Payloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">
+    <MergedPayloads Include="$([System.IO.Directory]::GetDirectories($(MergedPayloadsRootDirectory)))" Condition="Exists('$(MergedPayloadsRootDirectory)')" />
+
+    <MergedPayloads Update="@(MergedPayloads)">
+      <PayloadGroup>$([MSBuild]::MakeRelative($(MergedPayloadsRootDirectory), %(FullPath)))</PayloadGroup>
+      <PayloadDirectory>%(FullPath)</PayloadDirectory>
+      <PayloadLaunchFile>$(MergedPayloadsRootDirectory)%(FileName)\Launch.txt</PayloadLaunchFile>
+    </MergedPayloads>
+
+    <MergedPayloads Update="@(MergedPayloads)">
+      <MergedTestRunScript>$(MergedPayloadsRootDirectory)%(PayloadGroup)\$([System.IO.File]::ReadAllText('%(PayloadLaunchFile)'))</MergedTestRunScript>
+      <PayloadZipFile>$(MergedPayloadsRootDirectory)%(PayloadGroup).zip</PayloadZipFile>
+    </MergedPayloads>
+
+    <HelixWorkItem Include="@(LegacyPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">
       <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
       <Command>dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs)</Command>
       <Command Condition=" '%(TestGroup)' != '' ">dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</Command>
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
     </HelixWorkItem>
 
-    <XHarnessApkToTest Include="@(Payloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'Android'">
+    <HelixWorkItem Include="@(MergedPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">
+      <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
+      <Command>%(MergedTestRunScript)</Command>
+      <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
+    </HelixWorkItem>
+
+    <XHarnessApkToTest Include="@(LegacyPayloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'Android'">
       <TestTimeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</TestTimeout>
       <CustomCommands>dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs)</CustomCommands>
       <CustomCommands Condition=" '%(TestGroup)' != '' ">dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</CustomCommands>
     </XHarnessApkToTest>
     
-    <XHarnessAppBundleToTest Include="@(Payloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator'">
+    <XHarnessApkToTest Include="@(MergedPayloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'Android'">
+      <TestTimeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</TestTimeout>
+      <CustomCommands>%(MergedTestRunScript)</CustomCommands>
+    </XHarnessApkToTest>
+    
+    <XHarnessAppBundleToTest Include="@(LegacyPayloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator'">
       <TestTarget Condition="'$(TargetArchitecture)' == 'arm64'">ios-simulator-64</TestTarget>
       <TestTarget Condition="'$(TargetArchitecture)' == 'x64'">ios-simulator-64</TestTarget>
       <TestTimeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</TestTimeout>
@@ -424,8 +476,15 @@
       <CustomCommands Condition=" '%(TestGroup)' != '' ">dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</CustomCommands>
     </XHarnessAppBundleToTest>
 
+    <XHarnessAppBundleToTest Include="@(MergedPayloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator'">
+      <TestTarget Condition="'$(TargetArchitecture)' == 'arm64'">ios-simulator-64</TestTarget>
+      <TestTarget Condition="'$(TargetArchitecture)' == 'x64'">ios-simulator-64</TestTarget>
+      <TestTimeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</TestTimeout>
+      <CustomCommands>%(MergedTestRunScript)</CustomCommands>
+    </XHarnessAppBundleToTest>
+
     <HelixWorkItem Condition="'$(PALTestsDir)' != '' and '$(TestWrapperTargetsWindows)' != 'true'" Include="PALTests">
-      <PayloadArchive>$(PayloadsRootDirectory)paltests.tar.gz</PayloadArchive>
+      <PayloadArchive>$(LegacyPayloadsRootDirectory)paltests.tar.gz</PayloadArchive>
       <Command>./runpaltestshelix.sh</Command>
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
     </HelixWorkItem>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -271,7 +271,7 @@
       <_MergedWrapperRunScript Include="$([System.IO.Path]::ChangeExtension('%(_MergedWrapperMarker.Identity)', '.$(TestScriptExtension)'))" />
     </ItemGroup>
 
-    <Exec Command="chmod +x %(_MergedWrapperRunScript.Identity)" Condition="'$(TargetOSSpec)' != 'windows'" />
+    <Exec Command="chmod a+rwx %(_MergedWrapperRunScript.Identity)" Condition="'$(TargetOSSpec)' != 'windows'" />
   </Target>
 
   <Target Name="PrepareMergedTestPayloadDirectory"
@@ -435,13 +435,13 @@
     <MergedPayloads Include="$([System.IO.Directory]::GetDirectories($(MergedPayloadsRootDirectory)))" Condition="Exists('$(MergedPayloadsRootDirectory)')" />
 
     <MergedPayloads Update="@(MergedPayloads)">
-      <PayloadGroup>$([MSBuild]::MakeRelative($(MergedPayloadsRootDirectory), %(FullPath)))</PayloadGroup>
       <PayloadDirectory>%(FullPath)</PayloadDirectory>
       <PayloadHelixCommandFile>$(MergedPayloadsRootDirectory)%(FileName)\HelixCommand.txt</PayloadHelixCommandFile>
     </MergedPayloads>
 
     <MergedPayloads Update="@(MergedPayloads)">
       <MergedTestHelixCommand>$([System.IO.File]::ReadAllText('%(PayloadHelixCommandFile)'))</MergedTestHelixCommand>
+      <PayloadGroup>$([System.IO.Path]::GetDirectoryName('%(MergedTestHelixCommand)'))</PayloadGroup>
       <PayloadZipFile>$(MergedPayloadsRootDirectory)%(PayloadGroup).zip</PayloadZipFile>
     </MergedPayloads>
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -275,7 +275,10 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PrepareMergedTestPayloadDirectory" Outputs="%(_MergedWrapperRunScript.FileName)" DependsOnTargets="DiscoverMergedTestWrappers">
+  <Target Name="PrepareMergedTestPayloadDirectory"
+      Outputs="%(_MergedWrapperRunScript.FileName)"
+      DependsOnTargets="DiscoverMergedTestWrappers"
+      Condition="'@(_MergedWrapperRunScript)' != ''">
     <PropertyGroup>
       <_MergedWrapperDirectory>%(_MergedWrapperRunScript.RootDir)%(Directory)</_MergedWrapperDirectory>
       <_MergedWrapperName>%(_MergedWrapperRunScript.FileName)</_MergedWrapperName>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -443,7 +443,7 @@
       <PayloadZipFile>$(MergedPayloadsRootDirectory)%(PayloadGroup).zip</PayloadZipFile>
     </MergedPayloads>
 
-    <MergedPayloads Update="@(MergedPayloads)" Condition="'$(TargetOSSpec)' != 'windows'">
+    <MergedPayloads Update="@(MergedPayloads)" Condition="'$(TargetOS)' != 'windows'">
       <MergedTestHelixCommand>chmod +x %(MergedPayloads.MergedTestHelixCommand)%0A%(MergedPayloads.MergedTestHelixCommand)</MergedTestHelixCommand>
     </MergedPayloads>
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -168,7 +168,7 @@
       <_TestGroupingExists>@(_TestGroupingRelevant->AnyHaveMetadataValue('TestGroup','$(_PayloadGroup)'))</_TestGroupingExists>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(_FileDirectory)' != ''">
       <!-- If no TestGrouping is defined, all the files under $(_FileDirectory) and its subdirectories goes to the PayloadDirectory. -->
       <_PayloadFiles Include="$(_FileDirectory)**" Exclude="@(_TestGroupingRelevant)" Condition="'$(_TestGroupingExists)' != 'true'" />
       <!-- If there is a TestGrouping, then take only the files that belong to the TestGroup == $(_PayloadGroup). -->
@@ -248,16 +248,10 @@
   </Target>
 
   <Target Name="PrepareMergedTestPayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectory">
-    <PropertyGroup>
-      <_MergedWrapperDirectory>%(_MergedWrapperRunScript.RootDir)%(Directory)</_MergedWrapperDirectory>
-      <_MergedWrapperRelativeDir>%(_MergedWrapperRunScript.RelativeDir)</_MergedWrapperRelativeDir>
-      <_MergedWrapperFile>%(_MergedWrapperRunScript.FileName)</_MergedWrapperFile>
-    </PropertyGroup>
-
     <ItemGroup>
       <_Scenario Include="$(_Scenarios.Split(','))" />
       <_ProjectsToBuild Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_MergedWrapperRelativeDir)</AdditionalProperties>
+        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_MergedWrapperName)</AdditionalProperties>
       </_ProjectsToBuild>
     </ItemGroup>
 
@@ -265,7 +259,12 @@
   </Target>
 
   <Target Name="PrepareMergedTestPayloadDirectory" Outputs="%(_MergedWrapperRunScript.FileName)" DependsOnTargets="DiscoverMergedTestWrappers">
+    <PropertyGroup>
+      <_MergedWrapperDirectory>%(_MergedWrapperRunScript.RootDir)%(Directory)</_MergedWrapperDirectory>
+    </PropertyGroup>
+
     <ItemGroup>
+      <_MergedWrapperName Include="%(_MergedWrapperRunScript.FileName)" />
       <_PayloadFiles Include="$(_MergedWrapperDirectory)**" />
       <_PayloadFiles Update="@(_PayloadFiles)">
         <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
@@ -277,10 +276,11 @@
     <ItemGroup>
       <!-- Remove the managed pdbs from our payloads.
            This is for performance reasons to reduce our helix payload size  -->
-      <ReducedPayloadFiles Include="@(_PayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
+      <ReducedPayloadFilesFinal Include="@(_PayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
     </ItemGroup>
 
     <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
+    <WriteLinesToFile File="$(PayloadsRootDirectory)\%(_MergedWrapperRunScript.FileName)\Launch.txt" Lines="%(_MergedWrapperRunScript.Identity)" />
   </Target>
 
   <PropertyGroup>
@@ -393,6 +393,7 @@
       <PayloadGroup>$([MSBuild]::MakeRelative($(PayloadsRootDirectory), %(FullPath)))</PayloadGroup>
       <PayloadDirectory>%(FullPath)</PayloadDirectory>
       <XUnitWrapperDlls>$([System.String]::Join(' ', $([System.IO.Directory]::GetFiles(%(FullPath), '*.XUnitWrapper.dll', SearchOption.AllDirectories))).Replace($([MSBuild]::EnsureTrailingSlash(%(FullPath))),''))</XUnitWrapperDlls>
+      <IsMergedTestWrapper>false</IsMergedTestWrapper>
     </Payloads>
 
     <Payloads Update="@(Payloads)">

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -176,31 +176,31 @@
 
     <ItemGroup Condition="'$(_FileDirectory)' != ''">
       <!-- If no TestGrouping is defined, all the files under $(_FileDirectory) and its subdirectories goes to the PayloadDirectory. -->
-      <_PayloadFiles Include="$(_FileDirectory)**" Exclude="@(_TestGroupingRelevant)" Condition="'$(_TestGroupingExists)' != 'true'" />
+      <_LegacyPayloadFiles Include="$(_FileDirectory)**" Exclude="@(_TestGroupingRelevant)" Condition="'$(_TestGroupingExists)' != 'true'" />
       <!-- If there is a TestGrouping, then take only the files that belong to the TestGroup == $(_PayloadGroup). -->
-      <_PayloadFiles Include="@(_TestGroupingRelevant->WithMetadataValue('TestGroup','$(_PayloadGroup)')->DistinctWithCase())" Condition="'$(_TestGroupingExists)' == 'true'" />
-      <_PayloadFiles Include="$(_FileDirectory)*" Condition="'$(_TestGroupingExists)' == 'true'" />
-      <_PayloadFiles Include="$(_FileDirectory)/*.app" Condition="'$(_TestGroupingExists)' == 'true'" />
-      <_PayloadFiles Include="$(_FileDirectory)/*.app/**" Condition="'$(_TestGroupingExists)' == 'true'" />
+      <_LegacyPayloadFiles Include="@(_TestGroupingRelevant->WithMetadataValue('TestGroup','$(_PayloadGroup)')->DistinctWithCase())" Condition="'$(_TestGroupingExists)' == 'true'" />
+      <_LegacyPayloadFiles Include="$(_FileDirectory)*" Condition="'$(_TestGroupingExists)' == 'true'" />
+      <_LegacyPayloadFiles Include="$(_FileDirectory)/*.app" Condition="'$(_TestGroupingExists)' == 'true'" />
+      <_LegacyPayloadFiles Include="$(_FileDirectory)/*.app/**" Condition="'$(_TestGroupingExists)' == 'true'" />
 
-      <_PayloadFiles Update="@(_PayloadFiles)">
+      <_LegacyPayloadFiles Update="@(_LegacyPayloadFiles)">
         <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
              MakeRelative function calls Escape function internally that replaces all the Unicode characters with %<xx>. -->
         <FileRelativeToPayloadsRootDirectory>$(_PayloadGroup)\$([System.IO.Path]::GetRelativePath($(TestBinDir), %(FullPath)))</FileRelativeToPayloadsRootDirectory>
-      </_PayloadFiles>
+      </_LegacyPayloadFiles>
     </ItemGroup>
 
     <ItemGroup>
       <!-- Remove the managed pdbs from our payloads.
            This is for performance reasons to reduce our helix payload size  -->
-      <ReducedPayloadFiles Include="@(_PayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
+      <ReducedLegacyPayloadFiles Include="@(_LegacyPayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
 
-      <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.sh' and '$(TestWrapperTargetsWindows)' == 'true' "/>
-      <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.cmd' and '$(TestWrapperTargetsWindows)' != 'true' "/>
-      <ReducedPayloadFilesFinal Remove="@(_MergedWrapperRunScript)" />
+      <ReducedLegacyPayloadFilesFinal Include="@(ReducedLegacyPayloadFiles)" Condition=" '%(Extension)' != '.sh' and '$(TestWrapperTargetsWindows)' == 'true' "/>
+      <ReducedLegacyPayloadFilesFinal Include="@(ReducedLegacyPayloadFiles)" Condition=" '%(Extension)' != '.cmd' and '$(TestWrapperTargetsWindows)' != 'true' "/>
+      <ReducedLegacyPayloadFilesFinal Remove="@(_MergedWrapperRunScript)" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(LegacyPayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
+    <Copy SourceFiles="@(ReducedLegacyPayloadFilesFinal)" DestinationFiles="@(ReducedLegacyPayloadFilesFinal->'$(LegacyPayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
   </Target>
 
   <Target Name="PrepareCorrelationPayloadDirectory">
@@ -217,7 +217,7 @@
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/tieringtest.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' != 'true' and '$(_TieringTest)' == 'true'" />
   </Target>
 
-  <Target Name="CreateTestEnvFiles">
+  <Target Name="CreateTestEnvFiles" Condition="'$(PayloadGroups)' != ''">
     <!-- This target creates one __TestEnv file for each combination of %(_PayloadGroups.Identity) and $(Scenario). -->
 
     <ItemGroup>
@@ -282,22 +282,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_PayloadFiles Include="$(_MergedWrapperDirectory)**" />
-      <_PayloadFiles Update="@(_PayloadFiles)">
+      <_MergedPayloadFiles Include="$(_MergedWrapperDirectory)**" />
+      <_MergedPayloadFiles Update="@(_MergedPayloadFiles)">
         <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
              MakeRelative function calls Escape function internally that replaces all the Unicode characters with %<xx>. -->
         <FileRelativeToPayloadsRootDirectory>$([System.IO.Path]::GetRelativePath($(TestBinDir), %(FullPath)))</FileRelativeToPayloadsRootDirectory>
-      </_PayloadFiles>
+      </_MergedPayloadFiles>
     </ItemGroup>
 
     <ItemGroup>
       <!-- Remove the managed pdbs from our payloads.
            This is for performance reasons to reduce our helix payload size  -->
-      <ReducedPayloadFilesFinal Include="@(_PayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
+      <ReducedMergedPayloadFilesFinal Include="@(_MergedPayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
     </ItemGroup>
 
-    <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\%(FileRelativeToPayloadsRootDirectory)')" />
-    <WriteLinesToFile File="$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\Launch.txt" Lines="$(_MergedWrapperRunScriptRelative)" />
+    <Copy SourceFiles="@(ReducedMergedPayloadFilesFinal)" DestinationFiles="@(ReducedMergedPayloadFilesFinal->'$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\%(FileRelativeToPayloadsRootDirectory)')" />
+    <WriteLinesToFile File="$(MergedPayloadsRootDirectory)\$(_MergedWrapperName)\HelixCommand.txt" Lines="$(_MergedWrapperRunScriptRelative)" />
   </Target>
 
   <PropertyGroup>
@@ -435,11 +435,11 @@
     <MergedPayloads Update="@(MergedPayloads)">
       <PayloadGroup>$([MSBuild]::MakeRelative($(MergedPayloadsRootDirectory), %(FullPath)))</PayloadGroup>
       <PayloadDirectory>%(FullPath)</PayloadDirectory>
-      <PayloadLaunchFile>$(MergedPayloadsRootDirectory)%(FileName)\Launch.txt</PayloadLaunchFile>
+      <PayloadHelixCommandFile>$(MergedPayloadsRootDirectory)%(FileName)\HelixCommand.txt</PayloadHelixCommandFile>
     </MergedPayloads>
 
     <MergedPayloads Update="@(MergedPayloads)">
-      <MergedTestRunScript>$([System.IO.File]::ReadAllText('%(PayloadLaunchFile)'))</MergedTestRunScript>
+      <MergedTestHelixCommand>$([System.IO.File]::ReadAllText('%(PayloadHelixCommandFile)'))</MergedTestHelixCommand>
       <PayloadZipFile>$(MergedPayloadsRootDirectory)%(PayloadGroup).zip</PayloadZipFile>
     </MergedPayloads>
 
@@ -452,7 +452,7 @@
 
     <HelixWorkItem Include="@(MergedPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">
       <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
-      <Command>%(MergedTestRunScript)</Command>
+      <Command>%(MergedTestHelixCommand)</Command>
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
     </HelixWorkItem>
 
@@ -464,7 +464,7 @@
     
     <XHarnessApkToTest Include="@(MergedPayloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'Android'">
       <TestTimeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</TestTimeout>
-      <CustomCommands>%(MergedTestRunScript)</CustomCommands>
+      <CustomCommands>%(MergedTestHelixCommand)</CustomCommands>
     </XHarnessApkToTest>
     
     <XHarnessAppBundleToTest Include="@(LegacyPayloads->Metadata('PayloadZipFile'))" Condition="'$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator'">
@@ -479,7 +479,7 @@
       <TestTarget Condition="'$(TargetArchitecture)' == 'arm64'">ios-simulator-64</TestTarget>
       <TestTarget Condition="'$(TargetArchitecture)' == 'x64'">ios-simulator-64</TestTarget>
       <TestTimeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</TestTimeout>
-      <CustomCommands>%(MergedTestRunScript)</CustomCommands>
+      <CustomCommands>%(MergedTestHelixCommand)</CustomCommands>
     </XHarnessAppBundleToTest>
 
     <HelixWorkItem Condition="'$(PALTestsDir)' != '' and '$(TestWrapperTargetsWindows)' != 'true'" Include="PALTests">

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -242,14 +242,11 @@
   <Target Name="PreparePayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectories;PrepareLegacyPayloadDirectories" />
 
   <Target Name="PrepareLegacyPayloadDirectories" DependsOnTargets="PrepareLegacyPayloadDirectory">
-    <PropertyGroup>
-      <_LegacyPayloadGroups>@(_XUnitWrapperDll->Metadata('PayloadGroup')->DistinctWithCase())</_LegacyPayloadGroups>
-    </PropertyGroup>
-
     <ItemGroup>
+      <_LegacyPayloadGroups Include="@(_XUnitWrapperDll->Metadata('PayloadGroup')->DistinctWithCase())" />
       <_Scenario Include="$(_Scenarios.Split(','))" />
       <_ProjectsToBuild Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=$(_LegacyPayloadGroups);IsMergedTestWrapper=false</AdditionalProperties>
+        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_LegacyPayloadGroups);IsMergedTestWrapper=false</AdditionalProperties>
       </_ProjectsToBuild>
     </ItemGroup>
 
@@ -257,11 +254,8 @@
   </Target>
 
   <Target Name="PrepareMergedTestPayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectory">
-    <PropertyGroup>
-      <_MergedPayloadGroups>@(_MergedWrapperName)</_MergedPayloadGroups>
-    </PropertyGroup>
-
     <ItemGroup>
+      <_MergedPayloadGroups Include="$(_MergedWrapperName)" />
       <_Scenario Include="$(_Scenarios.Split(','))" />
       <_ProjectsToBuild Include="$(MSBuildProjectFile)">
         <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_MergedPayloadGroups);IsMergedTestWrapper=true</AdditionalProperties>
@@ -284,7 +278,7 @@
     <PropertyGroup>
       <_MergedWrapperDirectory>%(_MergedWrapperRunScript.RootDir)%(Directory)</_MergedWrapperDirectory>
       <_MergedWrapperName>%(_MergedWrapperRunScript.FileName)</_MergedWrapperName>
-      <_MergedWrapperRunScriptRelative>$([System.IO.Path]::GetRelativePath($(TestBinDir), %(_MergedWrapperRunScript.FullPath)))</_MergedWrapperRunScriptRelative>
+      <_MergedWrapperRunScriptRelative Condition="'%(_MergedWrapperRunScript.Identity)' != ''">$([System.IO.Path]::GetRelativePath($(TestBinDir), %(_MergedWrapperRunScript.FullPath)))</_MergedWrapperRunScriptRelative>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -441,7 +441,7 @@
 
     <MergedPayloads Update="@(MergedPayloads)">
       <MergedTestHelixCommand>$([System.IO.File]::ReadAllText('%(PayloadHelixCommandFile)'))</MergedTestHelixCommand>
-      <PayloadGroup>$([System.IO.Path]::GetDirectoryName('%(MergedTestHelixCommand)'))</PayloadGroup>
+      <PayloadGroup>$([System.IO.Path]::GetDirectoryName('%(MergedTestHelixCommand)').Replace('/', '-').Replace('\', '-'))</PayloadGroup>
       <PayloadZipFile>$(MergedPayloadsRootDirectory)%(PayloadGroup).zip</PayloadZipFile>
     </MergedPayloads>
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -445,7 +445,7 @@
     </MergedPayloads>
 
     <MergedPayloads Update="@(MergedPayloads)">
-      <MergedTestRunScript>$(MergedPayloadsRootDirectory)%(PayloadGroup)\$([System.IO.File]::ReadAllText('%(PayloadLaunchFile)'))</MergedTestRunScript>
+      <MergedTestRunScript>$([System.IO.File]::ReadAllText('%(PayloadLaunchFile)'))</MergedTestRunScript>
       <PayloadZipFile>$(MergedPayloadsRootDirectory)%(PayloadGroup).zip</PayloadZipFile>
     </MergedPayloads>
 

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -55,7 +55,7 @@
     <Error Condition="'$(_Scenarios)' == ''" Text="_Scenarios not set" />
 
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="PrepareCorrelationPayloadDirectory" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePayloadsDirectories" Properties="Scenarios=$(_Scenarios)" StopOnFirstFailure="true" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePayloadDirectories" Properties="Scenarios=$(_Scenarios)" StopOnFirstFailure="true" />
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePALTestArchive" Properties="$(_PropertiesToPass)" StopOnFirstFailure="true" />
 
     <ItemGroup>
@@ -124,7 +124,7 @@
 
   <Import Project="testgrouping.proj" />
 
-  <Target Name="DiscoverAllXUnitWrappers">
+  <Target Name="DiscoverLegacyXUnitWrappers">
     <ItemGroup>
       <_XUnitWrapperDll Include="%(TestGrouping.XUnitWrapperDll)" Condition="Exists('%(XUnitWrapperDll)')">
         <PayloadGroup>%(TestGroup)</PayloadGroup>
@@ -146,7 +146,14 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PreparePayloadDirectory" Outputs="%(_XUnitWrapperDll.FileName)%(PayloadGroup)" DependsOnTargets="DiscoverAllXUnitWrappers">
+  <Target Name="DiscoverMergedTestWrappers">
+    <ItemGroup>
+      <_MergedWrapperMarker Include="$(TestBinDir)**\*.MergedTestAssembly" />
+      <_MergedWrapperRunScript Include="$([System.IO.Path]::ChangeExtension('%(_MergedWrapperMarker.Identity)', '.$(TestScriptExtension)'))" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="PrepareLegacyPayloadDirectory" Outputs="%(_XUnitWrapperDll.FileName)%(PayloadGroup)" DependsOnTargets="DiscoverLegacyXUnitWrappers">
     <PropertyGroup>
       <_FileDirectory>%(_XUnitWrapperDll.RootDir)%(Directory)</_FileDirectory>
       <_PayloadGroup>%(_XUnitWrapperDll.PayloadGroup)</_PayloadGroup>
@@ -184,6 +191,7 @@
 
       <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.sh' and '$(TestWrapperTargetsWindows)' == 'true' "/>
       <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.cmd' and '$(TestWrapperTargetsWindows)' != 'true' "/>
+      <ReducedPayloadFilesFinal Remove="@(_MergedWrapperRunScript)" />
     </ItemGroup>
 
     <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
@@ -222,7 +230,9 @@
           Command="tar -czvf $(PayloadsRootDirectory)paltests.tar.gz `ls -A`"/>
   </Target>
 
-  <Target Name="PreparePayloadsDirectories" DependsOnTargets="PreparePayloadDirectory">
+  <Target Name="PreparePayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectories;PrepareLegacyPayloadDirectories" />
+
+  <Target Name="PrepareLegacyPayloadDirectories" DependsOnTargets="PrepareLegacyPayloadDirectory">
     <PropertyGroup>
       <_PayloadGroups>@(_XUnitWrapperDll->Metadata('PayloadGroup')->DistinctWithCase())</_PayloadGroups>
     </PropertyGroup>
@@ -237,12 +247,51 @@
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
   </Target>
 
+  <Target Name="PrepareMergedTestPayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectory">
+    <PropertyGroup>
+      <_MergedWrapperDirectory>%(_MergedWrapperRunScript.RootDir)%(Directory)</_MergedWrapperDirectory>
+      <_MergedWrapperRelativeDir>%(_MergedWrapperRunScript.RelativeDir)</_MergedWrapperRelativeDir>
+      <_MergedWrapperFile>%(_MergedWrapperRunScript.FileName)</_MergedWrapperFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_Scenario Include="$(_Scenarios.Split(','))" />
+      <_ProjectsToBuild Include="$(MSBuildProjectFile)">
+        <AdditionalProperties>Scenario=%(_Scenario.Identity);PayloadGroups=@(_MergedWrapperRelativeDir)</AdditionalProperties>
+      </_ProjectsToBuild>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFiles" StopOnFirstFailure="true" />
+  </Target>
+
+  <Target Name="PrepareMergedTestPayloadDirectory" Outputs="%(_MergedWrapperRunScript.FileName)" DependsOnTargets="DiscoverMergedTestWrappers">
+    <ItemGroup>
+      <_PayloadFiles Include="$(_MergedWrapperDirectory)**" />
+      <_PayloadFiles Update="@(_PayloadFiles)">
+        <!-- Never use [MSBuild]::MakeRelative here! We have some files containing Unicode characters in their %(FullPath) and
+             MakeRelative function calls Escape function internally that replaces all the Unicode characters with %<xx>. -->
+        <FileRelativeToPayloadsRootDirectory>$([System.IO.Path]::GetRelativePath($(TestBinDir), %(FullPath)))</FileRelativeToPayloadsRootDirectory>
+      </_PayloadFiles>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Remove the managed pdbs from our payloads.
+           This is for performance reasons to reduce our helix payload size  -->
+      <ReducedPayloadFiles Include="@(_PayloadFiles)" Condition=" '%(Extension)' != '.pdb' " />
+
+      <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.sh' and '$(TestWrapperTargetsWindows)' == 'true' "/>
+      <ReducedPayloadFilesFinal Include="@(ReducedPayloadFiles)" Condition=" '%(Extension)' != '.cmd' and '$(TestWrapperTargetsWindows)' != 'true' "/>
+    </ItemGroup>
+
+    <Copy SourceFiles="@(ReducedPayloadFilesFinal)" DestinationFiles="@(ReducedPayloadFilesFinal->'$(PayloadsRootDirectory)%(FileRelativeToPayloadsRootDirectory)')" />
+  </Target>
+
   <PropertyGroup>
     <IsRunningOnMobileTargets>false</IsRunningOnMobileTargets>
     <IsRunningOnMobileTargets Condition="'$(TargetOS)' == 'Android' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator' ">true</IsRunningOnMobileTargets>
   </PropertyGroup>
 
-  <Target Name="ZipPayloadDirectory" AfterTargets="PreparePayloadsDirectories" Condition="'$(IsRunningOnMobileTargets)' == 'true'">
+  <Target Name="ZipPayloadDirectory" AfterTargets="PrepareLegacyPayloadDirectories" Condition="'$(IsRunningOnMobileTargets)' == 'true'">
     <ItemGroup>
       <Payloads Include="$([System.IO.Directory]::GetDirectories($(PayloadsRootDirectory)))" Condition="Exists('$(PayloadsRootDirectory)')" />
       <Payloads Update="@(Payloads)">

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -450,6 +450,8 @@
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
     </HelixWorkItem>
 
+    <Exec Command="chmod +x $(MergedPayloadsRootDirectory)/%(FileName)/%(MergedTestHelixCommand)" Condition="'$(TargetOSSpec)' != 'windows'" />
+
     <HelixWorkItem Include="@(MergedPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">
       <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>
       <Command>%(MergedTestHelixCommand)</Command>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -444,7 +444,7 @@
     </MergedPayloads>
 
     <MergedPayloads Update="@(MergedPayloads)" Condition="'$(TargetOSSpec)' != 'windows'">
-      <MergedTestHelixCommand>chmod +x %(MergedPayloads.MergedTestHelixCommand) &amp;&amp; %(MergedPayloads.MergedTestHelixCommand)</MergedTestHelixCommand>
+      <MergedTestHelixCommand>chmod +x %(MergedPayloads.MergedTestHelixCommand)%0A%(MergedPayloads.MergedTestHelixCommand)</MergedTestHelixCommand>
     </MergedPayloads>
 
     <HelixWorkItem Include="@(LegacyPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -270,6 +270,8 @@
       <_MergedWrapperMarker Include="$(TestBinDir)**\*.MergedTestAssembly" />
       <_MergedWrapperRunScript Include="$([System.IO.Path]::ChangeExtension('%(_MergedWrapperMarker.Identity)', '.$(TestScriptExtension)'))" />
     </ItemGroup>
+
+    <Exec Command="chmod +x %(_MergedWrapperRunScript.Identity)" Condition="'$(TargetOSSpec)' != 'windows'" />
   </Target>
 
   <Target Name="PrepareMergedTestPayloadDirectory"
@@ -449,8 +451,6 @@
       <Command Condition=" '%(TestGroup)' != '' ">dotnet $(XUnitRunnerDll) %(XUnitWrapperDlls) $(XUnitRunnerArgs) -trait TestGroup=%(TestGroup)</Command>
       <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
     </HelixWorkItem>
-
-    <Exec Command="chmod +x $(MergedPayloadsRootDirectory)/%(FileName)/%(MergedTestHelixCommand)" Condition="'$(TargetOSSpec)' != 'windows'" />
 
     <HelixWorkItem Include="@(MergedPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">
       <PayloadDirectory>%(PayloadDirectory)</PayloadDirectory>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -444,7 +444,7 @@
     </MergedPayloads>
 
     <MergedPayloads Update="@(MergedPayloads)" Condition="'$(TargetOSSpec)' != 'windows'">
-      <MergedTestHelixCommand>chmod +x %(MergedPayloads.MergedTestHelixCommand) && %(MergedPayloads.MergedTestHelixCommand)</MergedTestHelixCommand>
+      <MergedTestHelixCommand>chmod +x %(MergedPayloads.MergedTestHelixCommand) &amp;&amp; %(MergedPayloads.MergedTestHelixCommand)</MergedTestHelixCommand>
     </MergedPayloads>
 
     <HelixWorkItem Include="@(LegacyPayloads->Metadata('PayloadGroup'))" Condition=" '$(IsRunningOnMobileTargets)' == 'false' ">

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -83,8 +83,8 @@
   </Target>
 
   <Target Name="RunSingleMergedTest">
-    <Exec Command="chmod +x $(TestWrapperScript)" WorkingDirectory="$(BaseOutputPathWithConfig)" Condition="'$(TargetOSSpec)' != 'windows'" />
-    <Exec Command="$(TestWrapperScript) &gt;$(RedirectOutputToFile)" WorkingDirectory="$(BaseOutputPathWithConfig)" />
+    <Exec Command="chmod +x $(TestWrapperScript)" WorkingDirectory="$(BaseOutputPathWithConfig)" Condition="'$(TargetOS)' != 'windows'" />
+    <Exec Command="$(TestWrapperScript) &gt;$(RedirectOutputToFile)" WorkingDirectory="$(BaseOutputPathWithConfig)" Timeout="$(__TestTimeout)" />
     <Copy SourceFiles="$(TestResultsXmlFile)" DestinationFiles="$(TestResultsCopyTo)" />
   </Target>
 

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -83,6 +83,7 @@
   </Target>
 
   <Target Name="RunSingleMergedTest">
+    <Exec Command="chmod +x $(TestWrapperScript)" WorkingDirectory="$(BaseOutputPathWithConfig)" Condition="'$(TargetOSSpec)' != 'windows'" />
     <Exec Command="$(TestWrapperScript) &gt;$(RedirectOutputToFile)" WorkingDirectory="$(BaseOutputPathWithConfig)" />
     <Copy SourceFiles="$(TestResultsXmlFile)" DestinationFiles="$(TestResultsCopyTo)" />
   </Target>

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -29,6 +29,7 @@
       <MergedTestWrapperScripts Update="@(MergedTestWrapperScripts)">
         <RedirectOutputToFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.log'))</RedirectOutputToFile>
         <TestResultsXmlFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.testResults.xml'))</TestResultsXmlFile>
+        <TestResultsCopyTo>$(__LogsDir)\%(MergedTestWrapperScripts.FileName).testRun.xml</TestResultsCopyTo>
       </MergedTestWrapperScripts>
     </ItemGroup>
   </Target>
@@ -80,14 +81,13 @@
 
   <Target Name="RunSingleMergedTest">
     <Exec Command="$(TestWrapperScript) &gt;$(RedirectOutputToFile)" WorkingDirectory="$(BaseOutputPathWithConfig)" />
-    <!-- TODO: this only works when running a single merged wrapper, we need to fix run.py to accept multiple results files -->
-    <Copy SourceFiles="$(TestResultsXmlFile)" DestinationFiles="$(__TestRunXmlLog)" />
+    <Copy SourceFiles="$(TestResultsXmlFile)" DestinationFiles="$(TestResultsCopyTo)" />
   </Target>
 
   <Target Name="RunMergedTests" DependsOnTargets="PrepareTestsToRun">
     <ItemGroup>
       <_ProjectsToBuild Include="$(MSBuildThisFileFullPath)">
-        <AdditionalProperties>TestWrapperScript=%(MergedTestWrapperScripts.Identity);RedirectOutputToFile=%(MergedTestWrapperScripts.RedirectOutputToFile);TestResultsXmlFile=%(MergedTestWrapperScripts.TestResultsXmlFile)</AdditionalProperties>
+        <AdditionalProperties>TestWrapperScript=%(MergedTestWrapperScripts.Identity);RedirectOutputToFile=%(MergedTestWrapperScripts.RedirectOutputToFile);TestResultsXmlFile=%(MergedTestWrapperScripts.TestResultsXmlFile);TestResultsCopyTo=%(MergedTestWrapperScripts.TestResultsCopyTo)</AdditionalProperties>
       </_ProjectsToBuild>
     </ItemGroup>
 

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -29,7 +29,10 @@
       <MergedTestWrapperScripts Update="@(MergedTestWrapperScripts)">
         <RedirectOutputToFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.log'))</RedirectOutputToFile>
         <TestResultsXmlFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.testResults.xml'))</TestResultsXmlFile>
-        <TestResultsCopyTo>$(__LogsDir)\%(MergedTestWrapperScripts.FileName).testRun.xml</TestResultsCopyTo>
+        <RelativeResultsPath>$([System.IO.Path]::GetRelativePath('$(TestBinDir)', $([System.IO.Path]::GetDirectoryName('%(MergedTestWrapperScripts.Identity)'))))</RelativeResultsPath>
+      </MergedTestWrapperScripts>
+      <MergedTestWrapperScripts Update="@(MergedTestWrapperScripts)">
+        <TestResultsCopyTo>$(__LogsDir)\$([MSBuild]::ValueOrDefault('%(MergedTestWrapperScripts.RelativeResultsPath)', '').Replace('/', '.').Replace('\', '.')).testRun.xml</TestResultsCopyTo>
       </MergedTestWrapperScripts>
     </ItemGroup>
   </Target>

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -10,24 +10,34 @@
       <__TestRunHtmlLog Condition="'$(__TestRunHtmlLog)' == ''">$(__LogsDir)\TestRun.html</__TestRunHtmlLog>
       <__TestRunXmlLog Condition="'$(__TestRunXmlLog)' == ''">$(__LogsDir)\TestRun.xml</__TestRunXmlLog>
   </PropertyGroup>
-  <Target Name="FindTestDirectories">
+
+  <Target Name="FindLegacyTestDirectories">
     <ItemGroup>
-      <AllTestAssemblies Include="$(BaseOutputPathWithConfig)\**\*.XUnitWrapper.dll" />
-      <TestAssemblies Include="@(AllTestAssemblies)" Exclude="@(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity)\%(Identity).XUnitWrapper.dll')" />
+      <LegacyTestAssemblies Include="$(BaseOutputPathWithConfig)\**\*.XUnitWrapper.dll" />
+      <TestAssemblies Include="@(LegacyTestAssemblies)" Exclude="@(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity)\%(Identity).XUnitWrapper.dll')" />
     </ItemGroup>
 
-    <Error  Text=" The wrappers must be compiled and placed at $(TestAssemblyDir)\*\ before they can be run, Do a clean Test Run"
-            Condition="'@(AllTestAssemblies)' == ''" />
-
-    <Message Text= "AllTestAssemblies= @(AllTestAssemblies)"/>
+    <Message Text= "LegacyTestAssemblies= @(LegacyTestAssemblies)"/>
     <Message Text= "TestAssemblies= @(TestAssemblies)"/>
     <Message Text= "_SkipTestAssemblies= @(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity)\%(Identity).XUnitWrapper.dll')"/>
   </Target>
 
-  <Target Name="RunTests"
-          DependsOnTargets="FindTestDirectories"
-          Condition="'$(SkipTests)' != 'True'">
+  <Target Name="FindMergedTestDirectories">
+    <ItemGroup>
+      <_MergedTestAssemblyMarkers Include="$(BaseOutputPathWithConfig)\**\*.MergedTestAssembly" />
+      <MergedTestWrapperScripts Include="$([System.IO.Path]::ChangeExtension('%(_MergedTestAssemblyMarkers.Identity)', '.$(TestScriptExtension)'))" />
+      <MergedTestWrapperScripts Update="@(MergedTestWrapperScripts)">
+        <RedirectOutputToFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.log'))</RedirectOutputToFile>
+        <TestResultsXmlFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.testResults.xml'))</TestResultsXmlFile>
+      </MergedTestWrapperScripts>
+    </ItemGroup>
+  </Target>
 
+  <Target Name="PrepareTestsToRun"
+          DependsOnTargets="FindLegacyTestDirectories;FindMergedTestDirectories">
+
+    <Error  Text=" The wrappers must be compiled and placed at $(TestAssemblyDir)\*\ before they can be run, Do a clean Test Run"
+            Condition="'@(LegacyTestAssemblies)' == '' and '@(MergedTestWrapperScripts)' == ''" />
 
     <PropertyGroup>
       <ExcludeTraits Condition="'$(ExcludeTraits)'==''">category=outerloop;category=failing</ExcludeTraits>
@@ -66,14 +76,35 @@
       <TestAssemblies Remove="@(TestAssemblies)" />
       <TestAssemblies Include="@(_TestAssembliesRelative)" />
     </ItemGroup>
+  </Target>
 
+  <Target Name="RunSingleMergedTest">
+    <Exec Command="$(TestWrapperScript) &gt;$(RedirectOutputToFile)" WorkingDirectory="$(BaseOutputPathWithConfig)" />
+    <!-- TODO: this only works when running a single merged wrapper, we need to fix run.py to accept multiple results files -->
+    <Copy SourceFiles="$(TestResultsXmlFile)" DestinationFiles="$(__TestRunXmlLog)" />
+  </Target>
+
+  <Target Name="RunMergedTests" DependsOnTargets="PrepareTestsToRun">
+    <ItemGroup>
+      <_ProjectsToBuild Include="$(MSBuildThisFileFullPath)">
+        <AdditionalProperties>TestWrapperScript=%(MergedTestWrapperScripts.Identity);RedirectOutputToFile=%(MergedTestWrapperScripts.RedirectOutputToFile);TestResultsXmlFile=%(MergedTestWrapperScripts.TestResultsXmlFile)</AdditionalProperties>
+      </_ProjectsToBuild>
+    </ItemGroup>
+
+    <MSBuild Projects="@(_ProjectsToBuild)" Targets="RunSingleMergedTest" BuildInParallel="true" Condition="'@(MergedTestWrapperScripts)' != ''" />
+  </Target>
+
+  <Target Name="RunLegacyTests" DependsOnTargets="PrepareTestsToRun">
     <PropertyGroup>
       <XunitCommandLine>$(CorerunExecutable) $(XunitConsoleRunner) @(TestAssemblies->'%(Identity)', ' ') $(XunitArgs)</XunitCommandLine>
     </PropertyGroup>
 
     <Exec Command="$(XunitCommandLine)"
-          WorkingDirectory="$(BaseOutputPathWithConfig)"/>
-
+          WorkingDirectory="$(BaseOutputPathWithConfig)"
+          Condition="'@(TestAssemblies)' != ''" />
   </Target>
 
+  <Target Name="RunTests" DependsOnTargets="RunMergedTests;RunLegacyTests" Condition="'$(SkipTests)' != 'True'">
+    <!-- TODO - merged reporting? -->
+  </Target>
 </Project>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -180,8 +180,9 @@
     <CLRTestMSBuildArgs>/p:MSBuildEnableWorkloadResolver=false</CLRTestMSBuildArgs>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestsCommonProject)' != 'true'">
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">true</BuildAsStandalone>
-    <OutputType>Exe</OutputType>
+  <PropertyGroup>
+    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == '' and '$(IsTestsCommonProject)' == 'true'">false</BuildAsStandalone>
+    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
+    <OutputType Condition="$(BuildAsStandalone)">Exe</OutputType>
   </PropertyGroup>
 </Project>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -182,9 +182,8 @@
     <CLRTestMSBuildArgs>/p:MSBuildEnableWorkloadResolver=false</CLRTestMSBuildArgs>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == '' and '$(IsTestsCommonProject)' == 'true'">false</BuildAsStandalone>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">false</BuildAsStandalone>
+  <PropertyGroup Condition="'$(IsTestsCommonProject)' != 'true'">
+    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">true</BuildAsStandalone>
     <OutputType Condition="$(BuildAsStandalone)">Exe</OutputType>
   </PropertyGroup>
 </Project>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -167,6 +167,8 @@
   <PropertyGroup>
     <TestWrapperTargetsWindows>false</TestWrapperTargetsWindows>
     <TestWrapperTargetsWindows Condition=" ('$(TargetsWindows)' != '' And '$(TargetsWindows)' ) OR ('$(TargetOS)' == 'Android' And '$(TargetArchitecture)' == 'arm64' )">true</TestWrapperTargetsWindows>
+    <TestScriptExtension Condition="'$(TestWrapperTargetsWindows)' != 'true' ">sh</TestScriptExtension>
+    <TestScriptExtension Condition="'$(TestWrapperTargetsWindows)' == 'true' ">cmd</TestScriptExtension>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -248,6 +248,11 @@
      <Copy SourceFiles="$(AssemblyName).reflect.xml"
            DestinationFolder="$(OutputPath)"
        Condition="Exists('$(AssemblyName).reflect.xml')"/>
+
+    <WriteLinesToFile
+        Condition="'$(IsMergedTestAssembly)' == 'true'"
+        File="$(OutputPath)\$(MSBuildProjectName).MergedTestAssembly"
+        Lines="MergedTestAssembly" />
   </Target>
 
   <PropertyGroup>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -12,7 +12,7 @@
   <!-- Default priority building values. -->
   <PropertyGroup>
     <CLRTestTargetUnsupported Condition="'$(IsMergedTestAssembly)' == 'true' and $(BuildAsStandalone)">true</CLRTestTargetUnsupported>
-    <OutputType Condition="'$(OutputType)' == '' and '$(IsMergedTestAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
+    <OutputType Condition="'$(IsMergedTestAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -12,7 +12,7 @@
   <!-- Default priority building values. -->
   <PropertyGroup>
     <CLRTestTargetUnsupported Condition="'$(IsMergedTestAssembly)' == 'true' and $(BuildAsStandalone)">true</CLRTestTargetUnsupported>
-    <OutputType Condition="'$(IsMergedTestAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
+    <OutputType Condition="'$(OutputType)' == '' and '$(IsMergedTestAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -11,7 +11,10 @@
 
   <!-- Default priority building values. -->
   <PropertyGroup>
-    <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildAndRun</CLRTestKind>
+    <CLRTestTargetUnsupported Condition="'$(IsMergedTestAssembly)' == 'true' and $(BuildAsStandalone)">true</CLRTestTargetUnsupported>
+    <OutputType Condition="'$(IsMergedTestAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
+    <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
+    <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
   </PropertyGroup>
 

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -11,8 +11,8 @@
 
   <!-- Default priority building values. -->
   <PropertyGroup>
-    <CLRTestTargetUnsupported Condition="'$(IsMergedTestAssembly)' == 'true' and $(BuildAsStandalone)">true</CLRTestTargetUnsupported>
-    <OutputType Condition="'$(IsMergedTestAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and $(BuildAsStandalone)">true</CLRTestTargetUnsupported>
+    <OutputType Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
@@ -250,7 +250,7 @@
        Condition="Exists('$(AssemblyName).reflect.xml')"/>
 
     <WriteLinesToFile
-        Condition="'$(IsMergedTestAssembly)' == 'true'"
+        Condition="'$(IsMergedTestRunnerAssembly)' == 'true'"
         File="$(OutputPath)\$(MSBuildProjectName).MergedTestAssembly"
         Lines="MergedTestAssembly" />
   </Target>
@@ -425,12 +425,16 @@
     </ItemGroup>
   </Target>
 
-  <PropertyGroup Condition="'$(Language)' == 'C#' and ('$(BuildAsStandalone)' == 'true' or '$(RequiresProcessIsolation)' == 'true' or '$(IsMergedTestAssembly)' == 'true')">
+  <PropertyGroup Condition="'$(Language)' == 'C#' and ('$(BuildAsStandalone)' == 'true' or '$(RequiresProcessIsolation)' == 'true' or '$(IsMergedTestRunnerAssembly)' == 'true')">
     <ReferenceXUnitWrapperGenerator Condition="'$(ReferenceXUnitWrapperGenerator)' == ''">true</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ReferenceXUnitWrapperGenerator)' == 'true'">
     <ProjectReference Include="$(RepoRoot)/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsMergedTestRunnerAssembly)' == 'true'">
+    <ProjectReference Include="$(RepoRoot)/src/tests/Common/XUnitWrapperLibrary/XUnitWrapperLibrary.csproj" />
   </ItemGroup>
 
   <Import Project="$(RepoRoot)/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.props" />

--- a/src/tests/JIT/Methodical/Arrays/range.csproj
+++ b/src/tests/JIT/Methodical/Arrays/range.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="range/*.ilproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Methodical/Arrays/range.csproj
+++ b/src/tests/JIT/Methodical/Arrays/range.csproj
@@ -1,8 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="range/*.ilproj" />
-  </ItemGroup>
-</Project>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range2.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgfloat64_range2.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5a.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5a.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5a.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5a.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5b.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5b.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5b.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_0_5b.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_m1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_m1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_m1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_m1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_neg_range.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_neg_range.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_neg_range.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_neg_range.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range2.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_dbgint32_range2.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range2.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relfloat64_range2.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5a.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5a.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5a.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5a.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5b.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5b.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5b.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_0_5b.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_m1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_m1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_m1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_m1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_neg_range.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_neg_range.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_neg_range.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_neg_range.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range1.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range1.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range1.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range2.ilproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>true</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range2.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relint32_range2.ilproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relnegIndexRngChkElim.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relnegIndexRngChkElim.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/_il_relnegIndexRngChkElim.ilproj
+++ b/src/tests/JIT/Methodical/Arrays/range/_il_relnegIndexRngChkElim.ilproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/Arrays/range/float64_range1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/float64_range1.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 
@@ -96,7 +96,7 @@
       ret
     } // end of method 'Test::try_index'
 
-    .method public hidebysig static int32
+    .method private hidebysig static int32
             Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (

--- a/src/tests/JIT/Methodical/Arrays/range/float64_range1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/float64_range1.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 
@@ -96,7 +96,7 @@
       ret
     } // end of method 'Test::try_index'
 
-    .method private hidebysig static int32
+    .method public hidebysig static int32
             Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (

--- a/src/tests/JIT/Methodical/Arrays/range/float64_range2.il
+++ b/src/tests/JIT/Methodical/Arrays/range/float64_range2.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/float64_range2.il
+++ b/src/tests/JIT/Methodical/Arrays/range/float64_range2.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_0.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_0.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_0.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_0.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_0_5a.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_0_5a.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_0_5a.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_0_5a.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_0_5b.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_0_5b.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_0_5b.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_0_5b.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_1.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_1.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_m1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_m1.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_m1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_m1.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_neg_range.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_neg_range.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_neg_range.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_neg_range.il
@@ -31,7 +31,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_range1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_range1.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_range1.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_range1.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_range2.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_range2.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class public auto ansi Test
+  .class private auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/JIT/Methodical/Arrays/range/int32_range2.il
+++ b/src/tests/JIT/Methodical/Arrays/range/int32_range2.il
@@ -32,7 +32,7 @@
 .module 'test.exe'
 .namespace JitTest
 {
-  .class private auto ansi Test
+  .class public auto ansi Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static int32 

--- a/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == '' and '$(IsTestsCommonProject)' == 'true'">false</BuildAsStandalone>
+    <OutputType Condition="$(BuildAsStandalone)">Exe</OutputType>
+  </PropertyGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/Directory.Build.props
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <PropertyGroup>
-    <BuildAsStandalone Condition="'$(BuildAsStandalone)' == '' and '$(IsTestsCommonProject)' == 'true'">false</BuildAsStandalone>
-    <OutputType Condition="$(BuildAsStandalone)">Exe</OutputType>
+    <BuildAsStandalone>false</BuildAsStandalone>
   </PropertyGroup>
+
+  <Import Project="..\..\..\Directory.Build.props" />
 </Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest0/Generated0.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest0/Generated0.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
+   <PropertyGroup>
+     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Generated0.il" />

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1/Generated1.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1/Generated1.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest10/Generated10.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest10/Generated10.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest100/Generated100.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest100/Generated100.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1000/Generated1000.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1000/Generated1000.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1001/Generated1001.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1001/Generated1001.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1002/Generated1002.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1002/Generated1002.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1003/Generated1003.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1003/Generated1003.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1004/Generated1004.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1004/Generated1004.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1005/Generated1005.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1005/Generated1005.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1006/Generated1006.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1006/Generated1006.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1007/Generated1007.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1007/Generated1007.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1008/Generated1008.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1008/Generated1008.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1009/Generated1009.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1009/Generated1009.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest101/Generated101.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest101/Generated101.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1010/Generated1010.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1010/Generated1010.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1011/Generated1011.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1011/Generated1011.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1012/Generated1012.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1012/Generated1012.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1013/Generated1013.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1013/Generated1013.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1014/Generated1014.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1014/Generated1014.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1015/Generated1015.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1015/Generated1015.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1016/Generated1016.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1016/Generated1016.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1017/Generated1017.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1017/Generated1017.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1018/Generated1018.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1018/Generated1018.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1019/Generated1019.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1019/Generated1019.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest102/Generated102.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest102/Generated102.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1020/Generated1020.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1020/Generated1020.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1021/Generated1021.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1021/Generated1021.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1022/Generated1022.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1022/Generated1022.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1023/Generated1023.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1023/Generated1023.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1024/Generated1024.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1024/Generated1024.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1025/Generated1025.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1025/Generated1025.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1026/Generated1026.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1026/Generated1026.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1027/Generated1027.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1027/Generated1027.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1028/Generated1028.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1028/Generated1028.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1029/Generated1029.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1029/Generated1029.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest103/Generated103.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest103/Generated103.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1030/Generated1030.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1030/Generated1030.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1031/Generated1031.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1031/Generated1031.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1032/Generated1032.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1032/Generated1032.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1033/Generated1033.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1033/Generated1033.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1034/Generated1034.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1034/Generated1034.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1035/Generated1035.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1035/Generated1035.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1036/Generated1036.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1036/Generated1036.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1037/Generated1037.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1037/Generated1037.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1038/Generated1038.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1038/Generated1038.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1039/Generated1039.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1039/Generated1039.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest104/Generated104.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest104/Generated104.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1040/Generated1040.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1040/Generated1040.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1041/Generated1041.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1041/Generated1041.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1042/Generated1042.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1042/Generated1042.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1043/Generated1043.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1043/Generated1043.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1044/Generated1044.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1044/Generated1044.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1045/Generated1045.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1045/Generated1045.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1046/Generated1046.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1046/Generated1046.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1047/Generated1047.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1047/Generated1047.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1048/Generated1048.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1048/Generated1048.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1049/Generated1049.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1049/Generated1049.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest105/Generated105.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest105/Generated105.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1050/Generated1050.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1050/Generated1050.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1051/Generated1051.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1051/Generated1051.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1052/Generated1052.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1052/Generated1052.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1053/Generated1053.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1053/Generated1053.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1054/Generated1054.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1054/Generated1054.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1055/Generated1055.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1055/Generated1055.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1056/Generated1056.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1056/Generated1056.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1057/Generated1057.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1057/Generated1057.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1058/Generated1058.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1058/Generated1058.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1059/Generated1059.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1059/Generated1059.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest106/Generated106.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest106/Generated106.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1060/Generated1060.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1060/Generated1060.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1061/Generated1061.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1061/Generated1061.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1062/Generated1062.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1062/Generated1062.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1063/Generated1063.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1063/Generated1063.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1064/Generated1064.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1064/Generated1064.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1065/Generated1065.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1065/Generated1065.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1066/Generated1066.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1066/Generated1066.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1067/Generated1067.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1067/Generated1067.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1068/Generated1068.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1068/Generated1068.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1069/Generated1069.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1069/Generated1069.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest107/Generated107.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest107/Generated107.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1070/Generated1070.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1070/Generated1070.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1071/Generated1071.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1071/Generated1071.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1072/Generated1072.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1072/Generated1072.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1073/Generated1073.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1073/Generated1073.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1074/Generated1074.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1074/Generated1074.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1075/Generated1075.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1075/Generated1075.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1076/Generated1076.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1076/Generated1076.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1077/Generated1077.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1077/Generated1077.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1078/Generated1078.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1078/Generated1078.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1079/Generated1079.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1079/Generated1079.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest108/Generated108.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest108/Generated108.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1080/Generated1080.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1080/Generated1080.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1081/Generated1081.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1081/Generated1081.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1082/Generated1082.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1082/Generated1082.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1083/Generated1083.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1083/Generated1083.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1084/Generated1084.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1084/Generated1084.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1085/Generated1085.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1085/Generated1085.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1086/Generated1086.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1086/Generated1086.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1087/Generated1087.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1087/Generated1087.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1088/Generated1088.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1088/Generated1088.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1089/Generated1089.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1089/Generated1089.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest109/Generated109.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest109/Generated109.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1090/Generated1090.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1090/Generated1090.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1091/Generated1091.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1091/Generated1091.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1092/Generated1092.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1092/Generated1092.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1093/Generated1093.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1093/Generated1093.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1094/Generated1094.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1094/Generated1094.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1095/Generated1095.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1095/Generated1095.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1096/Generated1096.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1096/Generated1096.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1097/Generated1097.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1097/Generated1097.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1098/Generated1098.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1098/Generated1098.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1099/Generated1099.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1099/Generated1099.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest11/Generated11.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest11/Generated11.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest110/Generated110.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest110/Generated110.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1100/Generated1100.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1100/Generated1100.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1101/Generated1101.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1101/Generated1101.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1102/Generated1102.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1102/Generated1102.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1103/Generated1103.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1103/Generated1103.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1104/Generated1104.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1104/Generated1104.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1105/Generated1105.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1105/Generated1105.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1106/Generated1106.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1106/Generated1106.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1107/Generated1107.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1107/Generated1107.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1108/Generated1108.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1108/Generated1108.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1109/Generated1109.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1109/Generated1109.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest111/Generated111.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest111/Generated111.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1110/Generated1110.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1110/Generated1110.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1111/Generated1111.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1111/Generated1111.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1112/Generated1112.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1112/Generated1112.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1113/Generated1113.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1113/Generated1113.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1114/Generated1114.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1114/Generated1114.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1115/Generated1115.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1115/Generated1115.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1116/Generated1116.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1116/Generated1116.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1117/Generated1117.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1117/Generated1117.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1118/Generated1118.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1118/Generated1118.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1119/Generated1119.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1119/Generated1119.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest112/Generated112.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest112/Generated112.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1120/Generated1120.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1120/Generated1120.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1121/Generated1121.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1121/Generated1121.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1122/Generated1122.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1122/Generated1122.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1123/Generated1123.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1123/Generated1123.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1124/Generated1124.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1124/Generated1124.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1125/Generated1125.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1125/Generated1125.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1126/Generated1126.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1126/Generated1126.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1127/Generated1127.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1127/Generated1127.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1128/Generated1128.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1128/Generated1128.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1129/Generated1129.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1129/Generated1129.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest113/Generated113.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest113/Generated113.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1130/Generated1130.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1130/Generated1130.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1131/Generated1131.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1131/Generated1131.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1132/Generated1132.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1132/Generated1132.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1133/Generated1133.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1133/Generated1133.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1134/Generated1134.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1134/Generated1134.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1135/Generated1135.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1135/Generated1135.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1136/Generated1136.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1136/Generated1136.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1137/Generated1137.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1137/Generated1137.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1138/Generated1138.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1138/Generated1138.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1139/Generated1139.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1139/Generated1139.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest114/Generated114.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest114/Generated114.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1140/Generated1140.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1140/Generated1140.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1141/Generated1141.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1141/Generated1141.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1142/Generated1142.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1142/Generated1142.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1143/Generated1143.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1143/Generated1143.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1144/Generated1144.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1144/Generated1144.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1145/Generated1145.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1145/Generated1145.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1146/Generated1146.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1146/Generated1146.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1147/Generated1147.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1147/Generated1147.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1148/Generated1148.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1148/Generated1148.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1149/Generated1149.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1149/Generated1149.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest115/Generated115.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest115/Generated115.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1150/Generated1150.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1150/Generated1150.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1151/Generated1151.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1151/Generated1151.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1152/Generated1152.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1152/Generated1152.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1153/Generated1153.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1153/Generated1153.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1154/Generated1154.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1154/Generated1154.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1155/Generated1155.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1155/Generated1155.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1156/Generated1156.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1156/Generated1156.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1157/Generated1157.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1157/Generated1157.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1158/Generated1158.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1158/Generated1158.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1159/Generated1159.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1159/Generated1159.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest116/Generated116.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest116/Generated116.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1160/Generated1160.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1160/Generated1160.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1161/Generated1161.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1161/Generated1161.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1162/Generated1162.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1162/Generated1162.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1163/Generated1163.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1163/Generated1163.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1164/Generated1164.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1164/Generated1164.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1165/Generated1165.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1165/Generated1165.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1166/Generated1166.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1166/Generated1166.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1167/Generated1167.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1167/Generated1167.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1168/Generated1168.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1168/Generated1168.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1169/Generated1169.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1169/Generated1169.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest117/Generated117.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest117/Generated117.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1170/Generated1170.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1170/Generated1170.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1171/Generated1171.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1171/Generated1171.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1172/Generated1172.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1172/Generated1172.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1173/Generated1173.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1173/Generated1173.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1174/Generated1174.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1174/Generated1174.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1175/Generated1175.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1175/Generated1175.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1176/Generated1176.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1176/Generated1176.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1177/Generated1177.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1177/Generated1177.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1178/Generated1178.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1178/Generated1178.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1179/Generated1179.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1179/Generated1179.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest118/Generated118.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest118/Generated118.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1180/Generated1180.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1180/Generated1180.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1181/Generated1181.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1181/Generated1181.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1182/Generated1182.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1182/Generated1182.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1183/Generated1183.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1183/Generated1183.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1184/Generated1184.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1184/Generated1184.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1185/Generated1185.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1185/Generated1185.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1186/Generated1186.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1186/Generated1186.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1187/Generated1187.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1187/Generated1187.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1188/Generated1188.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1188/Generated1188.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1189/Generated1189.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1189/Generated1189.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest119/Generated119.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest119/Generated119.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1190/Generated1190.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1190/Generated1190.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1191/Generated1191.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1191/Generated1191.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1192/Generated1192.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1192/Generated1192.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1193/Generated1193.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1193/Generated1193.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1194/Generated1194.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1194/Generated1194.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1195/Generated1195.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1195/Generated1195.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1196/Generated1196.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1196/Generated1196.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1197/Generated1197.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1197/Generated1197.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1198/Generated1198.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1198/Generated1198.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1199/Generated1199.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1199/Generated1199.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest12/Generated12.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest12/Generated12.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest120/Generated120.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest120/Generated120.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1200/Generated1200.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1200/Generated1200.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1201/Generated1201.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1201/Generated1201.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1202/Generated1202.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1202/Generated1202.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1203/Generated1203.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1203/Generated1203.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1204/Generated1204.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1204/Generated1204.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1205/Generated1205.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1205/Generated1205.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1206/Generated1206.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1206/Generated1206.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1207/Generated1207.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1207/Generated1207.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1208/Generated1208.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1208/Generated1208.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1209/Generated1209.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1209/Generated1209.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest121/Generated121.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest121/Generated121.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1210/Generated1210.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1210/Generated1210.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1211/Generated1211.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1211/Generated1211.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1212/Generated1212.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1212/Generated1212.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1213/Generated1213.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1213/Generated1213.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1214/Generated1214.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1214/Generated1214.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1215/Generated1215.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1215/Generated1215.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1216/Generated1216.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1216/Generated1216.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1217/Generated1217.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1217/Generated1217.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1218/Generated1218.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1218/Generated1218.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1219/Generated1219.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1219/Generated1219.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest122/Generated122.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest122/Generated122.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1220/Generated1220.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1220/Generated1220.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1221/Generated1221.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1221/Generated1221.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1222/Generated1222.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1222/Generated1222.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1223/Generated1223.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1223/Generated1223.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1224/Generated1224.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1224/Generated1224.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1225/Generated1225.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1225/Generated1225.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1226/Generated1226.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1226/Generated1226.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1227/Generated1227.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1227/Generated1227.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1228/Generated1228.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1228/Generated1228.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1229/Generated1229.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1229/Generated1229.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest123/Generated123.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest123/Generated123.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1230/Generated1230.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1230/Generated1230.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1231/Generated1231.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1231/Generated1231.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1232/Generated1232.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1232/Generated1232.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1233/Generated1233.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1233/Generated1233.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1234/Generated1234.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1234/Generated1234.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1235/Generated1235.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1235/Generated1235.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1236/Generated1236.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1236/Generated1236.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1237/Generated1237.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1237/Generated1237.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1238/Generated1238.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1238/Generated1238.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1239/Generated1239.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1239/Generated1239.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest124/Generated124.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest124/Generated124.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1240/Generated1240.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1240/Generated1240.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1241/Generated1241.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1241/Generated1241.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1242/Generated1242.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1242/Generated1242.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1243/Generated1243.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1243/Generated1243.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1244/Generated1244.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1244/Generated1244.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1245/Generated1245.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1245/Generated1245.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1246/Generated1246.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1246/Generated1246.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1247/Generated1247.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1247/Generated1247.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1248/Generated1248.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1248/Generated1248.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1249/Generated1249.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1249/Generated1249.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest125/Generated125.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest125/Generated125.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1250/Generated1250.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1250/Generated1250.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1251/Generated1251.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1251/Generated1251.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1252/Generated1252.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1252/Generated1252.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1253/Generated1253.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1253/Generated1253.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1254/Generated1254.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1254/Generated1254.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1255/Generated1255.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1255/Generated1255.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1256/Generated1256.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1256/Generated1256.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1257/Generated1257.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1257/Generated1257.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1258/Generated1258.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1258/Generated1258.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1259/Generated1259.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1259/Generated1259.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest126/Generated126.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest126/Generated126.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1260/Generated1260.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1260/Generated1260.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1261/Generated1261.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1261/Generated1261.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1262/Generated1262.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1262/Generated1262.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1263/Generated1263.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1263/Generated1263.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1264/Generated1264.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1264/Generated1264.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1265/Generated1265.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1265/Generated1265.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1266/Generated1266.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1266/Generated1266.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1267/Generated1267.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1267/Generated1267.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1268/Generated1268.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1268/Generated1268.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1269/Generated1269.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1269/Generated1269.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest127/Generated127.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest127/Generated127.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1270/Generated1270.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1270/Generated1270.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1271/Generated1271.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1271/Generated1271.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1272/Generated1272.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1272/Generated1272.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1273/Generated1273.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1273/Generated1273.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1274/Generated1274.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1274/Generated1274.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1275/Generated1275.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1275/Generated1275.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1276/Generated1276.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1276/Generated1276.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1277/Generated1277.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1277/Generated1277.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1278/Generated1278.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1278/Generated1278.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1279/Generated1279.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1279/Generated1279.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest128/Generated128.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest128/Generated128.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1280/Generated1280.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1280/Generated1280.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1281/Generated1281.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1281/Generated1281.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1282/Generated1282.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1282/Generated1282.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1283/Generated1283.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1283/Generated1283.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1284/Generated1284.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1284/Generated1284.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1285/Generated1285.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1285/Generated1285.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1286/Generated1286.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1286/Generated1286.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1287/Generated1287.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1287/Generated1287.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1288/Generated1288.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1288/Generated1288.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1289/Generated1289.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1289/Generated1289.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest129/Generated129.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest129/Generated129.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1290/Generated1290.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1290/Generated1290.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1291/Generated1291.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1291/Generated1291.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1292/Generated1292.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1292/Generated1292.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1293/Generated1293.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1293/Generated1293.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1294/Generated1294.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1294/Generated1294.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1295/Generated1295.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1295/Generated1295.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1296/Generated1296.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1296/Generated1296.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1297/Generated1297.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1297/Generated1297.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1298/Generated1298.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1298/Generated1298.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1299/Generated1299.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1299/Generated1299.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest13/Generated13.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest13/Generated13.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest130/Generated130.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest130/Generated130.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1300/Generated1300.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1300/Generated1300.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1301/Generated1301.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1301/Generated1301.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1302/Generated1302.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1302/Generated1302.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1303/Generated1303.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1303/Generated1303.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1304/Generated1304.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1304/Generated1304.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1305/Generated1305.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1305/Generated1305.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1306/Generated1306.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1306/Generated1306.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1307/Generated1307.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1307/Generated1307.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1308/Generated1308.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1308/Generated1308.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1309/Generated1309.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1309/Generated1309.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest131/Generated131.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest131/Generated131.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1310/Generated1310.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1310/Generated1310.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1311/Generated1311.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1311/Generated1311.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1312/Generated1312.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1312/Generated1312.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1313/Generated1313.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1313/Generated1313.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1314/Generated1314.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1314/Generated1314.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1315/Generated1315.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1315/Generated1315.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1316/Generated1316.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1316/Generated1316.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1317/Generated1317.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1317/Generated1317.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1318/Generated1318.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1318/Generated1318.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1319/Generated1319.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1319/Generated1319.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest132/Generated132.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest132/Generated132.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1320/Generated1320.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1320/Generated1320.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1321/Generated1321.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1321/Generated1321.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1322/Generated1322.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1322/Generated1322.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1323/Generated1323.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1323/Generated1323.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1324/Generated1324.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1324/Generated1324.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1325/Generated1325.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1325/Generated1325.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1326/Generated1326.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1326/Generated1326.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1327/Generated1327.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1327/Generated1327.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1328/Generated1328.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1328/Generated1328.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1329/Generated1329.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1329/Generated1329.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest133/Generated133.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest133/Generated133.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1330/Generated1330.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1330/Generated1330.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1331/Generated1331.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1331/Generated1331.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1332/Generated1332.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1332/Generated1332.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1333/Generated1333.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1333/Generated1333.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1334/Generated1334.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1334/Generated1334.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1335/Generated1335.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1335/Generated1335.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1336/Generated1336.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1336/Generated1336.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1337/Generated1337.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1337/Generated1337.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1338/Generated1338.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1338/Generated1338.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1339/Generated1339.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1339/Generated1339.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest134/Generated134.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest134/Generated134.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1340/Generated1340.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1340/Generated1340.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1341/Generated1341.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1341/Generated1341.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1342/Generated1342.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1342/Generated1342.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1343/Generated1343.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1343/Generated1343.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1344/Generated1344.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1344/Generated1344.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1345/Generated1345.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1345/Generated1345.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1346/Generated1346.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1346/Generated1346.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1347/Generated1347.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1347/Generated1347.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1348/Generated1348.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1348/Generated1348.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1349/Generated1349.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1349/Generated1349.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest135/Generated135.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest135/Generated135.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1350/Generated1350.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1350/Generated1350.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1351/Generated1351.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1351/Generated1351.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1352/Generated1352.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1352/Generated1352.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1353/Generated1353.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1353/Generated1353.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1354/Generated1354.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1354/Generated1354.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1355/Generated1355.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1355/Generated1355.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1356/Generated1356.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1356/Generated1356.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1357/Generated1357.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1357/Generated1357.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1358/Generated1358.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1358/Generated1358.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1359/Generated1359.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1359/Generated1359.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest136/Generated136.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest136/Generated136.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1360/Generated1360.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1360/Generated1360.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1361/Generated1361.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1361/Generated1361.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1362/Generated1362.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1362/Generated1362.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1363/Generated1363.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1363/Generated1363.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1364/Generated1364.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1364/Generated1364.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1365/Generated1365.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1365/Generated1365.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1366/Generated1366.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1366/Generated1366.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1367/Generated1367.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1367/Generated1367.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1368/Generated1368.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1368/Generated1368.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1369/Generated1369.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1369/Generated1369.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest137/Generated137.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest137/Generated137.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1370/Generated1370.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1370/Generated1370.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1371/Generated1371.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1371/Generated1371.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1372/Generated1372.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1372/Generated1372.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1373/Generated1373.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1373/Generated1373.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1374/Generated1374.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1374/Generated1374.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1375/Generated1375.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1375/Generated1375.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1376/Generated1376.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1376/Generated1376.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1377/Generated1377.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1377/Generated1377.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1378/Generated1378.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1378/Generated1378.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1379/Generated1379.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1379/Generated1379.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest138/Generated138.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest138/Generated138.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1380/Generated1380.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1380/Generated1380.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1381/Generated1381.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1381/Generated1381.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1382/Generated1382.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1382/Generated1382.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1383/Generated1383.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1383/Generated1383.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1384/Generated1384.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1384/Generated1384.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1385/Generated1385.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1385/Generated1385.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1386/Generated1386.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1386/Generated1386.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1387/Generated1387.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1387/Generated1387.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1388/Generated1388.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1388/Generated1388.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1389/Generated1389.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1389/Generated1389.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest139/Generated139.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest139/Generated139.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1390/Generated1390.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1390/Generated1390.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1391/Generated1391.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1391/Generated1391.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1392/Generated1392.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1392/Generated1392.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1393/Generated1393.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1393/Generated1393.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1394/Generated1394.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1394/Generated1394.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1395/Generated1395.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1395/Generated1395.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1396/Generated1396.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1396/Generated1396.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1397/Generated1397.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1397/Generated1397.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1398/Generated1398.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1398/Generated1398.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1399/Generated1399.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1399/Generated1399.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest14/Generated14.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest14/Generated14.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest140/Generated140.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest140/Generated140.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1400/Generated1400.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1400/Generated1400.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1401/Generated1401.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1401/Generated1401.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1402/Generated1402.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1402/Generated1402.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1403/Generated1403.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1403/Generated1403.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1404/Generated1404.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1404/Generated1404.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1405/Generated1405.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1405/Generated1405.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1406/Generated1406.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1406/Generated1406.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1407/Generated1407.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1407/Generated1407.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1408/Generated1408.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1408/Generated1408.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1409/Generated1409.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1409/Generated1409.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest141/Generated141.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest141/Generated141.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1410/Generated1410.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1410/Generated1410.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1411/Generated1411.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1411/Generated1411.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1412/Generated1412.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1412/Generated1412.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1413/Generated1413.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1413/Generated1413.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1414/Generated1414.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1414/Generated1414.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1415/Generated1415.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1415/Generated1415.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1416/Generated1416.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1416/Generated1416.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1417/Generated1417.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1417/Generated1417.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1418/Generated1418.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1418/Generated1418.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1419/Generated1419.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1419/Generated1419.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest142/Generated142.il
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest142/Generated142.il
@@ -556,13 +556,10 @@
 		)
 		.entrypoint
 		.maxstack  10
-    L1:
 		call void Generated142::MethodCallingTest()
 		call void Generated142::ConstrainedCallsTest()
 		call void Generated142::StructConstrainedInterfaceCallsTest()
 		call void Generated142::CalliTest()
-        ldc.i4 1
-        brtrue.s L1
 		ldc.i4 100
 		ret
 	}

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest142/Generated142.il
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest142/Generated142.il
@@ -556,10 +556,13 @@
 		)
 		.entrypoint
 		.maxstack  10
+    L1:
 		call void Generated142::MethodCallingTest()
 		call void Generated142::ConstrainedCallsTest()
 		call void Generated142::StructConstrainedInterfaceCallsTest()
 		call void Generated142::CalliTest()
+        ldc.i4 1
+        brtrue.s L1
 		ldc.i4 100
 		ret
 	}

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest142/Generated142.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest142/Generated142.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1420/Generated1420.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1420/Generated1420.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1421/Generated1421.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1421/Generated1421.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1422/Generated1422.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1422/Generated1422.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1423/Generated1423.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1423/Generated1423.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1424/Generated1424.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1424/Generated1424.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1425/Generated1425.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1425/Generated1425.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1426/Generated1426.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1426/Generated1426.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1427/Generated1427.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1427/Generated1427.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1428/Generated1428.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1428/Generated1428.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1429/Generated1429.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1429/Generated1429.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest143/Generated143.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest143/Generated143.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1430/Generated1430.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1430/Generated1430.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1431/Generated1431.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1431/Generated1431.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1432/Generated1432.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1432/Generated1432.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1433/Generated1433.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1433/Generated1433.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1434/Generated1434.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1434/Generated1434.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1435/Generated1435.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1435/Generated1435.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1436/Generated1436.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1436/Generated1436.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1437/Generated1437.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1437/Generated1437.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1438/Generated1438.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1438/Generated1438.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1439/Generated1439.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1439/Generated1439.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest144/Generated144.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest144/Generated144.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1440/Generated1440.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1440/Generated1440.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1441/Generated1441.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1441/Generated1441.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1442/Generated1442.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1442/Generated1442.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1443/Generated1443.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1443/Generated1443.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1444/Generated1444.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1444/Generated1444.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1445/Generated1445.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1445/Generated1445.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1446/Generated1446.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1446/Generated1446.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1447/Generated1447.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1447/Generated1447.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1448/Generated1448.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1448/Generated1448.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1449/Generated1449.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1449/Generated1449.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest145/Generated145.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest145/Generated145.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1450/Generated1450.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1450/Generated1450.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1451/Generated1451.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1451/Generated1451.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1452/Generated1452.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1452/Generated1452.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1453/Generated1453.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1453/Generated1453.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1454/Generated1454.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1454/Generated1454.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1455/Generated1455.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1455/Generated1455.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1456/Generated1456.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1456/Generated1456.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1457/Generated1457.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1457/Generated1457.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1458/Generated1458.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1458/Generated1458.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1459/Generated1459.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1459/Generated1459.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest146/Generated146.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest146/Generated146.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1460/Generated1460.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1460/Generated1460.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1461/Generated1461.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1461/Generated1461.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1462/Generated1462.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1462/Generated1462.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1463/Generated1463.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1463/Generated1463.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1464/Generated1464.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1464/Generated1464.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1465/Generated1465.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1465/Generated1465.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1466/Generated1466.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1466/Generated1466.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1467/Generated1467.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1467/Generated1467.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1468/Generated1468.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1468/Generated1468.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1469/Generated1469.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1469/Generated1469.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest147/Generated147.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest147/Generated147.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1470/Generated1470.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1470/Generated1470.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1471/Generated1471.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1471/Generated1471.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1472/Generated1472.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1472/Generated1472.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1473/Generated1473.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1473/Generated1473.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1474/Generated1474.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1474/Generated1474.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1475/Generated1475.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1475/Generated1475.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1476/Generated1476.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1476/Generated1476.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1477/Generated1477.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1477/Generated1477.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1478/Generated1478.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1478/Generated1478.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1479/Generated1479.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1479/Generated1479.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest148/Generated148.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest148/Generated148.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1480/Generated1480.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1480/Generated1480.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1481/Generated1481.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1481/Generated1481.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1482/Generated1482.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1482/Generated1482.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1483/Generated1483.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1483/Generated1483.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1484/Generated1484.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1484/Generated1484.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1485/Generated1485.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1485/Generated1485.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1486/Generated1486.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1486/Generated1486.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1487/Generated1487.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1487/Generated1487.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1488/Generated1488.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1488/Generated1488.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1489/Generated1489.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1489/Generated1489.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest149/Generated149.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest149/Generated149.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1490/Generated1490.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1490/Generated1490.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1491/Generated1491.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1491/Generated1491.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1492/Generated1492.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1492/Generated1492.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1493/Generated1493.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1493/Generated1493.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1494/Generated1494.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1494/Generated1494.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1495/Generated1495.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1495/Generated1495.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1496/Generated1496.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1496/Generated1496.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1497/Generated1497.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1497/Generated1497.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1498/Generated1498.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1498/Generated1498.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1499/Generated1499.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1499/Generated1499.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest15/Generated15.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest15/Generated15.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest150/Generated150.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest150/Generated150.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1500/Generated1500.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest1500/Generated1500.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest151/Generated151.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest151/Generated151.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest152/Generated152.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest152/Generated152.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest153/Generated153.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest153/Generated153.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest154/Generated154.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest154/Generated154.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest155/Generated155.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest155/Generated155.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest156/Generated156.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest156/Generated156.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest157/Generated157.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest157/Generated157.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest158/Generated158.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest158/Generated158.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest159/Generated159.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest159/Generated159.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest16/Generated16.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest16/Generated16.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest160/Generated160.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest160/Generated160.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest161/Generated161.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest161/Generated161.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest162/Generated162.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest162/Generated162.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest163/Generated163.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest163/Generated163.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest164/Generated164.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest164/Generated164.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest165/Generated165.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest165/Generated165.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest166/Generated166.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest166/Generated166.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest167/Generated167.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest167/Generated167.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest168/Generated168.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest168/Generated168.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest169/Generated169.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest169/Generated169.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest17/Generated17.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest17/Generated17.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest170/Generated170.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest170/Generated170.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest171/Generated171.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest171/Generated171.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest172/Generated172.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest172/Generated172.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest173/Generated173.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest173/Generated173.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest174/Generated174.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest174/Generated174.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest175/Generated175.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest175/Generated175.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest176/Generated176.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest176/Generated176.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest177/Generated177.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest177/Generated177.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest178/Generated178.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest178/Generated178.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest179/Generated179.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest179/Generated179.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest18/Generated18.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest18/Generated18.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest180/Generated180.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest180/Generated180.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest181/Generated181.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest181/Generated181.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest182/Generated182.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest182/Generated182.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest183/Generated183.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest183/Generated183.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest184/Generated184.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest184/Generated184.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest185/Generated185.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest185/Generated185.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest186/Generated186.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest186/Generated186.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest187/Generated187.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest187/Generated187.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest188/Generated188.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest188/Generated188.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest189/Generated189.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest189/Generated189.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest19/Generated19.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest19/Generated19.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest190/Generated190.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest190/Generated190.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest191/Generated191.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest191/Generated191.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest192/Generated192.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest192/Generated192.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest193/Generated193.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest193/Generated193.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest194/Generated194.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest194/Generated194.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest195/Generated195.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest195/Generated195.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest196/Generated196.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest196/Generated196.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest197/Generated197.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest197/Generated197.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest198/Generated198.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest198/Generated198.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest199/Generated199.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest199/Generated199.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest2/Generated2.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest2/Generated2.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest20/Generated20.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest20/Generated20.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest200/Generated200.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest200/Generated200.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest201/Generated201.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest201/Generated201.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest202/Generated202.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest202/Generated202.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest203/Generated203.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest203/Generated203.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest204/Generated204.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest204/Generated204.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest205/Generated205.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest205/Generated205.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest206/Generated206.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest206/Generated206.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest207/Generated207.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest207/Generated207.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest208/Generated208.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest208/Generated208.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest209/Generated209.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest209/Generated209.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest21/Generated21.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest21/Generated21.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest210/Generated210.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest210/Generated210.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest211/Generated211.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest211/Generated211.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest212/Generated212.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest212/Generated212.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest213/Generated213.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest213/Generated213.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest214/Generated214.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest214/Generated214.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest215/Generated215.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest215/Generated215.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest216/Generated216.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest216/Generated216.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest217/Generated217.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest217/Generated217.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest218/Generated218.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest218/Generated218.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest219/Generated219.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest219/Generated219.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest22/Generated22.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest22/Generated22.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest220/Generated220.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest220/Generated220.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest221/Generated221.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest221/Generated221.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest222/Generated222.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest222/Generated222.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest223/Generated223.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest223/Generated223.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest224/Generated224.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest224/Generated224.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest225/Generated225.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest225/Generated225.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest226/Generated226.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest226/Generated226.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest227/Generated227.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest227/Generated227.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest228/Generated228.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest228/Generated228.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest229/Generated229.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest229/Generated229.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest23/Generated23.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest23/Generated23.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest230/Generated230.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest230/Generated230.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest231/Generated231.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest231/Generated231.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest232/Generated232.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest232/Generated232.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest233/Generated233.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest233/Generated233.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest234/Generated234.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest234/Generated234.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest235/Generated235.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest235/Generated235.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest236/Generated236.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest236/Generated236.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest237/Generated237.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest237/Generated237.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest238/Generated238.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest238/Generated238.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest239/Generated239.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest239/Generated239.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest24/Generated24.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest24/Generated24.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest240/Generated240.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest240/Generated240.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest241/Generated241.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest241/Generated241.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest242/Generated242.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest242/Generated242.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest243/Generated243.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest243/Generated243.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest244/Generated244.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest244/Generated244.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest245/Generated245.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest245/Generated245.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest246/Generated246.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest246/Generated246.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest247/Generated247.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest247/Generated247.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest248/Generated248.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest248/Generated248.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest249/Generated249.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest249/Generated249.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest25/Generated25.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest25/Generated25.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest250/Generated250.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest250/Generated250.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest251/Generated251.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest251/Generated251.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest252/Generated252.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest252/Generated252.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest253/Generated253.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest253/Generated253.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest254/Generated254.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest254/Generated254.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest255/Generated255.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest255/Generated255.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest256/Generated256.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest256/Generated256.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest257/Generated257.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest257/Generated257.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest258/Generated258.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest258/Generated258.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest259/Generated259.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest259/Generated259.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest26/Generated26.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest26/Generated26.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest260/Generated260.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest260/Generated260.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest261/Generated261.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest261/Generated261.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest262/Generated262.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest262/Generated262.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest263/Generated263.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest263/Generated263.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest264/Generated264.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest264/Generated264.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest265/Generated265.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest265/Generated265.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest266/Generated266.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest266/Generated266.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest267/Generated267.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest267/Generated267.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest268/Generated268.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest268/Generated268.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest269/Generated269.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest269/Generated269.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest27/Generated27.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest27/Generated27.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest270/Generated270.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest270/Generated270.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest271/Generated271.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest271/Generated271.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest272/Generated272.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest272/Generated272.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest273/Generated273.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest273/Generated273.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest274/Generated274.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest274/Generated274.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest275/Generated275.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest275/Generated275.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest276/Generated276.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest276/Generated276.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest277/Generated277.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest277/Generated277.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest278/Generated278.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest278/Generated278.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest279/Generated279.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest279/Generated279.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest28/Generated28.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest28/Generated28.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest280/Generated280.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest280/Generated280.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest281/Generated281.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest281/Generated281.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest282/Generated282.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest282/Generated282.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest283/Generated283.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest283/Generated283.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest284/Generated284.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest284/Generated284.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest285/Generated285.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest285/Generated285.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest286/Generated286.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest286/Generated286.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest287/Generated287.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest287/Generated287.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest288/Generated288.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest288/Generated288.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest289/Generated289.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest289/Generated289.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest29/Generated29.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest29/Generated29.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest290/Generated290.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest290/Generated290.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest291/Generated291.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest291/Generated291.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest292/Generated292.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest292/Generated292.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest293/Generated293.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest293/Generated293.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest294/Generated294.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest294/Generated294.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest295/Generated295.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest295/Generated295.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest296/Generated296.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest296/Generated296.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest297/Generated297.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest297/Generated297.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest298/Generated298.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest298/Generated298.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest299/Generated299.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest299/Generated299.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest3/Generated3.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest3/Generated3.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest30/Generated30.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest30/Generated30.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest300/Generated300.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest300/Generated300.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest301/Generated301.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest301/Generated301.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest302/Generated302.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest302/Generated302.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest303/Generated303.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest303/Generated303.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest304/Generated304.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest304/Generated304.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest305/Generated305.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest305/Generated305.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest306/Generated306.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest306/Generated306.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest307/Generated307.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest307/Generated307.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest308/Generated308.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest308/Generated308.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest309/Generated309.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest309/Generated309.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest31/Generated31.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest31/Generated31.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest310/Generated310.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest310/Generated310.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest311/Generated311.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest311/Generated311.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest312/Generated312.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest312/Generated312.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest313/Generated313.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest313/Generated313.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest314/Generated314.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest314/Generated314.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest315/Generated315.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest315/Generated315.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest316/Generated316.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest316/Generated316.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest317/Generated317.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest317/Generated317.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest318/Generated318.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest318/Generated318.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest319/Generated319.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest319/Generated319.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest32/Generated32.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest32/Generated32.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest320/Generated320.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest320/Generated320.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest321/Generated321.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest321/Generated321.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest322/Generated322.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest322/Generated322.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest323/Generated323.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest323/Generated323.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest324/Generated324.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest324/Generated324.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest325/Generated325.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest325/Generated325.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest326/Generated326.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest326/Generated326.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest327/Generated327.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest327/Generated327.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest328/Generated328.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest328/Generated328.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest329/Generated329.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest329/Generated329.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest33/Generated33.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest33/Generated33.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest330/Generated330.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest330/Generated330.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest331/Generated331.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest331/Generated331.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest332/Generated332.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest332/Generated332.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest333/Generated333.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest333/Generated333.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest334/Generated334.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest334/Generated334.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest335/Generated335.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest335/Generated335.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest336/Generated336.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest336/Generated336.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest337/Generated337.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest337/Generated337.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest338/Generated338.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest338/Generated338.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest339/Generated339.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest339/Generated339.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest34/Generated34.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest34/Generated34.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest340/Generated340.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest340/Generated340.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest341/Generated341.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest341/Generated341.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest342/Generated342.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest342/Generated342.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest343/Generated343.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest343/Generated343.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest344/Generated344.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest344/Generated344.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest345/Generated345.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest345/Generated345.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest346/Generated346.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest346/Generated346.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest347/Generated347.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest347/Generated347.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest348/Generated348.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest348/Generated348.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest349/Generated349.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest349/Generated349.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest35/Generated35.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest35/Generated35.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest350/Generated350.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest350/Generated350.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest351/Generated351.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest351/Generated351.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest352/Generated352.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest352/Generated352.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest353/Generated353.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest353/Generated353.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest354/Generated354.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest354/Generated354.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest355/Generated355.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest355/Generated355.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest356/Generated356.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest356/Generated356.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest357/Generated357.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest357/Generated357.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest358/Generated358.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest358/Generated358.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest359/Generated359.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest359/Generated359.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest36/Generated36.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest36/Generated36.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest360/Generated360.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest360/Generated360.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest361/Generated361.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest361/Generated361.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest362/Generated362.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest362/Generated362.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest363/Generated363.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest363/Generated363.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest364/Generated364.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest364/Generated364.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest365/Generated365.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest365/Generated365.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest366/Generated366.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest366/Generated366.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest367/Generated367.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest367/Generated367.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest368/Generated368.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest368/Generated368.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest369/Generated369.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest369/Generated369.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest37/Generated37.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest37/Generated37.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest370/Generated370.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest370/Generated370.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest371/Generated371.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest371/Generated371.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest372/Generated372.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest372/Generated372.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest373/Generated373.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest373/Generated373.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest374/Generated374.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest374/Generated374.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest375/Generated375.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest375/Generated375.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest376/Generated376.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest376/Generated376.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest377/Generated377.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest377/Generated377.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest378/Generated378.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest378/Generated378.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest379/Generated379.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest379/Generated379.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest38/Generated38.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest38/Generated38.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest380/Generated380.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest380/Generated380.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest381/Generated381.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest381/Generated381.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest382/Generated382.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest382/Generated382.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest383/Generated383.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest383/Generated383.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest384/Generated384.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest384/Generated384.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest385/Generated385.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest385/Generated385.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest386/Generated386.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest386/Generated386.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest387/Generated387.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest387/Generated387.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest388/Generated388.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest388/Generated388.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest389/Generated389.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest389/Generated389.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest39/Generated39.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest39/Generated39.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest390/Generated390.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest390/Generated390.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest391/Generated391.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest391/Generated391.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest392/Generated392.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest392/Generated392.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest393/Generated393.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest393/Generated393.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest394/Generated394.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest394/Generated394.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest395/Generated395.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest395/Generated395.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest396/Generated396.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest396/Generated396.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest397/Generated397.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest397/Generated397.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest398/Generated398.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest398/Generated398.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest399/Generated399.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest399/Generated399.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest4/Generated4.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest4/Generated4.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest40/Generated40.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest40/Generated40.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest400/Generated400.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest400/Generated400.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest401/Generated401.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest401/Generated401.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest402/Generated402.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest402/Generated402.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest403/Generated403.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest403/Generated403.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest404/Generated404.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest404/Generated404.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest405/Generated405.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest405/Generated405.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest406/Generated406.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest406/Generated406.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest407/Generated407.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest407/Generated407.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest408/Generated408.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest408/Generated408.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest409/Generated409.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest409/Generated409.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest41/Generated41.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest41/Generated41.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest410/Generated410.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest410/Generated410.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest411/Generated411.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest411/Generated411.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest412/Generated412.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest412/Generated412.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest413/Generated413.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest413/Generated413.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest414/Generated414.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest414/Generated414.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest415/Generated415.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest415/Generated415.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest416/Generated416.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest416/Generated416.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest417/Generated417.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest417/Generated417.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest418/Generated418.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest418/Generated418.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest419/Generated419.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest419/Generated419.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.il
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.il
@@ -941,7 +941,8 @@
 		call void Generated42::ConstrainedCallsTest()
 		call void Generated42::StructConstrainedInterfaceCallsTest()
 		call void Generated42::CalliTest()
-		ldc.i4 101
+        ldnull
+		call instance int32 [mscorlib]System.String::get_Length()
 		ret
 	}
 }

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.il
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.il
@@ -941,7 +941,7 @@
 		call void Generated42::ConstrainedCallsTest()
 		call void Generated42::StructConstrainedInterfaceCallsTest()
 		call void Generated42::CalliTest()
-		ldc.i4 100
+		ldc.i4 101
 		ret
 	}
 }

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.il
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.il
@@ -941,8 +941,7 @@
 		call void Generated42::ConstrainedCallsTest()
 		call void Generated42::StructConstrainedInterfaceCallsTest()
 		call void Generated42::CalliTest()
-        ldnull
-		call instance int32 [mscorlib]System.String::get_Length()
+		ldc.i4 100
 		ret
 	}
 }

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest42/Generated42.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest420/Generated420.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest420/Generated420.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest421/Generated421.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest421/Generated421.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest422/Generated422.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest422/Generated422.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest423/Generated423.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest423/Generated423.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest424/Generated424.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest424/Generated424.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest425/Generated425.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest425/Generated425.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest426/Generated426.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest426/Generated426.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest427/Generated427.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest427/Generated427.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest428/Generated428.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest428/Generated428.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest429/Generated429.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest429/Generated429.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest43/Generated43.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest43/Generated43.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest430/Generated430.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest430/Generated430.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest431/Generated431.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest431/Generated431.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest432/Generated432.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest432/Generated432.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest433/Generated433.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest433/Generated433.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest434/Generated434.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest434/Generated434.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest435/Generated435.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest435/Generated435.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest436/Generated436.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest436/Generated436.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest437/Generated437.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest437/Generated437.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest438/Generated438.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest438/Generated438.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest439/Generated439.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest439/Generated439.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest44/Generated44.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest44/Generated44.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest440/Generated440.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest440/Generated440.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest441/Generated441.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest441/Generated441.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest442/Generated442.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest442/Generated442.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest443/Generated443.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest443/Generated443.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest444/Generated444.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest444/Generated444.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest445/Generated445.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest445/Generated445.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest446/Generated446.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest446/Generated446.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest447/Generated447.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest447/Generated447.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest448/Generated448.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest448/Generated448.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest449/Generated449.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest449/Generated449.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest45/Generated45.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest45/Generated45.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest450/Generated450.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest450/Generated450.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest451/Generated451.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest451/Generated451.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest452/Generated452.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest452/Generated452.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest453/Generated453.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest453/Generated453.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest454/Generated454.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest454/Generated454.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest455/Generated455.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest455/Generated455.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest456/Generated456.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest456/Generated456.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest457/Generated457.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest457/Generated457.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest458/Generated458.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest458/Generated458.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest459/Generated459.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest459/Generated459.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest46/Generated46.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest46/Generated46.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest460/Generated460.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest460/Generated460.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest461/Generated461.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest461/Generated461.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest462/Generated462.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest462/Generated462.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest463/Generated463.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest463/Generated463.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest464/Generated464.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest464/Generated464.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest465/Generated465.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest465/Generated465.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest466/Generated466.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest466/Generated466.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest467/Generated467.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest467/Generated467.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest468/Generated468.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest468/Generated468.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest469/Generated469.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest469/Generated469.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest47/Generated47.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest47/Generated47.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest470/Generated470.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest470/Generated470.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest471/Generated471.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest471/Generated471.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest472/Generated472.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest472/Generated472.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest473/Generated473.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest473/Generated473.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest474/Generated474.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest474/Generated474.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest475/Generated475.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest475/Generated475.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest476/Generated476.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest476/Generated476.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest477/Generated477.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest477/Generated477.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest478/Generated478.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest478/Generated478.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest479/Generated479.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest479/Generated479.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest48/Generated48.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest48/Generated48.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest480/Generated480.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest480/Generated480.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest481/Generated481.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest481/Generated481.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest482/Generated482.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest482/Generated482.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest483/Generated483.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest483/Generated483.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest484/Generated484.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest484/Generated484.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest485/Generated485.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest485/Generated485.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest486/Generated486.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest486/Generated486.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest487/Generated487.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest487/Generated487.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest488/Generated488.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest488/Generated488.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest489/Generated489.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest489/Generated489.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest49/Generated49.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest49/Generated49.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest490/Generated490.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest490/Generated490.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest491/Generated491.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest491/Generated491.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest492/Generated492.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest492/Generated492.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest493/Generated493.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest493/Generated493.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest494/Generated494.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest494/Generated494.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest495/Generated495.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest495/Generated495.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest496/Generated496.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest496/Generated496.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest497/Generated497.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest497/Generated497.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest498/Generated498.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest498/Generated498.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest499/Generated499.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest499/Generated499.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest5/Generated5.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest5/Generated5.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest50/Generated50.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest50/Generated50.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest500/Generated500.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest500/Generated500.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest501/Generated501.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest501/Generated501.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest502/Generated502.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest502/Generated502.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest503/Generated503.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest503/Generated503.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest504/Generated504.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest504/Generated504.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest505/Generated505.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest505/Generated505.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest506/Generated506.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest506/Generated506.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest507/Generated507.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest507/Generated507.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest508/Generated508.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest508/Generated508.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest509/Generated509.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest509/Generated509.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest51/Generated51.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest51/Generated51.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest510/Generated510.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest510/Generated510.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest511/Generated511.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest511/Generated511.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest512/Generated512.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest512/Generated512.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest513/Generated513.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest513/Generated513.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest514/Generated514.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest514/Generated514.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest515/Generated515.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest515/Generated515.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest516/Generated516.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest516/Generated516.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest517/Generated517.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest517/Generated517.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest518/Generated518.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest518/Generated518.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest519/Generated519.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest519/Generated519.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest52/Generated52.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest52/Generated52.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest520/Generated520.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest520/Generated520.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest521/Generated521.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest521/Generated521.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest522/Generated522.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest522/Generated522.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest523/Generated523.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest523/Generated523.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest524/Generated524.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest524/Generated524.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest525/Generated525.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest525/Generated525.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest526/Generated526.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest526/Generated526.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest527/Generated527.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest527/Generated527.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest528/Generated528.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest528/Generated528.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest529/Generated529.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest529/Generated529.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest53/Generated53.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest53/Generated53.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest530/Generated530.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest530/Generated530.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest531/Generated531.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest531/Generated531.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest532/Generated532.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest532/Generated532.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest533/Generated533.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest533/Generated533.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest534/Generated534.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest534/Generated534.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest535/Generated535.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest535/Generated535.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest536/Generated536.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest536/Generated536.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest537/Generated537.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest537/Generated537.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest538/Generated538.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest538/Generated538.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest539/Generated539.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest539/Generated539.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest54/Generated54.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest54/Generated54.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest540/Generated540.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest540/Generated540.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest541/Generated541.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest541/Generated541.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest542/Generated542.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest542/Generated542.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest543/Generated543.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest543/Generated543.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest544/Generated544.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest544/Generated544.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest545/Generated545.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest545/Generated545.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest546/Generated546.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest546/Generated546.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest547/Generated547.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest547/Generated547.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest548/Generated548.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest548/Generated548.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest549/Generated549.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest549/Generated549.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest55/Generated55.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest55/Generated55.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest550/Generated550.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest550/Generated550.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest551/Generated551.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest551/Generated551.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest552/Generated552.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest552/Generated552.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest553/Generated553.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest553/Generated553.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest554/Generated554.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest554/Generated554.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest555/Generated555.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest555/Generated555.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest556/Generated556.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest556/Generated556.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest557/Generated557.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest557/Generated557.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest558/Generated558.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest558/Generated558.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest559/Generated559.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest559/Generated559.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest56/Generated56.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest56/Generated56.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest560/Generated560.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest560/Generated560.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest561/Generated561.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest561/Generated561.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest562/Generated562.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest562/Generated562.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest563/Generated563.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest563/Generated563.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest564/Generated564.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest564/Generated564.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest565/Generated565.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest565/Generated565.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest566/Generated566.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest566/Generated566.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest567/Generated567.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest567/Generated567.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest568/Generated568.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest568/Generated568.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest569/Generated569.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest569/Generated569.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest57/Generated57.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest57/Generated57.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest570/Generated570.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest570/Generated570.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest571/Generated571.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest571/Generated571.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest572/Generated572.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest572/Generated572.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest573/Generated573.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest573/Generated573.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest574/Generated574.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest574/Generated574.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest575/Generated575.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest575/Generated575.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest576/Generated576.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest576/Generated576.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest577/Generated577.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest577/Generated577.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest578/Generated578.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest578/Generated578.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest579/Generated579.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest579/Generated579.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest58/Generated58.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest58/Generated58.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest580/Generated580.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest580/Generated580.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest581/Generated581.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest581/Generated581.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest582/Generated582.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest582/Generated582.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest583/Generated583.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest583/Generated583.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest584/Generated584.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest584/Generated584.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest585/Generated585.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest585/Generated585.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest586/Generated586.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest586/Generated586.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest587/Generated587.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest587/Generated587.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest588/Generated588.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest588/Generated588.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest589/Generated589.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest589/Generated589.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest59/Generated59.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest59/Generated59.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest590/Generated590.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest590/Generated590.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest591/Generated591.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest591/Generated591.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest592/Generated592.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest592/Generated592.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest593/Generated593.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest593/Generated593.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest594/Generated594.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest594/Generated594.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest595/Generated595.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest595/Generated595.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest596/Generated596.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest596/Generated596.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest597/Generated597.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest597/Generated597.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest598/Generated598.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest598/Generated598.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest599/Generated599.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest599/Generated599.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest6/Generated6.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest6/Generated6.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest60/Generated60.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest60/Generated60.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest600/Generated600.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest600/Generated600.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest601/Generated601.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest601/Generated601.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest602/Generated602.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest602/Generated602.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest603/Generated603.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest603/Generated603.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest604/Generated604.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest604/Generated604.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest605/Generated605.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest605/Generated605.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest606/Generated606.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest606/Generated606.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest607/Generated607.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest607/Generated607.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest608/Generated608.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest608/Generated608.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest609/Generated609.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest609/Generated609.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest61/Generated61.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest61/Generated61.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest610/Generated610.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest610/Generated610.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest611/Generated611.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest611/Generated611.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest612/Generated612.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest612/Generated612.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest613/Generated613.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest613/Generated613.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest614/Generated614.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest614/Generated614.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest615/Generated615.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest615/Generated615.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest616/Generated616.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest616/Generated616.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest617/Generated617.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest617/Generated617.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest618/Generated618.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest618/Generated618.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest619/Generated619.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest619/Generated619.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest62/Generated62.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest62/Generated62.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest620/Generated620.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest620/Generated620.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest621/Generated621.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest621/Generated621.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest622/Generated622.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest622/Generated622.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest623/Generated623.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest623/Generated623.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest624/Generated624.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest624/Generated624.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest625/Generated625.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest625/Generated625.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest626/Generated626.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest626/Generated626.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest627/Generated627.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest627/Generated627.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest628/Generated628.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest628/Generated628.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest629/Generated629.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest629/Generated629.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest63/Generated63.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest63/Generated63.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest630/Generated630.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest630/Generated630.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest631/Generated631.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest631/Generated631.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest632/Generated632.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest632/Generated632.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest633/Generated633.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest633/Generated633.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest634/Generated634.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest634/Generated634.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest635/Generated635.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest635/Generated635.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest636/Generated636.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest636/Generated636.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest637/Generated637.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest637/Generated637.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest638/Generated638.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest638/Generated638.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest639/Generated639.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest639/Generated639.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest64/Generated64.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest64/Generated64.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest640/Generated640.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest640/Generated640.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest641/Generated641.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest641/Generated641.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest642/Generated642.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest642/Generated642.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest643/Generated643.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest643/Generated643.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest644/Generated644.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest644/Generated644.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest645/Generated645.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest645/Generated645.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest646/Generated646.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest646/Generated646.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest647/Generated647.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest647/Generated647.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest648/Generated648.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest648/Generated648.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest649/Generated649.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest649/Generated649.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest65/Generated65.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest65/Generated65.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest650/Generated650.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest650/Generated650.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest651/Generated651.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest651/Generated651.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest652/Generated652.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest652/Generated652.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest653/Generated653.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest653/Generated653.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest654/Generated654.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest654/Generated654.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest655/Generated655.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest655/Generated655.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest656/Generated656.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest656/Generated656.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest657/Generated657.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest657/Generated657.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest658/Generated658.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest658/Generated658.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest659/Generated659.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest659/Generated659.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest66/Generated66.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest66/Generated66.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest660/Generated660.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest660/Generated660.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest661/Generated661.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest661/Generated661.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest662/Generated662.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest662/Generated662.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest663/Generated663.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest663/Generated663.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest664/Generated664.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest664/Generated664.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest665/Generated665.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest665/Generated665.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest666/Generated666.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest666/Generated666.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest667/Generated667.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest667/Generated667.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest668/Generated668.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest668/Generated668.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest669/Generated669.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest669/Generated669.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest67/Generated67.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest67/Generated67.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest670/Generated670.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest670/Generated670.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest671/Generated671.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest671/Generated671.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest672/Generated672.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest672/Generated672.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest673/Generated673.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest673/Generated673.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest674/Generated674.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest674/Generated674.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest675/Generated675.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest675/Generated675.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest676/Generated676.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest676/Generated676.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest677/Generated677.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest677/Generated677.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest678/Generated678.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest678/Generated678.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest679/Generated679.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest679/Generated679.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest68/Generated68.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest68/Generated68.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest680/Generated680.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest680/Generated680.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest681/Generated681.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest681/Generated681.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest682/Generated682.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest682/Generated682.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest683/Generated683.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest683/Generated683.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest684/Generated684.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest684/Generated684.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest685/Generated685.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest685/Generated685.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest686/Generated686.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest686/Generated686.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest687/Generated687.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest687/Generated687.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest688/Generated688.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest688/Generated688.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest689/Generated689.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest689/Generated689.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest69/Generated69.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest69/Generated69.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest690/Generated690.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest690/Generated690.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest691/Generated691.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest691/Generated691.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest692/Generated692.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest692/Generated692.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest693/Generated693.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest693/Generated693.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest694/Generated694.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest694/Generated694.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest695/Generated695.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest695/Generated695.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest696/Generated696.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest696/Generated696.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest697/Generated697.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest697/Generated697.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest698/Generated698.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest698/Generated698.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest699/Generated699.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest699/Generated699.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest7/Generated7.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest7/Generated7.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest70/Generated70.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest70/Generated70.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest700/Generated700.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest700/Generated700.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest701/Generated701.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest701/Generated701.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest702/Generated702.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest702/Generated702.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest703/Generated703.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest703/Generated703.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest704/Generated704.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest704/Generated704.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest705/Generated705.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest705/Generated705.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest706/Generated706.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest706/Generated706.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest707/Generated707.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest707/Generated707.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest708/Generated708.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest708/Generated708.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest709/Generated709.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest709/Generated709.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest71/Generated71.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest71/Generated71.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest710/Generated710.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest710/Generated710.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest711/Generated711.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest711/Generated711.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest712/Generated712.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest712/Generated712.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest713/Generated713.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest713/Generated713.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest714/Generated714.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest714/Generated714.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest715/Generated715.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest715/Generated715.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest716/Generated716.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest716/Generated716.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest717/Generated717.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest717/Generated717.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest718/Generated718.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest718/Generated718.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest719/Generated719.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest719/Generated719.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest72/Generated72.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest72/Generated72.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest720/Generated720.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest720/Generated720.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest721/Generated721.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest721/Generated721.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest722/Generated722.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest722/Generated722.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest723/Generated723.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest723/Generated723.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest724/Generated724.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest724/Generated724.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest725/Generated725.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest725/Generated725.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest726/Generated726.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest726/Generated726.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest727/Generated727.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest727/Generated727.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest728/Generated728.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest728/Generated728.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest729/Generated729.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest729/Generated729.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest73/Generated73.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest73/Generated73.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest730/Generated730.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest730/Generated730.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest731/Generated731.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest731/Generated731.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest732/Generated732.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest732/Generated732.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest733/Generated733.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest733/Generated733.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest734/Generated734.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest734/Generated734.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest735/Generated735.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest735/Generated735.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest736/Generated736.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest736/Generated736.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest737/Generated737.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest737/Generated737.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest738/Generated738.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest738/Generated738.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest739/Generated739.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest739/Generated739.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest74/Generated74.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest74/Generated74.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest740/Generated740.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest740/Generated740.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest741/Generated741.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest741/Generated741.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest742/Generated742.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest742/Generated742.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest743/Generated743.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest743/Generated743.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest744/Generated744.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest744/Generated744.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest745/Generated745.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest745/Generated745.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest746/Generated746.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest746/Generated746.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest747/Generated747.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest747/Generated747.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest748/Generated748.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest748/Generated748.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest749/Generated749.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest749/Generated749.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest75/Generated75.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest75/Generated75.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest750/Generated750.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest750/Generated750.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest751/Generated751.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest751/Generated751.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest752/Generated752.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest752/Generated752.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest753/Generated753.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest753/Generated753.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest754/Generated754.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest754/Generated754.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest755/Generated755.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest755/Generated755.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest756/Generated756.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest756/Generated756.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest757/Generated757.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest757/Generated757.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest758/Generated758.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest758/Generated758.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest759/Generated759.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest759/Generated759.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest76/Generated76.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest76/Generated76.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest760/Generated760.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest760/Generated760.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest761/Generated761.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest761/Generated761.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest762/Generated762.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest762/Generated762.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest763/Generated763.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest763/Generated763.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest764/Generated764.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest764/Generated764.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest765/Generated765.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest765/Generated765.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest766/Generated766.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest766/Generated766.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest767/Generated767.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest767/Generated767.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest768/Generated768.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest768/Generated768.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest769/Generated769.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest769/Generated769.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest77/Generated77.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest77/Generated77.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest770/Generated770.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest770/Generated770.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest771/Generated771.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest771/Generated771.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest772/Generated772.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest772/Generated772.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest773/Generated773.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest773/Generated773.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest774/Generated774.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest774/Generated774.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest775/Generated775.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest775/Generated775.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest776/Generated776.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest776/Generated776.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest777/Generated777.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest777/Generated777.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest778/Generated778.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest778/Generated778.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest779/Generated779.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest779/Generated779.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest78/Generated78.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest78/Generated78.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest780/Generated780.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest780/Generated780.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest781/Generated781.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest781/Generated781.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest782/Generated782.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest782/Generated782.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest783/Generated783.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest783/Generated783.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest784/Generated784.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest784/Generated784.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest785/Generated785.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest785/Generated785.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest786/Generated786.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest786/Generated786.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest787/Generated787.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest787/Generated787.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest788/Generated788.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest788/Generated788.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest789/Generated789.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest789/Generated789.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest79/Generated79.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest79/Generated79.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest790/Generated790.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest790/Generated790.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest791/Generated791.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest791/Generated791.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest792/Generated792.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest792/Generated792.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest793/Generated793.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest793/Generated793.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest794/Generated794.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest794/Generated794.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest795/Generated795.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest795/Generated795.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest796/Generated796.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest796/Generated796.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest797/Generated797.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest797/Generated797.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest798/Generated798.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest798/Generated798.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest799/Generated799.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest799/Generated799.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest8/Generated8.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest8/Generated8.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest80/Generated80.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest80/Generated80.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest800/Generated800.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest800/Generated800.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest801/Generated801.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest801/Generated801.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest802/Generated802.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest802/Generated802.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest803/Generated803.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest803/Generated803.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest804/Generated804.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest804/Generated804.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest805/Generated805.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest805/Generated805.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest806/Generated806.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest806/Generated806.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest807/Generated807.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest807/Generated807.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest808/Generated808.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest808/Generated808.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest809/Generated809.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest809/Generated809.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest81/Generated81.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest81/Generated81.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest810/Generated810.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest810/Generated810.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest811/Generated811.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest811/Generated811.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest812/Generated812.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest812/Generated812.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest813/Generated813.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest813/Generated813.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest814/Generated814.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest814/Generated814.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest815/Generated815.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest815/Generated815.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest816/Generated816.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest816/Generated816.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest817/Generated817.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest817/Generated817.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest818/Generated818.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest818/Generated818.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest819/Generated819.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest819/Generated819.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest82/Generated82.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest82/Generated82.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest820/Generated820.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest820/Generated820.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest821/Generated821.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest821/Generated821.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest822/Generated822.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest822/Generated822.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest823/Generated823.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest823/Generated823.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest824/Generated824.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest824/Generated824.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest825/Generated825.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest825/Generated825.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest826/Generated826.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest826/Generated826.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest827/Generated827.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest827/Generated827.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest828/Generated828.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest828/Generated828.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest829/Generated829.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest829/Generated829.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest83/Generated83.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest83/Generated83.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest830/Generated830.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest830/Generated830.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest831/Generated831.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest831/Generated831.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest832/Generated832.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest832/Generated832.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest833/Generated833.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest833/Generated833.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest834/Generated834.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest834/Generated834.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest835/Generated835.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest835/Generated835.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest836/Generated836.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest836/Generated836.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest837/Generated837.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest837/Generated837.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest838/Generated838.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest838/Generated838.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest839/Generated839.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest839/Generated839.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest84/Generated84.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest84/Generated84.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest840/Generated840.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest840/Generated840.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest841/Generated841.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest841/Generated841.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest842/Generated842.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest842/Generated842.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest843/Generated843.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest843/Generated843.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest844/Generated844.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest844/Generated844.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest845/Generated845.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest845/Generated845.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest846/Generated846.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest846/Generated846.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest847/Generated847.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest847/Generated847.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest848/Generated848.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest848/Generated848.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest849/Generated849.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest849/Generated849.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest85/Generated85.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest85/Generated85.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest850/Generated850.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest850/Generated850.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest851/Generated851.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest851/Generated851.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest852/Generated852.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest852/Generated852.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest853/Generated853.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest853/Generated853.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest854/Generated854.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest854/Generated854.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest855/Generated855.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest855/Generated855.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest856/Generated856.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest856/Generated856.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest857/Generated857.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest857/Generated857.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest858/Generated858.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest858/Generated858.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest859/Generated859.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest859/Generated859.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest86/Generated86.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest86/Generated86.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest860/Generated860.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest860/Generated860.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest861/Generated861.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest861/Generated861.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest862/Generated862.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest862/Generated862.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest863/Generated863.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest863/Generated863.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest864/Generated864.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest864/Generated864.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest865/Generated865.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest865/Generated865.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest866/Generated866.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest866/Generated866.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest867/Generated867.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest867/Generated867.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest868/Generated868.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest868/Generated868.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest869/Generated869.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest869/Generated869.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest87/Generated87.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest87/Generated87.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest870/Generated870.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest870/Generated870.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest871/Generated871.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest871/Generated871.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest872/Generated872.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest872/Generated872.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest873/Generated873.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest873/Generated873.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest874/Generated874.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest874/Generated874.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest875/Generated875.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest875/Generated875.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest876/Generated876.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest876/Generated876.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest877/Generated877.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest877/Generated877.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest878/Generated878.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest878/Generated878.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest879/Generated879.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest879/Generated879.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest88/Generated88.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest88/Generated88.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest880/Generated880.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest880/Generated880.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest881/Generated881.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest881/Generated881.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest882/Generated882.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest882/Generated882.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest883/Generated883.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest883/Generated883.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest884/Generated884.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest884/Generated884.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest885/Generated885.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest885/Generated885.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest886/Generated886.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest886/Generated886.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest887/Generated887.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest887/Generated887.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest888/Generated888.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest888/Generated888.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest889/Generated889.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest889/Generated889.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest89/Generated89.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest89/Generated89.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest890/Generated890.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest890/Generated890.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest891/Generated891.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest891/Generated891.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest892/Generated892.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest892/Generated892.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest893/Generated893.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest893/Generated893.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest894/Generated894.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest894/Generated894.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest895/Generated895.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest895/Generated895.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest896/Generated896.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest896/Generated896.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest897/Generated897.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest897/Generated897.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest898/Generated898.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest898/Generated898.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest899/Generated899.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest899/Generated899.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest9/Generated9.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest9/Generated9.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest90/Generated90.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest90/Generated90.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest900/Generated900.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest900/Generated900.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest901/Generated901.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest901/Generated901.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest902/Generated902.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest902/Generated902.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest903/Generated903.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest903/Generated903.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest904/Generated904.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest904/Generated904.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest905/Generated905.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest905/Generated905.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest906/Generated906.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest906/Generated906.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest907/Generated907.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest907/Generated907.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest908/Generated908.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest908/Generated908.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest909/Generated909.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest909/Generated909.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest91/Generated91.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest91/Generated91.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest910/Generated910.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest910/Generated910.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest911/Generated911.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest911/Generated911.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest912/Generated912.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest912/Generated912.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest913/Generated913.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest913/Generated913.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest914/Generated914.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest914/Generated914.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest915/Generated915.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest915/Generated915.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest916/Generated916.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest916/Generated916.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest917/Generated917.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest917/Generated917.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest918/Generated918.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest918/Generated918.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest919/Generated919.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest919/Generated919.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest92/Generated92.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest92/Generated92.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest920/Generated920.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest920/Generated920.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest921/Generated921.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest921/Generated921.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest922/Generated922.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest922/Generated922.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest923/Generated923.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest923/Generated923.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest924/Generated924.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest924/Generated924.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest925/Generated925.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest925/Generated925.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest926/Generated926.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest926/Generated926.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest927/Generated927.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest927/Generated927.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest928/Generated928.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest928/Generated928.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest929/Generated929.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest929/Generated929.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest93/Generated93.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest93/Generated93.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest930/Generated930.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest930/Generated930.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest931/Generated931.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest931/Generated931.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest932/Generated932.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest932/Generated932.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest933/Generated933.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest933/Generated933.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest934/Generated934.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest934/Generated934.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest935/Generated935.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest935/Generated935.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest936/Generated936.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest936/Generated936.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest937/Generated937.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest937/Generated937.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest938/Generated938.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest938/Generated938.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest939/Generated939.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest939/Generated939.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest94/Generated94.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest94/Generated94.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest940/Generated940.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest940/Generated940.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest941/Generated941.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest941/Generated941.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest942/Generated942.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest942/Generated942.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest943/Generated943.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest943/Generated943.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest944/Generated944.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest944/Generated944.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest945/Generated945.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest945/Generated945.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest946/Generated946.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest946/Generated946.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest947/Generated947.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest947/Generated947.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest948/Generated948.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest948/Generated948.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest949/Generated949.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest949/Generated949.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest95/Generated95.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest95/Generated95.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest950/Generated950.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest950/Generated950.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest951/Generated951.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest951/Generated951.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest952/Generated952.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest952/Generated952.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest953/Generated953.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest953/Generated953.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest954/Generated954.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest954/Generated954.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest955/Generated955.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest955/Generated955.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest956/Generated956.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest956/Generated956.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest957/Generated957.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest957/Generated957.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest958/Generated958.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest958/Generated958.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest959/Generated959.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest959/Generated959.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest96/Generated96.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest96/Generated96.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest960/Generated960.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest960/Generated960.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest961/Generated961.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest961/Generated961.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest962/Generated962.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest962/Generated962.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest963/Generated963.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest963/Generated963.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest964/Generated964.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest964/Generated964.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest965/Generated965.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest965/Generated965.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest966/Generated966.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest966/Generated966.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest967/Generated967.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest967/Generated967.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest968/Generated968.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest968/Generated968.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest969/Generated969.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest969/Generated969.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest97/Generated97.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest97/Generated97.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest970/Generated970.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest970/Generated970.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest971/Generated971.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest971/Generated971.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest972/Generated972.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest972/Generated972.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest973/Generated973.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest973/Generated973.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest974/Generated974.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest974/Generated974.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest975/Generated975.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest975/Generated975.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest976/Generated976.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest976/Generated976.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest977/Generated977.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest977/Generated977.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest978/Generated978.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest978/Generated978.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest979/Generated979.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest979/Generated979.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest98/Generated98.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest98/Generated98.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest980/Generated980.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest980/Generated980.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest981/Generated981.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest981/Generated981.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest982/Generated982.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest982/Generated982.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest983/Generated983.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest983/Generated983.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest984/Generated984.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest984/Generated984.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest985/Generated985.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest985/Generated985.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest986/Generated986.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest986/Generated986.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest987/Generated987.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest987/Generated987.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest988/Generated988.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest988/Generated988.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest989/Generated989.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest989/Generated989.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest99/Generated99.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest99/Generated99.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest990/Generated990.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest990/Generated990.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest991/Generated991.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest991/Generated991.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest992/Generated992.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest992/Generated992.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest993/Generated993.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest993/Generated993.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest994/Generated994.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest994/Generated994.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest995/Generated995.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest995/Generated995.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest996/Generated996.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest996/Generated996.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest997/Generated997.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest997/Generated997.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest998/Generated998.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest998/Generated998.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest999/Generated999.ilproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTest999/Generated999.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestAssembly>true</IsMergedTestAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest?/Generated*.ilproj" />
+    <ProjectReference Include="TypeGeneratorTest??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
-    <IsMergedTestAssembly>true</IsMergedTestAssembly>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="TypeGeneratorTest?/Generated*.ilproj" />

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <CLRTestPriority>1</CLRTestPriority>
     <IsMergedTestAssembly>true</IsMergedTestAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests0-99.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
     <IsMergedTestAssembly>true</IsMergedTestAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests100-199.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests100-199.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest1??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1000-1099.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1000-1099.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest10??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1100-1199.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1100-1199.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest11??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1200-1299.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1200-1299.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest12??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1300-1399.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1300-1399.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest13??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1400-1599.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests1400-1599.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest14??/Generated*.ilproj" />
+    <ProjectReference Include="TypeGeneratorTest15??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests200-299.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests200-299.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest2??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests300-399.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests300-399.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest3??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests400-499.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests400-499.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest4??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests500-599.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests500-599.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest5??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests600-699.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests600-699.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest6??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests700-799.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests700-799.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest7??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests800-899.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests800-899.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest8??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests900-999.csproj
+++ b/src/tests/Loader/classloader/TypeGeneratorTests/TypeGeneratorTests900-999.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+    <IsMergedTestRunnerAssembly>true</IsMergedTestRunnerAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="TypeGeneratorTest9??/Generated*.ilproj" />
+    <ProjectReference Include="TestFramework/TestFramework.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -49,7 +49,6 @@
            Text="$(XunitTestBinBase) does not exist. Please run src\tests\build / src/tests/build.sh from the repo root at least once to get the tests built." />
 
     <ItemGroup>
-
       <AllTestDirsNonCanonicalPaths Include="$([System.IO.Directory]::GetDirectories(`$(XunitTestBinBase)`))" />
       <AllTestDirsPaths Include="@(AllTestDirsNonCanonicalPaths)" />
       <AllTestDirsPaths Include="@(AllTestDirsNonCanonicalPaths)" >
@@ -57,13 +56,15 @@
       </AllTestDirsPaths>
       <SkipTestDirsPaths Include="$([System.IO.Path]::GetFullPath('$(XunitTestBinBase)%(_SkipTestDir.Identity)'))" />
       <NonExcludedTestDirectories Include="@(AllTestDirsPaths -> '%(Path)')" Exclude="@(SkipTestDirsPaths)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(LegacyRunnableTestPaths)' != ''">
       <TopLevelDirectories Include="@(NonExcludedTestDirectories)" />
       <SecondLevel Include="$([System.IO.Directory]::GetDirectories(%(TopLevelDirectories.Identity)))" />
       <SecondLevelDirectories Include="@(SecondLevel)">
         <Path>$([System.IO.Path]::GetFullPath(%(LegacyRunnableTestPaths.Identity)))</Path>
       </SecondLevelDirectories>
       <TestDirectoriesWithDup Include="@(SecondLevelDirectories -> '%(Identity)')" Condition="$([System.String]::new('%(Path)').StartsWith('%(Identity)'))" />
-
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(TestDirectoriesWithDup)">
@@ -258,7 +259,11 @@
   </Target>
 
   <Target Name="BuildAllAndroidApp" DependsOnTargets="GetListOfTestCmds;FindCmdDirectories">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="BuildAndroidApp" Properties="_CMDDIR=%(TestDirectories.Identity)" />
+    <MSBuild
+      Projects="$(MSBuildProjectFile)"
+      Targets="BuildAndroidApp"
+      Properties="_CMDDIR=%(TestDirectories.Identity)"
+      Condition="'@(TestDirectories)' != ''" />
   </Target>
 
   <UsingTask TaskName="AppleAppBuilderTask" AssemblyFile="$(AppleAppBuilderTasksAssemblyPath)" />
@@ -369,6 +374,7 @@
       Projects="@(RunProj)"
       Targets="BuildiOSApp"
       BuildInParallel="true"
+      Condition="'@(TestDirectories)' != ''"
       />
   </Target>
 

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -62,7 +62,7 @@
       <TopLevelDirectories Include="@(NonExcludedTestDirectories)" />
       <SecondLevel Include="$([System.IO.Directory]::GetDirectories(%(TopLevelDirectories.Identity)))" />
       <SecondLevelDirectories Include="@(SecondLevel)">
-        <Path>$([System.IO.Path]::GetFullPath(%(AllRunnableTestPaths.Identity)))</Path>
+        <Path>$([System.IO.Path]::GetFullPath(%(LegacyRunnableTestPaths.Identity)))</Path>
       </SecondLevelDirectories>
       <TestDirectoriesWithDup Include="@(SecondLevelDirectories -> '%(Identity)')" Condition="$([System.String]::new('%(Path)').StartsWith('%(Identity)'))" />
 
@@ -88,7 +88,7 @@
         Text="$(XunitTestBinBase) does not exist. Please run src\tests\build / src/tests/build.sh from the repo root at least once to get the tests built." />
 
     <PropertyGroup>
-        <TestCount>@(AllRunnableTestPaths->Count())</TestCount>
+        <TestCount>@(LegacyRunnableTestPaths->Count())</TestCount>
     </PropertyGroup>
 
     <Message Text="Found $(TestCount) built tests"/>
@@ -378,6 +378,9 @@
     <ItemGroup>
       <AllRunnableTestPaths Include="$(XunitTestBinBase)\**\*.$(TestScriptExtension)"/>
       <AllRunnableTestPaths Remove="$(XunitTestBinBase)\**\run-v8.sh" Condition="'$(TargetArchitecture)' == 'wasm'" />
+      <MergedAssemblyMarkerPaths Include="$(XunitTestBinBase)\**\*.MergedTestAssembly"/>
+      <MergedRunnableTestPaths Include="$([System.IO.Path]::ChangeExtension('%(MergedAssemblyMarkerPaths.Identity)', '.$(TestScriptExtension)'))" />
+      <LegacyRunnableTestPaths Include="@(AllRunnableTestPaths)" Exclude="@(MergedRunnableTestPaths)" />
     </ItemGroup>
   </Target>
 

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -7,8 +7,6 @@
     <XunitTestBinBase Condition="'$(XunitTestBinBase)'==''" >$(BaseOutputPathWithConfig)</XunitTestBinBase>
     <XunitWrapperGeneratedCSDirBase>$(XunitTestBinBase)\TestWrappers\</XunitWrapperGeneratedCSDirBase>
     <MSBuildEnableAllPropertyFunctions>1</MSBuildEnableAllPropertyFunctions>
-    <TestScriptExtension Condition="'$(TestWrapperTargetsWindows)' != 'true' ">sh</TestScriptExtension>
-    <TestScriptExtension Condition="'$(TestWrapperTargetsWindows)' == 'true' ">cmd</TestScriptExtension>
     <Language>C#</Language>
     <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
   </PropertyGroup>

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -1147,7 +1147,6 @@ def find_test_from_name(host_os, test_location, test_name):
 
     location = starting_path
     if not os.path.isfile(location):
-        print("Warning: couldn't find test: %s" % test_name)
         return None
 
     assert(os.path.isfile(location))

--- a/src/tests/xunit-wrappers.targets
+++ b/src/tests/xunit-wrappers.targets
@@ -91,7 +91,7 @@ $(_XunitEpilog)
 
   <Import Project="$(MSBuildThisFileDirectory)Common/testgrouping.proj" />
 
-  <Target Name="CreateXunitFacts">
+  <Target Name="CreateXunitFacts" DependsOnTargets="GetListOfTestCmds">
     <!-- NOTE! semicolons must be escaped with %3B boooo -->
 
     <PropertyGroup>
@@ -254,6 +254,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
     <ItemGroup>
       <AllCMDsPresent Include="$(_CMDDIR)\**\*.$(TestScriptExtension)" />
       <AllCMDsPresent Remove="$(_CMDDIR)\**\run-v8.sh" Condition="'$(TargetArchitecture)' == 'wasm'" />
+      <AllCMDsPresent Remove="@(MergedRunnableTestPaths)" />
       <TestGroupingDistinctWithCase Include="@(TestGrouping->Metadata('FullPath')->DistinctWithCase())" />
       <TestGroupingNotRelevant Include="@(TestGroupingDistinctWithCase)" Exclude="@(AllCMDsPresent)" />
       <GroupedCMDs Include="@(TestGroupingDistinctWithCase)" Exclude="@(TestGroupingNotRelevant)" />

--- a/src/tests/xunit-wrappers.targets
+++ b/src/tests/xunit-wrappers.targets
@@ -1,6 +1,10 @@
 <Project>
   <Target Name="CreateAllWrappers" DependsOnTargets="GetListOfTestCmds;FindCmdDirectories">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateXunitWrapper;BuildXunitWrapper" Properties="_CMDDIR=%(TestDirectories.Identity)" />
+    <MSBuild
+      Projects="$(MSBuildProjectFile)"
+      Targets="CreateXunitWrapper;BuildXunitWrapper"
+      Properties="_CMDDIR=%(TestDirectories.Identity)"
+      Condition="'@(TestDirectories)' != ''" />
   </Target>
 
   <Target Name="CreateXunitWrapper" DependsOnTargets="CreateXunitFacts">
@@ -255,6 +259,9 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
       <AllCMDsPresent Include="$(_CMDDIR)\**\*.$(TestScriptExtension)" />
       <AllCMDsPresent Remove="$(_CMDDIR)\**\run-v8.sh" Condition="'$(TargetArchitecture)' == 'wasm'" />
       <AllCMDsPresent Remove="@(MergedRunnableTestPaths)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(AllCMDsPresent)' != ''">
       <TestGroupingDistinctWithCase Include="@(TestGrouping->Metadata('FullPath')->DistinctWithCase())" />
       <TestGroupingNotRelevant Include="@(TestGroupingDistinctWithCase)" Exclude="@(AllCMDsPresent)" />
       <GroupedCMDs Include="@(TestGroupingDistinctWithCase)" Exclude="@(TestGroupingNotRelevant)" />


### PR DESCRIPTION
This is an initial attempt to introduce a group project. As of the initial commit it doesn't yet have any Helix identity of its own - in grouped (non-standalone) mode, the group project replaces its initial component projects and ends up with a single Helix xUnit result (as it still gets run through the xUnit wrapper logic).

We need to decide whether this is acceptable or whether we need to retain the original behavior of each test case reporting its results individually in a way that can be parsed by our scripts. This is going to become even more important once we start pushing towards converting all tests to the new style. Assuming we want to keep the individual test cases visible in AzDO, this change will require an additional delta to implement the relevant logic.

The change switches over the first 100 type generator tests (numbers 0-99); to facilitate lab coverage, it also sets BuildAsStandalone to false by default in contrast to Jeremy's original implementation. I have verified locally that by setting BuildAsStandalone to true I get the original 1501 tests with individual results. By not setting BuildAsStandalone or by setting it to false, I'm receiving the correct number of 1402 tests (1401 original non-merged tests from 100 onward and the one extra grouped test).

Thanks

Tomas