### PR TITLE
Returns today's date

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
@@ -39,6 +39,11 @@ namespace System
         }
 
         /// <summary>
+        /// Returns today's date
+        /// </summary>
+        public static DateOnly Today => FromDateTime(DateTime.Today);
+
+        /// <summary>
         /// Gets the earliest possible date that can be created.
         /// </summary>
         public static DateOnly MinValue => new DateOnly(MinDayNumber);


### PR DESCRIPTION
`DateTime` has a `Today` property. It seems reasonable that either `DateOnly` should have the same property or `DateTime` should have a `TodayDateOnly` property. This seemed slightly cleaner to me.