### PR TITLE
Clean up test intermediates when clean test rebuild is requested

### DIFF
--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -146,8 +146,10 @@ set "__TestBinDir=%__TestRootDir%\%__OSPlatformConfig%"
 set "__TestIntermediatesDir=%__TestRootDir%\obj\%__OSPlatformConfig%"
 
 if "%__RebuildTests%" == "1" (
-    echo Removing tests build dir^: !__TestBinDir!
+    echo Removing test build dir^: !__TestBinDir!
     rmdir /s /q !__TestBinDir!
+    echo Removing test intermediate dir^: !__TestIntermediatesDir!
+    rmdir /s /q !__TestIntermediatesDir!
 )
 
 REM We have different managed and native intermediate dirs because the managed bits will include

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -5,11 +5,10 @@ build_Tests()
     echo "${__MsgPrefix}Building Tests..."
 
     __ProjectFilesDir="$__TestDir"
-    __TestBinDir="$__TestWorkingDir"
     __Exclude="$__RepoRootDir/src/tests/issues.targets"
 
-    if [[ -f  "${__TestWorkingDir}/build_info.json" ]]; then
-        rm  "${__TestWorkingDir}/build_info.json"
+    if [[ -f  "${__TestBinDir}/build_info.json" ]]; then
+        rm  "${__TestBinDir}/build_info.json"
     fi
 
     if [[ "$__RebuildTests" -ne 0 ]]; then
@@ -363,7 +362,7 @@ __OSPlatformConfig="$__TargetOS.$__BuildArch.$__BuildType"
 __BinDir="$__RootBinDir/bin/coreclr/$__OSPlatformConfig"
 __PackagesBinDir="$__BinDir/.nuget"
 __TestDir="$__RepoRootDir/src/tests"
-__TestWorkingDir="$__RootBinDir/tests/coreclr/$__OSPlatformConfig"
+__TestBinDir="$__RootBinDir/tests/coreclr/$__OSPlatformConfig"
 __IntermediatesDir="$__RootBinDir/obj/coreclr/$__OSPlatformConfig"
 __TestIntermediatesDir="$__RootBinDir/tests/coreclr/obj/$__OSPlatformConfig"
 __CrossCompIntermediatesDir="$__IntermediatesDir/crossgen"
@@ -382,9 +381,11 @@ if [[ -z "$HOME" ]]; then
 fi
 
 if [[ "$__RebuildTests" -ne 0 ]]; then
-    if [[ -d "${__TestWorkingDir}" ]]; then
-        echo "Removing tests build dir: ${__TestWorkingDir}"
-        rm -rf "${__TestWorkingDir}"
+    if [[ -d "${__TestBinDir}" ]]; then
+        echo "Removing test build dir: ${__TestBinDir}"
+        rm -rf "${__TestBinDir}"
+        echo "Removing test intermediate dir: ${__TestIntermediatesDir}"
+        rm -rf "${__TestIntermediatesDir}" 
     fi
 fi
 

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -381,12 +381,10 @@ if [[ -z "$HOME" ]]; then
 fi
 
 if [[ "$__RebuildTests" -ne 0 ]]; then
-    if [[ -d "${__TestBinDir}" ]]; then
-        echo "Removing test build dir: ${__TestBinDir}"
-        rm -rf "${__TestBinDir}"
-        echo "Removing test intermediate dir: ${__TestIntermediatesDir}"
-        rm -rf "${__TestIntermediatesDir}" 
-    fi
+    echo "Removing test build dir: ${__TestBinDir}"
+    rm -rf "${__TestBinDir}"
+    echo "Removing test intermediate dir: ${__TestIntermediatesDir}"
+    rm -rf "${__TestIntermediatesDir}" 
 fi
 
 build_Tests


### PR DESCRIPTION
I hit this problem locally when working on the test merging -
I made a change in Jeremy's Roslyn generator logic adding a hard
FailFast and the tests continued building normally even when
specifying the rebuild option because the XUnitWrapperGenerator
project remained in the intermediate test folder and didn't get
actually rebuilt. As an additional tiny cleanup I have also replaced
__TestWorkingDir with __TestBinDir in the Unix version of the script
as they are always identical.

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 