### PR TITLE
Environment variable should override property for gcServer.

### DIFF
--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -428,7 +428,7 @@ BOOL CLRConfig::IsConfigEnabled(const ConfigDWORDInfo & info)
 //
 // Arguments:
 //     * info - see file:../inc/CLRConfig.h for details.
-//
+//     * isDefault - the value was not set or had an invalid format so the default was returned.
 //     * result - the result.
 //
 // Return value:
@@ -449,9 +449,7 @@ DWORD CLRConfig::GetConfigValue(const ConfigDWORDInfo & info, /* [Out] */ bool *
 
     DWORD resultMaybe;
     HRESULT hr = GetConfigDWORD(info.name, info.defaultValue, &resultMaybe, info.options);
-
-    // Ignore the default value even if it's set explicitly.
-    if (resultMaybe != info.defaultValue)
+    if (SUCCEEDED(hr))
     {
         *isDefault = false;
         return resultMaybe;

--- a/src/tests/baseservices/RuntimeConfiguration/TestConfig.cs
+++ b/src/tests/baseservices/RuntimeConfiguration/TestConfig.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+using System.Runtime;
+
+using Xunit;
+
+class TestConfig
+{
+    const int Success = 100;
+    const int Fail = 101;
+
+    [Fact]
+    [EnvVar("DOTNET_gcServer", "1")]
+    static int Verify_ServerGC_Env_Enable(string[] _)
+    {
+        return GCSettings.IsServerGC
+            ? Success
+            : Fail;
+    }
+
+    [Fact]
+    [ConfigProperty("DOTNET_gcServer", "0")]
+    static int Verify_ServerGC_Env_Disable(string[] _)
+    {
+        return GCSettings.IsServerGC
+            ? Fail
+            : Success;
+    }
+
+    [Fact]
+    [ConfigProperty("System.GC.Server", "true")]
+    static int Verify_ServerGC_Prop_Enable(string[] _)
+    {
+        return GCSettings.IsServerGC
+            ? Success
+            : Fail;
+    }
+
+    [Fact]
+    [ConfigProperty("System.GC.Server", "false")]
+    static int Verify_ServerGC_Prop_Disable(string[] _)
+    {
+        return GCSettings.IsServerGC
+            ? Fail
+            : Success;
+    }
+
+    [Fact]
+    [EnvVar("DOTNET_gcServer", "0")]
+    [ConfigProperty("System.GC.Server", "true")]
+    static int Verify_ServerGC_Env_Override_Prop(string[] _)
+    {
+        return GCSettings.IsServerGC
+            ? Fail
+            : Success;
+    }
+
+    static int Main(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            return RunTests();
+        }
+
+        MethodInfo infos = typeof(TestConfig).GetMethod(args[0], BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        if (infos is null)
+        {
+            return Fail;
+        }
+        return (int)infos.Invoke(null, new object[] { args[1..] });
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    class EnvVarAttribute : Attribute
+    {
+        public EnvVarAttribute(string name, string value) { Name = name; Value = value; }
+        public string Name { get; init; }
+        public string Value { get; init; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    class ConfigPropertyAttribute : Attribute
+    {
+        public ConfigPropertyAttribute(string name, string value) { Name = name; Value = value; }
+        public string Name { get; init; }
+        public string Value { get; init; }
+    }
+
+    static int RunTests()
+    {
+        string corerunPath = GetCorerunPath();
+        MethodInfo[] infos = typeof(TestConfig).GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        foreach (var mi in infos)
+        {
+            var factMaybe = mi.GetCustomAttributes(typeof(FactAttribute));
+            if (!factMaybe.Any())
+            {
+                continue;
+            }
+
+            using Process process = new();
+
+            StringBuilder arguments = new();
+            var configProperties = mi.GetCustomAttributes(typeof(ConfigPropertyAttribute));
+
+            foreach (Attribute cp in configProperties)
+            {
+                ConfigPropertyAttribute configProp = (ConfigPropertyAttribute)cp;
+                arguments.Append($"-p {configProp.Name}={configProp.Value} ");
+            }
+
+            arguments.Append($"\"{System.Reflection.Assembly.GetExecutingAssembly().Location}\" {mi.Name}");
+
+            process.StartInfo.FileName = corerunPath;
+            process.StartInfo.Arguments = arguments.ToString();
+
+            var envVariables = mi.GetCustomAttributes(typeof(EnvVarAttribute));
+            foreach (string key in Environment.GetEnvironmentVariables().Keys)
+            {
+                process.StartInfo.EnvironmentVariables[key] = Environment.GetEnvironmentVariable(key);
+            }
+
+            Console.WriteLine($"Running: {process.StartInfo.Arguments}");
+            foreach (Attribute ev in envVariables)
+            {
+                EnvVarAttribute envVar = (EnvVarAttribute)ev;
+                process.StartInfo.EnvironmentVariables[envVar.Name] = envVar.Value;
+                Console.WriteLine($"    set {envVar.Name}={envVar.Value}");
+            }
+
+            process.Start();
+            process.WaitForExit();
+            if (process.ExitCode != Success)
+            {
+                Console.WriteLine($"Failed: {mi.Name}");
+                return process.ExitCode;
+            }
+        }
+
+        return Success;
+    }
+
+    static string GetCorerunPath()
+    {
+        string corerunName = "corerun";
+        if (TestLibrary.Utilities.IsWindows)
+        {
+            corerunName += ".exe";
+        }
+        return Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), corerunName);
+    }
+}

--- a/src/tests/baseservices/RuntimeConfiguration/TestConfig.csproj
+++ b/src/tests/baseservices/RuntimeConfiguration/TestConfig.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- This test provides no interesting scenarios for GCStress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TestConfig.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -876,6 +876,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
             <Issue>Tests features specific to coreclr</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/RuntimeConfiguration/*">
+            <Issue>Tests features specific to coreclr</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/CollectibleAssemblies/ByRefLocals/**">
             <Issue>https://github.com/dotnet/runtime/issues/40394</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes #61674 

Add tests for the scenario.

The added tests can also be used to validate any of the configuration properties and environment variables used for start-up.

/cc @cshung @elinor-fung 

@jkoritzinsky and @trylek Can you please confirm the methodology in this new test works with the system being built?
