### PR TITLE
Add a github action to sync shared source from aspnetcore

### DIFF
--- a/.github/workflows/aspnetcore-sync-checkdiff.ps1
+++ b/.github/workflows/aspnetcore-sync-checkdiff.ps1
@@ -1,0 +1,3 @@
+# Check the code is in sync
+$changed = (select-string "nothing to commit" artifacts\status.txt).count -eq 0
+return $changed

--- a/.github/workflows/aspnetcore-sync.yml
+++ b/.github/workflows/aspnetcore-sync.yml
@@ -1,0 +1,72 @@
+name: AspNetCore->Runtime Code Sync
+on:
+  # Manual run
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  compare_repos:
+    # Comment out this line to test the scripts in a fork
+    if: github.repository == 'dotnet/runtime'
+    name: Compare the shared code in the AspNetCore and Runtime repos and send a PR to Runtime if they're out of sync.
+    runs-on: windows-latest
+    steps:
+    - name: Checkout aspnetcore
+      uses: actions/checkout@v2.0.0
+      with:
+        # Test this script using changes in a fork
+        repository: 'dotnet/aspnetcore'
+        # repository: 'tratcher/aspnetcore'
+        path: aspnetcore
+        ref: main
+    - name: Checkout runtime
+      uses: actions/checkout@v2.0.0
+      with:
+        # Test this script using changes in a fork
+        repository: 'dotnet/runtime'
+        # repository: 'tratcher/runtime'
+        path: runtime
+        ref: main
+    - name: Copy
+      shell: cmd
+      working-directory: .\aspnetcore\src\Shared\runtime\
+      env:
+        RUNTIME_REPO: d:\a\runtime\runtime\runtime\
+      run: CopyToRuntime.cmd
+    - name: Diff
+      shell: cmd
+      working-directory: .\runtime\
+      run: |
+        mkdir ..\artifacts
+        git status > ..\artifacts\status.txt
+        git diff > ..\artifacts\diff.txt
+    - uses: actions/upload-artifact@v1
+      with:
+        name: results
+        path: artifacts
+    - name: Check
+      id: check
+      shell: pwsh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $changed = .\runtime\.github\workflows\aspnetcore-sync-checkdiff.ps1
+        echo "::set-output name=changed::$changed"
+    - name: Send PR
+      if: steps.check.outputs.changed == 'true'
+      # https://github.com/marketplace/actions/create-pull-request
+      uses: dotnet/actions-create-pull-request@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: .\runtime
+        commit-message: 'Sync shared code from aspnetcore'
+        title: 'Sync shared code from aspnetcore'
+        body: 'This PR was automatically generated to sync shared code changes from aspnetcore. Fixes https://github.com/dotnet/aspnetcore/issues/18943'
+        labels: area-System.Net.Http
+        base: main
+        branch: github-action/sync-aspnetcore
+        branch-suffix: timestamp

--- a/.github/workflows/aspnetcore-sync.yml
+++ b/.github/workflows/aspnetcore-sync.yml
@@ -12,7 +12,7 @@ jobs:
   compare_repos:
     # Comment out this line to test the scripts in a fork
     if: github.repository == 'dotnet/runtime'
-    name: Compare the shared code in the AspNetCore and Runtime repos and send a PR to Runtime if they're out of sync.
+    name: Sync Code
     runs-on: windows-latest
     steps:
     - name: Checkout aspnetcore
@@ -20,7 +20,6 @@ jobs:
       with:
         # Test this script using changes in a fork
         repository: 'dotnet/aspnetcore'
-        # repository: 'tratcher/aspnetcore'
         path: aspnetcore
         ref: main
     - name: Checkout runtime
@@ -28,7 +27,6 @@ jobs:
       with:
         # Test this script using changes in a fork
         repository: 'dotnet/runtime'
-        # repository: 'tratcher/runtime'
         path: runtime
         ref: main
     - name: Copy


### PR DESCRIPTION
This mirrors an action we have in aspnetcore to sync changes to shared HTTP source code files.
https://github.com/dotnet/aspnetcore/actions/workflows/runtime-sync.yml

The one in aspnet triggers on a nightly schedule and sends a PR to aspnetcore if it detects any diffs. However, sometimes changes need to be submitted to runtime instead. The new action added here will only trigger manually, and will send a pr to runtime with any diffs.