### PR TITLE
Add test that ensures that it's possible to zip a named pipe on Unix

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Compression.Tests
@@ -136,6 +139,41 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        [Fact]
+        public async Task CanZipNamedPipe()
+        {
+            string destPath = Path.Combine(TestDirectory, "dest.zip");
+
+            string subFolderPath = Path.Combine(TestDirectory, "subfolder");
+            string fifoPath = Path.Combine(subFolderPath, "namedPipe");
+            Directory.CreateDirectory(subFolderPath); // mandatory before calling mkfifo
+            Assert.Equal(0, mkfifo(fifoPath, 438 /* 666 in octal */));
+
+            byte[] contentBytes = { 1, 2, 3, 4, 5 };
+
+            await Task.WhenAll(
+                Task.Run(() =>
+                {
+                    using FileStream fs = new (fifoPath, FileMode.Open, FileAccess.Write, FileShare.Read);
+                    foreach (byte content in contentBytes)
+                    {
+                        fs.WriteByte(content);
+                    }
+                }),
+                Task.Run(() =>
+                {
+                    ZipFile.CreateFromDirectory(subFolderPath, destPath);
+
+                    using ZipArchive zippedFolder = ZipFile.OpenRead(destPath);
+                    using Stream unzippedPipe = zippedFolder.Entries.Single().Open();
+
+                    byte[] readBytes = new byte[contentBytes.Length];
+                    Assert.Equal(contentBytes.Length, unzippedPipe.Read(readBytes));
+                    Assert.Equal<byte>(contentBytes, readBytes);
+                    Assert.Equal(0, unzippedPipe.Read(readBytes)); // EOF
+                }));
+        }
+
         private static string GetExpectedPermissions(string expectedPermissions)
         {
             if (string.IsNullOrEmpty(expectedPermissions))
@@ -156,5 +194,9 @@ namespace System.IO.Compression.Tests
 
             return expectedPermissions;
         }
+
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int mkfifo(string path, int mode);
     }
 }

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Unix.cs
@@ -140,6 +140,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
         public async Task CanZipNamedPipe()
         {
             string destPath = Path.Combine(TestDirectory, "dest.zip");
@@ -194,7 +195,6 @@ namespace System.IO.Compression.Tests
 
             return expectedPermissions;
         }
-
 
         [DllImport("libc", SetLastError = true)]
         private static extern int mkfifo(string path, int mode);


### PR DESCRIPTION
Contributes to #62231