### PR TITLE
[SuperPMI] Added a new optional -compile argument

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -210,6 +210,17 @@ Specify the failure `limit` after which replay and asmdiffs will exit if it sees
 more than `limit` failures.
 """
 
+compile_help = """
+Compile only those method contexts whose indices are specified.
+Indices can be either a single index, comma separated values,
+a range, or the name of a .MCL file with newline delimited indices.
+e.g. -compile 20
+e.g. -compile 20,25,30,32
+e.g. -compile 10-99
+e.g. -compile 5,10-99,101,201-300
+e.g. -compile failed.mcl
+"""
+
 # Start of parser object creation.
 
 parser = argparse.ArgumentParser(description=description)
@@ -297,6 +308,7 @@ replay_common_parser.add_argument("-product_location", help=product_location_hel
 replay_common_parser.add_argument("--force_download", action="store_true", help=force_download_help)
 replay_common_parser.add_argument("-jit_ee_version", help=jit_ee_version_help)
 replay_common_parser.add_argument("-private_store", action="append", help=private_store_help)
+replay_common_parser.add_argument("-compile", help=compile_help)
 
 # subparser for replay
 replay_parser = subparsers.add_parser("replay", description=replay_description, parents=[core_root_parser, target_parser, superpmi_common_parser, replay_common_parser])
@@ -1212,7 +1224,7 @@ class SuperPMIReplay:
             if self.coreclr_args.arch != self.coreclr_args.target_arch:
                 repro_flags += [ "-target", self.coreclr_args.target_arch ]
 
-            if not self.coreclr_args.sequential:
+            if not self.coreclr_args.sequential and not self.coreclr_args.compile:
                 common_flags += [ "-p" ]
 
             if self.coreclr_args.break_on_assert:
@@ -1220,6 +1232,9 @@ class SuperPMIReplay:
 
             if self.coreclr_args.break_on_error:
                 common_flags += [ "-boe" ]
+
+            if self.coreclr_args.compile:
+                common_flags += [ "-c", self.coreclr_args.compile ]
 
             if self.coreclr_args.spmi_log_file is not None:
                 common_flags += [ "-w", self.coreclr_args.spmi_log_file ]
@@ -1452,7 +1467,7 @@ class SuperPMIReplayAsmDiffs:
                 flags += base_option_flags
                 flags += diff_option_flags
 
-                if not self.coreclr_args.sequential:
+                if not self.coreclr_args.sequential and not self.coreclr_args.compile:
                     flags += [ "-p" ]
 
                 if self.coreclr_args.break_on_assert:
@@ -1460,6 +1475,9 @@ class SuperPMIReplayAsmDiffs:
 
                 if self.coreclr_args.break_on_error:
                     flags += [ "-boe" ]
+
+                if self.coreclr_args.compile:
+                    flags += [ "-c", self.coreclr_args.compile ]
 
                 if self.coreclr_args.spmi_log_file is not None:
                     flags += [ "-w", self.coreclr_args.spmi_log_file ]
@@ -2969,6 +2987,11 @@ def setup_args(args):
                             "mch_files",
                             lambda unused: True,
                             "Unable to set mch_files")
+
+        coreclr_args.verify(args,
+                            "compile",
+                            lambda unused: True,
+                            "Method context not valid")
 
         coreclr_args.verify(args,
                             "private_store",

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -210,15 +210,8 @@ Specify the failure `limit` after which replay and asmdiffs will exit if it sees
 more than `limit` failures.
 """
 
-compile_help = """
-Compile only those method contexts whose indices are specified.
-Indices can be either a single index, comma separated values,
-a range, or the name of a .MCL file with newline delimited indices.
-e.g. -compile 20
-e.g. -compile 20,25,30,32
-e.g. -compile 10-99
-e.g. -compile 5,10-99,101,201-300
-e.g. -compile failed.mcl
+compile_help = """\
+Compile only specified method contexts, e.g., `-compile 20,25`. This is passed directly to the superpmi.exe `-compile` argument. See `superpmi.exe -?` for full documentation about allowed formats.
 """
 
 # Start of parser object creation.

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -301,7 +301,7 @@ replay_common_parser.add_argument("-product_location", help=product_location_hel
 replay_common_parser.add_argument("--force_download", action="store_true", help=force_download_help)
 replay_common_parser.add_argument("-jit_ee_version", help=jit_ee_version_help)
 replay_common_parser.add_argument("-private_store", action="append", help=private_store_help)
-replay_common_parser.add_argument("-compile", help=compile_help)
+replay_common_parser.add_argument("-compile", "-c", help=compile_help)
 
 # subparser for replay
 replay_parser = subparsers.add_parser("replay", description=replay_description, parents=[core_root_parser, target_parser, superpmi_common_parser, replay_common_parser])


### PR DESCRIPTION
Closes #62188 

I added an optional `-compile` argument which is just directly thrown into superpmi.exe

Using:
With an index:
`py .\superpmi.py asmdiffs-jit_name clrjit_universal_arm64_x64.dll --altjit -target_os Linux -target_arch arm64 -arch x64 -filter coreclr_tests -compile 1`

With a range:
`py .\superpmi.py replay -jit_name clrjit_universal_arm64_x64.dll --altjit -target_os Linux -target_arch arm64 -arch x64 -filter coreclr_tests -compile 1-200`

Without -compile:
`py .\superpmi.py asmdiffs-jit_name clrjit_universal_arm64_x64.dll --altjit -target_os Linux -target_arch arm64 -arch x64 -filter coreclr_tests`

Do I need to make a check for compliance with the format or can I omit this point in the script?