### PR TITLE
Fix TimeSpan support in sourcegen

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -75,6 +75,7 @@ namespace System.Text.Json.SourceGeneration
 
             private readonly Type _booleanType;
             private readonly Type _charType;
+            private readonly Type _timeSpanType;
             private readonly Type _dateTimeType;
             private readonly Type _nullableOfTType;
             private readonly Type _objectType;
@@ -202,6 +203,7 @@ namespace System.Text.Json.SourceGeneration
 
                 _booleanType = _metadataLoadContext.Resolve(SpecialType.System_Boolean);
                 _charType = _metadataLoadContext.Resolve(SpecialType.System_Char);
+                _timeSpanType = _metadataLoadContext.Resolve(typeof(TimeSpan));
                 _dateTimeType = _metadataLoadContext.Resolve(SpecialType.System_DateTime);
                 _nullableOfTType = _metadataLoadContext.Resolve(SpecialType.System_Nullable_T);
                 _objectType = _metadataLoadContext.Resolve(SpecialType.System_Object);
@@ -1506,6 +1508,7 @@ namespace System.Text.Json.SourceGeneration
                 _knownTypes.Add(_stringType);
 
                 AddTypeIfNotNull(_knownTypes, _byteArrayType);
+                AddTypeIfNotNull(_knownTypes, _timeSpanType);
                 AddTypeIfNotNull(_knownTypes, _dateTimeOffsetType);
                 AddTypeIfNotNull(_knownTypes, _guidType);
                 AddTypeIfNotNull(_knownTypes, _uriType);

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -75,12 +75,12 @@ namespace System.Text.Json.SourceGeneration
 
             private readonly Type _booleanType;
             private readonly Type _charType;
-            private readonly Type _timeSpanType;
             private readonly Type _dateTimeType;
             private readonly Type _nullableOfTType;
             private readonly Type _objectType;
             private readonly Type _stringType;
 
+            private readonly Type? _timeSpanType;
             private readonly Type? _dateTimeOffsetType;
             private readonly Type? _byteArrayType;
             private readonly Type? _guidType;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -399,7 +399,8 @@ namespace System.Text.Json.SourceGeneration.Tests
                 EndDate = DateTime.UtcNow.AddYears(1),
                 Name = "Just a name",
                 ImageUrl = "https://www.dotnetfoundation.org/theme/img/carousel/foundation-diagram-content.png",
-                StartDate = DateTime.UtcNow
+                StartDate = DateTime.UtcNow,
+                Offset = TimeSpan.FromHours(2)
             };
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
@@ -60,6 +60,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         public string Description { get; set; }
         public DateTimeOffset StartDate { get; set; }
         public DateTimeOffset EndDate { get; set; }
+        public TimeSpan Offset { get; set; }
     }
 
     public class CampaignSummaryViewModel


### PR DESCRIPTION
Brings TimeSpan sourcegen serialization semantics in sync with the reflection-based serializer.

Fix #62082.