### PR TITLE
Start building a universal System.Linq.Expressions library

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -236,6 +236,7 @@
       <ILLinkArgs Condition="'$(ILLinkRewritePDBs)' == 'true' and Exists('$(ILLinkTrimAssemblySymbols)')">$(ILLinkArgs) -b true</ILLinkArgs>
       <!-- pass the non-embedded descriptors xml file on the command line -->
       <ILLinkArgs Condition="'$(ILLinkDescriptorsLibraryBuildXml)' != ''">$(ILLinkArgs) -x "$(ILLinkDescriptorsLibraryBuildXml)"</ILLinkArgs>
+      <ILLinkArgs Condition="'$(ILLinkSubstitutionsLibraryBuildXml)' != ''">$(ILLinkArgs) --substitutions "$(ILLinkSubstitutionsLibraryBuildXml)"</ILLinkArgs>
       <!-- suppress warnings with the following codes:
            IL2008: Could not find type A specified in resource B
            IL2009: Could not find method A in type B specified in resource C

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -255,6 +255,7 @@
       <!-- IL2067-IL2091: Unsatisfied DynamicallyAccessedMembers requirements -->
       <LinkerNoWarn>$(LinkerNoWarn);IL2067;IL2068;IL2069;IL2070;IL2071;IL2072;IL2073;IL2074;IL2075;IL2076;IL2077;IL2078;IL2079;IL2080;IL2081;IL2082;IL2083;IL2084;IL2085;IL2086;IL2087;IL2088;IL2089;IL2090;IL2091</LinkerNoWarn>
       <ILLinkArgs>$(ILLinkArgs) --nowarn $(LinkerNoWarn)</ILLinkArgs>
+      <ILLinkArgs Condition="'$(ILLinkDisableIPConstProp)' == 'true'">$(ILLinkArgs) --disable-opt ipconstprop</ILLinkArgs>
     </PropertyGroup>
 
     <MakeDir Directories="$(ILLinkTrimInputPath)" />

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -82,15 +82,7 @@ namespace System
         private static readonly Lazy<bool> s_LinqExpressionsBuiltWithIsInterpretingOnly = new Lazy<bool>(GetLinqExpressionsBuiltWithIsInterpretingOnly);
         private static bool GetLinqExpressionsBuiltWithIsInterpretingOnly()
         {
-            Type type = typeof(LambdaExpression);
-            if (type != null)
-            {
-                // The "Accept" method is under FEATURE_COMPILE conditional so it should not exist
-                MethodInfo methodInfo = type.GetMethod("Accept", BindingFlags.NonPublic | BindingFlags.Static);
-                return methodInfo == null;
-            }
-
-            return false;
+            return !(bool)typeof(LambdaExpression).GetMethod("get_CanCompileToIL").Invoke(null, Array.Empty<object>());
         }
 
         // Please make sure that you have the libgdiplus dependency installed.

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.IsInterpreting.LibraryBuild.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.IsInterpreting.LibraryBuild.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="System.Linq.Expressions">
+    <type fullname="System.Linq.Expressions.LambdaExpression">
+      <method signature="System.Boolean get_CanCompileToIL()" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
@@ -1,0 +1,13 @@
+<linker>
+  <assembly fullname="System.Linq.Expressions">
+    <type fullname="System.Linq.Expressions.LambdaExpression">
+      <method signature="System.Boolean get_CanCompileToIL()" feature="System.Linq.Expressions.CanCompileToIL" featurevalue="false" body="stub" value="false" />
+    </type>
+    <type fullname="System.Dynamic.Utils.DelegateHelpers">
+      <method signature="System.Boolean get_CanEmitObjectArrayDelegate()" feature="System.Linq.Expressions.CanEmitObjectArrayDelegate" featurevalue="false" body="stub" value="false" />
+    </type>
+    <type fullname="System.Linq.Expressions.Interpreter.CallInstruction">
+      <method signature="System.Boolean get_CanCreateArbitraryDelegates()" feature="System.Linq.Expressions.CanCreateArbitraryDelegates" featurevalue="false" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.Linq.Expressions/src/MatchingRefApiCompatBaseline.txt
+++ b/src/libraries/System.Linq.Expressions/src/MatchingRefApiCompatBaseline.txt
@@ -15,4 +15,6 @@ TypesMustExist : Type 'System.Linq.Expressions.Interpreter.LightLambda' does not
 TypesMustExist : Type 'System.Runtime.CompilerServices.CallSiteOps' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.Runtime.CompilerServices.Closure' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.Runtime.CompilerServices.RuntimeOps' does not exist in the reference but it does exist in the implementation.
-Total Issues: 16
+MembersMustExist : Member 'public System.Boolean System.Linq.Expressions.LambdaExpression.CanCompileToIL.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Boolean System.Linq.Expressions.LambdaExpression.CanInterpret.get()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 18

--- a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -6,6 +6,13 @@
     <IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting>
     <ILLinkSubstitutionsLibraryBuildXml Condition="'$(IsInterpreting)' == 'true'">ILLink\ILLink.Substitutions.IsInterpreting.LibraryBuild.xml</ILLinkSubstitutionsLibraryBuildXml>
     <DefineConstants> $(DefineConstants);FEATURE_FAST_CREATE</DefineConstants>
+
+    <!--
+      Disable constant propagation so that methods referenced from ILLink.Substitutions.xml don't get inlined
+      with a wrong value at library build time and the substitution can still be selected at publish time.
+      For iOS/tvOS/Catalyst we prefer smaller size by default, so keep constprop enabled to get rid of the expression compiler.
+    -->
+    <ILLinkDisableIPConstProp Condition="'$(TargetsiOS)' != 'true' and '$(TargetstvOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true'">true</ILLinkDisableIPConstProp>
   </PropertyGroup>
   <ItemGroup>
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />

--- a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <FeatureInterpret>true</FeatureInterpret>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-MacCatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsInterpreting>false</IsInterpreting>
     <IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting>
-    <DefineConstants> $(DefineConstants);FEATURE_DLG_INVOKE;FEATURE_FAST_CREATE</DefineConstants>
-    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
-    <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
+    <ILLinkSubstitutionsLibraryBuildXml Condition="'$(IsInterpreting)' == 'true'">ILLink\ILLink.Substitutions.IsInterpreting.LibraryBuild.xml</ILLinkSubstitutionsLibraryBuildXml>
+    <DefineConstants> $(DefineConstants);FEATURE_FAST_CREATE</DefineConstants>
   </PropertyGroup>
+  <ItemGroup>
+    <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Obsoletions.cs"
              Link="Common\System\Obsoletions.cs" />
@@ -125,7 +126,7 @@
     <Compile Include="System\Dynamic\UnaryOperationBinder.cs" />
     <Compile Include="System\Dynamic\IInvokeOnGetBinder.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsInterpreting)' != 'true'">
+  <ItemGroup>
     <Compile Include="System\Linq\Expressions\Compiler\AssemblyGen.cs" />
     <Compile Include="System\Dynamic\Utils\Helpers.cs" />
     <Compile Include="System\Linq\Expressions\Compiler\AnalyzedTree.cs" />
@@ -157,7 +158,7 @@
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.ExpressionQuoter.cs" />
     <Compile Include="System\Runtime\CompilerServices\RuntimeOps.RuntimeVariableList.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsInterpreting)' == 'true' Or '$(FeatureInterpret)' == 'true'">
