### PR TITLE
Follow up to universal System.Linq.Expressions

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
@@ -109,7 +109,7 @@ namespace System.Linq.Expressions.Compiler
 
         private static Type MakeNewCustomDelegate(Type[] types)
         {
-            if (LambdaExpression.CanCompileToIL)
+            if (RuntimeFeature.IsDynamicCodeSupported)
             {
                 Type returnType = types[types.Length - 1];
                 Type[] parameters = types.RemoveLast();

--- a/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -415,7 +415,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), method));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void AndAlso_NoMethod_NotStatic_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -428,7 +428,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void OrElse_NoMethod_NotStatic_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -441,7 +441,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void AndAlso_NoMethod_VoidReturnType_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -454,7 +454,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("method", () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void OrElse_NoMethod_VoidReturnType_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -467,7 +467,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("method", () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]
@@ -483,7 +483,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]
@@ -499,7 +499,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void AndAlso_NoMethod_ExpressionDoesntMatchMethodParameters_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -512,7 +512,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void OrElse_NoMethod_ExpressionDoesntMatchMethodParameters_ThrowsInvalidOperationException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -526,7 +526,7 @@ namespace System.Linq.Expressions.Tests
         }
 
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void AndAlso_NoMethod_ReturnTypeNotEqualToParameterTypes_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -539,7 +539,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void OrElse_NoMethod_ReturnTypeNotEqualToParameterTypes_ThrowsArgumentException()
         {
             TypeBuilder type = GetTypeBuilder();
@@ -569,7 +569,7 @@ namespace System.Linq.Expressions.Tests
             yield return new object[] { GetTypeBuilder(), typeof(bool), new Type[0] };
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void Method_TrueOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[] parameterTypes)
         {
@@ -590,7 +590,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void Method_FalseOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[]parameterTypes)
         {
@@ -611,7 +611,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void AndAlso_NoMethod_TrueOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[] parameterTypes)
         {
@@ -630,7 +630,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [MemberData(nameof(Operator_IncorrectMethod_TestData))]
         public static void OrElse_NoMethod_TrueOperatorIncorrectMethod_ThrowsArgumentException(TypeBuilder builder, Type returnType, Type[] parameterTypes)
         {
@@ -649,7 +649,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [InlineData("op_True")]
         [InlineData("op_False")]
         public static void Method_NoTrueFalseOperator_ThrowsArgumentException(string name)
@@ -672,7 +672,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj), createdMethod));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [InlineData("op_True")]
         [InlineData("op_False")]
         public static void AndAlso_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(string name)
@@ -692,7 +692,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [InlineData("op_True")]
         [InlineData("op_False")]
         public static void OrElse_NoMethod_NoTrueFalseOperator_ThrowsArgumentException(string name)
