### PR TITLE
Flip IL offset check

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -876,7 +876,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             for (int i = 0; i < schema.Length; i++)
             {
                 var elem = schema[i];
-                if (elem.ILOffset == ilOffset)
+                if (elem.ILOffset != ilOffset)
                     continue;
 
                 if (elem.InstrumentationKind == PgoInstrumentationKind.GetLikelyClass)


### PR DESCRIPTION
Just a small fix for dotnet-pgo's dump/compare commands. cc @dotnet/jit-contrib 