+  <ItemGroup>
     <Compile Include="System\Dynamic\Utils\DelegateHelpers.cs" />
     <Compile Include="System\Linq\Expressions\Interpreter\AddInstruction.cs" />
     <Compile Include="System\Linq\Expressions\Interpreter\AndInstruction.cs" />

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
@@ -7,7 +7,6 @@ namespace System.Dynamic
 {
     internal static partial class UpdateDelegates
     {
-#if FEATURE_COMPILE
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
         internal static TRet UpdateAndExecute1<T0, TRet>(CallSite site, T0 arg0)
         {
@@ -2895,6 +2894,5 @@ namespace System.Dynamic
             site._match = false;
             return;
         }
-#endif
     }
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.tt
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.tt
@@ -13,7 +13,6 @@ namespace System.Dynamic
 {
     internal static partial class UpdateDelegates
     {
-#if FEATURE_COMPILE
 <#
 for (int i = 1; i <= 10; i++)
 {
@@ -330,6 +329,5 @@ for (int i = 1; i <= 10; i++)
     }
 }
 #>
-#endif
     }
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -12,7 +12,7 @@ namespace System.Dynamic.Utils
     internal static class DelegateHelpers
     {
         // This can be flipped to true using feature switches at publishing time
-        internal static bool CanEmitObjectArrayDelegate => string.Empty != null; // HACK: complex enough so that ILLink doesn't constprop at library build
+        internal static bool CanEmitObjectArrayDelegate => true;
 
         // Separate class so that the it can be trimmed away and doesn't get conflated
         // with the Reflection.Emit statics below.

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/DelegateHelpers.cs
@@ -19,9 +19,14 @@ namespace System.Dynamic.Utils
         private static class DynamicDelegateLightup
         {
             public static Func<Type, Func<object?[], object?>, Delegate> CreateObjectArrayDelegate { get; }
-                = Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments")!
-                  .GetMethod("CreateObjectArrayDelegate")!
-                  .CreateDelegate<Func<Type, Func<object?[], object?>, Delegate>>();
+                = CreateObjectArrayDelegateInternal();
+
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:UnrecognizedReflectionPattern",
+                Justification = "Works around https://github.com/dotnet/linker/issues/2392")]
+            private static Func<Type, Func<object?[], object?>, Delegate> CreateObjectArrayDelegateInternal()
+                => Type.GetType("Internal.Runtime.Augments.DynamicDelegateAugments")!
+                    .GetMethod("CreateObjectArrayDelegate")!
+                    .CreateDelegate<Func<Type, Func<object?[], object?>, Delegate>>();
         }
 
         internal static Delegate CreateObjectArrayDelegate(Type delegateType, Func<object?[], object?> handler)

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeExtensions.cs
@@ -80,7 +80,6 @@ namespace System.Dynamic.Utils
             return pis;
         }
 
-#if FEATURE_COMPILE
         // Expression trees/compiler just use IsByRef, why do we need this?
         // (see LambdaCompiler.EmitArguments for usage in the compiler)
         internal static bool IsByRefParameter(this ParameterInfo pi)
@@ -91,6 +90,5 @@ namespace System.Dynamic.Utils
 
             return (pi.Attributes & ParameterAttributes.Out) == ParameterAttributes.Out;
         }
-#endif
     }
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -911,8 +911,6 @@ namespace System.Dynamic.Utils
             return delegateType.GetMethod("Invoke", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
         }
 
-#if FEATURE_COMPILE
-
         internal static bool IsUnsigned(this Type type) => IsUnsigned(GetNonNullableType(type).GetTypeCode());
 
         internal static bool IsUnsigned(this TypeCode typeCode)
@@ -945,8 +943,6 @@ namespace System.Dynamic.Utils
                     return false;
             }
         }
-
-#endif
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "The Array 'Get' method is dynamically constructed and is not included in IL. It is not subject to trimming.")]

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Common/CachedReflectionInfo.cs
@@ -159,7 +159,6 @@ namespace System.Linq.Expressions
                                  (s_Math_Pow_Double_Double = typeof(Math).GetMethod(nameof(Math.Pow), new[] { typeof(double), typeof(double) })!);
 
         // Closure and RuntimeOps helpers are used only in the compiler.
-#if FEATURE_COMPILE
         private static ConstructorInfo? s_Closure_ObjectArray_ObjectArray;
         public static ConstructorInfo Closure_ObjectArray_ObjectArray =>
                                        s_Closure_ObjectArray_ObjectArray ??
@@ -194,6 +193,5 @@ namespace System.Linq.Expressions
         public static MethodInfo RuntimeOps_Quote =>
                                   s_RuntimeOps_Quote ??
                                  (s_RuntimeOps_Quote = typeof(RuntimeOps).GetMethod(nameof(RuntimeOps.Quote))!);
-#endif
     }
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
@@ -84,8 +84,6 @@ namespace System.Linq.Expressions.Compiler
             return nextTypeInfo;
         }
 
-#if !FEATURE_COMPILE
-
         public delegate object VBCallSiteDelegate0<T>(T callSite, object instance);
         public delegate object VBCallSiteDelegate1<T>(T callSite, object instance, ref object arg1);
         public delegate object VBCallSiteDelegate2<T>(T callSite, object instance, ref object arg1, ref object arg2);
@@ -94,7 +92,6 @@ namespace System.Linq.Expressions.Compiler
         public delegate object VBCallSiteDelegate5<T>(T callSite, object instance, ref object arg1, ref object arg2, ref object arg3, ref object arg4, ref object arg5);
         public delegate object VBCallSiteDelegate6<T>(T callSite, object instance, ref object arg1, ref object arg2, ref object arg3, ref object arg4, ref object arg5, ref object arg6);
         public delegate object VBCallSiteDelegate7<T>(T callSite, object instance, ref object arg1, ref object arg2, ref object arg3, ref object arg4, ref object arg5, ref object arg6, ref object arg7);
-
 
         private static Type TryMakeVBStyledCallSite(Type[] types)
         {
@@ -128,7 +125,6 @@ namespace System.Linq.Expressions.Compiler
                 default: return null;
             }
         }
-#endif
 
         /// <summary>
         /// Creates a new delegate, or uses a func/action
@@ -163,11 +159,14 @@ namespace System.Linq.Expressions.Compiler
 
             if (needCustom)
             {
-#if FEATURE_COMPILE
-                return MakeNewCustomDelegate(types);
-#else
-                return TryMakeVBStyledCallSite(types) ?? MakeNewCustomDelegate(types);
-#endif
+                if (LambdaExpression.CanCompileToIL)
+                {
+                    return MakeNewCustomDelegate(types);
+                }
+                else
+                {
+                    return TryMakeVBStyledCallSite(types) ?? MakeNewCustomDelegate(types);
+                }
             }
 
             Type result;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
@@ -107,26 +107,27 @@ namespace System.Linq.Expressions.Compiler
             return mo.Expression is ParameterExpression pe && pe.IsByRef;
         }
 
-#if FEATURE_COMPILE
-        private const MethodAttributes CtorAttributes = MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public;
-        private const MethodImplAttributes ImplAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
-        private const MethodAttributes InvokeAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual;
-        private static readonly Type[] s_delegateCtorSignature = { typeof(object), typeof(IntPtr) };
-#endif
-
         private static Type MakeNewCustomDelegate(Type[] types)
         {
-#if FEATURE_COMPILE
-            Type returnType = types[types.Length - 1];
-            Type[] parameters = types.RemoveLast();
+            if (LambdaExpression.CanCompileToIL)
+            {
+                Type returnType = types[types.Length - 1];
+                Type[] parameters = types.RemoveLast();
+                Type[] delegateCtorSignature = { typeof(object), typeof(IntPtr) };
 
-            TypeBuilder builder = AssemblyGen.DefineDelegateType("Delegate" + types.Length);
-            builder.DefineConstructor(CtorAttributes, CallingConventions.Standard, s_delegateCtorSignature).SetImplementationFlags(ImplAttributes);
-            builder.DefineMethod("Invoke", InvokeAttributes, returnType, parameters).SetImplementationFlags(ImplAttributes);
-            return builder.CreateTypeInfo()!;
-#else
-            throw new PlatformNotSupportedException();
-#endif
+                const MethodAttributes ctorAttributes = MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public;
+                const MethodImplAttributes implAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
+                const MethodAttributes invokeAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual;
+
+                TypeBuilder builder = AssemblyGen.DefineDelegateType("Delegate" + types.Length);
+                builder.DefineConstructor(ctorAttributes, CallingConventions.Standard, delegateCtorSignature).SetImplementationFlags(implAttributes);
+                builder.DefineMethod("Invoke", invokeAttributes, returnType, parameters).SetImplementationFlags(implAttributes);
+                return builder.CreateTypeInfo()!;
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
         }
     }
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -13,9 +13,7 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal partial class CallInstruction
     {
-#if FEATURE_DLG_INVOKE
         private const int MaxHelpers = 5;
-#endif
 
 #if FEATURE_FAST_CREATE
         private const int MaxArgs = 3;
@@ -158,7 +156,6 @@ namespace System.Linq.Expressions.Interpreter
         }
 #endif
 
-#if FEATURE_DLG_INVOKE
         [return: DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes.PublicConstructors)]
         private static Type GetHelperType(MethodInfo info, Type[] arrTypes)
         {
@@ -211,10 +208,8 @@ namespace System.Linq.Expressions.Interpreter
             }
             return t;
         }
