### PR TITLE
Fix method HttpHeadersNonValidated uses to get HeaderDescriptor

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1051,7 +1051,7 @@ namespace System.Net.Http.Headers
             throw new InvalidOperationException(SR.Format(SR.net_http_headers_not_allowed_header_name, name));
         }
 
-        private bool TryGetHeaderDescriptor(string name, out HeaderDescriptor descriptor)
+        internal bool TryGetHeaderDescriptor(string name, out HeaderDescriptor descriptor)
         {
             if (string.IsNullOrEmpty(name))
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeadersNonValidated.cs
@@ -32,7 +32,7 @@ namespace System.Net.Http.Headers
         /// <returns>true if the collection contains the header; otherwise, false.</returns>
         public bool Contains(string headerName) =>
             _headers is HttpHeaders headers &&
-            HeaderDescriptor.TryGet(headerName, out HeaderDescriptor descriptor) &&
+            headers.TryGetHeaderDescriptor(headerName, out HeaderDescriptor descriptor) &&
             headers.TryGetHeaderValue(descriptor, out _);
 
         /// <summary>Gets the values for the specified header name.</summary>
@@ -62,7 +62,7 @@ namespace System.Net.Http.Headers
         public bool TryGetValues(string headerName, out HeaderStringValues values)
         {
             if (_headers is HttpHeaders headers &&
-                HeaderDescriptor.TryGet(headerName, out HeaderDescriptor descriptor) &&
+                headers.TryGetHeaderDescriptor(headerName, out HeaderDescriptor descriptor) &&
                 headers.TryGetHeaderValue(descriptor, out object? info))
             {
                 HttpHeaders.GetStoreValuesAsStringOrStringArray(descriptor, info, out string? singleValue, out string[]? multiValue);

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -2113,6 +2113,44 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
+        public void AddHeaders_ResponseHeaderToRequestHeaders_Success()
+        {
+            const string Name = "WWW-Authenticate";
+            const string Value = "Basic realm=\"Access to the staging site\", charset=\"UTF-8\"";
+
+            var request = new HttpRequestMessage();
+            Assert.True(request.Headers.TryAddWithoutValidation(Name, Value));
+
+            Assert.True(request.Headers.Contains(Name));
+            Assert.True(request.Headers.NonValidated.Contains(Name));
+
+            Assert.True(request.Headers.TryGetValues(Name, out IEnumerable<string> values));
+            Assert.Equal(Value, values.Single());
+
+            Assert.True(request.Headers.NonValidated.TryGetValues(Name, out HeaderStringValues nvValues));
+            Assert.Equal(Value, nvValues.Single());
+        }
+
+        [Fact]
+        public void AddHeaders_RequestHeaderToResponseHeaders_Success()
+        {
+            const string Name = "Referer";
+            const string Value = "https://dot.net";
+
+            var response = new HttpResponseMessage();
+            Assert.True(response.Headers.TryAddWithoutValidation(Name, Value));
+
+            Assert.True(response.Headers.Contains(Name));
+            Assert.True(response.Headers.NonValidated.Contains(Name));
+
+            Assert.True(response.Headers.TryGetValues(Name, out IEnumerable<string> values));
+            Assert.Equal(Value, values.Single());
+
+            Assert.True(response.Headers.NonValidated.TryGetValues(Name, out HeaderStringValues nvValues));
+            Assert.Equal(Value, nvValues.Single());
+        }
+
+        [Fact]
         public void HeaderStringValues_Default_Empty()
         {
             HeaderStringValues v = default;


### PR DESCRIPTION
We have two non-public methods for getting a HeaderDescriptor from a string name, one static on HeaderDescriptor and one instance on HttpHeaders.  HttpHeadersNonValidated was using the former, but this then doesn't take into account custom logic used by HttpHeaders in other methods, like TryAddWithoutValidation, which means some methods on HttpHeadersNonValidated can't find the corresponding headers.

Fixes https://github.com/dotnet/runtime/issues/62024