### PR TITLE
make sure OpenSSL is initialized before Tls13Supported code runs

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -191,8 +191,14 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Tls13Supported")]
-        private static partial int Tls13SupportedImpl();
-        internal static readonly bool Tls13Supported = Tls13SupportedImpl() != 0;
+        private static partial int Tls13SupportedNative();
+        internal static readonly bool Tls13Supported = Tls13SupportedImpl();
+
+        internal static bool Tls13SupportedImpl()
+        {
+            EsureInitialized();
+            return Tls13SupportedNative() != 0;
+        }
 
         internal static SafeSharedX509NameStackHandle SslGetClientCAList(SafeSslHandle ssl)
         {


### PR DESCRIPTION
This is regression caused by #46640.  `Tls13Supported` can be called before static constructor runs. It was OK in 5.0 since the OpenSSL library was initialized via 
```
__attribute__((constructor))
static void InitializeOpenSSLShim()
```

With 6.0, it will be initialized when Ssl us used but some properties like CiphersSuitePolicy can be used before in order to prepare everything needed. 

@bartonjs suggested different fix on #61891.  It works as expected but I did not like the fact that it removed the `readonly` attribute on  `Tls13Supported`. I don't know if the impact is measurable but it feels like it would better to do little bit more one time instead of loosing some optimization on every SslStream. 

In similar note, [Comments](https://github.com/dotnet/runtime/pull/46640/files#r555390474) on the change agreed that `InitializeOpenSSLShim` is idempotent. While that is true, loading symbols and library is externally visible and non-trivial amount of system calls and other operations. When somebody debugs loading, seeing the operation multiple times would not make it easier. I added simple lock to make the loading exactly once like we did in 5.0. Since this is static method, the extra cost should be negligible IMHO. 

fixes #61891.