-#endif
     }
 
-#if FEATURE_DLG_INVOKE
     internal sealed class ActionCallInstruction : CallInstruction
     {
         private readonly Action _target;
@@ -577,6 +572,4 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string ToString() => "Call(" + _target.Method + ")";
     }
-
-#endif
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Expressions.Interpreter
         /// </summary>
         public abstract int ArgumentCount { get; }
 
-        private static bool CanCreateArbitraryDelegates => string.Empty != null;
+        private static bool CanCreateArbitraryDelegates => true;
 
         #region Construction
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -16,13 +16,13 @@ namespace System.Linq.Expressions.Interpreter
         /// </summary>
         public abstract int ArgumentCount { get; }
 
+        private static bool CanCreateArbitraryDelegates => string.Empty != null;
+
         #region Construction
 
         public override string InstructionName => "Call";
 
-#if FEATURE_DLG_INVOKE
         private static readonly CacheDict<MethodInfo, CallInstruction> s_cache = new CacheDict<MethodInfo, CallInstruction>(256);
-#endif
 
         public static CallInstruction Create(MethodInfo info)
         {
@@ -47,9 +47,9 @@ namespace System.Linq.Expressions.Interpreter
                 return GetArrayAccessor(info, argumentCount);
             }
 
-#if !FEATURE_DLG_INVOKE
-            return new MethodInfoCallInstruction(info, argumentCount);
-#else
+            if (!CanCreateArbitraryDelegates)
+                return new MethodInfoCallInstruction(info, argumentCount);
+
             if (!info.IsStatic && info.DeclaringType!.IsValueType)
             {
                 return new MethodInfoCallInstruction(info, argumentCount);
@@ -119,7 +119,6 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             return res;
-#endif
         }
 
         private static CallInstruction GetArrayAccessor(MethodInfo info, int argumentCount)
@@ -171,12 +170,11 @@ namespace System.Linq.Expressions.Interpreter
         {
             array.SetValue(value, index0, index1, index2);
         }
-#if FEATURE_DLG_INVOKE
+
         private static bool ShouldCache(MethodInfo info)
         {
             return true;
         }
-#endif
 
 #if FEATURE_FAST_CREATE
         /// <summary>
@@ -215,7 +213,6 @@ namespace System.Linq.Expressions.Interpreter
         }
 #endif
 
-#if FEATURE_DLG_INVOKE
         /// <summary>
         /// Uses reflection to create new instance of the appropriate ReflectedCaller
         /// </summary>
@@ -243,7 +240,6 @@ namespace System.Linq.Expressions.Interpreter
                 throw ContractUtils.Unreachable;
             }
         }
-#endif
 
         #endregion
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -26,7 +26,7 @@ namespace System.Linq.Expressions
         private readonly Expression _body;
 
         // This can be flipped to false using feature switches at publishing time
-        public static bool CanCompileToIL => string.Empty != null; // HACK: something that is complicated enough that IL Linker won't constprop it at library build
+        public static bool CanCompileToIL => true;
 
         // This could be flipped to false using feature switches at publishing time
         public static bool CanInterpret => true;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -25,6 +25,12 @@ namespace System.Linq.Expressions
 
         private readonly Expression _body;
 
+        // This can be flipped to false using feature switches at publishing time
+        public static bool CanCompileToIL => string.Empty != null; // HACK: something that is complicated enough that IL Linker won't constprop it at library build
+
+        // This could be flipped to false using feature switches at publishing time
+        public static bool CanInterpret => true;
+
         internal LambdaExpression(Expression body)
         {
             _body = body;
@@ -130,11 +136,15 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public Delegate Compile()
         {
-#if FEATURE_COMPILE
-            return Compiler.LambdaCompiler.Compile(this);
-#else
-            return new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
-#endif
+            if (CanCompileToIL)
+            {
+                return Compiler.LambdaCompiler.Compile(this);
+            }
+            else
+            {
+                Debug.Assert(CanInterpret);
+                return new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            }
         }
 
         /// <summary>
@@ -144,12 +154,11 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public Delegate Compile(bool preferInterpretation)
         {
-#if FEATURE_COMPILE && FEATURE_INTERPRET
-            if (preferInterpretation)
+            if (CanCompileToIL && CanInterpret && preferInterpretation)
             {
                 return new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
             }
-#endif
+
             return Compile();
         }
 
@@ -169,10 +178,7 @@ namespace System.Linq.Expressions
         }
 #endif
 
-
-#if FEATURE_COMPILE
         internal abstract LambdaExpression Accept(Compiler.StackSpiller spiller);
-#endif
 
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
@@ -210,11 +216,15 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public new TDelegate Compile()
         {
-#if FEATURE_COMPILE
-            return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
-#else
-            return (TDelegate)(object)new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
-#endif
+            if (CanCompileToIL)
+            {
+                return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
+            }
+            else
+            {
+                Debug.Assert(CanInterpret);
+                return (TDelegate)(object)new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
+            }
         }
 
         /// <summary>
@@ -224,12 +234,11 @@ namespace System.Linq.Expressions
         /// <returns>A delegate containing the compiled version of the lambda.</returns>
         public new TDelegate Compile(bool preferInterpretation)
         {
-#if FEATURE_COMPILE && FEATURE_INTERPRET
-            if (preferInterpretation)
+            if (CanCompileToIL && CanInterpret && preferInterpretation)
             {
                 return (TDelegate)(object)new Interpreter.LightCompiler().CompileTop(this).CreateDelegate();
             }
-#endif
+
             return Compile();
         }
 
@@ -290,7 +299,6 @@ namespace System.Linq.Expressions
             return visitor.VisitLambda(this);
         }
 
-#if FEATURE_COMPILE
         internal override LambdaExpression Accept(Compiler.StackSpiller spiller)
         {
             return spiller.Rewrite(this);
@@ -312,7 +320,6 @@ namespace System.Linq.Expressions
 
             return new FullExpression<TDelegate>(body, name, tailCall, parameters);
         }
-#endif
 
         /// <summary>
         /// Produces a delegate that represents the lambda expression.
@@ -325,7 +332,6 @@ namespace System.Linq.Expressions
         }
     }
 
-#if !FEATURE_COMPILE
     // Separate expression creation class to hide the CreateExpressionFunc function from users reflecting on Expression<T>
     internal static class ExpressionCreator<TDelegate>
     {
@@ -346,7 +352,6 @@ namespace System.Linq.Expressions
             return new FullExpression<TDelegate>(body, name, tailCall, parameters);
         }
     }
