### PR TITLE
Exclude a newly added test on Mono

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1519,6 +1519,9 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Directed/debugging/poison/**">
             <Issue>Tests coreclr JIT's debug poisoning of address taken variables</Issue>
         </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Directed/debugging/debuginfo/**">
+            <Issue>Tests coreclr JIT's debug info generation</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems in interpreter runtime mode -->


### PR DESCRIPTION
I didn't notice this failure before.

Fix #62031