### PR TITLE
Support unloadability in `DispatchProxy`.

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.csproj
@@ -21,6 +21,7 @@
     <Reference Include="System.Reflection.Primitives" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Loader" />
     <Reference Include="System.Threading" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -115,9 +115,19 @@ namespace System.Reflection
 
             public ProxyAssembly(AssemblyLoadContext alc)
             {
-                string? alcName = alc.Name;
-                string name = string.IsNullOrEmpty(alcName) ? $"DispatchProxyTypes.{alc.GetHashCode()}" : $"DispatchProxyTypes.{alcName}";
-                _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.RunAndCollect);
+                string name;
+                if (alc == AssemblyLoadContext.Default)
+                {
+                    name = "ProxyBuilder";
+                }
+                else
+                {
+                    string? alcName = alc.Name;
+                    name = string.IsNullOrEmpty(alcName) ? $"DispatchProxyTypes.{alc.GetHashCode()}" : $"DispatchProxyTypes.{alcName}";
+                }
+                AssemblyBuilderAccess builderAccess =
+                    alc.IsCollectible ? AssemblyBuilderAccess.RunAndCollect : AssemblyBuilderAccess.Run;
+                _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), builderAccess);
                 _mb = _ab.DefineDynamicModule("MainModule");
             }
 

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -128,7 +128,7 @@ namespace System.Reflection
                 AssemblyBuilderAccess builderAccess =
                     alc.IsCollectible ? AssemblyBuilderAccess.RunAndCollect : AssemblyBuilderAccess.Run;
                 _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), builderAccess);
-                _mb = _ab.DefineDynamicModule("MainModule");
+                _mb = _ab.DefineDynamicModule("testmod");
             }
 
             // Gets or creates the ConstructorInfo for the IgnoresAccessChecksAttribute.

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -67,10 +67,7 @@ namespace System.Reflection
             Debug.Assert(interfaceType != null);
 
             AssemblyLoadContext? alc = AssemblyLoadContext.GetLoadContext(baseType.Assembly);
-            if (alc == null)
-            {
-                throw new ArgumentException($"Impossible, the type is certainly provided by the runtime.", nameof(baseType));
-            }
+            Debug.Assert(alc != null);
 
             ProxyAssembly proxyAssembly = s_alcProxyAssemblyMap.GetValue(alc, static x => new ProxyAssembly(x));
             GeneratedTypeInfo proxiedType = proxyAssembly.GetProxyType(baseType, interfaceType);

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -119,7 +119,7 @@ namespace System.Reflection
             public ProxyAssembly(AssemblyLoadContext alc)
             {
                 string? alcName = alc.Name;
-                string name = alcName is null ? $"DispatchProxyTypes.{alc.GetHashCode()}" : $"DispatchProxyTypes.{alcName}";
+                string name = string.IsNullOrEmpty(alcName) ? $"DispatchProxyTypes.{alc.GetHashCode()}" : $"DispatchProxyTypes.{alcName}";
                 _ab = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.RunAndCollect);
                 _mb = _ab.DefineDynamicModule("MainModule");
             }

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -631,6 +631,9 @@ namespace DispatchProxyTests
         [Fact]
         public static void Test_Unloadability()
         {
+            if (typeof(DispatchProxyTests).Assembly.Location == "")
+                return;
+
             WeakReference wr = CreateProxyInUnloadableAlc();
 
             for (int i = 0; i < 10 && wr.IsAlive; i++)
@@ -656,6 +659,9 @@ namespace DispatchProxyTests
         [Fact]
         public static void Test_Multiple_AssemblyLoadContexts()
         {
+            if (typeof(DispatchProxyTests).Assembly.Location == "")
+                return;
+
             object proxyDefaultAlc = CreateTestDispatchProxy(typeof(TestDispatchProxy));
             Assert.True(proxyDefaultAlc.GetType().IsAssignableTo(typeof(TestDispatchProxy)));
 

--- a/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/tests/DispatchProxyTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
 using System.Text;
 using Xunit;
 
@@ -621,6 +623,56 @@ namespace DispatchProxyTests
             invocation(proxy);
 
             Assert.Equal(expected, result);
+        }
+
+        private static TestType_IHelloService CreateTestHelloProxy() =>
+            DispatchProxy.Create<TestType_IHelloService, TestDispatchProxy>();
+
+        [Fact]
+        public static void Test_Unloadability()
+        {
+            WeakReference wr = CreateProxyInUnloadableAlc();
+
+            for (int i = 0; i < 10 && wr.IsAlive; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            Assert.False(wr.IsAlive, "The ALC could not be unloaded.");
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static WeakReference CreateProxyInUnloadableAlc()
+            {
+                var alc = new AssemblyLoadContext(nameof(Test_Unloadability), true);
+                alc.LoadFromAssemblyPath(typeof(DispatchProxyTests).Assembly.Location)
+                    .GetType(typeof(DispatchProxyTests).FullName, true)
+                    .GetMethod(nameof(CreateTestHelloProxy), BindingFlags.Static | BindingFlags.NonPublic)
+                    .Invoke(null, null);
+                return new WeakReference(alc);
+            }
+        }
+
+        [Fact]
+        public static void Test_Multiple_AssemblyLoadContexts()
+        {
+            object proxyDefaultAlc = CreateTestDispatchProxy(typeof(TestDispatchProxy));
+            Assert.True(proxyDefaultAlc.GetType().IsAssignableTo(typeof(TestDispatchProxy)));
+
+            Type proxyCustomAlcType =
+                new AssemblyLoadContext(nameof(Test_Multiple_AssemblyLoadContexts))
+                    .LoadFromAssemblyPath(typeof(DispatchProxyTests).Assembly.Location)
+                    .GetType(typeof(TestDispatchProxy).FullName, true);
+
+            object proxyCustomAlc = CreateTestDispatchProxy(proxyCustomAlcType);
+            Assert.True(proxyCustomAlc.GetType().IsAssignableTo(proxyCustomAlcType));
+
+            static object CreateTestDispatchProxy(Type type) =>
+                typeof(DispatchProxy)
+                    .GetMethod(nameof(DispatchProxy.Create))
+                    // It has to be a type shared in both ALCs.
+                    .MakeGenericMethod(typeof(IDisposable), type)
+                    .Invoke(null, null);
         }
     }
 }


### PR DESCRIPTION
The `System.Reflection.DispatchProxy` type used to be incompatible with unloadability, because the `AssemblyBuilder` with the generated proxy types is created with `AssemblyBuilderAccess.Run` and because all proxy types were associated with a single one.

This PR creates a separate `AssemblyBuilder`, one for each `AssemblyLoadContext` of the base type's assembly, and passes `AssemblyBuilderAccess.RunAndCollect` to it (_edit:_ only if the associated ALC is unloadable). It also cleans-up some code.

Besides allowing unneeded proxy types to be granularly unloaded, it also added support for creating proxies for the same type in different ALC. I added tests for both cases.

Fixes #60468
Fixes #62050