### PR TITLE
Handle when DestroyStructure API passes null to the IL marshaller

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/StructureToPtrTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/StructureToPtrTests.cs
@@ -256,6 +256,30 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(*opaqueData, *marshaledOpaqueData);
         }
 
+        [Fact]
+        public void StructureToPtr_Flat_And_Nested_NonBlittableStructure_Success()
+        {
+            MarshalAndDestroy(new NonBlittableStruct_Flat
+            {
+                del = null,
+                b = 0x55,
+            });
+
+            MarshalAndDestroy(new NonBlittableStruct_Nested
+            {
+                s = { del = null },
+                b = 0x55,
+            });
+
+            static unsafe void MarshalAndDestroy<T>(T value) where T : struct
+            {
+                int sizeof_T = Marshal.SizeOf<T>();
+                void* ptr = stackalloc byte[sizeof_T];
+                Marshal.StructureToPtr(value, (IntPtr)ptr, false);
+                Marshal.DestroyStructure<T>((IntPtr)ptr);
+            }
+        }
+
         public struct StructWithIntField
         {
             public int value;
@@ -317,6 +341,23 @@ namespace System.Runtime.InteropServices.Tests
         {
             public OpaqueStruct opaque;
             public string str;
+        }
+
+        public struct NonBlittableStruct_Flat
+        {
+            public Delegate del;
+            public byte b;
+        }
+
+        public struct NonBlittableStruct_Nested
+        {
+            public struct InnerStruct
+            {
+                public Delegate del;
+            }
+
+            public InnerStruct s;
+            public byte b;
         }
     }
 }


### PR DESCRIPTION
During the clean up phase for IL marshallers, managed value types passed as `nullptr` can cause failures.
This is an issue with field marshallers of nested non-blittable types only.

https://github.com/dotnet/runtime/blob/f24b363c99df37dce5bc974eb879188110801d36/src/coreclr/vm/marshalnative.cpp#L228-L238

Fixes https://github.com/dotnet/runtime/issues/61839

/cc @jkoritzinsky @elinor-fung 