@@ -712,7 +712,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.OrElse(Expression.Constant(obj), Expression.Constant(obj)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void Method_ParamsDontMatchOperator_ThrowsInvalidOperationException()
         {
             TypeBuilder builder = GetTypeBuilder();
@@ -733,7 +733,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(5), Expression.Constant(5), createdMethod));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void AndAlso_NoMethod_ParamsDontMatchOperator_ThrowsInvalidOperationException()
         {
             TypeBuilder builder = GetTypeBuilder();
@@ -751,7 +751,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidOperationException>(() => Expression.OrElse(Expression.Constant(5), Expression.Constant(5)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void OrElse_NoMethod_ParamsDontMatchOperator_ThrowsInvalidOperationException()
         {
             TypeBuilder builder = GetTypeBuilder();
@@ -817,14 +817,14 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("(a OrElse b)", e2.ToString());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void AndAlsoGlobalMethod()
         {
             MethodInfo method = GlobalMethod(typeof(int), new[] { typeof(int), typeof(int) });
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.AndAlso(Expression.Constant(1), Expression.Constant(2), method));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void OrElseGlobalMethod()
         {
             MethodInfo method = GlobalMethod(typeof(int), new [] { typeof(int), typeof(int) });

--- a/src/libraries/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -2373,7 +2373,7 @@ namespace System.Linq.Expressions.Tests
             yield return typeof(Int64Enum);
             yield return typeof(UInt64Enum);
 
-            if (PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly)
+            if (PlatformDetection.IsReflectionEmitSupported)
             {
                 yield return NonCSharpTypes.CharEnumType;
                 yield return NonCSharpTypes.BoolEnumType;

--- a/src/libraries/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -302,7 +302,7 @@ namespace System.Linq.Expressions.Tests
                 VerifyTypeConstant(value, useInterpreter);
             }
 
-            if (PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly)
+            if (PlatformDetection.IsReflectionEmitSupported)
             {
                 VerifyTypeConstant(GetTypeBuilder(), useInterpreter);
             }
@@ -328,13 +328,23 @@ namespace System.Linq.Expressions.Tests
                 typeof(SomePublicMethodsForLdToken).GetMethod(nameof(SomePublicMethodsForLdToken.Qux), BindingFlags.Public | BindingFlags.Static),
                 typeof(SomePublicMethodsForLdToken).GetMethod(nameof(SomePublicMethodsForLdToken.Qux), BindingFlags.Public | BindingFlags.Static).MakeGenericMethod(typeof(int)),
                 typeof(List<>).GetMethod(nameof(List<int>.Add)),
-                typeof(List<int>).GetMethod(nameof(List<int>.Add)),
-                GlobalMethod(Type.EmptyTypes),
-                GlobalMethod(typeof(PrivateGenericClass<int>)),
-                GlobalMethod(typeof(PrivateGenericClass<>))
+                typeof(List<int>).GetMethod(nameof(List<int>.Add))
             })
             {
                 VerifyMethodInfoConstant(value, useInterpreter);
+            }
+
+            if (PlatformDetection.IsReflectionEmitSupported)
+            {
+                foreach (MethodInfo value in new MethodInfo[]
+                {
+                    GlobalMethod(Type.EmptyTypes),
+                    GlobalMethod(typeof(PrivateGenericClass<int>)),
+                    GlobalMethod(typeof(PrivateGenericClass<>))
+                })
+                {
+                    VerifyMethodInfoConstant(value, useInterpreter);
+                }
             }
         }
 

--- a/src/libraries/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/DelegateType/GetDelegateTypeTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -57,7 +58,7 @@ namespace System.Linq.Expressions.Tests
         [MemberData(nameof(ManagedPointerTypeArgs))]
         public void CantBeFunc(Type[] typeArgs)
         {
-            if (PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly)
+            if (!RuntimeFeature.IsDynamicCodeSupported)
             {
                 Assert.Throws<PlatformNotSupportedException>(() => Expression.GetDelegateType(typeArgs));
             }
@@ -83,7 +84,7 @@ namespace System.Linq.Expressions.Tests
         public void CantBeAction(Type[] typeArgs)
         {
             Type[] delegateArgs = typeArgs.Append(typeof(void)).ToArray();
-            if (PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly)
+            if (!RuntimeFeature.IsDynamicCodeSupported)
             {
                 Assert.Throws<PlatformNotSupportedException>(() => Expression.GetDelegateType(delegateArgs));
             }

--- a/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
@@ -231,8 +231,7 @@ namespace System.Dynamic.Tests
             return Activator.CreateInstance(typeBuild.CreateType());
         }
 
-        // We're not testing compilation, but we do need Reflection.Emit for the test
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void NonIndexerParameterizedDirectAccess()
         {
             // If a parameterized property isn't the type's indexer, we should be allowed to use the
@@ -243,8 +242,7 @@ namespace System.Dynamic.Tests
             Assert.Equal(19, value);
         }
 
-        // We're not testing compilation, but we do need Reflection.Emit for the test
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void NonIndexerParameterizedGetterAndSetterIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(true, true);
@@ -254,8 +252,7 @@ namespace System.Dynamic.Tests
             Assert.Contains("set_ItemProp", ex.Message);
         }
 
-        // We're not testing compilation, but we do need Reflection.Emit for the test
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void NonIndexerParameterizedGetterOnlyIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(true, false);
@@ -265,8 +262,7 @@ namespace System.Dynamic.Tests
             Assert.Contains("get_ItemProp", ex.Message);
         }
 
-        // We're not testing compilation, but we do need Reflection.Emit for the test
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void NonIndexerParameterizedSetterOnlyIndexAccess()
         {
             dynamic d = GetObjectWithNonIndexerParameterProperty(false, true);
@@ -335,8 +331,7 @@ namespace System.Dynamic.Tests
                 int arg10) => 11;
         }
 
-        // We're not testing compilation, but we do need Reflection.Emit for the test
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public void ManyArities()
         {
             dynamic d = new ManyOverloads();
@@ -380,8 +375,7 @@ namespace System.Dynamic.Tests
             return testObjects.SelectMany(i => testObjects.Select(j => new[] { i, j }));
         }
 
