### PR TITLE
Implement PEM exports for RSA PKCS#1 and ECPrivateKey

### DIFF
--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -397,6 +397,7 @@ namespace System.Security.Cryptography
     {
         protected ECAlgorithm() { }
         public virtual byte[] ExportECPrivateKey() { throw null; }
+        public string ExportECPrivateKeyPem() { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportExplicitParameters(bool includePrivateParameters) { throw null; }
         public virtual System.Security.Cryptography.ECParameters ExportParameters(bool includePrivateParameters) { throw null; }
         public virtual void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
@@ -410,6 +411,7 @@ namespace System.Security.Cryptography
         public override void ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public override void ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual bool TryExportECPrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportECPrivateKeyPem(System.Span<char> destination, out int charsWritten) { throw null; }
         public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public override bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
@@ -1025,7 +1027,9 @@ namespace System.Security.Cryptography
         public virtual byte[] EncryptValue(byte[] rgb) { throw null; }
         public abstract System.Security.Cryptography.RSAParameters ExportParameters(bool includePrivateParameters);
         public virtual byte[] ExportRSAPrivateKey() { throw null; }
+        public string ExportRSAPrivateKeyPem() { throw null; }
         public virtual byte[] ExportRSAPublicKey() { throw null; }
+        public string ExportRSAPublicKeyPem() { throw null; }
         public override void FromXmlString(string xmlString) { }
         protected virtual byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         protected virtual byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
@@ -1050,7 +1054,9 @@ namespace System.Security.Cryptography
         public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
         public override bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public virtual bool TryExportRSAPrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportRSAPrivateKeyPem(System.Span<char> destination, out int charsWritten) { throw null; }
         public virtual bool TryExportRSAPublicKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportRSAPublicKeyPem(System.Span<char> destination, out int charsWritten) { throw null; }
         public override bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected virtual bool TryHashData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
         public virtual bool TrySignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding, out int bytesWritten) { throw null; }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSA.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSA.cs
@@ -850,6 +850,159 @@ namespace System.Security.Cryptography
             base.ImportFromEncryptedPem(input, passwordBytes);
         }
 
