### PR TITLE
[mono] Fix warnings with recent clang/gcc

### DIFF
--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1545,8 +1545,8 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 	 */
 
 
-	MonoClass *add_method_klass = NULL;
 #ifdef ALLOW_METHOD_ADD
+	MonoClass *add_method_klass = NULL;
 	uint32_t add_param_method_index = 0;
 #endif
 
@@ -1666,7 +1666,9 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 				/* rva points probably into image_base IL stream. can this ever happen? */
 				g_print ("TODO: this case is still a bit contrived. token=0x%08x with rva=0x%04x\n", log_token, rva);
 			}
+#ifdef ALLOW_METHOD_ADD
 			add_method_klass = NULL;
+#endif
 			break;
 		}
 		case MONO_TABLE_TYPEDEF: {
@@ -1941,7 +1943,6 @@ hot_reload_table_bounds_check (MonoImage *base_image, int table_index, int token
 	g_assert (base_info);
 
 	GList *list = base_info->delta_info;
-	MonoImage *dmeta;
 	MonoTableInfo *table;
 	/* result row, 0-based */
 	int ridx;
@@ -1952,7 +1953,6 @@ hot_reload_table_bounds_check (MonoImage *base_image, int table_index, int token
 			return TRUE;
 		DeltaInfo *delta_info = (DeltaInfo*)list->data;
 		g_assert (delta_info);
-		dmeta = delta_info->delta_image;
 		if (delta_info->generation > exposed_gen)
 			return TRUE;
 		list = list->next;

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6697,11 +6697,13 @@ emit_method_code (MonoAotCompile *acfg, MonoCompile *cfg)
 		 * - it allows the setting of breakpoints of aot-ed methods.
 		 */
 
-		// Comment out to force dedup to link these symbols and forbid compiling
+		// Enable to force dedup to link these symbols and forbid compiling
 		// in duplicated code. This is an "assert when linking if broken" trick.
-		/*if (mono_aot_can_dedup (method) && (acfg->aot_opts.dedup || acfg->aot_opts.dedup_include))*/
-			/*debug_sym = mono_aot_get_mangled_method_name (method);*/
-		/*else*/
+#if FALSE
+		if (mono_aot_can_dedup (method) && (acfg->aot_opts.dedup || acfg->aot_opts.dedup_include))
+			debug_sym = mono_aot_get_mangled_method_name (method);
+		else
+#endif
 			debug_sym = get_debug_sym (method, "", acfg->method_label_hash);
 
 		cfg->asm_debug_symbol = g_strdup (debug_sym);
@@ -6709,11 +6711,13 @@ emit_method_code (MonoAotCompile *acfg, MonoCompile *cfg)
 		if (acfg->need_no_dead_strip)
 			fprintf (acfg->fp, "	.no_dead_strip %s\n", debug_sym);
 
-		// Comment out to force dedup to link these symbols and forbid compiling
+		// Enable to force dedup to link these symbols and forbid compiling
 		// in duplicated code. This is an "assert when linking if broken" trick.
-		/*if (mono_aot_can_dedup (method) && (acfg->aot_opts.dedup || acfg->aot_opts.dedup_include))*/
-			/*emit_global_inner (acfg, debug_sym, TRUE);*/
-		/*else*/
+#if FALSE
+		if (mono_aot_can_dedup (method) && (acfg->aot_opts.dedup || acfg->aot_opts.dedup_include))
+			emit_global_inner (acfg, debug_sym, TRUE);
+		else
+#endif
 			emit_local_symbol (acfg, debug_sym, symbol, TRUE);
 
 		emit_label (acfg, debug_sym);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6699,7 +6699,7 @@ emit_method_code (MonoAotCompile *acfg, MonoCompile *cfg)
 
 		// Enable to force dedup to link these symbols and forbid compiling
 		// in duplicated code. This is an "assert when linking if broken" trick.
-#if FALSE
+#if 0
 		if (mono_aot_can_dedup (method) && (acfg->aot_opts.dedup || acfg->aot_opts.dedup_include))
 			debug_sym = mono_aot_get_mangled_method_name (method);
 		else
@@ -6713,7 +6713,7 @@ emit_method_code (MonoAotCompile *acfg, MonoCompile *cfg)
 
 		// Enable to force dedup to link these symbols and forbid compiling
 		// in duplicated code. This is an "assert when linking if broken" trick.
-#if FALSE
+#if 0
 		if (mono_aot_can_dedup (method) && (acfg->aot_opts.dedup || acfg->aot_opts.dedup_include))
 			emit_global_inner (acfg, debug_sym, TRUE);
 		else

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -12136,7 +12136,7 @@ mono_ins_no_side_effects (MonoInst *ins)
 	if (mono_op_no_side_effects (ins->opcode))
 		return TRUE;
 	if (ins->opcode == OP_AOTCONST) {
-		MonoJumpInfoType type = (MonoJumpInfoType)ins->inst_p1;
+		MonoJumpInfoType type = (MonoJumpInfoType)(intptr_t)ins->inst_p1;
 		// Some AOTCONSTs have side effects
 		switch (type) {
 		case MONO_PATCH_INFO_TYPE_FROM_HANDLE:


### PR DESCRIPTION
- Unused/unset variables in hot_reload.c
- Misleading indentation in aot-compiler.c
- Cast to smaller integer type in method-to-ir.c 