### PR TITLE
FileSystemEntry.Unix: don't resolve DT_LNK/DT_UNKNOWN unless it is needed.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -140,7 +140,8 @@ namespace System.IO.Enumeration
         public FileSystemInfo ToFileSystemInfo()
         {
             string fullPath = ToFullPath();
-            return FileSystemInfo.Create(fullPath, new string(FileName), IsDirectory, ref _status);
+            _status.InitiallyDirectory = IsDirectory;
+            return FileSystemInfo.Create(fullPath, new string(FileName), ref _status);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -18,9 +18,7 @@ namespace System.IO
         // Positive number: the error code returned by the lstat call
         private int _initializedFileCache;
 
-        // We track intent of creation to know whether or not we want to (1) create a
-        // DirectoryInfo around this status struct or (2) actually are part of a DirectoryInfo.
-        // Set to true during initialization when the DirectoryEntry's INodeType describes a directory
+        // Track if we are part of a DirectoryInfo.
         internal bool InitiallyDirectory { get; set; }
 
         // Is a directory as of the last refresh

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.Unix.cs
@@ -15,9 +15,9 @@ namespace System.IO
             _fileStatus.InvalidateCaches();
         }
 
-        internal static FileSystemInfo Create(string fullPath, string fileName, bool isDirectory, ref FileStatus fileStatus)
+        internal static FileSystemInfo Create(string fullPath, string fileName, ref FileStatus fileStatus)
         {
-            FileSystemInfo info = isDirectory
+            FileSystemInfo info = fileStatus.InitiallyDirectory
                 ? (FileSystemInfo)new DirectoryInfo(fullPath, fileName: fileName, isNormalized: true)
                 : new FileInfo(fullPath, fileName: fileName, isNormalized: true);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystemInfo.Unix.cs
@@ -15,9 +15,9 @@ namespace System.IO
             _fileStatus.InvalidateCaches();
         }
 
-        internal static FileSystemInfo Create(string fullPath, string fileName, ref FileStatus fileStatus)
+        internal static FileSystemInfo Create(string fullPath, string fileName, bool isDirectory, ref FileStatus fileStatus)
         {
-            FileSystemInfo info = fileStatus.InitiallyDirectory
+            FileSystemInfo info = isDirectory
                 ? (FileSystemInfo)new DirectoryInfo(fullPath, fileName: fileName, isNormalized: true)
                 : new FileInfo(fullPath, fileName: fileName, isNormalized: true);
 


### PR DESCRIPTION
For GetFileSystemEntries we don't need to resolve DT_LNK/DT_UNKNOWN types
since the API will only return the name.

Fixes https://github.com/dotnet/runtime/issues/59947.

@adamsitnik @dotnet/area-system-io ptal.

cc @nmoreaud