-#endif
 
     internal sealed class Expression0<TDelegate> : Expression<TDelegate>
     {
@@ -616,11 +621,16 @@ namespace System.Linq.Expressions
 
             if (!factories.TryGetValue(delegateType, out fastPath))
             {
-#if FEATURE_COMPILE
-                MethodInfo create = typeof(Expression<>).MakeGenericType(delegateType).GetMethod("Create", BindingFlags.Static | BindingFlags.NonPublic)!;
-#else
-                MethodInfo create = typeof(ExpressionCreator<>).MakeGenericType(delegateType).GetMethod("CreateExpressionFunc", BindingFlags.Static | BindingFlags.Public)!;
-#endif
+                MethodInfo create;
+                if (LambdaExpression.CanCompileToIL)
+                {
+                    create = typeof(Expression<>).MakeGenericType(delegateType).GetMethod("Create", BindingFlags.Static | BindingFlags.NonPublic)!;
+                }
+                else
+                {
+                    create = typeof(ExpressionCreator<>).MakeGenericType(delegateType).GetMethod("CreateExpressionFunc", BindingFlags.Static | BindingFlags.Public)!;
+                }
+
                 if (delegateType.IsCollectible)
                 {
                     return (LambdaExpression)create.Invoke(null, new object?[] { body, name, tailCall, parameters })!;
@@ -708,11 +718,14 @@ namespace System.Linq.Expressions
         {
             ReadOnlyCollection<ParameterExpression> parameterList = parameters.ToReadOnly();
             ValidateLambdaArgs(typeof(TDelegate), ref body, parameterList, nameof(TDelegate));
-#if FEATURE_COMPILE
-            return Expression<TDelegate>.Create(body, name, tailCall, parameterList);
-#else
-            return ExpressionCreator<TDelegate>.CreateExpressionFunc(body, name, tailCall, parameterList);
-#endif
+            if (LambdaExpression.CanCompileToIL)
+            {
+                return Expression<TDelegate>.Create(body, name, tailCall, parameterList);
+            }
+            else
+            {
+                return ExpressionCreator<TDelegate>.CreateExpressionFunc(body, name, tailCall, parameterList);
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -279,24 +279,15 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-#if FEATURE_COMPILE
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
             Justification = "UpdateDelegates methods don't have ILLink annotations.")]
-#endif
         internal T MakeUpdateDelegate()
         {
-#if !FEATURE_COMPILE
             Type target = typeof(T);
             MethodInfo invoke = target.GetInvokeMethod();
 
-            s_cachedNoMatch = CreateCustomNoMatchDelegate(invoke);
-            return CreateCustomUpdateDelegate(invoke);
-#else
-            Type target = typeof(T);
-            Type[] args;
-            MethodInfo invoke = target.GetInvokeMethod();
-
-            if (target.IsGenericType && IsSimpleSignature(invoke, out args))
+            if (System.Linq.Expressions.LambdaExpression.CanCompileToIL
+                && target.IsGenericType && IsSimpleSignature(invoke, out Type[] args))
             {
                 MethodInfo? method = null;
                 MethodInfo? noMatchMethod = null;
@@ -326,10 +317,8 @@ namespace System.Runtime.CompilerServices
 
             s_cachedNoMatch = CreateCustomNoMatchDelegate(invoke);
             return CreateCustomUpdateDelegate(invoke);
-#endif
         }
 
-#if FEATURE_COMPILE
         private static bool IsSimpleSignature(MethodInfo invoke, out Type[] sig)
         {
             ParameterInfo[] pis = invoke.GetParametersCached();
@@ -354,7 +343,6 @@ namespace System.Runtime.CompilerServices
             sig = args;
             return supported;
         }
-#endif
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
             Justification = "CallSiteOps methods don't have trimming annotations.")]

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/DebugInfoGenerator.cs
@@ -32,7 +32,6 @@ namespace System.Runtime.CompilerServices
         /// <param name="sequencePoint">Debug information corresponding to the sequence point.</param>
         public abstract void MarkSequencePoint(LambdaExpression method, int ilOffset, DebugInfoExpression sequencePoint);
 
-#if FEATURE_COMPILE
         internal virtual void MarkSequencePoint(LambdaExpression method, MethodBase methodBase, ILGenerator ilg, DebugInfoExpression sequencePoint)
         {
             MarkSequencePoint(method, ilg.ILOffset, sequencePoint);
@@ -42,6 +41,5 @@ namespace System.Runtime.CompilerServices
         {
             // nop
         }
-#endif
     }
 }

--- a/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -494,8 +494,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(1, func());
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_NullableIntCoalesceToNullableInt()
         {
@@ -523,7 +522,6 @@ namespace System.Linq.Expressions.Tests
                     IL_0015: ret
                 }");
         }
-#endif
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CoalesceWideningLeft(bool useInterpreter)

--- a/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -415,9 +415,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), method));
         }
 
-#if FEATURE_COMPILE
-
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void AndAlso_NoMethod_NotStatic_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -430,7 +428,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void OrElse_NoMethod_NotStatic_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -443,7 +441,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void AndAlso_NoMethod_VoidReturnType_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -456,7 +454,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("method", () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void OrElse_NoMethod_VoidReturnType_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -469,7 +467,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("method", () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]
@@ -485,7 +483,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]
@@ -501,7 +499,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void AndAlso_NoMethod_ExpressionDoesntMatchMethodParameters_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -514,7 +512,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void OrElse_NoMethod_ExpressionDoesntMatchMethodParameters_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -528,7 +526,7 @@ namespace System.Linq.Expressions.Tests
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void AndAlso_NoMethod_ReturnTypeNotEqualToParameterTypes_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -541,7 +539,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void OrElse_NoMethod_ReturnTypeNotEqualToParameterTypes_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -571,7 +569,7 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { GetTypeBuilder(), typeof(bool), new Type[0] };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void Method_TrueOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[] parameterTypes)
         {
@@ -592,7 +590,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void Method_FalseOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[]parameterTypes)
         {
@@ -613,7 +611,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void AndAlso_NoMethod_TrueOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[] parameterTypes)
         {
@@ -632,7 +630,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void OrElse_NoMethod_TrueOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[] parameterTypes)
         {
@@ -651,7 +649,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [InlineData("op_True")]
         [InlineData("op_False")]
         public static void Method_NoTrueFalseOperator_ThrowsArgumentException(string name)
@@ -674,7 +672,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [InlineData("op_True")]
         [InlineData("op_False")]
         public static void AndAlso_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(string name)
@@ -694,7 +692,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [InlineData("op_True")]
         [InlineData("op_False")]
         public static void OrElse_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(string name)
@@ -714,7 +712,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Method_ParamsDontMatchOperator_ThrowsInvalidOperationException()
         {
             TypeBuilder builder = GetTypeBuilder();
@@ -735,7 +733,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), createdMethod));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void AndAlso_NoMethod_ParamsDontMatchOperator_ThrowsInvalidOperationException()
         {
             TypeBuilder builder = GetTypeBuilder();
@@ -753,7 +751,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(5), Expression.Constant(5)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void OrElse_NoMethod_ParamsDontMatchOperator_ThrowsInvalidOperationException()
         {
             TypeBuilder builder = GetTypeBuilder();
@@ -770,8 +768,6 @@ namespace System.Linq.Expressions.Tests
             TypeInfo createdType = builder.CreateTypeInfo();
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(5), Expression.Constant(5)));
         }
-
-#endif
 
         [Fact]
         public static void ImplicitConversionToBool_ThrowsArgumentException()
@@ -821,15 +817,14 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("(a OrElse b)", e2.ToString());
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void AndAlsoGlobalMethod()
         {
             MethodInfo method = GlobalMethod(typeof(int), new[] { typeof(int), typeof(int) });
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(1), Expression.Constant(2), method));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void OrElseGlobalMethod()
         {
             MethodInfo method = GlobalMethod(typeof(int), new [] { typeof(int), typeof(int) });
@@ -851,7 +846,6 @@ namespace System.Linq.Expressions.Tests
             module.CreateGlobalFunctions();
             return module.GetMethod(globalMethod.Name);
         }
-#endif
 
         public class NonGenericClass
         {

--- a/src/libraries/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2372,10 +2372,12 @@ namespace System.Linq.Expressions.Tests
             yield return typeof(UInt32Enum);
             yield return typeof(Int64Enum);
             yield return typeof(UInt64Enum);
-#if FEATURE_COMPILE
-            yield return NonCSharpTypes.CharEnumType;
-            yield return NonCSharpTypes.BoolEnumType;
-#endif
+
+            if (PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly)
+            {
+                yield return NonCSharpTypes.CharEnumType;
+                yield return NonCSharpTypes.BoolEnumType;
+            }
         }
 
         public static IEnumerable<object[]> EnumerableTypeArgs() => EnumerableTypes().Select(t => new object[] { t });

