### PR TITLE
Fix clang 13 induced runtime issues

### DIFF
--- a/src/coreclr/inc/corhlpr.h
+++ b/src/coreclr/inc/corhlpr.h
@@ -336,7 +336,7 @@ struct COR_ILMETHOD_SECT
     const COR_ILMETHOD_SECT* Next() const
     {
         if (!More()) return(0);
-        return ((COR_ILMETHOD_SECT*)(((BYTE *)this) + DataSize()))->Align();
+        return ((COR_ILMETHOD_SECT*)Align(((BYTE *)this) + DataSize()));
     }
 
     const BYTE* Data() const
@@ -374,9 +374,9 @@ struct COR_ILMETHOD_SECT
         return((AsSmall()->Kind & CorILMethod_Sect_FatFormat) != 0);
     }
 
-    const COR_ILMETHOD_SECT* Align() const
+    static const void* Align(const void* p)
     {
-        return((COR_ILMETHOD_SECT*) ((((UINT_PTR) this) + 3) & ~3));
+        return((void*) ((((UINT_PTR) p) + 3) & ~3));
     }
 
 protected:
@@ -579,7 +579,7 @@ typedef struct tagCOR_ILMETHOD_FAT : IMAGE_COR_ILMETHOD_FAT
 
     const COR_ILMETHOD_SECT* GetSect() const {
         if (!More()) return (0);
-        return(((COR_ILMETHOD_SECT*) (GetCode() + GetCodeSize()))->Align());
+        return(((COR_ILMETHOD_SECT*) COR_ILMETHOD_SECT::Align(GetCode() + GetCodeSize())));
     }
 } COR_ILMETHOD_FAT;
 

--- a/src/coreclr/jit/bitsetasshortlong.h
+++ b/src/coreclr/jit/bitsetasshortlong.h
@@ -345,7 +345,7 @@ public:
     {
         if (IsShort(env))
         {
-            (size_t&)(int&) out = (size_t)out & ((size_t)gen | (size_t)in);
+            out = (BitSetShortLongRep)((size_t)out & ((size_t)gen | (size_t)in));
         }
         else
         {
@@ -361,7 +361,7 @@ public:
     {
         if (IsShort(env))
         {
-            (size_t&)(int&) in = (size_t)use | ((size_t)out & ~(size_t)def);
+            in = (BitSetShortLongRep)((size_t)use | ((size_t)out & ~(size_t)def));
         }
         else
         {


### PR DESCRIPTION
The clang 13 optimizer started to assume that "this" pointer is always
properly aligned. That lead to elimination of some code that was actually
needed.
It also takes pointer aliasing rules more strictly in one place in jit.
That caused the optimizer to falsely assume that a callee with an argument
passed by reference is not modifying that argument and used a stale
copy of the original value at the caller site.

This change fixes both of the issues. With this fix, runtime compiled
using clang 13 seems to be fully functional.

Close #61671