### PR TITLE
Use ReadOnlySpan<char> instead of strings on SourceGenerator engine

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -240,7 +240,7 @@ namespace System.Text.RegularExpressions.Generator
             bool hasTextInfo = false;
 
             // Emit locals initialization
-            writer.WriteLine("global::System.ReadOnlySpan<char> runtextSpan = base.runtext!;");
+            writer.WriteLine("global::System.ReadOnlySpan<char> runtextSpan = base.runtext;");
             writer.WriteLine("int runtextpos = base.runtextpos;");
             writer.WriteLine("int runtextend = base.runtextend;");
             if (rtl)


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/59629

Related: https://github.com/dotnet/runtime/issues/59629

This is similar to the linked related PR, except that this is doing it only for the FindFirstChar method for the Source Generator engine.

cc: @stephentoub @danmoseley 