--- a/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/CompilerTests.cs
@@ -27,8 +27,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(n, f());
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void EmitConstantsToIL_NonNullableValueTypes()
         {
             VerifyEmitConstantsToIL((bool)true);
@@ -49,7 +48,7 @@ namespace System.Linq.Expressions.Tests
             VerifyEmitConstantsToIL((decimal)49.95m);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void EmitConstantsToIL_NullableValueTypes()
         {
             VerifyEmitConstantsToIL((bool?)null);
@@ -85,14 +84,14 @@ namespace System.Linq.Expressions.Tests
             VerifyEmitConstantsToIL((DateTime?)null);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void EmitConstantsToIL_ReferenceTypes()
         {
             VerifyEmitConstantsToIL((string)null);
             VerifyEmitConstantsToIL((string)"bar");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void EmitConstantsToIL_Enums()
         {
             VerifyEmitConstantsToIL(ConstantsEnum.A);
@@ -100,21 +99,21 @@ namespace System.Linq.Expressions.Tests
             VerifyEmitConstantsToIL((ConstantsEnum?)ConstantsEnum.A);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void EmitConstantsToIL_ShareReferences()
         {
             var o = new object();
             VerifyEmitConstantsToIL(Expression.Equal(Expression.Constant(o), Expression.Constant(o)), 1, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void EmitConstantsToIL_LiftedToClosure()
         {
             VerifyEmitConstantsToIL(DateTime.Now, 1);
             VerifyEmitConstantsToIL((DateTime?)DateTime.Now, 1);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void VariableBinder_CatchBlock_Filter1()
         {
             // See https://github.com/dotnet/runtime/issues/18676 for reported issue
@@ -128,7 +127,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void VariableBinder_CatchBlock_Filter2()
         {
             // See https://github.com/dotnet/runtime/issues/18676 for reported issue
@@ -142,7 +141,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_Simple()
         {
@@ -159,7 +158,7 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_Exceptions()
         {
@@ -220,7 +219,7 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_Closure1()
         {
@@ -255,7 +254,7 @@ namespace System.Linq.Expressions.Tests
                 appendInnerLambdas: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_Closure2()
         {
@@ -313,7 +312,7 @@ namespace System.Linq.Expressions.Tests
                 appendInnerLambdas: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_Closure3()
         {
@@ -431,7 +430,6 @@ namespace System.Linq.Expressions.Tests
 
             Assert.Throws<InvalidOperationException>(() => e.Compile());
         }
-#endif
     }
 
     public enum ConstantsEnum

--- a/src/libraries/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -278,14 +278,12 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-#if FEATURE_COMPILE
         private static TypeBuilder GetTypeBuilder()
         {
             AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect);
             ModuleBuilder module = assembly.DefineDynamicModule("Name");
             return module.DefineType("Type");
         }
-#endif
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckTypeConstantTest(bool useInterpreter)
@@ -296,9 +294,6 @@ namespace System.Linq.Expressions.Tests
                 typeof(int),
                 typeof(Func<string>),
                 typeof(List<>).GetGenericArguments()[0],
-#if FEATURE_COMPILE
-                GetTypeBuilder(),
-#endif
                 typeof(PrivateGenericClass<>).GetGenericArguments()[0],
                 typeof(PrivateGenericClass<>),
                 typeof(PrivateGenericClass<int>)
@@ -306,9 +301,12 @@ namespace System.Linq.Expressions.Tests
             {
                 VerifyTypeConstant(value, useInterpreter);
             }
-        }
 
-#if FEATURE_COMPILE
+            if (PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly)
+            {
+                VerifyTypeConstant(GetTypeBuilder(), useInterpreter);
+            }
+        }
 
         private static MethodInfo GlobalMethod(params Type[] parameterTypes)
         {
@@ -319,7 +317,8 @@ namespace System.Linq.Expressions.Tests
             return module.GetMethod(globalMethod.Name);
         }
 
-        [Theory, ClassData(typeof(CompilationTypes))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ClassData(typeof(CompilationTypes))]
         public static void CheckMethodInfoConstantTest(bool useInterpreter)
         {
             foreach (MethodInfo value in new MethodInfo[]
@@ -338,7 +337,6 @@ namespace System.Linq.Expressions.Tests
                 VerifyMethodInfoConstant(value, useInterpreter);
             }
         }
-#endif
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public static void CheckConstructorInfoConstantTest(bool useInterpreter)

--- a/src/libraries/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
@@ -57,17 +57,20 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ManagedPointerTypeArgs))]
         public void CantBeFunc(Type[] typeArgs)
         {
-#if !FEATURE_COMPILE
-            Assert.Throws<PlatformNotSupportedException>(() => Expression.GetDelegateType(typeArgs));
-#else
-            Type delType = Expression.GetDelegateType(typeArgs);
-            Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
-            Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
-            Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
-            Reflection.MethodInfo method = delType.GetMethod("Invoke");
-            Assert.Equal(typeArgs.Last(), method.ReturnType);
-            Assert.Equal(typeArgs.Take(typeArgs.Length - 1), method.GetParameters().Select(p => p.ParameterType));
-#endif
+            if (PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly)
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => Expression.GetDelegateType(typeArgs));
+            }
+            else
+            {
+                Type delType = Expression.GetDelegateType(typeArgs);
+                Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
+                Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
+                Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
+                Reflection.MethodInfo method = delType.GetMethod("Invoke");
+                Assert.Equal(typeArgs.Last(), method.ReturnType);
+                Assert.Equal(typeArgs.Take(typeArgs.Length - 1), method.GetParameters().Select(p => p.ParameterType));
+            }
         }
 
         [Theory]
@@ -80,17 +83,20 @@ namespace System.Linq.Expressions.Tests
         public void CantBeAction(Type[] typeArgs)
         {
             Type[] delegateArgs = typeArgs.Append(typeof(void)).ToArray();
-#if !FEATURE_COMPILE
-            Assert.Throws<PlatformNotSupportedException>(() => Expression.GetDelegateType(delegateArgs));
-#else
-            Type delType = Expression.GetDelegateType(delegateArgs);
-            Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
-            Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
-            Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
-            Reflection.MethodInfo method = delType.GetMethod("Invoke");
-            Assert.Equal(typeof(void), method.ReturnType);
-            Assert.Equal(typeArgs, method.GetParameters().Select(p => p.ParameterType));
-#endif
+            if (PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly)
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => Expression.GetDelegateType(delegateArgs));
+            }
+            else
+            {
+                Type delType = Expression.GetDelegateType(delegateArgs);
+                Assert.True(typeof(MulticastDelegate).IsAssignableFrom(delType));
+                Assert.DoesNotMatch(new Regex(@"System\.Action"), delType.FullName);
+                Assert.DoesNotMatch(new Regex(@"System\.Func"), delType.FullName);
+                Reflection.MethodInfo method = delType.GetMethod("Invoke");
+                Assert.Equal(typeof(void), method.ReturnType);
+                Assert.Equal(typeArgs, method.GetParameters().Select(p => p.ParameterType));
+            }
         }
 
         // Open generic type args aren't useful directly with Expressions, but creating them is allowed.

--- a/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
@@ -186,8 +186,6 @@ namespace System.Dynamic.Tests
             Assert.Same(info, new MinimumOverrideInvokeMemberBinding("name", false, info).CallInfo);
         }
 
-#if FEATURE_COMPILE // We're not testing compilation, but we do need Reflection.Emit for the test
-
         private static dynamic GetObjectWithNonIndexerParameterProperty(bool hasGetter, bool hasSetter)
         {
             TypeBuilder typeBuild = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestAssembly"), AssemblyBuilderAccess.RunAndCollect)
@@ -233,7 +231,8 @@ namespace System.Dynamic.Tests
             return Activator.CreateInstance(typeBuild.CreateType());
         }
 
-        [Fact]
+        // We're not testing compilation, but we do need Reflection.Emit for the test
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void NonIndexerParameterizedDirectAccess()
         {
             // If a parameterized property isn't the type's indexer, we should be allowed to use the
@@ -244,7 +243,8 @@ namespace System.Dynamic.Tests
             Assert.Equal(19, value);
         }
 
-        [Fact]
+        // We're not testing compilation, but we do need Reflection.Emit for the test
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void NonIndexerParameterizedGetterAndSetterIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(true, true);
@@ -254,7 +254,8 @@ namespace System.Dynamic.Tests
             Assert.Contains("set_ItemProp", ex.Message);
         }
 
-        [Fact]
+        // We're not testing compilation, but we do need Reflection.Emit for the test
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void NonIndexerParameterizedGetterOnlyIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(true, false);
@@ -264,7 +265,8 @@ namespace System.Dynamic.Tests
             Assert.Contains("get_ItemProp", ex.Message);
         }
 
-        [Fact]
+        // We're not testing compilation, but we do need Reflection.Emit for the test
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void NonIndexerParameterizedSetterOnlyIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(false, true);
@@ -333,7 +335,8 @@ namespace System.Dynamic.Tests
                 int arg10) => 11;
         }
 
-        [Fact]
+        // We're not testing compilation, but we do need Reflection.Emit for the test
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void ManyArities()
         {
             dynamic d = new ManyOverloads();
@@ -377,7 +380,9 @@ namespace System.Dynamic.Tests
             return testObjects.SelectMany(i => testObjects.Select(j => new[] { i, j }));
         }
 
