### PR TITLE
Remove extraneous support in the test runner generator for referencing corelib directly.

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/OptionsHelper.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/OptionsHelper.cs
@@ -6,7 +6,6 @@ namespace XUnitWrapperGenerator;
 
 public static class OptionsHelper
 {
-    private const string ReferenceSystemPrivateCoreLibOption = "build_property.ReferenceSystemPrivateCoreLib";
     private const string IsMergedTestRunnerAssemblyOption = "build_property.IsMergedTestRunnerAssembly";
     private const string PriorityOption = "build_property.Priority";
     private const string RuntimeFlavorOption = "build_property.RuntimeFlavor";
@@ -28,8 +27,6 @@ public static class OptionsHelper
             && int.TryParse(value, out int result)
                 ? result : 0;
     }
-
-    internal static bool ReferenceSystemPrivateCoreLib(this AnalyzerConfigOptions options) => options.GetBoolOption(ReferenceSystemPrivateCoreLibOption);
 
     internal static bool IsMergedTestRunnerAssembly(this AnalyzerConfigOptions options) => options.GetBoolOption(IsMergedTestRunnerAssemblyOption);
 

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -98,18 +98,16 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                     return;
                 }
 
-                bool referenceCoreLib = configOptions.GlobalOptions.ReferenceSystemPrivateCoreLib();
-
                 bool isMergedTestRunnerAssembly = configOptions.GlobalOptions.IsMergedTestRunnerAssembly();
 
                 // TODO: add error (maybe in MSBuild that referencing CoreLib directly from a merged test runner is not supported)
-                if (isMergedTestRunnerAssembly && !referenceCoreLib)
+                if (isMergedTestRunnerAssembly)
                 {
                     context.AddSource("FullRunner.g.cs", GenerateFullTestRunner(methods, aliasMap, assemblyName));
                 }
                 else
                 {
-                    string consoleType = referenceCoreLib ? "Internal.Console" : "System.Console";
+                    string consoleType = "System.Console";
                     context.AddSource("SimpleRunner.g.cs", GenerateStandaloneSimpleTestRunner(methods, aliasMap, consoleType));
                 }
             });
@@ -144,7 +142,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         builder.AppendLine(string.Join("\n", aliasMap.Values.Where(alias => alias != "global").Select(alias => $"extern alias {alias};")));
         builder.AppendLine("try {");
         builder.AppendLine(string.Join("\n", testInfos.Select(m => m.GenerateTestExecution(reporter))));
-        builder.AppendLine($"}} catch(System.Exception ex) {{ {consoleType}.WriteLine(ex.ToString()); return 101; }}");
+        builder.AppendLine("} catch(System.Exception ex) { System.Console.WriteLine(ex.ToString()); return 101; }");
         builder.AppendLine("return 100;");
         return builder.ToString();
     }


### PR DESCRIPTION
This support for our tests was removed, but I didn't remove the support in the wrapper generator.