### PR TITLE
Add path information to INotifyInstanceUserLimitExceeded

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/Resources/Strings.resx
@@ -177,7 +177,7 @@
     <value>The system limit on the number of inotify instances has been reached.</value>
   </data>
   <data name="IOException_INotifyInstanceUserLimitExceeded_Value" xml:space="preserve">
-    <value>The configured user limit ({0}) on the number of inotify instances has been reached, or the per-process limit on the number of open file descriptors has been reached.</value>
+    <value>The configured user limit ({0}) on the number of inotify instances has been reached (see {1}), or the per-process limit on the number of open file descriptors has been reached.</value>
   </data>
   <data name="IOException_INotifyWatchesUserLimitExceeded_Value" xml:space="preserve">
     <value>The configured user limit ({0}) on the number of inotify watches has been reached, or the operating system failed to allocate a required resource.</value>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -41,7 +41,7 @@ namespace System.IO
                     case Interop.Error.EMFILE:
                         string? maxValue = ReadMaxUserLimit(MaxUserInstancesPath);
                         string message = !string.IsNullOrEmpty(maxValue) ?
-                            SR.Format(SR.IOException_INotifyInstanceUserLimitExceeded_Value, maxValue) :
+                            SR.Format(SR.IOException_INotifyInstanceUserLimitExceeded_Value, maxValue, MaxUserInstancesPath) :
                             SR.IOException_INotifyInstanceUserLimitExceeded;
                         throw new IOException(message, error.RawErrno);
                     case Interop.Error.ENFILE:


### PR DESCRIPTION
When you are a .NET developer, chances are you do not know what `inotify` is, why it is needed and how it is configured, so when you get this error, you are helpless.  I added the configuration file path to the error message to make your life a bit easier.