### PR TITLE
Issue #61971 - Fix a bug causing EventCounter to fire twice on linux

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -288,15 +288,20 @@ namespace System.Diagnostics.Tracing
                         {
                             onTimers.Add(counterGroup);
                         }
-
-                        int millisecondsTillNextPoll = (int)((counterGroup._nextPollingTimeStamp - now).TotalMilliseconds);
-                        millisecondsTillNextPoll = Math.Max(1, millisecondsTillNextPoll);
-                        sleepDurationInMilliseconds = Math.Min(sleepDurationInMilliseconds, millisecondsTillNextPoll);
+                        else
+                        {
+                            int millisecondsTillNextPoll = (int)((counterGroup._nextPollingTimeStamp - now).TotalMilliseconds);
+                            millisecondsTillNextPoll = Math.Max(1, millisecondsTillNextPoll);
+                            sleepDurationInMilliseconds = Math.Min(sleepDurationInMilliseconds, millisecondsTillNextPoll);
+                        }
                     }
                 }
-                foreach (CounterGroup onTimer in onTimers)
+                foreach (CounterGroup counterGroup in onTimers)
                 {
-                    onTimer.OnTimer();
+                    counterGroup.OnTimer();
+                    int millisecondsTillNextPoll = (int)((counterGroup._nextPollingTimeStamp - DateTime.UtcNow).TotalMilliseconds);
+                    millisecondsTillNextPoll = Math.Max(1, millisecondsTillNextPoll);
+                    sleepDurationInMilliseconds = Math.Min(sleepDurationInMilliseconds, millisecondsTillNextPoll);
                 }
                 onTimers.Clear();
                 if (sleepDurationInMilliseconds == int.MaxValue)


### PR DESCRIPTION
The #61971 bug was introduced in c67684b because the `sleepDurationInMilliseconds` started to be calculated using `counterGroup._nextPollingTimeStamp` before updating it.

The fix here is to calculate the  `sleepDurationInMilliseconds` after having run the `counterGroup.OnTimer();` (the function which is updating the `counterGroup._nextPollingTimeStamp`) in the cases where we do an update on the CounterGroup