### PR TITLE
Reduce allocations in code generated by Logging generators (#61162)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -156,7 +156,7 @@ namespace {lc.Namespace}
             {nestedIndentation}}}
 ");
                 _builder.Append($@"
-            {nestedIndentation}public static string Format(__{lm.Name}Struct state, global::System.Exception? ex) => state.ToString();
+            {nestedIndentation}public static readonly global::System.Func<__{lm.Name}Struct, global::System.Exception?, string> Format = (state, ex) => state.ToString();
 
             {nestedIndentation}public int Count => {lm.TemplateParameters.Count + 1};
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -16,10 +16,18 @@ namespace Microsoft.Extensions.Logging.Generators
             private const int MaxLoggerMessageDefineArguments = 6;
             private const int DefaultStringBuilderCapacity = 1024;
 
+            private static readonly string s_generatedTypeSummary =
+                "<summary> " +
+                "The implementation of this type is subject to change without further notice, " +
+                "do not use it directly in your code. " +
+                "</summary>";
             private static readonly string s_generatedCodeAttribute =
                 $"global::System.CodeDom.Compiler.GeneratedCodeAttribute(" +
                 $"\"{typeof(Emitter).Assembly.GetName().Name}\", " +
                 $"\"{typeof(Emitter).Assembly.GetName().Version}\")";
+            private static readonly string s_editorBrowsableAttribute =
+                "global::System.ComponentModel.EditorBrowsableAttribute(" +
+                "global::System.ComponentModel.EditorBrowsableState.Never)";
             private readonly StringBuilder _builder = new StringBuilder(DefaultStringBuilderCapacity);
             private bool _needEnumerationHelper;
 
@@ -127,7 +135,9 @@ namespace {lc.Namespace}
             private void GenStruct(LoggerMethod lm, string nestedIndentation)
             {
                 _builder.AppendLine($@"
+        {nestedIndentation}/// {s_generatedTypeSummary}
         {nestedIndentation}[{s_generatedCodeAttribute}]
+        {nestedIndentation}[{s_editorBrowsableAttribute}]
         {nestedIndentation}private readonly struct __{lm.Name}Struct : global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.KeyValuePair<string, object?>>
         {nestedIndentation}{{");
                 GenFields(lm, nestedIndentation);
@@ -489,7 +499,9 @@ namespace {lc.Namespace}
                 if (_needEnumerationHelper)
                 {
                                 _builder.Append($@"
+/// {s_generatedTypeSummary}
 [{s_generatedCodeAttribute}]
+[{s_editorBrowsableAttribute}]
 internal static class __LoggerMessageGenerator
 {{
     public static string Enumerate(global::System.Collections.IEnumerable? enumerable)

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Extensions.Logging.Generators
 
             private static readonly string s_generatedTypeSummary =
                 "<summary> " +
-                "The implementation of this type is subject to change without further notice, " +
-                "do not use it directly in your code. " +
+                "This API supports the logging infrastructure and is not intended to be used directly from your code. " +
+                "It is subject to change in the future. " +
                 "</summary>";
             private static readonly string s_generatedCodeAttribute =
                 $"global::System.CodeDom.Compiler.GeneratedCodeAttribute(" +

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/.editorconfig
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/.editorconfig
@@ -1,0 +1,4 @@
+# editorconfig.org
+
+[*.generated.txt]
+insert_final_newline = false

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDefaultValues.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDefaultValues.generated.txt
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
                 return $"";
             }
 
-            public static string Format(__M0Struct state, global::System.Exception? ex) => state.ToString();
+            public static readonly global::System.Func<__M0Struct, global::System.Exception?, string> Format = (state, ex) => state.ToString();
 
             public int Count => 1;
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDefaultValues.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDefaultValues.generated.txt
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 {
     partial class TestWithDefaultValues 
     {
-        /// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
+        /// <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         private readonly struct __M0Struct : global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.KeyValuePair<string, object?>>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDefaultValues.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDefaultValues.generated.txt
@@ -5,7 +5,9 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 {
     partial class TestWithDefaultValues 
     {
+        /// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         private readonly struct __M0Struct : global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.KeyValuePair<string, object?>>
         {
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDynamicLogLevel.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDynamicLogLevel.generated.txt
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
                 return $"M9";
             }
 
-            public static string Format(__M9Struct state, global::System.Exception? ex) => state.ToString();
+            public static readonly global::System.Func<__M9Struct, global::System.Exception?, string> Format = (state, ex) => state.ToString();
 
             public int Count => 1;
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDynamicLogLevel.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDynamicLogLevel.generated.txt
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 {
     partial class TestWithDynamicLogLevel 
     {
-        /// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
+        /// <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         private readonly struct __M9Struct : global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.KeyValuePair<string, object?>>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDynamicLogLevel.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithDynamicLogLevel.generated.txt
@@ -5,7 +5,9 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 {
     partial class TestWithDynamicLogLevel 
     {
+        /// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         private readonly struct __M9Struct : global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.KeyValuePair<string, object?>>
         {
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithMoreThan6Params.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithMoreThan6Params.generated.txt
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
                 return $"M9 {p1} {p2} {p3} {p4} {p5} {p6} {p7}";
             }
 
-            public static string Format(__Method9Struct state, global::System.Exception? ex) => state.ToString();
+            public static readonly global::System.Func<__Method9Struct, global::System.Exception?, string> Format = (state, ex) => state.ToString();
 
             public int Count => 8;
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithMoreThan6Params.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithMoreThan6Params.generated.txt
@@ -5,7 +5,9 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 {
     partial class TestWithMoreThan6Params 
     {
+        /// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
+        [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         private readonly struct __Method9Struct : global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.KeyValuePair<string, object?>>
         {
             private readonly global::System.Int32 _p1;
@@ -88,7 +90,9 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
         }
     }
 }
+/// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
+[global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
 internal static class __LoggerMessageGenerator
 {
     public static string Enumerate(global::System.Collections.IEnumerable? enumerable)

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithMoreThan6Params.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithMoreThan6Params.generated.txt
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
 {
     partial class TestWithMoreThan6Params 
     {
-        /// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
+        /// <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
         private readonly struct __Method9Struct : global::System.Collections.Generic.IReadOnlyList<global::System.Collections.Generic.KeyValuePair<string, object?>>
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
         }
     }
 }
-/// <summary> The implementation of this type is subject to change without further notice, do not use it directly in your code. </summary>
+/// <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
 [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Never)]
 internal static class __LoggerMessageGenerator


### PR DESCRIPTION
Use a lambda instead of a method group in 'Format' method.