### PR TITLE
Fix calling NLS with Cultures has alternative sort names

### DIFF
--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -479,7 +479,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expected, new CultureInfo(name).TextInfo.ToString());
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
         [InlineData("es-ES")]
         [InlineData("es-ES_tradnl")]
         public void TestAsciiCodePageWithCulturesWithAlternativeSortNames(string cultureName)

--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -287,7 +287,7 @@ namespace System.Globalization.Tests
                 }
                 yield return new object[] { cultureName, "\u0130", "i" };
                 yield return new object[] { cultureName, "i", "i" };
-                
+
             }
 
             // ICU has special tailoring for the en-US-POSIX locale which treats "i" and "I" as different letters
@@ -477,6 +477,14 @@ namespace System.Globalization.Tests
         public void ToStringTest(string name, string expected)
         {
             Assert.Equal(expected, new CultureInfo(name).TextInfo.ToString());
+        }
+
+        [Theory]
+        [InlineData("es-ES")]
+        [InlineData("es-ES_tradnl")]
+        public void TestAsciiCodePageWithCulturesWithAlternativeSortNames(string cultureName)
+        {
+            AssemblyTrademarkAttribute.Equals(1252, CultureInfo.GetCultureInfo(cultureName).TextInfo.ANSICodePage);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
@@ -47,8 +47,8 @@ namespace System.Globalization
         private string NlsGetLocaleInfo(LocaleStringData type)
         {
             Debug.Assert(ShouldUseUserOverrideNlsData);
-            Debug.Assert(_sWindowsName != null, "[CultureData.DoGetLocaleInfo] Expected _sWindowsName to be populated by already");
-            return NlsGetLocaleInfo(_sWindowsName, type);
+            Debug.Assert(_sRealName != null, "[CultureData.DoGetLocaleInfo] Expected _sRealName to be populated by already");
+            return NlsGetLocaleInfo(_sRealName, type);
         }
 
         // For LOCALE_SPARENT we need the option of using the "real" name (forcing neutral names) instead of the
@@ -74,15 +74,15 @@ namespace System.Globalization
 
             // Ask OS for data, note that we presume it returns success, so we have to know that
             // sWindowsName is valid before calling.
-            Debug.Assert(_sWindowsName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sWindowsName to be populated by already");
-            return GetLocaleInfoExInt(_sWindowsName, lctype);
+            Debug.Assert(_sRealName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sRealName to be populated by already");
+            return GetLocaleInfoExInt(_sRealName, lctype);
         }
 
         private int[] NlsGetLocaleInfo(LocaleGroupingData type)
         {
             Debug.Assert(ShouldUseUserOverrideNlsData);
-            Debug.Assert(_sWindowsName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sWindowsName to be populated by already");
-            return ConvertWin32GroupString(GetLocaleInfoFromLCType(_sWindowsName, (uint)type, _bUseOverrides));
+            Debug.Assert(_sRealName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sRealName to be populated by already");
+            return ConvertWin32GroupString(GetLocaleInfoFromLCType(_sRealName, (uint)type, _bUseOverrides));
         }
 
         internal static bool NlsIsEnsurePredefinedLocaleName(string name)
@@ -94,16 +94,16 @@ namespace System.Globalization
         private string? NlsGetTimeFormatString()
         {
             Debug.Assert(ShouldUseUserOverrideNlsData);
-            Debug.Assert(_sWindowsName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sWindowsName to be populated by already");
-            return ReescapeWin32String(GetLocaleInfoFromLCType(_sWindowsName, Interop.Kernel32.LOCALE_STIMEFORMAT, _bUseOverrides));
+            Debug.Assert(_sRealName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sRealName to be populated by already");
+            return ReescapeWin32String(GetLocaleInfoFromLCType(_sRealName, Interop.Kernel32.LOCALE_STIMEFORMAT, _bUseOverrides));
         }
 
         private int NlsGetFirstDayOfWeek()
         {
             Debug.Assert(ShouldUseUserOverrideNlsData);
-            Debug.Assert(_sWindowsName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sWindowsName to be populated by already");
+            Debug.Assert(_sRealName != null, "[CultureData.DoGetLocaleInfoInt] Expected _sRealName to be populated by already");
 
-            int result = GetLocaleInfoExInt(_sWindowsName, Interop.Kernel32.LOCALE_IFIRSTDAYOFWEEK | (!_bUseOverrides ? Interop.Kernel32.LOCALE_NOUSEROVERRIDE : 0));
+            int result = GetLocaleInfoExInt(_sRealName, Interop.Kernel32.LOCALE_IFIRSTDAYOFWEEK | (!_bUseOverrides ? Interop.Kernel32.LOCALE_NOUSEROVERRIDE : 0));
 
             // Win32 and .NET disagree on the numbering for days of the week, so we have to convert.
             return ConvertFirstDayOfWeekMonToSun(result);
@@ -529,7 +529,7 @@ namespace System.Globalization
 
                 for (int i = 0; i < context.strings.Count; i++)
                 {
-                    if (string.Equals(context.strings[i], _sWindowsName, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals(context.strings[i], _sRealName, StringComparison.OrdinalIgnoreCase))
                         return true;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/61977

In .NET 6.0 and when running on Windows, we have switched to call NLS to get some properties which are not available with ICU. CultureInfo.TextInfo.ANSICodePage is a good example of that. When we are calling NLS in such cases we use the internal culture name stored in `_sWindowsName`. The problem here is when using cultures which have alternative sorts (e.g. `es-ES_tradnl`) such names will be stored as `es_ES@collation=tradnl` to be used when calling ICU too. If this name is used with NLS, the calls will fail. The fix here is to use the name that works with Windows which is stored in the field `sRealName` instead. On NLS mode, _sWindowsName is same as _sRealName so this change shouldn't affect this mode.