### PR TITLE
Stop marking volatile indirections as `NO_CSE`

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2258,9 +2258,7 @@ GenTree* Compiler::impRuntimeLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken
                                           void*                   compileTimeHandle)
 {
     GenTree* ctxTree = getRuntimeContextTree(pLookup->lookupKind.runtimeLookupKind);
-#if 0
-    ctxTree->gtFlags |= GTF_DONT_CSE;   // ToDo Remove this
-#endif
+
     CORINFO_RUNTIME_LOOKUP* pRuntimeLookup = &pLookup->runtimeLookup;
     // It's available only via the run-time helper function
     if (pRuntimeLookup->indirections == CORINFO_USEHELPER)
@@ -14495,7 +14493,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (prefixFlags & PREFIX_VOLATILE)
                 {
                     assert(op1->OperGet() == GT_IND);
-                    op1->gtFlags |= GTF_DONT_CSE;      // Can't CSE a volatile
                     op1->gtFlags |= GTF_ORDER_SIDEEFF; // Prevent this from being reordered
                     op1->gtFlags |= GTF_IND_VOLATILE;
                 }
@@ -14592,7 +14589,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (prefixFlags & PREFIX_VOLATILE)
                 {
                     assert(op1->OperGet() == GT_IND);
-                    op1->gtFlags |= GTF_DONT_CSE;      // Can't CSE a volatile
                     op1->gtFlags |= GTF_ORDER_SIDEEFF; // Prevent this from being reordered
                     op1->gtFlags |= GTF_IND_VOLATILE;
                 }
@@ -15629,7 +15625,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                     if (prefixFlags & PREFIX_VOLATILE)
                     {
-                        op1->gtFlags |= GTF_DONT_CSE;      // Can't CSE a volatile
                         op1->gtFlags |= GTF_ORDER_SIDEEFF; // Prevent this from being reordered
 
                         if (!usesHelper)
@@ -15869,7 +15864,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     if (prefixFlags & PREFIX_VOLATILE)
                     {
                         assert((op1->OperGet() == GT_FIELD) || (op1->OperGet() == GT_IND));
-                        op1->gtFlags |= GTF_DONT_CSE;      // Can't CSE a volatile
                         op1->gtFlags |= GTF_ORDER_SIDEEFF; // Prevent this from being reordered
                         op1->gtFlags |= GTF_IND_VOLATILE;
                     }


### PR DESCRIPTION
It is unnecessary - we model volatile indirections as mutating the global heap in value numbering and thus they can only ever be CSE defs, which is legal in our model (only volatile operations serve as mutators as per ECMA).

We get some good small diffs this way.

However, the real purpose of this change is making fixing the incorrect assertions for L-value indirections (#13762, [reproduction](https://gist.github.com/SingleAccretion/18e5cb3425548c9bc94ff627a886e231)), which will be identified by the presence of the `GTF_NO_CSE` flag, as that is the only reliable way to detect L-values in the compiler, mostly zero-diff.

We could venture and add something like a `GTF_LVALUE` flag (I think we had one with that very name at some point...), but that seems very risky - how many a place today forgets about `GTF_NO_CSE`, certainly plumbing the new flag through will not be a pleasant, or good, long-term solution. The proper solution is to delete `GT_ASG`, but that,  of course, is not something done in one weekend :), and it seems bad to leave known silent bad codegen bugs hanging around in the meantime.

[Full diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1507095&view=ms.vss-build-web.run-extensions-tab).