-        // We're not testing compilation, but we do need Reflection.Emit for the test
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Theory]
         [MemberData(nameof(SameNameObjectPairs))]
         public void OperationOnTwoObjectsDifferentTypesOfSameName(object x, object y)
         {

--- a/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Dynamic/InvokeMemberBindingTests.cs
@@ -54,7 +54,7 @@ namespace System.Dynamic.Tests
             yield return new[] {new object()};
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55070", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55070", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         [Theory, MemberData(nameof(ObjectArguments))]
         public void InvokeVirtualMethod(object value)
         {

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -240,7 +240,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(4, func());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ClassData(typeof(CompilationTypes))]
         public void CatchFromExternallyThrownString(bool useInterpreter)
         {

--- a/src/libraries/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions.Tests
                 .DefineDynamicModule("TestModule")
                 .DefineType("TestType");
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ActiveIssue("https://github.com/mono/mono/issues/14920", TestRuntimes.Mono)]
         public void NoAccessorIndexedProperty()
         {
@@ -113,7 +113,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void ByRefIndexedProperty()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -144,7 +144,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void VoidIndexedProperty()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -172,7 +172,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ActiveIssue("https://github.com/mono/mono/issues/14927", TestRuntimes.Mono)]
         public void IndexedPropertyGetReturnsWrongType()
         {
@@ -201,7 +201,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void IndexedPropertySetterNoParams()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -229,7 +229,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void IndexedPropertySetterByrefValueType()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -257,7 +257,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void IndexedPropertySetterNotReturnVoid()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -285,7 +285,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void IndexedPropertyGetterInstanceSetterStatic()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -325,7 +325,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ActiveIssue("https://github.com/mono/mono/issues/14927", TestRuntimes.Mono)]
         public void IndexedPropertySetterValueTypeNotMatchPropertyType()
         {
@@ -354,7 +354,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void IndexedPropertyGetterSetterArgCountMismatch()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -394,7 +394,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void IndexedPropertyGetterSetterArgumentTypeMismatch()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -434,7 +434,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0), Expression.Constant(0), Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void IndexedPropertyVarArgs()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -464,7 +464,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyName", () => Expression.Property(instance, "Item", Expression.Constant(0), Expression.Constant(0), Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public void NullInstanceInstanceProperty()
         {
             PropertyInfo prop = typeof(Dictionary<int, int>).GetProperty("Item");
@@ -472,7 +472,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("instance", () => Expression.Property(null, prop, index));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void InstanceToStaticProperty()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();
@@ -500,7 +500,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("instance", () => Expression.Property(instance, prop, Expression.Constant(0)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void ByRefIndexer()
         {
             TypeBuilder typeBuild = GetTestTypeBuilder();

--- a/src/libraries/System.Linq.Expressions/tests/InterpreterTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/InterpreterTests.cs
@@ -101,9 +101,7 @@ namespace System.Linq.Expressions.Tests
                   }");
         }
 
-        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
-        // but this functionality relies on private reflection and that would not work with AOT
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         [ActiveIssue ("https://github.com/dotnet/runtime/issues/53599", platforms: TestPlatforms.MacCatalyst, runtimes: TestRuntimes.Mono)]
         public static void ConstructorThrows_StackTrace()
         {
@@ -112,9 +110,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(), "Thrower..ctor");
         }
 
-        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
-        // but this functionality relies on private reflection and that would not work with AOT
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public static void PropertyGetterThrows_StackTrace()
         {
             Expression<Func<Thrower, int>> e = t => t.Bar;
@@ -122,9 +118,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Bar");
         }
 
-        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
-        // but this functionality relies on private reflection and that would not work with AOT
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public static void PropertySetterThrows_StackTrace()
         {
             ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
@@ -133,9 +127,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Bar");
         }
 
-        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
-        // but this functionality relies on private reflection and that would not work with AOT
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public static void IndexerGetterThrows_StackTrace()
         {
             ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
@@ -144,9 +136,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.get_Item");
         }
 
-        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
-        // but this functionality relies on private reflection and that would not work with AOT
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public static void IndexerSetterThrows_StackTrace()
         {
             ParameterExpression t = Expression.Parameter(typeof(Thrower), "t");
@@ -155,9 +145,7 @@ namespace System.Linq.Expressions.Tests
             AssertStackTrace(() => f(new Thrower(error: false)), "Thrower.set_Item");
         }
 
-        // IsNotLinqExpressionsBuiltWithIsInterpretingOnly is not directly required,
-        // but this functionality relies on private reflection and that would not work with AOT
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public static void MethodThrows_StackTrace()
         {
             Expression<Action<Thrower>> e = t => t.Foo();

--- a/src/libraries/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -244,8 +244,7 @@ namespace System.Linq.Expressions.Tests
             Assert.NotSame(invoke, new ParameterAndConstantChangingVisitor().Visit(invoke));
         }
 
-        // When we don't have IsNotLinqExpressionsBuiltWithIsInterpretingOnly we don't have the Reflection.Emit used in the tests.
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ClassData(typeof(CompilationTypes))]
         public static void InvokePrivateDelegate(bool useInterpreter)
         {
@@ -263,8 +262,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal(42, invFunc());
         }
 
-        // When we don't have IsNotLinqExpressionsBuiltWithIsInterpretingOnly we don't have the Reflection.Emit used in the tests.
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ClassData(typeof(CompilationTypes))]
         public static void InvokePrivateDelegateTypeLambda(bool useInterpreter)
         {

--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -268,9 +269,9 @@ namespace System.Linq.Expressions.Tests
                 double, double, double, double,
                 bool>), exp.Type);
 