-        [Theory, MemberData(nameof(SameNameObjectPairs))]
+        // We're not testing compilation, but we do need Reflection.Emit for the test
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [MemberData(nameof(SameNameObjectPairs))]
         public void OperationOnTwoObjectsDifferentTypesOfSameName(object x, object y)
         {
             dynamic dX = x;
@@ -385,8 +390,6 @@ namespace System.Dynamic.Tests
             bool equal = dX.Equals(dY);
             Assert.Equal(x == y, equal);
         }
-
-#endif
 
         public class FuncWrapper<TResult>
         {

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -240,9 +240,8 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(4, func());
         }
 
-#if FEATURE_COMPILE
-
-        [Theory, ClassData(typeof(CompilationTypes))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ClassData(typeof(CompilationTypes))]
         public void CatchFromExternallyThrownString(bool useInterpreter)
         {
             foreach (bool assemblyWraps in new []{false, true})
@@ -274,7 +273,6 @@ namespace System.Linq.Expressions.Tests
                 Assert.Equal("An Exceptional Exception!", func());
             }
         }
-#endif
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
@@ -1006,11 +1004,14 @@ namespace System.Linq.Expressions.Tests
                 )
             );
             Expression<Func<int>> lambda = Expression.Lambda<Func<int>>(tryExp);
-#if FEATURE_COMPILE
-            Assert.Throws<InvalidOperationException>(() => lambda.Compile(false));
-#else
-            lambda.Compile(true);
-#endif
+            if (PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly)
+            {
+                Assert.Throws<InvalidOperationException>(() => lambda.Compile(false));
+            }
+            else
+            {
+                lambda.Compile(true);
+            }
         }
 
         [Theory, InlineData(true)]

--- a/src/libraries/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/libraries/System.Linq.Expressions/tests/HelperTypes.cs
@@ -246,13 +246,23 @@ namespace System.Linq.Expressions.Tests
 
     internal class CompilationTypes : IEnumerable<object[]>
     {
-        private static readonly IEnumerable<object[]> Booleans = new[]
+        private static IEnumerable<object[]> Booleans
         {
-#if FEATURE_COMPILE && FEATURE_INTERPRET
-            new object[] {false},
-#endif
-            new object[] {true},
-        };
+            get
+            {
+                return LambdaExpression.CanCompileToIL ?
+                    new[]
+                    {
+                        new object[] {false},
+                        new object[] {true},
+                    }
+                    :
+                    new[]
+                    {
+                        new object[] {true},
+                    };
+            }
+        }
 
         public IEnumerator<object[]> GetEnumerator() => Booleans.GetEnumerator();
 
@@ -366,7 +376,6 @@ namespace System.Linq.Expressions.Tests
     public enum Int64Enum : long { A = long.MaxValue }
     public enum UInt64Enum : ulong { A = ulong.MaxValue }
 
-#if FEATURE_COMPILE
     public static class NonCSharpTypes
     {
         private static Type _charEnumType;
@@ -412,7 +421,6 @@ namespace System.Linq.Expressions.Tests
             }
         }
     }
-#endif
 
     public class FakeExpression : Expression
     {
@@ -467,15 +475,17 @@ namespace System.Linq.Expressions.Tests
     {
         public static void Verify(this LambdaExpression expression, string il, string instructions)
         {
-#if FEATURE_COMPILE
-            expression.VerifyIL(il);
-#endif
+            if (LambdaExpression.CanCompileToIL)
+            {
+                expression.VerifyIL(il);
+            }
 
             // FEATURE_COMPILE is not directly required,
             // but this functionality relies on private reflection and that would not work with AOT
-#if FEATURE_INTERPRET && FEATURE_COMPILE
-            expression.VerifyInstructions(instructions);
-#endif
+            if (LambdaExpression.CanCompileToIL && LambdaExpression.CanInterpret)
+            {
+                expression.VerifyInstructions(instructions);
+            }
         }
     }
 

--- a/src/libraries/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/libraries/System.Linq.Expressions/tests/HelperTypes.cs
@@ -480,7 +480,7 @@ namespace System.Linq.Expressions.Tests
                 expression.VerifyIL(il);
             }
 
-            // FEATURE_COMPILE is not directly required,
+            // LambdaExpression.CanCompileToIL is not directly required,
             // but this functionality relies on private reflection and that would not work with AOT
             if (LambdaExpression.CanCompileToIL && LambdaExpression.CanInterpret)
             {

--- a/src/libraries/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -92,13 +92,12 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("xs[i, j]", e3.ToString());
         }
 
-#if FEATURE_COMPILE
         private static TypeBuilder GetTestTypeBuilder() =>
             AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestAssembly"), AssemblyBuilderAccess.RunAndCollect)
                 .DefineDynamicModule("TestModule")
                 .DefineType("TestType");
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14920", TestRuntimes.Mono)]
         public void NoAccessorIndexedProperty()
         {
@@ -114,7 +113,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void ByRefIndexedProperty()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -145,7 +144,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void VoidIndexedProperty()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -173,7 +172,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14927", TestRuntimes.Mono)]
         public void IndexedPropertyGetReturnsWrongType()
         {
@@ -202,7 +201,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void IndexedPropertySetterNoParams()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -230,7 +229,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void IndexedPropertySetterByrefValueType()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -258,7 +257,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void IndexedPropertySetterNotReturnVoid()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -286,7 +285,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void IndexedPropertyGetterInstanceSetterStatic()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -326,7 +325,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14927", TestRuntimes.Mono)]
         public void IndexedPropertySetterValueTypeNotMatchPropertyType()
         {
@@ -355,7 +354,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void IndexedPropertyGetterSetterArgCountMismatch()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -395,7 +394,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void IndexedPropertyGetterSetterArgumentTypeMismatch()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -435,7 +434,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0), Expression.Constant(0), Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void IndexedPropertyVarArgs()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -465,7 +464,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0), Expression.Constant(0), Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void NullInstanceInstanceProperty()
         {
             PropertyInfo prop = typeof(Dictionary<int, int>).GetProperty("Item");
@@ -473,7 +472,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("instance", () => Expression.Property(null, prop, index));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void InstanceToStaticProperty()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -501,7 +500,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("instance", () => Expression.Property(instance, prop, Expression.Constant(0)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void ByRefIndexer()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -528,9 +527,6 @@ namespace System.Linq.Expressions.Tests
             Expression instance = Expression.Default(type);
             AssertExtensions.Throws<ArgumentException>("indexes[0]", () => Expression.Property(instance, prop, Expression.Constant(0)));
         }
-
-// FEATURE_COMPILE
-#endif
 
         [Fact]
         public void CallWithoutIndices()

--- a/src/libraries/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -1,10 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// FEATURE_COMPILE is not directly required,
-// but this functionality relies on private reflection and that would not work with AOT
-#if FEATURE_INTERPRET && FEATURE_COMPILE
-
 using System.Linq.Expressions.Interpreter;
 using System.Reflection;
 using Xunit;
@@ -15,7 +11,9 @@ namespace System.Linq.Expressions.Tests
     {
         private static readonly PropertyInfo s_debugView = typeof(LightLambda).GetPropertyAssert("DebugView");
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void VerifyInstructions_Simple()
         {
             // Using an unchecked multiplication to ensure that a mul instruction is emitted (and not mul.ovf)
@@ -46,7 +44,9 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void VerifyInstructions_Exceptions()
         {
             ParameterExpression x = Expression.Parameter(typeof(int), "x");
@@ -101,7 +101,9 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue ("https://github.com/dotnet/runtime/issues/53599", platforms: TestPlatforms.MacCatalyst, runtimes: TestRuntimes.Mono)]
         public static void ConstructorThrows_StackTrace()
         {
@@ -110,7 +112,9 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(), "Thrower..ctor");
         }
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void PropertyGetterThrows_StackTrace()
         {
             Expression<Func<Thrower, int>> e = t => t.Bar;
@@ -118,7 +122,9 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Bar");
         }
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void PropertySetterThrows_StackTrace()
         {
             ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
@@ -127,7 +133,9 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Bar");
         }
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void IndexerGetterThrows_StackTrace()
         {
             ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
@@ -136,7 +144,9 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Item");
         }
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void IndexerSetterThrows_StackTrace()
         {
             ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
@@ -145,7 +155,9 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Item");
         }
 
-        [Fact]
+        // FEATURE_COMPILE is not directly required,
+        // but this functionality relies on private reflection and that would not work with AOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void MethodThrows_StackTrace()
         {
             Expression<Action<Thrower>> e = t => t.Foo();
@@ -232,5 +244,3 @@ namespace System.Linq.Expressions.Tests
         }
     }
 }
-
-#endif

--- a/src/libraries/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Expressions.Tests
     {
         private static readonly PropertyInfo s_debugView = typeof(LightLambda).GetPropertyAssert("DebugView");
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void VerifyInstructions_Simple()
@@ -44,7 +44,7 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void VerifyInstructions_Exceptions()
@@ -101,7 +101,7 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue ("https://github.com/dotnet/runtime/issues/53599", platforms: TestPlatforms.MacCatalyst, runtimes: TestRuntimes.Mono)]
@@ -112,7 +112,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(), "Thrower..ctor");
         }
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void PropertyGetterThrows_StackTrace()
@@ -122,7 +122,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Bar");
         }
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void PropertySetterThrows_StackTrace()
@@ -133,7 +133,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Bar");
         }
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void IndexerGetterThrows_StackTrace()
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Item");
         }
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void IndexerSetterThrows_StackTrace()
@@ -155,7 +155,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Item");
         }
 
