### PR TITLE
Console.Unix: fix OpenStandardInput Stream sometimes throwing for Reads.

### DIFF
--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -121,7 +121,7 @@ namespace System.IO
                 bytesUsedTotal += bytesUsed;
                 charsUsedTotal += charsUsed;
 
-                if (charsUsed == 0)
+                if (charsUsed < chunk.Span.Length || buffer.IsEmpty)
                 {
                     break;
                 }

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -116,6 +116,8 @@ namespace System.IO
             int charsUsedTotal = 0;
             foreach (ReadOnlyMemory<char> chunk in _readLineSB.GetChunks())
             {
+                Debug.Assert(!buffer.IsEmpty);
+
                 encoder.Convert(chunk.Span, buffer, flush: false, out int charsUsed, out int bytesUsed, out bool completed);
                 buffer = buffer.Slice(bytesUsed);
                 bytesUsedTotal += bytesUsed;

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -121,7 +121,7 @@ namespace System.IO
                 bytesUsedTotal += bytesUsed;
                 charsUsedTotal += charsUsed;
 
-                if (charsUsed < chunk.Span.Length || buffer.IsEmpty)
+                if (!completed || buffer.IsEmpty)
                 {
                     break;
                 }

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -46,6 +46,23 @@ namespace System
         }
 
         [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void ReadFromOpenStandardInput()
+        {
+            // The implementation in StdInReader uses a StringBuilder for caching. We want this builder to use
+            // multiple chunks. So the expectedLine is longer than 16 characters (StringBuilder.DefaultCapacity).
+            string expectedLine = $"This is a test for ReadFromOpenStandardInput.";
+            Assert.True(expectedLine.Length > 16);
+            Console.WriteLine($"Please type the sentence (without the quotes): \"{expectedLine}\"");
+            using Stream inputStream = Console.OpenStandardInput();
+            for (int i = 0; i < expectedLine.Length; i++)
+            {
+                Assert.Equal((byte)expectedLine[i], inputStream.ReadByte());
+            }
+            Assert.Equal((byte)'\n', inputStream.ReadByte());
+            AssertUserExpectedResults("the characters you typed properly echoed as you typed");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
         public static void ConsoleReadSupportsBackspace()
         {
             const string expectedLine = "aab\r";

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.IO;
+using System.Text;
 using Xunit;
 
 namespace System
@@ -51,7 +52,7 @@ namespace System
             // The implementation in StdInReader uses a StringBuilder for caching. We want this builder to use
             // multiple chunks. So the expectedLine is longer than 16 characters (StringBuilder.DefaultCapacity).
             string expectedLine = $"This is a test for ReadFromOpenStandardInput.";
-            Assert.True(expectedLine.Length > 16);
+            Assert.True(expectedLine.Length > new StringBuilder().Capacity);
             Console.WriteLine($"Please type the sentence (without the quotes): \"{expectedLine}\"");
             using Stream inputStream = Console.OpenStandardInput();
             for (int i = 0; i < expectedLine.Length; i++)


### PR DESCRIPTION
When connected to a terminal reads happen line-by-line.
This was added in .NET 5 by https://github.com/dotnet/runtime/pull/39192.

StdInReader caches the line in a StringBuilder.

Instead of returning when the destination buffer is full, an attempt
was made to decode the next chunk from the StringBuilder (if there is
one). This causes the encoder to throw for encoding into an empty buffer.

Fixes https://github.com/dotnet/runtime/issues/61865.

@dotnet/area-system-console ptal.

cc @dmbarbour