### PR TITLE
[wasm][debugger] Implement Runtime.evaluate.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/EvaluateExpression.cs
@@ -329,7 +329,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             expression = expression.Trim();
             if (!expression.StartsWith('('))
             {
-                expression = "(" + expression + ")";
+                expression = "(" + expression + "\n)";
             }
             SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(expression + @";", cancellationToken: token);
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -401,7 +401,17 @@ namespace Microsoft.WebAssembly.Diagnostics
                     {
                         return await Step(id, StepKind.Over, token);
                     }
-
+                case "Runtime.evaluate":
+                    {
+                        if (context.CallStack != null)
+                        {
+                            Frame scope = context.CallStack.First<Frame>();
+                            return await OnEvaluateOnCallFrame(id,
+                                    scope.Id,
+                                    args?["expression"]?.Value<string>(), token);
+                        }
+                        break;
+                    }
                 case "Debugger.evaluateOnCallFrame":
                     {
                         if (!DotnetObjectId.TryParse(args?["callFrameId"], out DotnetObjectId objectId))

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -841,6 +841,37 @@ namespace DebuggerTests
             return (null, res);
         }
 
+        internal async Task RuntimeEvaluateAndCheck(params (string expression, JObject expected)[] args)
+        {
+            foreach (var arg in args)
+            {
+                var (eval_val, _) = await RuntimeEvaluate(arg.expression);
+                try
+                {
+                    await CheckValue(eval_val, arg.expected, arg.expression);
+                }
+                catch
+                {
+                    Console.WriteLine($"CheckValue failed for {arg.expression}. Expected: {arg.expected}, vs {eval_val}");
+                    throw;
+                }
+            }
+        }
+        internal async Task<(JToken, Result)> RuntimeEvaluate(string expression, bool expect_ok = true)
+        {
+            var evaluate_req = JObject.FromObject(new
+            {
+                expression = expression
+            });
+
+            var res = await cli.SendCommand("Runtime.evaluate", evaluate_req, token);
+            AssertEqual(expect_ok, res.IsOk, $"Runtime.evaluate ('{expression}') returned {res.IsOk} instead of {expect_ok}, with Result: {res}");
+            if (res.IsOk)
+                return (res.Value["result"], res);
+
+            return (null, res);
+        }
+
         internal async Task<(JToken, Result)> SetVariableValueOnCallFrame(JObject parms, bool expect_ok = true)
         {
             var res = await cli.SendCommand("Debugger.setVariableValue", parms, token);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -840,6 +840,20 @@ namespace DebuggerTests
                     ("  str", "ReferenceError")
                 );
             });
+        
+        [Fact]
+        public async Task EvaluateConstantValueUsingRuntimeEvaluate() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateTestsClass", "EvaluateLocals", 9, "EvaluateLocals",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateTestsClass:EvaluateLocals'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               var dt = new DateTime(2020, 1, 2, 3, 4, 5);
+               await RuntimeEvaluateAndCheck(
+                   ("15\n//comment as vs does\n", TNumber(15)),
+                   ("15", TNumber(15)),
+                   ("\"15\"\n//comment as vs does\n", TString("15")),
+                   ("\"15\"", TString("15")));
+           });
 
     }
 


### PR DESCRIPTION
Implement Runtime.Evaluate, the behavior is the same of Debugger.EvaluateOnCallFrame and use the first frame to evaluate.
Implementing it make possible to set variable value from VSCode and Visual Studio.

Fixes [#61974](https://github.com/dotnet/runtime/issues/61974)
Original Issues: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1366427/
JSDebugger Issue: https://github.com/microsoft/vscode-js-debug/issues/1143