### PR TITLE
Run Codespaces prebuild only in upstream repo

### DIFF
--- a/.github/workflows/create-codespaces-prebuild.yml
+++ b/.github/workflows/create-codespaces-prebuild.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
 jobs:
   createPrebuild:
+    # Only run in the main repository since it will fail in forks
+    if: github.repository == 'dotnet/runtime'
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
The codespaces prebuild action can only run in the dotnet/runtime repo and not forks. The feature needs to be enabled for each repo and will fail if it isn't enabled. In order to minimize failure notifications, add a check to the action so it only runs against dotnet/runtime.