### PR TITLE
Update hash of the new CSE when resizing

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -655,6 +655,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
                     }
                 }
 
+                hval                           = optCSEKeyToHashIndex(key, newOptCSEhashSize);
                 optCSEhash                     = newOptCSEhash;
                 optCSEhashSize                 = newOptCSEhashSize;
                 optCSEhashMaxCountBeforeResize = optCSEhashMaxCountBeforeResize * s_optCSEhashGrowthFactor;


### PR DESCRIPTION
The CSE logic maintains a custom hashtable implementation.

It triggers a resize at the same time as adding a new CSE, but forgets the hash of the new CSE needs to be updated from its pre-resize value. Failing to do so can lead to losing some CSEs, though not in a correctness-impacting way, I believe.

This was causing spurious diffs over at #61933.

We are expecting small diffs due to some new CSEs.

<details>
<summary>For example, here is one Win-x64 diff</summary>

We discover the CSE "earlier":
```diff
 CSE candidate #19, key=$1a51 in BB04, [cost= 4, size=12]:
-N008 (  4, 12) CSE #19 (use)[010348] #---G-------              *  IND       ref    $1a51
-N007 (  2, 10)              [010347] H-----------              \--*  CNS_INT(h) long   0xC46CA260 [ICON_STR_HDL] $14e2
+N008 (  4, 12) CSE #19 (use)[010304] #---G-------              *  IND       ref    $1a51
+N007 (  2, 10)              [010303] H-----------              \--*  CNS_INT(h) long   0xC46CA260 [ICON_STR_HDL] $14e2

 CSE candidate #20, key=$1ca2 in BB04, [cost= 4, size=12]:
 N008 (  4, 12) CSE #20 (use)[010700] #---G-------              *  IND       ref    $1ca2
@@ -332708,14 +332708,15 @@ BB04 [010216] Use of CSE #18 [weight=0.50]
 BB04 [004187] Use of CSE #01 [weight=0.50]
 BB04 [004198] Use of CSE #01 [weight=0.50]
 BB04 [004204] Use of CSE #01 [weight=0.50]
+BB04 [010260] Def of CSE #19 [weight=0.50]
 BB04 [004243] Use of CSE #01 [weight=0.50]
 BB04 [004254] Use of CSE #01 [weight=0.50]
 BB04 [004260] Use of CSE #01 [weight=0.50]
-BB04 [010304] Def of CSE #19 [weight=0.50]
+BB04 [010304] Use of CSE #19 [weight=0.50] *** Now Live Across Call ***
 BB04 [004299] Use of CSE #01 [weight=0.50]
 BB04 [004310] Use of CSE #01 [weight=0.50]
 BB04 [004316] Use of CSE #01 [weight=0.50]
-BB04 [010348] Use of CSE #19 [weight=0.50] *** Now Live Across Call ***
+BB04 [010348] Use of CSE #19 [weight=0.50]
 BB04 [004355] Use of CSE #01 [weight=0.50]
 BB04 [004366] Use of CSE #01 [weight=0.50]
 BB04 [004372] Use of CSE #01 [weight=0.50]
```
</details>

[Full diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1483426&view=ms.vss-build-web.run-extensions-tab).