-            // From this point on, the tests require IsLinqExpressionsBuiltWithIsInterpretingOnly (RefEmit) support as SLE needs to create delegate types on the fly.
+            // From this point on, the tests require Ref.Emit support as SLE needs to create delegate types on the fly.
             // You can't instantiate Func<> over 20 arguments or over byrefs.
-            if (PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly)
+            if (!RuntimeFeature.IsDynamicCodeSupported)
                 return;
 
             ParameterExpression[] paramList = Enumerable.Range(0, 20).Select(_ => Expression.Variable(typeof(int))).ToArray();
@@ -924,8 +925,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("delegateType", () => Expression.Lambda(typeof(Action<>), Expression.Empty(), false, Enumerable.Empty<ParameterExpression>()));
         }
 
-        // When we don't have IsLinqExpressionsBuiltWithIsInterpretingOnly we don't have the Reflection.Emit used in the tests.
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ClassData(typeof(CompilationTypes))]
         public void PrivateDelegate(bool useInterpreter)
         {

--- a/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -552,7 +552,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("member", () => Expression.MakeMemberAccess(Expression.Constant(new PC()), member));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ActiveIssue("https://github.com/mono/mono/issues/14920", TestRuntimes.Mono)]
         public static void Property_NoGetOrSetAccessors_ThrowsArgumentException()
         {

--- a/src/libraries/System.Linq.Expressions/tests/MemberInit/BindTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/MemberInit/BindTests.cs
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("bindings[0]", () => Expression.MemberInit(Expression.New(typeof(PropertyAndFields)), binding));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void GlobalMethod()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -295,7 +295,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("propertyAccessor", () => Expression.Bind(globalMethodInfo, Expression.Constant(2)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void GlobalField()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");

--- a/src/libraries/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/MemberInit/ListBindTests.cs
@@ -290,7 +290,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => Expression.ListBind(method));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void GlobalMethod()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");

--- a/src/libraries/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/MemberInit/MemberBindTests.cs
@@ -253,7 +253,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<InvalidProgramException>(() => exp.Compile(useInterpreter));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void GlobalMethod()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");

--- a/src/libraries/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/New/NewTests.cs
@@ -555,7 +555,7 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void GlobalMethodInMembers()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");
@@ -569,7 +569,7 @@ namespace System.Linq.Expressions.Tests
             AssertExtensions.Throws<ArgumentException>("members[0]", () => Expression.New(constructor, arguments, members));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void GlobalFieldInMembers()
         {
             ModuleBuilder module = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Name"), AssemblyBuilderAccess.RunAndCollect).DefineDynamicModule("Module");

--- a/src/libraries/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/New/NewWithByRefParameterTests.cs
@@ -70,7 +70,8 @@ namespace System.Linq.Expressions.Tests
             CreateByRefAliasing(useInterpreter: true);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/19286", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [Fact]
         public void CreateByRefAliasingCompiled()
         {
             CreateByRefAliasing(useInterpreter: false);


### PR DESCRIPTION
Most of this is test changes so that we run more tests when the expression IL compiler is disabled. There is one product change that we don't need to take, but felt like an improvement. I'll put comments inline in a bit.