-        // FEATURE_COMPILE is not directly required,
+        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
         // but this functionality relies on private reflection and that would not work with AOT
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void MethodThrows_StackTrace()

--- a/src/libraries/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -244,7 +244,7 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(invoke, new ParameterAndConstantChangingVisitor().Visit(invoke));
         }
 
-        // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+        // When we don't have IsNotLinqExpressionsBuiltWithIsInterpretingOnly we don't have the Reflection.Emit used in the tests.
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ClassData(typeof(CompilationTypes))]
         public static void InvokePrivateDelegate(bool useInterpreter)
@@ -263,7 +263,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(42, invFunc());
         }
 
-        // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+        // When we don't have IsNotLinqExpressionsBuiltWithIsInterpretingOnly we don't have the Reflection.Emit used in the tests.
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ClassData(typeof(CompilationTypes))]
         public static void InvokePrivateDelegateTypeLambda(bool useInterpreter)

--- a/src/libraries/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -244,9 +244,9 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(invoke, new ParameterAndConstantChangingVisitor().Visit(invoke));
         }
 
-#if FEATURE_COMPILE // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
-
-        [Theory, ClassData(typeof(CompilationTypes))]
+        // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ClassData(typeof(CompilationTypes))]
         public static void InvokePrivateDelegate(bool useInterpreter)
         {
             AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect);
@@ -263,7 +263,9 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(42, invFunc());
         }
 
-        [Theory, ClassData(typeof(CompilationTypes))]
+        // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ClassData(typeof(CompilationTypes))]
         public static void InvokePrivateDelegateTypeLambda(bool useInterpreter)
         {
             AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect);
@@ -278,7 +280,6 @@ namespace System.Linq.Expressions.Tests
             var invFunc = invLambda.Compile(useInterpreter);
             Assert.Equal(42, invFunc());
         }
-#endif
 
         private delegate void RefIntAction(ref int x);
 

--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -268,9 +268,11 @@ namespace System.Linq.Expressions.Tests
                 double, double, double, double,
                 bool>), exp.Type);
 
-#if FEATURE_COMPILE
             // From this point on, the tests require FEATURE_COMPILE (RefEmit) support as SLE needs to create delegate types on the fly.
             // You can't instantiate Func<> over 20 arguments or over byrefs.
+            if (PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly)
+                return;
+
             ParameterExpression[] paramList = Enumerable.Range(0, 20).Select(_ => Expression.Variable(typeof(int))).ToArray();
             exp = Expression.Lambda(
                 Expression.Constant(0),
@@ -302,7 +304,6 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(1, delMethod.GetParameters().Length);
             Assert.Equal(typeof(int).MakeByRefType(), delMethod.GetParameters()[0].ParameterType);
             Assert.Same(delType, Expression.Lambda(Expression.Constant(3L), Expression.Parameter(typeof(int).MakeByRefType())).Type);
-#endif //FEATURE_COMPILE
         }
 
         [Fact]
@@ -790,8 +791,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(23, result);
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void AboveByteMaxArityArgIL()
         {
             ParameterExpression[] pars = Enumerable.Range(0, 300)
@@ -808,7 +808,6 @@ namespace System.Linq.Expressions.Tests
 }
 ");
         }
-#endif
 
         private struct Mutable
         {
@@ -882,8 +881,7 @@ namespace System.Linq.Expressions.Tests
             Assert.True(result.Mutated);
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void AboveByteMaxArityArgAddressIL()
         {
             ParameterExpression parToMutate = Expression.Parameter(typeof(Mutable));
@@ -903,7 +901,6 @@ namespace System.Linq.Expressions.Tests
 }
 ");
         }
-#endif
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void ExcessiveArity(bool useInterpreter)
@@ -927,9 +924,9 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(Action<>), Expression.Empty(), false, Enumerable.Empty<ParameterExpression>()));
         }
 
-#if FEATURE_COMPILE // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
-
-        [Theory, ClassData(typeof(CompilationTypes))]
+        // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ClassData(typeof(CompilationTypes))]
         public void PrivateDelegate(bool useInterpreter)
         {
             AssemblyBuilder assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect);
@@ -943,8 +940,6 @@ namespace System.Linq.Expressions.Tests
             Assert.IsType(delType, del);
             Assert.Equal(42, del.DynamicInvoke());
         }
-
-#endif
 
         [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.Netcoreapp, "Optimization in .NET Core")]

--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -268,7 +268,7 @@ namespace System.Linq.Expressions.Tests
                 double, double, double, double,
                 bool>), exp.Type);
 
-            // From this point on, the tests require FEATURE_COMPILE (RefEmit) support as SLE needs to create delegate types on the fly.
+            // From this point on, the tests require IsLinqExpressionsBuiltWithIsInterpretingOnly (RefEmit) support as SLE needs to create delegate types on the fly.
             // You can't instantiate Func<> over 20 arguments or over byrefs.
             if (PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly)
                 return;
@@ -924,7 +924,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(Action<>), Expression.Empty(), false, Enumerable.Empty<ParameterExpression>()));
         }
 
-        // When we don't have FEATURE_COMPILE we don't have the Reflection.Emit used in the tests.
+        // When we don't have IsLinqExpressionsBuiltWithIsInterpretingOnly we don't have the Reflection.Emit used in the tests.
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ClassData(typeof(CompilationTypes))]
         public void PrivateDelegate(bool useInterpreter)

--- a/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -552,8 +552,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("member", () => Expression.MakeMemberAccess(Expression.Constant(new PC()), member));
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14920", TestRuntimes.Mono)]
         public static void Property_NoGetOrSetAccessors_ThrowsArgumentException()
         {
@@ -575,7 +574,6 @@ namespace System.Linq.Expressions.Tests
 
             AssertExtensions.Throws<ArgumentException>("property", () => Expression.MakeMemberAccess(expression, createdProperty));
         }
-#endif
 
         [Fact]
         public static void ToStringTest()

--- a/src/libraries/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -284,8 +284,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("bindings[0]", () => Expression.MemberInit(Expression.New(typeof(PropertyAndFields)), binding));
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void GlobalMethod()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -296,7 +295,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyAccessor", () => Expression.Bind(globalMethodInfo, Expression.Constant(2)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void GlobalField()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -305,6 +304,5 @@ namespace System.Linq.Expressions.Tests
             FieldInfo globalField = module.GetField(fieldBuilder.Name);
             AssertExtensions.Throws<ArgumentException>("member", () => Expression.Bind(globalField, Expression.Default(globalField.FieldType)));
         }
-#endif
     }
 }

--- a/src/libraries/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -290,8 +290,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(method));
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void GlobalMethod()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -301,7 +300,5 @@ namespace System.Linq.Expressions.Tests
             MethodInfo globalMethodInfo = module.GetMethod(globalMethod.Name);
             AssertExtensions.Throws<ArgumentException>("propertyAccessor", () => Expression.ListBind(globalMethodInfo));
         }
-#endif
-
     }
 }

--- a/src/libraries/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -253,8 +253,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void GlobalMethod()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -264,7 +263,6 @@ namespace System.Linq.Expressions.Tests
             MethodInfo globalMethodInfo = module.GetMethod(globalMethod.Name);
             AssertExtensions.Throws<ArgumentException>("propertyAccessor", () => Expression.MemberBind(globalMethodInfo));
         }
-#endif
 
         [Fact]
         public void WriteOnlyInnerProperty()

