### PR TITLE
No-op ConcurrentStack.PushRange(T[]) if empty

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -317,10 +317,6 @@ namespace System.Collections.Concurrent
                 throw new ArgumentNullException(nameof(items));
             }
 
-            // No op if the length is zero
-            if (items.Length == 0)
-                return;
-
             PushRange(items, 0, items.Length);
         }
 
@@ -414,7 +410,7 @@ namespace System.Collections.Concurrent
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ConcurrentStack_PushPopRange_CountOutOfRange);
             }
             int length = items.Length;
-            if (startIndex >= length || startIndex < 0)
+            if (startIndex > length || startIndex < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ConcurrentStack_PushPopRange_StartOutOfRange);
             }

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -316,6 +316,11 @@ namespace System.Collections.Concurrent
             {
                 throw new ArgumentNullException(nameof(items));
             }
+
+            // No op if the length is zero
+            if (items.Length == 0)
+                return;
+
             PushRange(items, 0, items.Length);
         }
 
@@ -348,7 +353,6 @@ namespace System.Collections.Concurrent
             // No op if the count is zero
             if (count == 0)
                 return;
-
 
             Node head, tail;
             head = tail = new Node(items[startIndex]);

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -316,7 +316,6 @@ namespace System.Collections.Concurrent
             {
                 throw new ArgumentNullException(nameof(items));
             }
-
             PushRange(items, 0, items.Length);
         }
 

--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
@@ -63,6 +63,16 @@ namespace System.Collections.Concurrent.Tests
             Assert.True(s.IsEmpty);
         }
 
+        [Fact]
+        public void PushRange_NoItems_NothingAdded_NoRangeSpecified()
+        {
+            var s = new ConcurrentStack<int>();
+            Assert.True(s.IsEmpty);
+
+            s.PushRange(new int[0]);
+            Assert.True(s.IsEmpty);
+        }
+
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(8, 10)]
         [InlineData(16, 100)]

--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
@@ -74,6 +74,17 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
+        public void PushRange_NoItems_NothingAdded_NonEmptyArrayWithZeroCountSpecified()
+        {
+            var s = new ConcurrentStack<int>();
+            Assert.True(s.IsEmpty);
+
+            int[] arr = new int[2];
+            s.PushRange(arr, arr.Length, 0);
+            Assert.True(s.IsEmpty);
+        }
+
+        [Fact]
         public void PushRange_NoItems_NothingAdded_EmptyArrayNoRangeSpecified()
         {
             var s = new ConcurrentStack<int>();

--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
@@ -64,7 +64,17 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [Fact]
-        public void PushRange_NoItems_NothingAdded_NoRangeSpecified()
+        public void PushRange_NoItems_NothingAdded_EmptyArrayWithRangeSpecified()
+        {
+            var s = new ConcurrentStack<int>();
+            Assert.True(s.IsEmpty);
+
+            s.PushRange(new int[0], 0, 0);
+            Assert.True(s.IsEmpty);
+        }
+
+        [Fact]
+        public void PushRange_NoItems_NothingAdded_EmptyArrayNoRangeSpecified()
         {
             var s = new ConcurrentStack<int>();
             Assert.True(s.IsEmpty);
@@ -141,11 +151,10 @@ namespace System.Collections.Concurrent.Tests
             var stack = new ConcurrentStack<int>();
             Assert.Throws<ArgumentNullException>(() => stack.PushRange(null));
             Assert.Throws<ArgumentNullException>(() => stack.PushRange(null, 0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[0], 0, 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[0], 0, 1));
             Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[1], 0, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[1], -1, 1));
             Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[1], 2, 1));
+            AssertExtensions.Throws<ArgumentException>(null, () => stack.PushRange(new int[0], 0, 1));
             AssertExtensions.Throws<ArgumentException>(null, () => stack.PushRange(new int[1], 0, 10));
         }
 

--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentStackTests.cs
@@ -141,6 +141,8 @@ namespace System.Collections.Concurrent.Tests
             var stack = new ConcurrentStack<int>();
             Assert.Throws<ArgumentNullException>(() => stack.PushRange(null));
             Assert.Throws<ArgumentNullException>(() => stack.PushRange(null, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[0], 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[0], 0, 1));
             Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[1], 0, -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[1], -1, 1));
             Assert.Throws<ArgumentOutOfRangeException>(() => stack.PushRange(new int[1], 2, 1));


### PR DESCRIPTION
Resolves #62121.
