### PR TITLE
Force new label after IG that ends with align instruction

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -344,8 +344,8 @@ void CodeGen::genCodeForBBlist()
 #if FEATURE_LOOP_ALIGN
         if (GetEmitter()->emitEndsWithAlignInstr())
         {
-            // we had better be planning on starting a new IG
-            assert(needLabel);
+            // Force new label if current IG ends with an align instruction.
+            needLabel = true;
         }
 #endif
 


### PR DESCRIPTION
Sometimes, we might end up having 2 `jmp` instructions as part of same block and we might prefer to add `align` instruction after the 1st jump but then we would assert that there is no label present. I can update the assert condition to something like below, but I think proper fix would be to set `needLabel = true` in such cases.

```c++
assert(needLabel ||  ((block->bbPrev->bbJumpKind == BBJ_ALWAYS) && (block->bbJumpKind == BBJ_ALWAYS)));
```

```asm
       E97AFFFFFF           jmp      G_M22669_IG12
       E9A0060000           jmp      G_M22669_IG78
```

Fixes: #61939