### PR TITLE
fix issue where HTTP2 connection could be scavenged but not disposed

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1999,7 +1999,8 @@ namespace System.Net.Http
                 if (freeIndex < list.Count)
                 {
                     // We know the connection at freeIndex is unusable, so dispose of it.
-                    toDispose ??= new List<HttpConnectionBase> { list[freeIndex] };
+                    toDispose ??= new List<HttpConnectionBase>();
+                    toDispose.Add(list[freeIndex]);
 
                     // Find the first item after the one to be removed that should be kept.
                     int current = freeIndex + 1;


### PR DESCRIPTION
When scavenging connections, if we end up scavenging at least one HTTP/1.1 connection and at least one HTTP2 connection for the same connection pool (i.e. origin server), the first HTTP2 connection will be removed from the connection list but not disposed, leading to a connection leak.

Having both HTTP/1.1 and HTTP2 connections to the same server is not common, but if this happens the impact is pretty bad.