+        /// <summary>
+        /// Exports the current key in the PKCS#1 RSAPrivateKey format, PEM encoded.
+        /// </summary>
+        /// <returns>A string containing the PEM-encoded PKCS#1 RSAPrivateKey.</returns>
+        /// <exception cref="CryptographicException">
+        /// The key could not be exported.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded PKCS#1 RSAPrivateKey will begin with <c>-----BEGIN RSA PRIVATE KEY-----</c>
+        ///   and end with <c>-----END RSA PRIVATE KEY-----</c>, with the base64 encoded DER
+        ///   contents of the key between the PEM boundaries.
+        /// </p>
+        /// <p>
+        ///   The PEM is encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public unsafe string ExportRSAPrivateKeyPem()
+        {
+            byte[] exported = ExportRSAPrivateKey();
+
+            // Fixed to prevent GC moves.
+            fixed (byte* pExported = exported)
+            {
+                try
+                {
+                    return PemKeyHelpers.CreatePemFromData(PemLabels.RsaPrivateKey, exported);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(exported);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Exports the public-key portion of the current key in the PKCS#1
+        /// RSAPublicKey format, PEM encoded.
+        /// </summary>
+        /// <returns>A string containing the PEM-encoded PKCS#1 RSAPublicKey.</returns>
+        /// <exception cref="CryptographicException">
+        /// The key could not be exported.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded PKCS#1 RSAPublicKey will begin with <c>-----BEGIN RSA PUBLIC KEY-----</c>
+        ///   and end with <c>-----END RSA PUBLIC KEY-----</c>, with the base64 encoded DER
+        ///   contents of the key between the PEM boundaries.
+        /// </p>
+        /// <p>
+        ///   The PEM is encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public string ExportRSAPublicKeyPem()
+        {
+            byte[] exported = ExportRSAPublicKey();
+            return PemKeyHelpers.CreatePemFromData(PemLabels.RsaPublicKey, exported);
+        }
+
+        /// <summary>
+        /// Attempts to export the current key in the PEM-encoded PKCS#1
+        /// RSAPrivateKey format into a provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        /// The character span to receive the PEM-encoded PKCS#1 RSAPrivateKey data.
+        /// </param>
+        /// <param name="charsWritten">
+        /// When this method returns, contains a value that indicates the number
+        /// of characters written to <paramref name="destination" />. This
+        /// parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="destination" /> is big enough
+        /// to receive the output; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        /// The key could not be exported.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded PKCS#1 RSAPrivateKey will begin with
+        ///   <c>-----BEGIN RSA PRIVATE KEY-----</c> and end with
+        ///   <c>-----END RSA PRIVATE KEY-----</c>, with the base64 encoded DER
+        ///   contents of the key between the PEM boundaries.
+        /// </p>
+        /// <p>
+        ///   The PEM is encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public bool TryExportRSAPrivateKeyPem(Span<char> destination, out int charsWritten)
+        {
+            static bool Export(RSA alg, Span<byte> destination, out int bytesWritten)
+            {
+                return alg.TryExportRSAPrivateKey(destination, out bytesWritten);
+            }
+
+            return PemKeyHelpers.TryExportToPem(
+                this,
+                PemLabels.RsaPrivateKey,
+                Export,
+                destination,
+                out charsWritten);
+        }
+
+        /// <summary>
+        /// Attempts to export the current key in the PEM-encoded PKCS#1
+        /// RSAPublicKey format into a provided buffer.
+        /// </summary>
+        /// <param name="destination">
+        /// The character span to receive the PEM-encoded PKCS#1 RSAPublicKey data.
+        /// </param>
+        /// <param name="charsWritten">
+        /// When this method returns, contains a value that indicates the number
+        /// of characters written to <paramref name="destination" />. This
+        /// parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="destination" /> is big enough
+        /// to receive the output; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        /// The key could not be exported.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded PKCS#1 RSAPublicKey will begin with
+        ///   <c>-----BEGIN RSA PUBLIC KEY-----</c> and end with
+        ///   <c>-----END RSA PUBLIC KEY-----</c>, with the base64 encoded DER
+        ///   contents of the key between the PEM boundaries.
+        /// </p>
+        /// <p>
+        ///   The PEM is encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public bool TryExportRSAPublicKeyPem(Span<char> destination, out int charsWritten)
+        {
+            static bool Export(RSA alg, Span<byte> destination, out int bytesWritten)
+            {
+                return alg.TryExportRSAPublicKey(destination, out bytesWritten);
+            }
+
+            return PemKeyHelpers.TryExportToPem(
+                this,
+                PemLabels.RsaPublicKey,
+                Export,
+                destination,
+                out charsWritten);
+        }
+
         private static void ClearPrivateParameters(in RSAParameters rsaParameters)
         {
             CryptographicOperations.ZeroMemory(rsaParameters.D);

--- a/src/libraries/System.Security.Cryptography/tests/ECPemExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ECPemExportTests.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
+    public static class ECPemExportTests
+    {
+        [Fact]
+        public static void ExportPem_ExportECPrivateKey()
+        {
+            string expectedPem =
+                "-----BEGIN EC PRIVATE KEY-----\n" +
+                "cGVubnk=\n" +
+                "-----END EC PRIVATE KEY-----";
+
+            static byte[] ExportECPrivateKey()
+            {
+                return new byte[] { 0x70, 0x65, 0x6e, 0x6e, 0x79 };
+            }
+
+            using (DelegateECAlgorithm ec = new DelegateECAlgorithm())
+            {
+                ec.ExportECPrivateKeyDelegate = ExportECPrivateKey;
+                Assert.Equal(expectedPem, ec.ExportECPrivateKeyPem());
+            }
+        }
+
+        [Fact]
+        public static void ExportPem_TryExportECPrivateKey()
+        {
+            string expectedPem =
+                "-----BEGIN EC PRIVATE KEY-----\n" +
+                "cGVubnk=\n" +
+                "-----END EC PRIVATE KEY-----";
+
+            static bool TryExportECPrivateKey(Span<byte> destination, out int bytesWritten)
+            {
+                ReadOnlySpan<byte> result = new byte[] { 0x70, 0x65, 0x6e, 0x6e, 0x79 };
+                bytesWritten = result.Length;
+                result.CopyTo(destination);
+                return true;
+            }
+
+            using (DelegateECAlgorithm ec = new DelegateECAlgorithm())
+            {
+                ec.TryExportECPrivateKeyDelegate = TryExportECPrivateKey;
+
+                int written;
+                bool result;
+                char[] buffer;
+
+                // buffer not enough
+                buffer = new char[expectedPem.Length - 1];
+                result = ec.TryExportECPrivateKeyPem(buffer, out written);
+                Assert.False(result, nameof(ec.TryExportECPrivateKeyPem));
+                Assert.Equal(0, written);
+
+                // buffer just enough
+                buffer = new char[expectedPem.Length];
+                result = ec.TryExportECPrivateKeyPem(buffer, out written);
+                Assert.True(result, nameof(ec.TryExportECPrivateKeyPem));
+                Assert.Equal(expectedPem.Length, written);
+                Assert.Equal(expectedPem, new string(buffer));
+
+                // buffer more than enough
+                buffer = new char[expectedPem.Length + 20];
+                buffer.AsSpan().Fill('!');
+                Span<char> bufferSpan = buffer.AsSpan(10);
+                result = ec.TryExportECPrivateKeyPem(bufferSpan, out written);
+                Assert.True(result, nameof(ec.TryExportECPrivateKeyPem));
+                Assert.Equal(expectedPem.Length, written);
+                Assert.Equal(expectedPem, new string(bufferSpan.Slice(0, written)));
+
+                // Ensure padding has not been touched.
+                AssertExtensions.FilledWith('!', buffer[0..10]);
+                AssertExtensions.FilledWith('!', buffer[^10..]);
+            }
+        }
+
+        private class DelegateECAlgorithm : ECAlgorithm
+        {
+            public delegate bool TryExportFunc(Span<byte> destination, out int bytesWritten);
+
+            public Func<byte[]> ExportECPrivateKeyDelegate = null;
+            public TryExportFunc TryExportECPrivateKeyDelegate = null;
+
+
+            public DelegateECAlgorithm()
+            {
+            }
+
+            public override byte[] ExportECPrivateKey() => ExportECPrivateKeyDelegate();
+
+            public override bool TryExportECPrivateKey(Span<byte> destination, out int bytesWritten) =>
+                TryExportECPrivateKeyDelegate(destination, out bytesWritten);
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/tests/RSATests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/RSATests.cs
@@ -230,6 +230,150 @@ namespace System.Security.Cryptography.Tests
             Assert.True(RSASignaturePadding.Pkcs1 != null);
         }
 
+        [Fact]
+        public static void ExportPem_ExportRSAPublicKey()
+        {
+            string expectedPem =
+                "-----BEGIN RSA PUBLIC KEY-----\n" +
+                "cGVubnk=\n" +
+                "-----END RSA PUBLIC KEY-----";
+
+            static byte[] ExportRSAPublicKey()
+            {
+                return new byte[] { 0x70, 0x65, 0x6e, 0x6e, 0x79 };
+            }
+
+            using (DelegateRSA rsa = new DelegateRSA())
+            {
+                rsa.ExportRSAPublicKeyDelegate = ExportRSAPublicKey;
+                Assert.Equal(expectedPem, rsa.ExportRSAPublicKeyPem());
+            }
+        }
+
+        [Fact]
+        public static void ExportPem_TryExportRSAPublicKey()
+        {
+            string expectedPem =
+                "-----BEGIN RSA PUBLIC KEY-----\n" +
+                "cGVubnk=\n" +
+                "-----END RSA PUBLIC KEY-----";
+
+            static bool TryExportRSAPublicKey(Span<byte> destination, out int bytesWritten)
+            {
+                ReadOnlySpan<byte> result = new byte[] { 0x70, 0x65, 0x6e, 0x6e, 0x79 };
+                bytesWritten = result.Length;
+                result.CopyTo(destination);
+                return true;
+            }
+
+            using (DelegateRSA rsa = new DelegateRSA())
+            {
+                rsa.TryExportRSAPublicKeyDelegate = TryExportRSAPublicKey;
+
+                int written;
+                bool result;
+                char[] buffer;
+
+                // buffer not enough
+                buffer = new char[expectedPem.Length - 1];
+                result = rsa.TryExportRSAPublicKeyPem(buffer, out written);
+                Assert.False(result, nameof(rsa.TryExportRSAPublicKeyPem));
+                Assert.Equal(0, written);
+
+                // buffer just enough
+                buffer = new char[expectedPem.Length];
+                result = rsa.TryExportRSAPublicKeyPem(buffer, out written);
+                Assert.True(result, nameof(rsa.TryExportRSAPublicKeyPem));
+                Assert.Equal(expectedPem.Length, written);
+                Assert.Equal(expectedPem, new string(buffer));
+
+                // buffer more than enough
+                buffer = new char[expectedPem.Length + 20];
+                buffer.AsSpan().Fill('!');
+                Span<char> bufferSpan = buffer.AsSpan(10);
+                result = rsa.TryExportRSAPublicKeyPem(bufferSpan, out written);
+                Assert.True(result, nameof(rsa.TryExportRSAPublicKeyPem));
+                Assert.Equal(expectedPem.Length, written);
+                Assert.Equal(expectedPem, new string(bufferSpan.Slice(0, written)));
+
+                // Ensure padding has not been touched.
+                AssertExtensions.FilledWith('!', buffer[0..10]);
+                AssertExtensions.FilledWith('!', buffer[^10..]);
+            }
+        }
+
+        [Fact]
+        public static void ExportPem_ExportRSAPrivateKey()
+        {
+            string expectedPem =
+                "-----BEGIN RSA PRIVATE KEY-----\n" +
+                "cGVubnk=\n" +
+                "-----END RSA PRIVATE KEY-----";
+
+            static byte[] ExportRSAPrivateKey()
+            {
+                return new byte[] { 0x70, 0x65, 0x6e, 0x6e, 0x79 };
+            }
+
+            using (DelegateRSA rsa = new DelegateRSA())
+            {
+                rsa.ExportRSAPrivateKeyDelegate = ExportRSAPrivateKey;
+                Assert.Equal(expectedPem, rsa.ExportRSAPrivateKeyPem());
+            }
+        }
+
+        [Fact]
+        public static void ExportPem_TryExportRSAPrivateKey()
+        {
+            string expectedPem =
+                "-----BEGIN RSA PRIVATE KEY-----\n" +
+                "cGVubnk=\n" +
+                "-----END RSA PRIVATE KEY-----";
+
+            static bool TryExportRSAPrivateKey(Span<byte> destination, out int bytesWritten)
+            {
+                ReadOnlySpan<byte> result = new byte[] { 0x70, 0x65, 0x6e, 0x6e, 0x79 };
+                bytesWritten = result.Length;
+                result.CopyTo(destination);
+                return true;
+            }
+
+            using (DelegateRSA rsa = new DelegateRSA())
+            {
+                rsa.TryExportRSAPrivateKeyDelegate = TryExportRSAPrivateKey;
+
+                int written;
+                bool result;
+                char[] buffer;
+
+                // buffer not enough
+                buffer = new char[expectedPem.Length - 1];
+                result = rsa.TryExportRSAPrivateKeyPem(buffer, out written);
+                Assert.False(result, nameof(rsa.TryExportRSAPrivateKeyPem));
+                Assert.Equal(0, written);
+
+                // buffer just enough
+                buffer = new char[expectedPem.Length];
+                result = rsa.TryExportRSAPrivateKeyPem(buffer, out written);
+                Assert.True(result, nameof(rsa.TryExportRSAPrivateKeyPem));
+                Assert.Equal(expectedPem.Length, written);
+                Assert.Equal(expectedPem, new string(buffer));
+
+                // buffer more than enough
+                buffer = new char[expectedPem.Length + 20];
+                buffer.AsSpan().Fill('!');
+                Span<char> bufferSpan = buffer.AsSpan(10);
+                result = rsa.TryExportRSAPrivateKeyPem(bufferSpan, out written);
+                Assert.True(result, nameof(rsa.TryExportRSAPrivateKeyPem));
+                Assert.Equal(expectedPem.Length, written);
+                Assert.Equal(expectedPem, new string(bufferSpan.Slice(0, written)));
+
+                // Ensure padding has not been touched.
+                AssertExtensions.FilledWith('!', buffer[0..10]);
+                AssertExtensions.FilledWith('!', buffer[^10..]);
+            }
+        }
+
         private sealed class EmptyRSA : RSA
         {
             public override RSAParameters ExportParameters(bool includePrivateParameters) => throw new NotImplementedException();
@@ -240,12 +384,17 @@ namespace System.Security.Cryptography.Tests
 
         private sealed class DelegateRSA : RSA
         {
+            public delegate bool TryExportFunc(Span<byte> destination, out int bytesWritten);
             public Func<byte[], RSAEncryptionPadding, byte[]> DecryptDelegate;
             public Func<byte[], RSAEncryptionPadding, byte[]> EncryptDelegate;
             public Func<byte[], HashAlgorithmName, RSASignaturePadding, byte[]> SignHashDelegate = null;
             public Func<byte[], byte[], HashAlgorithmName, RSASignaturePadding, bool> VerifyHashDelegate = null;
             public Func<byte[], int, int, HashAlgorithmName, byte[]> HashDataArrayDelegate = null;
             public Func<Stream, HashAlgorithmName, byte[]> HashDataStreamDelegate = null;
+            public Func<byte[]> ExportRSAPublicKeyDelegate = null;
+            public TryExportFunc TryExportRSAPublicKeyDelegate = null;
+            public Func<byte[]> ExportRSAPrivateKeyDelegate = null;
+            public TryExportFunc TryExportRSAPrivateKeyDelegate = null;
 
             public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding) =>
                 EncryptDelegate(data, padding);
@@ -264,6 +413,15 @@ namespace System.Security.Cryptography.Tests
 
             protected override byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm) =>
                 HashDataStreamDelegate(data, hashAlgorithm);
+
+            public override byte[] ExportRSAPublicKey() => ExportRSAPublicKeyDelegate();
+            public override byte[] ExportRSAPrivateKey() => ExportRSAPrivateKeyDelegate();
+
+            public override bool TryExportRSAPublicKey(Span<byte> destination, out int bytesWritten) =>
+                TryExportRSAPublicKeyDelegate(destination, out bytesWritten);
+
+            public override bool TryExportRSAPrivateKey(Span<byte> destination, out int bytesWritten) =>
+                TryExportRSAPrivateKeyDelegate(destination, out bytesWritten);
 
             public new bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
                 base.TryHashData(source, destination, hashAlgorithm, out bytesWritten);

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -213,6 +213,7 @@
     <Compile Include="ECDiffieHellmanTests.cs" />
     <Compile Include="ECDiffieHellmanPublicKeyTests.cs" />
     <Compile Include="ECDsaTests.cs" />
+    <Compile Include="ECPemExportTests.cs" />
     <Compile Include="FixedTimeEqualsTests.cs" />
     <Compile Include="HashAlgorithmNameTests.cs" />
     <Compile Include="HashAlgorithmTest.cs" />


### PR DESCRIPTION
Closes #51630. This is a replacement PR for https://github.com/dotnet/runtime/pull/61487.