--- a/src/libraries/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/New/NewTests.cs
@@ -555,8 +555,7 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void GlobalMethodInMembers()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -570,7 +569,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("members[0]", () => Expression.New(constructor, arguments, members));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void GlobalFieldInMembers()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -582,7 +581,6 @@ namespace System.Linq.Expressions.Tests
             MemberInfo[] members = { globalField };
             AssertExtensions.Throws<ArgumentException>("members[0]", () => Expression.New(constructor, arguments, members));
         }
-#endif
 
         static class StaticCtor
         {

--- a/src/libraries/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
@@ -70,13 +70,11 @@ namespace System.Linq.Expressions.Tests
             CreateByRefAliasing(useInterpreter: true);
         }
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public void CreateByRefAliasingCompiled()
         {
             CreateByRefAliasing(useInterpreter: false);
         }
-#endif
 
         [Theory, ClassData(typeof(CompilationTypes))]
         public void CreateByRefReferencingReadonly(bool useInterpreter)

--- a/src/libraries/System.Linq.Expressions/tests/StackSpillerTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/StackSpillerTests.cs
@@ -1676,9 +1676,7 @@ namespace System.Linq.Expressions.Tests
                     }");
         }
 
-#if FEATURE_COMPILE
-
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_Constant()
         {
             ParameterExpression xs = Expression.Parameter(typeof(int[]));
@@ -1736,7 +1734,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_Default()
         {
             ParameterExpression xs = Expression.Parameter(typeof(int[]));
@@ -1794,7 +1792,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_LiteralField_NotNetFramework()
         {
             Expression<Func<double>> e =
@@ -1842,7 +1840,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_StaticReadOnlyField()
         {
             Expression<Func<string>> e =
@@ -1891,7 +1889,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_RuntimeVariables1()
         {
             ParameterExpression f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
@@ -1950,7 +1948,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_RuntimeVariables2()
         {
             ParameterExpression f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
@@ -2028,7 +2026,7 @@ namespace System.Linq.Expressions.Tests
             );
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_NoSpillBeyondSpillSite1()
         {
             ParameterExpression f = Expression.Parameter(typeof(Func<int, int, int, int>));
@@ -2101,7 +2099,7 @@ namespace System.Linq.Expressions.Tests
                 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         public static void Spill_Optimizations_NoSpillBeyondSpillSite2()
         {
             ParameterExpression f = Expression.Parameter(typeof(Func<int, int, int, int>));
@@ -2186,8 +2184,6 @@ namespace System.Linq.Expressions.Tests
                   IL_001a: ret
                 }");
         }
-
-#endif
 
         private static void Test(Func<Expression, Expression> factory, Expression arg1)
         {

--- a/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/libraries/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -1,10 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <FeatureInterpret>true</FeatureInterpret>
-    <IsInterpreting>false</IsInterpreting>
-    <IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting>
-    <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
-    <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-MacCatalyst</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
@@ -221,7 +216,7 @@
     <Compile Include="Variables\VariableTests.cs" />
     <Compile Include="Visitor\VisitorTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(IsInterpreting)' != 'true' ">
+  <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Collections\DictionaryExtensions.cs"
              Link="Common\System\Collections\DictionaryExtensions.cs" />
     <Compile Include="ILReader\DynamicMethodILProvider.cs" />

--- a/src/libraries/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TestExtensions/InlinePerCompilationTypeAttribute.cs
@@ -9,13 +9,8 @@ namespace System.Linq.Expressions.Tests
 {
     internal class InlinePerCompilationTypeAttribute : DataAttribute
     {
-        private static readonly object[] s_boxedBooleans =
-        {
-            false,
-#if FEATURE_COMPILE && FEATURE_INTERPRET
-            true
-#endif
-        };
+        private static readonly object[] s_boxedBooleans = PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly ?
+            new object[] { false, true } : new object[] { false };
 
         private readonly object[] _data;
 

--- a/src/libraries/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TestExtensions/PerCompilationTypeAttribute.cs
@@ -32,42 +32,30 @@ namespace System.Linq.Expressions.Tests
             // we'd therefore end up with multiple copies of the last result.
             foreach (object[] received in delegatedTo.GetData(testMethod))
             {
-#if FEATURE_COMPILE
-                object[] withFalse = new object[received.Length + 1];
-#endif
+                object[] withFalse = null;                
+                if (PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly)
+                {
+                    withFalse = new object[received.Length + 1];
+                    withFalse[received.Length] = s_boxedFalse;
+                }
 
-#if FEATURE_INTERPRET
                 object[] withTrue = new object[received.Length + 1];
-#endif
-
-#if FEATURE_COMPILE
-                withFalse[received.Length] = s_boxedFalse;
-#endif
-
-#if FEATURE_INTERPRET
                 withTrue[received.Length] = s_boxedTrue;
-#endif
 
                 for (int i = 0; i != received.Length; ++i)
                 {
                     object arg = received[i];
 
-#if FEATURE_COMPILE
-                    withFalse[i] = arg;
-#endif
+                    if (withFalse != null)
+                        withFalse[i] = arg;
 
-#if FEATURE_INTERPRET
                     withTrue[i] = arg;
-#endif
                 }
 
-#if FEATURE_COMPILE
-                yield return withFalse;
-#endif
+                if (withFalse != null)
+                    yield return withFalse;
 
-#if  FEATURE_INTERPRET
                 yield return withTrue;
-#endif
             }
         }
     }

--- a/src/libraries/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
@@ -201,8 +201,7 @@ namespace System.Linq.Expressions.Tests
 
         #endregion
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_NullableShortNegateChecked()
         {
@@ -234,7 +233,5 @@ namespace System.Linq.Expressions.Tests
                     IL_001d: ret
                 }");
         }
-#endif
-
     }
 }

--- a/src/libraries/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -208,8 +208,7 @@ namespace System.Linq.Expressions.Tests
 
         #endregion
 
-#if FEATURE_COMPILE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
         [ActiveIssue("https://github.com/mono/mono/issues/14919", TestRuntimes.Mono)]
         public static void VerifyIL_ShortNegateChecked()
         {
@@ -229,7 +228,5 @@ namespace System.Linq.Expressions.Tests
                     IL_0004: ret
                 }");
         }
-#endif
-
     }
 }


### PR DESCRIPTION
System.Linq.Expressions currently offers multiple build time definitions to build different flavors of the library:

* `FEATURE_COMPILE` (defined everywhere except iOS/tvOS/Catalyst, and NativeAOT) - enables Reflection.Emit-based expression tree compiler.
* `FEATURE_INTERPRET` (always defined and not actually possible to build without) - enables the expression interpreter
* `FEATURE_DLG_INVOKE` (defined everywhere except NativeAOT, but we likely need to be able to run without it on iOS too because there's uninvestigated bugs around it ActiveIssue'd in #54970) - in the interpreter, use a delegate to invoke `CallInstructions` instead of `MethodInfo.Invoke`. The delegate might have to be Reflection.Emitted if it's not supportable with `Func`/`Action` (that's the uninvestigated iOS/tvOS/Catalyst bug).

For #61231, we need to be able to build a single System.Linq.Expression library that can switch between these build-time configurations _at publish time_ since we don't want to build a separate S.L.Expressions library for NativeAOT. There are advantages in having this setup for non-NativeAOT scenarios too. This pull request accomplishes that by mechanically changing the `#define`s into feature switches.

The feature switch is placed in the last proposed location for https://github.com/dotnet/runtime/issues/17973. I expect we'll want such API to be public at some point; now that Xamarin and NativeAOT use this formerly .NET Native-only thing the API request became relevant again.

This pull request is focused on the mechanical replacement of `#defines` with feature switches and it's already a lot bigger than I'm comfortable with.

There's some obvious "`!FEATURE_COMPILE` means this is .NET Native with everything what that meant" that I did not touch because this is meant to be a mechanical change. Some cleanup will be needed at some point. Right now this just mostly means we're running fewer tests than we could.

Validation:
* Verified that we're still running the same number of tests with CoreCLR as we previously were and they're all passing.
* Verified we're getting mostly the same size of the S.L.Expressions library on iOS (433 kB grew to ~~437~~ 436 kB, the diffs are expected).
* Verified things work on the NativeAOT side as well.

Cc @jkotas @marek-safar @MaximLipnin @steveisok @akoeplinger 