### PR TITLE
Dispose LdapConnections used by PrincipalContext.ValidateCredentials

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Context.cs
@@ -44,7 +44,7 @@ namespace System.DirectoryServices.AccountManagement
         public const string LDAP_CAP_ACTIVE_DIRECTORY_V61_OID = "1.2.840.113556.1.4.1935";
     }
 
-    internal sealed class CredentialValidator
+    internal sealed class CredentialValidator : IDisposable
     {
         private enum AuthMethod
         {
@@ -339,6 +339,14 @@ namespace System.DirectoryServices.AccountManagement
             else
             {
                 return (BindSam(_serverName, userName, password));
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (LdapConnection connection in _connCache.Values)
+            {
+                connection.Dispose();
             }
         }
     }
@@ -1013,6 +1021,8 @@ namespace System.DirectoryServices.AccountManagement
 
                 if (_queryCtx != null)
                     _queryCtx.Dispose();
+
+                _credValidate.Dispose();
 
                 _disposed = true;
                 GC.SuppressFinalize(this);


### PR DESCRIPTION
Currently, instances of `LdapConnection` created by `PrincipalContext.ValidateCredentials` are not disposed when the corresponding instance of `PrincipalContext` is disposed (for more information, see #62035). This PR fixes this by adding the required calls to `LdapConnection.Dispose()`.

--

Ensure that cached LdapConnection instances created by
PrincipalContext.ValidateCredentials are disposed when
the corresponding PrincipalContext is disposed.

Fix #62035