### PR TITLE
[wasm] Use cross origin policy headers

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
-    <WasmXHarnessArgs>$(WasmXHarnessArgs) --engine-arg=--expose-gc</WasmXHarnessArgs>
+    <WasmXHarnessArgs>$(WasmXHarnessArgs) --engine-arg=--expose-gc --web-server-use-cop</WasmXHarnessArgs>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\JavaScript\JavaScriptTests.cs" />

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
     public static class JavaScriptTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         public static void CoreTypes()
         {
             var arr = new Uint8ClampedArray(50);

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/SharedArrayBufferTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/SharedArrayBufferTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.JavaScript.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
     public static class SharedArrayBufferTests
     {
         private static Function _objectPrototype;

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/TypedArrayTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/TypedArrayTests.cs
@@ -108,7 +108,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Uint8ClampedArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -118,7 +117,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Uint8ArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -128,7 +126,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Uint16ArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -138,7 +135,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Uint32ArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -148,7 +144,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Int8ArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -158,7 +153,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Int16ArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -168,7 +162,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Int32ArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -178,7 +171,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Float32ArrayFromSharedArrayBuffer(Function objectPrototype)
         {
@@ -188,7 +180,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/61945", TestPlatforms.Browser)]
         [MemberData(nameof(Object_Prototype))]
         public static void Float64ArrayFromSharedArrayBuffer(Function objectPrototype)
         {


### PR DESCRIPTION
Use xharness arg `--web-server-use-cop` to set cross origin policy headers

```
Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Opener-Policy: same-origin
```

In Chrome 92 `SharedArrayBuffer` was disabled due to a vulnerability. To enable it site must be cross-origin isolated (by COEP and COOP headers). More info at https://developer.chrome.com/blog/enabling-shared-array-buffer/.

Fixes https://github.com/dotnet/runtime/issues/61945