### PR TITLE
use TestDisableParallelization property to disable parallel test execution

### DIFF
--- a/src/libraries/System.Private.Xml/tests/Readers/CharCheckingReader/System.Xml.RW.CharCheckingReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/CharCheckingReader/System.Xml.RW.CharCheckingReader.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestDisableParallelization>true</TestDisableParallelization>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CharReaderTests.cs" />
     <Compile Include="InheritedCases.cs" />
-    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />

--- a/src/libraries/System.Private.Xml/tests/Readers/CustomReader/System.Xml.RW.CustomReader.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/CustomReader/System.Xml.RW.CustomReader.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestDisableParallelization>true</TestDisableParallelization>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CReaderTestModule.cs" />
     <Compile Include="InheritedCases.cs" />
-    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />

--- a/src/libraries/System.Private.Xml/tests/Readers/NameTable/System.Xml.RW.NameTable.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/NameTable/System.Xml.RW.NameTable.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestDisableParallelization>true</TestDisableParallelization>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CNameTableTestModule.cs" />
@@ -10,7 +11,6 @@
     <Compile Include="TCUserNameTable.cs" />
     <Compile Include="TestFiles.cs" />
     <Compile Include="XmlNameTable.cs" />
-    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />

--- a/src/libraries/System.Private.Xml/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Readers/ReaderSettings/System.Xml.RW.ReaderSettings.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestDisableParallelization>true</TestDisableParallelization>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ConformanceSettings.cs" />
@@ -21,7 +22,6 @@
     <Compile Include="TCOneByteStream.cs" />
     <Compile Include="TCReaderSettings.cs" />
     <Compile Include="TCRSGeneric.cs" />
-    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)System\Xml\BaseLibManaged\BaseLibManaged.csproj" />

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/DisableParallelization.cs
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/DisableParallelization.cs
@@ -1,5 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-// Tests are old and depend on the static state
-[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Writers/XmlWriterApi/System.Xml.RW.XmlWriterApi.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestDisableParallelization>true</TestDisableParallelization>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EndOfLineHandlingTests.cs" />
@@ -25,7 +26,6 @@
     <Compile Include="TCNewLineChars.cs" />
     <Compile Include="TCNewLineHandling.cs" />
     <Compile Include="TCNewLineOnAttributes.cs" />
-    <Compile Include="DisableParallelization.cs" />
     <Compile Include="TCOmitXmlDecl.cs" />
     <Compile Include="TCStandAlone.cs" />
     <Compile Include="TCWriteAttributes.cs" />

--- a/src/libraries/System.Private.Xml/tests/XmlConvert/System.Xml.RW.XmlConvert.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/XmlConvert/System.Xml.RW.XmlConvert.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestDisableParallelization>true</TestDisableParallelization>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EncodeDecodeTests.cs" />
@@ -37,7 +38,6 @@
     <Compile Include="XmlIdeographicCharConvertTests1.cs" />
     <Compile Include="XmlIdeographicCharConvertTests2.cs" />
     <Compile Include="XmlIdeographicCharConvertTests3.cs" />
-    <Compile Include="$(CommonTestPath)System\Xml\DisableParallelization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />


### PR DESCRIPTION
It's defined in:

https://github.com/dotnet/runtime/blob/c66fa996b5cc32d94b2e6a8dfeb7c3d3a3098694/eng/testing/runsettings.targets#L30-L42

and I've tested that it works as expected.