### PR TITLE
Suppress trim warning caused by recent attribute removal changes

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -69,14 +69,23 @@ namespace System.ComponentModel
 
         // These are attributes that, when we discover them on interfaces, we do
         // not merge them into the attribute set for a class.
-        private static readonly Type[] s_skipInterfaceAttributeList = new Type[]
+        private static readonly Type[] s_skipInterfaceAttributeList = InitializeSkipInterfaceAttributeList();
+
+        [UnconditionalSuppressMessage ("ReflectionAnalysis", "IL2045:AttributeRemoval",
+            Justification = "The ComVisibleAttribute is marked for removal and it's referenced here. Since this array" +
+                            "contains only attributes which are going to be ignored, removing such attribute" +
+                            "will not break the functionality in any way.")]
+        private static Type[] InitializeSkipInterfaceAttributeList()
         {
+            return new Type[]
+            {
 #if FEATURE_SKIP_INTERFACE
-            typeof(System.Runtime.InteropServices.GuidAttribute),
-            typeof(System.Runtime.InteropServices.InterfaceTypeAttribute)
+                typeof(System.Runtime.InteropServices.GuidAttribute),
+                typeof(System.Runtime.InteropServices.InterfaceTypeAttribute)
 #endif
-            typeof(System.Runtime.InteropServices.ComVisibleAttribute),
-        };
+                typeof(System.Runtime.InteropServices.ComVisibleAttribute),
+            };
+        }
 
 
         internal static Guid ExtenderProviderKey { get; } = Guid.NewGuid();


### PR DESCRIPTION
This fixes a new warning generated by trimming some apps which was introduced in #54056.
The `ComVisibleAttribute` in this case is referenced, but if it's removed it doesn't change functionality in any way.

This fixes the failure seen in https://github.com/dotnet/sdk/pull/22668#issuecomment-976870471