### PR TITLE
Avoid printing debug info on 0 byte instructions

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6413,7 +6413,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
             size_t     curInstrAddr = (size_t)cp;
             instrDesc* curInstrDesc = id;
 
-            if ((emitComp->opts.disAsm || emitComp->verbose) && (JitConfig.JitDisasmWithDebugInfo() != 0))
+            if ((emitComp->opts.disAsm || emitComp->verbose) && (JitConfig.JitDisasmWithDebugInfo() != 0) &&
+                (id->idCodeSize() > 0))
             {
                 UNATIVE_OFFSET curCodeOffs = emitCurCodeOffs(cp);
                 while (nextMapping != emitComp->genPreciseIPmappings.end())


### PR DESCRIPTION
In particular do not attach it to INS_align that do not end up producing
any code.