### PR TITLE
Fix System.Object serialization with custom number handling

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
@@ -7,11 +7,6 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ObjectConverter : JsonConverter<object?>
     {
-        public ObjectConverter()
-        {
-            IsInternalConverterForNumberType = true;
-        }
-
         public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (options.UnknownTypeHandling == JsonUnknownTypeHandling.JsonElement)
@@ -49,16 +44,6 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             runtimeConverter.WriteAsPropertyNameCoreAsObject(writer, value, options, isWritingExtensionDataProperty);
-        }
-
-        internal override object? ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)
-        {
-            if (options.UnknownTypeHandling == JsonUnknownTypeHandling.JsonElement)
-            {
-                return JsonElement.ParseValue(ref reader);
-            }
-
-            return JsonNodeConverter.Instance.Read(ref reader, typeof(object), options);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.ReadTests.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text.Json.Nodes;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -654,6 +655,22 @@ namespace System.Text.Json.Serialization.Tests
             catch (JsonException) { }
 
             Assert.Equal(0, reader.BytesConsumed);
+        }
+
+        // Regression test for https://github.com/dotnet/runtime/issues/61995
+        [Theory]
+        [InlineData(JsonUnknownTypeHandling.JsonElement, typeof(JsonElement))]
+        [InlineData(JsonUnknownTypeHandling.JsonNode, typeof(JsonNode))]
+        public static void ReadObjectWithNumberHandling(JsonUnknownTypeHandling unknownTypeHandling, Type expectedType)
+        {
+            var options = new JsonSerializerOptions
+            {
+                NumberHandling = JsonNumberHandling.AllowReadingFromString,
+                UnknownTypeHandling = unknownTypeHandling
+            };
+
+            object result = JsonSerializer.Deserialize<object>(@"{ ""key"" : ""42"" }", options);
+            Assert.IsAssignableFrom(expectedType, result);
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.WriteTests.cs
@@ -139,7 +139,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("{\"name\":\"\u6D4B\u8A6611\"}", result);
         }
 
-        // Regressuib test fir https://github.com/dotnet/runtime/issues/61995
+        // Regression test for https://github.com/dotnet/runtime/issues/61995
         [Fact]
         public static void WriteObjectWithNumberHandling()
         {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.WriteTests.cs
@@ -138,5 +138,13 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Equal("{\"name\":\"\u6D4B\u8A6611\"}", result);
         }
+
+        // Regressuib test fir https://github.com/dotnet/runtime/issues/61995
+        [Fact]
+        public static void WriteObjectWithNumberHandling()
+        {
+            var options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowReadingFromString };
+            JsonSerializer.Serialize(new object(), options);
+        }
     }
 }


### PR DESCRIPTION
Fix #61995. Addresses a regression introduced by #54436.