### PR TITLE
Couple of debug info test fixes

### DIFF
--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.cs
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.cs
@@ -64,6 +64,9 @@ public unsafe class DebugInfoTest
         source.Clr.MethodLoadVerbose += e => methodTier[e.MethodID] = e.OptimizationTier;
         source.Clr.MethodILToNativeMap += e =>
         {
+            if (e.MethodID == 0)
+                return;
+
             var mappings = new (int, int)[e.CountOfMapEntries];
             for (int i = 0; i < mappings.Length; i++)
                 mappings[i] = (e.ILOffset(i), e.NativeOffset(i));

--- a/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
+++ b/src/tests/JIT/Directed/debugging/debuginfo/tester.csproj
@@ -4,6 +4,8 @@
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="tests_d.ilproj" Aliases="tests_d" />


### PR DESCRIPTION
It looks like in CI we are seeing a null method ID in some cases when
this test is run under R2R and GC stress. Add a check for this, and also
mark the test as stress incompatible like other ETW tests, since it runs
very slowly under stress modes.

Fix #62118