### PR TITLE
Shrink version name due to NuGet maximum

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>1</PatchVersion>
     <SdkBandVersion>6.0.100</SdkBandVersion>
-    <PreReleaseVersionLabel>mauipreview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>mauipre</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Set assembly version to align with major and minor version,
          as for the patches and revisions should be manually updated per assembly if it is serviced. -->

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -273,7 +273,7 @@
   </Target>
 
   <Target Name="ValidateAssemblyVersionsInRefPack" 
-          Condition="'$(SkipValidateAssemblyVersion)' != 'true' and '$(_AssemblyInTargetingPack)' == 'true' and ('$(PreReleaseVersionLabel)' == 'servicing' or '$(PreReleaseVersionLabel)' == 'mauipreview')"
+          Condition="'$(SkipValidateAssemblyVersion)' != 'true' and '$(_AssemblyInTargetingPack)' == 'true' and ('$(PreReleaseVersionLabel)' == 'servicing' or '$(PreReleaseVersionLabel)' == 'mauipre')"
           AfterTargets="CoreCompile" >
     <Error Condition="'$(AssemblyVersion)' != '$(LastReleasedStableAssemblyVersion)'" Text="AssemblyVersion should match last released assembly version $(LastReleasedStableAssemblyVersion)" />
   </Target>


### PR DESCRIPTION
`The special version part cannot exceed 20 characters.` error from NuGet. This name is the same length as known-good `preview`