### PR TITLE
[mono] Restrict the Selector.GetHandle intrinsic to GetHandle implementations that take an IntPtr.

### DIFF
--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -1933,6 +1933,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		if ((cfg->backend->have_objc_get_selector || cfg->compile_llvm) &&
 			!strcmp (cmethod->name, "GetHandle") && fsig->param_count == 1 &&
 		    (args [0]->opcode == OP_GOT_ENTRY || args [0]->opcode == OP_AOTCONST) &&
+		    args [0]->klass == mono_defaults.int_class &&
 		    cfg->compile_aot) {
 			MonoInst *pi;
 			MonoJumpInfoToken *ji;


### PR DESCRIPTION
As part of a large refactoring, we're might want to add additional
Selector.GetHandle overloads (that takes other types). Currently this crashes
the AOT compiler, because it tries to optimize method calls to those
overloads, without understanding them. So for now, restrict the optimization
to only the Selector.GetHandle(IntPtr) overload.

Ref: https://github.com/xamarin/xamarin-macios/issues/13087