### PR TITLE
Add ETW events for creation of VSD stubs

### DIFF
--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -89,6 +89,8 @@
                              message="$(string.RuntimePublisher.JitInstrumentationDataKeywordMessage)" symbol="CLR_JITINSTRUMENTEDDATA_KEYWORD" />
                     <keyword name="ProfilerKeyword" mask="0x20000000000"
                              message="$(string.RuntimePublisher.ProfilerKeywordMessage)" symbol="CLR_PROFILER_KEYWORD" />
+                    <keyword name="NativeStubsKeyword" mask="0x40000000000"
+                             message="$(string.RuntimePublisher.NativeStubsKeywordMessage)" symbol="CLR_NATIVE_STUBS_KEYWORD"/>
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -207,7 +209,7 @@
                       </opcodes>
                     </task>
 
-                  <task name="Contention" symbol="CLR_CONTENTION_TASK"
+                    <task name="Contention" symbol="CLR_CONTENTION_TASK"
                           value="8" eventGUID="{561410f5-a138-4ab3-945e-516483cddfbc}"
                           message="$(string.RuntimePublisher.ContentionTaskMessage)">
                         <opcodes>
@@ -446,7 +448,14 @@
                         <opcodes>
                         </opcodes>
                     </task>
-                <!--Next available ID is 38-->
+                    <task name="NativeStubs" symbol="CLR_NATIVE_STUBS_TASK"
+                          value="38" eventGUID="{DDD644B5-7D96-4294-9BE8-995BF99753B2}"
+                          message="$(string.RuntimePublisher.NativeStubsTaskMessage)">
+                        <opcodes>
+                            <opcode name="VSDStubCreated" message="$(string.RuntimePublisher.VSDStubCreatedMessage)" symbol="CLR_VSD_STUB_CREATED_OPCODE" value="11"/>
+                        </opcodes>
+                    </task>
+                    <!--Next available ID is 39-->
                 </tasks>
                 <!--Maps-->
                 <maps>
@@ -558,6 +567,12 @@
                       <map value="0x3" message="$(string.RuntimePublisher.ResolutionAttempted.IncompatibleVersion)"/>
                       <map value="0x4" message="$(string.RuntimePublisher.ResolutionAttempted.Failure)"/>
                       <map value="0x5" message="$(string.RuntimePublisher.ResolutionAttempted.Exception)"/>
+                    </valueMap>
+                    <valueMap name="VSDStubKindMap">
+                      <map value="0x0" message="$(string.RuntimePublisher.VSDStubKind.Lookup)"/>
+                      <map value="0x1" message="$(string.RuntimePublisher.VSDStubKind.Dispatch)"/>
+                      <map value="0x2" message="$(string.RuntimePublisher.VSDStubKind.Resolve)"/>
+                      <map value="0x3" message="$(string.RuntimePublisher.VSDStubKind.VTableCall)"/>
                     </valueMap>
 
                     <!-- BitMaps -->
@@ -3036,6 +3051,33 @@
                       </UserData>
                     </template>
 
+                    <template tid="VSDStubCreated">
+                      <data name="ClrInstanceID" inType="win:UInt16"/>
+                      <data name="VSDStubKind" map="VSDStubKindMap" inType="win:UInt8" />
+                      <data name="StartAddress" inType="win:UInt64" outType="win:HexInt64" />
+                      <data name="Size" inType="win:UInt32" outType="win:HexInt32" />
+                      <data name="DeclaringTypeID" inType="win:UInt64" outType="win:HexInt64" />
+                      <data name="DeclaredMethodID" inType="win:UInt64" outType="win:HexInt64" />
+                      <data name="DeclaredMethodNamespace" inType="win:UnicodeString" />
+                      <data name="DeclaredMethodName" inType="win:UnicodeString" />
+                      <data name="DeclaredMethodSignature" inType="win:UnicodeString" />
+                      <data name="GuessedTypeID" inType="win:UInt64" outType="win:HexInt64" />
+                      <UserData>
+                        <Settings xmlns="myNs">
+                          <ClrInstanceID> %1 </ClrInstanceID>
+                          <VSDStubKind> %2 </VSDStubKind>
+                          <StartAddress> %3 </StartAddress>
+                          <Size> %4 </Size>
+                          <DeclaringTypeID> %5 </DeclaringTypeID>
+                          <DeclaredMethodID> %6 </DeclaredMethodID>
+                          <DeclaredMethodNamespace> %7 </DeclaredMethodNamespace>
+                          <DeclaredMethodName> %8 </DeclaredMethodName>
+                          <DeclaredMethodSignature> %9 </DeclaredMethodSignature>
+                          <GuessedTypeID> %10 </GuessedTypeID>
+                        </Settings>
+                      </UserData>
+                    </template>
+
                     <template tid="YieldProcessorMeasurement">
                       <data name="ClrInstanceID" inType="win:UInt16"/>
                       <data name="NsPerYield" inType="win:Double"/>
@@ -3053,7 +3095,7 @@
                 <events>
                     <!-- CLR GC events, value reserved from 0 to 39 and 200 to 239 -->
                     <!-- Note the opcode's for GC events do include 0 to 9 for backward compatibility, even though
-          they don't mean what those predefined opcodes are supposed to mean -->
+                         they don't mean what those predefined opcodes are supposed to mean -->
                     <event value="1" version="0" level="win:Informational"  template="GCStart"
                            keywords="GCKeyword" opcode="win:Start"
                            task="GarbageCollection"
@@ -4106,9 +4148,15 @@
                     <event value="300" version="0" level="win:Informational"  template="ExecutionCheckpoint"
                            keywords ="PerfTrackKeyword" opcode="ExecutionCheckpoint" task="ExecutionCheckpoint" symbol="ExecutionCheckpoint"
                            message="$(string.RuntimePublisher.ExecutionCheckpointEventMessage)"/>
+
+                    <!-- Native stubs events, 310-320 -->
+                    <event value="310" version="0" level="win:Verbose"  template="VSDStubCreated"
+                           keywords="NativeStubsKeyword" opcode="VSDStubCreated"
+                           task="NativeStubs"
+                           symbol="VSDStubCreated"
+                           message="$(string.RuntimePublisher.VSDStubCreatedEventMessage)"/>
                 </events>
             </provider>
-
 
             <!--CLR Rundown Publisher-->
             <provider name="Microsoft-Windows-DotNETRuntimeRundown"
@@ -8389,6 +8437,7 @@
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2" />
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2;%nJittedMethodCount=%3" />
                 <string id="RuntimePublisher.ExecutionCheckpointEventMessage" value="ClrInstanceID=%1;Checkpoint=%2;Timestamp=%3"/>
+                <string id="RuntimePublisher.VSDStubCreatedEventMessage" value="ClrInstanceID=%1;%nVSDStubKind=%2;%nStartAddress=%3;%nSize=%4;%nDeclaringTypeID=%5;%nDeclaredMethodID=%6;%nDeclaredMethodNamespace=%7;%nDeclaredMethodName=%8;%nDeclaredMethodSignature=%9;%nGuessedTypeID=%10" />
 
                 <string id="RundownPublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
                 <string id="RundownPublisher.MethodDCStart_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
@@ -8559,6 +8608,7 @@
                 <string id="RuntimePublisher.ExecutionCheckpointTaskMessage" value="ExecutionCheckpoint" />
                 <string id="RuntimePublisher.ProfilerTaskMessage" value="Profiler" />
                 <string id="RuntimePublisher.YieldProcessorMeasurementTaskMessage" value="YieldProcessorMeasurement" />
+                <string id="RuntimePublisher.NativeStubsTaskMessage" value="NativeStubs" />
 
                 <string id="RundownPublisher.GCTaskMessage" value="GC" />
                 <string id="RundownPublisher.EEStartupTaskMessage" value="Runtime" />
@@ -8747,6 +8797,10 @@
                 <string id="RuntimePublisher.ResolutionAttempted.IncompatibleVersion" value="IncompatibleVersion" />
                 <string id="RuntimePublisher.ResolutionAttempted.Failure" value="Failure" />
                 <string id="RuntimePublisher.ResolutionAttempted.Exception" value="Exception" />
+                <string id="RuntimePublisher.VSDStubKind.Lookup" value="Lookup" />
+                <string id="RuntimePublisher.VSDStubKind.Dispatch" value="Lookup" />
+                <string id="RuntimePublisher.VSDStubKind.Resolve" value="Lookup" />
+                <string id="RuntimePublisher.VSDStubKind.VTableCall" value="Lookup" />
 
                 <string id="RundownPublisher.AppDomain.ExecutableMapMessage" value="Executable" />
                 <string id="RundownPublisher.AppDomain.SharedMapMessage" value="Shared" />
@@ -8898,6 +8952,7 @@
                 <string id="RuntimePublisher.TypeDiagnosticKeywordMessage" value="TypeDiagnostic" />
                 <string id="RuntimePublisher.JitInstrumentationDataKeywordMessage" value="JitInstrumentationData" />
                 <string id="RuntimePublisher.ProfilerKeywordMessage" value="Profiler" />
+                <string id="RuntimePublisher.NativeStubsKeywordMessage" value="NativeStubs" />
                 <string id="RuntimePublisher.GenAwareBeginEventMessage" value="NONE" />
                 <string id="RuntimePublisher.GenAwareEndEventMessage" value="NONE" />
                 <string id="RundownPublisher.GCKeywordMessage" value="GC" />
@@ -9045,6 +9100,8 @@
                 <string id="RuntimePublisher.ExecutionCheckpointOpcodeMessage" value="ExecutionCheckpoint" />
 
                 <string id="RuntimePublisher.ProfilerOpcodeMessage" value="ProfilerMessage" />
+
+                <string id="RuntimePublisher.VSDStubCreatedMessage" value="VSDStubCreated" />
 
                 <string id="RundownPublisher.GCSettingsOpcodeMessage" value="GCSettingsRundown" />
 

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -89,8 +89,8 @@
                              message="$(string.RuntimePublisher.JitInstrumentationDataKeywordMessage)" symbol="CLR_JITINSTRUMENTEDDATA_KEYWORD" />
                     <keyword name="ProfilerKeyword" mask="0x20000000000"
                              message="$(string.RuntimePublisher.ProfilerKeywordMessage)" symbol="CLR_PROFILER_KEYWORD" />
-                    <keyword name="NativeStubsKeyword" mask="0x40000000000"
-                             message="$(string.RuntimePublisher.NativeStubsKeywordMessage)" symbol="CLR_NATIVE_STUBS_KEYWORD"/>
+                    <keyword name="StubsKeyword" mask="0x40000000000"
+                             message="$(string.RuntimePublisher.StubsKeywordMessage)" symbol="CLR_STUBS_KEYWORD"/>
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -448,11 +448,11 @@
                         <opcodes>
                         </opcodes>
                     </task>
-                    <task name="NativeStubs" symbol="CLR_NATIVE_STUBS_TASK"
+                    <task name="Stubs" symbol="CLR_STUBS_TASK"
                           value="38" eventGUID="{DDD644B5-7D96-4294-9BE8-995BF99753B2}"
-                          message="$(string.RuntimePublisher.NativeStubsTaskMessage)">
+                          message="$(string.RuntimePublisher.StubsTaskMessage)">
                         <opcodes>
-                            <opcode name="VSDStubCreated" message="$(string.RuntimePublisher.VSDStubCreatedMessage)" symbol="CLR_VSD_STUB_CREATED_OPCODE" value="11"/>
+                            <opcode name="VSDStubCreated" message="$(string.RuntimePublisher.VSDStubCreatedOpcodeMessage)" symbol="CLR_VSD_STUB_CREATED_OPCODE" value="11"/>
                         </opcodes>
                     </task>
                     <!--Next available ID is 39-->
@@ -3051,30 +3051,30 @@
                       </UserData>
                     </template>
 
-                    <template tid="VSDStubCreated">
+                    <template tid="VSDStub">
                       <data name="ClrInstanceID" inType="win:UInt16"/>
                       <data name="VSDStubKind" map="VSDStubKindMap" inType="win:UInt8" />
                       <data name="StartAddress" inType="win:UInt64" outType="win:HexInt64" />
                       <data name="Size" inType="win:UInt32" outType="win:HexInt32" />
-                      <data name="DeclaringTypeID" inType="win:UInt64" outType="win:HexInt64" />
-                      <data name="DeclaredMethodID" inType="win:UInt64" outType="win:HexInt64" />
-                      <data name="DeclaredMethodNamespace" inType="win:UnicodeString" />
-                      <data name="DeclaredMethodName" inType="win:UnicodeString" />
-                      <data name="DeclaredMethodSignature" inType="win:UnicodeString" />
-                      <data name="GuessedTypeID" inType="win:UInt64" outType="win:HexInt64" />
+                      <data name="VirtualTypeID" inType="win:UInt64" outType="win:HexInt64" />
+                      <data name="VirtualMethodID" inType="win:UInt64" outType="win:HexInt64" />
+                      <data name="VirtualMethodNamespace" inType="win:UnicodeString" />
+                      <data name="VirtualMethodName" inType="win:UnicodeString" />
+                      <data name="VirtualMethodSignature" inType="win:UnicodeString" />
+                      <data name="DispatchTypeID" inType="win:UInt64" outType="win:HexInt64" />
                       <UserData>
-                        <Settings xmlns="myNs">
+                        <VSDStub xmlns="myNs">
                           <ClrInstanceID> %1 </ClrInstanceID>
                           <VSDStubKind> %2 </VSDStubKind>
                           <StartAddress> %3 </StartAddress>
                           <Size> %4 </Size>
-                          <DeclaringTypeID> %5 </DeclaringTypeID>
-                          <DeclaredMethodID> %6 </DeclaredMethodID>
-                          <DeclaredMethodNamespace> %7 </DeclaredMethodNamespace>
-                          <DeclaredMethodName> %8 </DeclaredMethodName>
-                          <DeclaredMethodSignature> %9 </DeclaredMethodSignature>
-                          <GuessedTypeID> %10 </GuessedTypeID>
-                        </Settings>
+                          <VirtualTypeID> %5 </VirtualTypeID>
+                          <VirtualMethodID> %6 </VirtualMethodID>
+                          <VirtualMethodNamespace> %7 </VirtualMethodNamespace>
+                          <VirtualMethodName> %8 </VirtualMethodName>
+                          <VirtualMethodSignature> %9 </VirtualMethodSignature>
+                          <DispatchTypeID> %10 </DispatchTypeID>
+                        </VSDStub>
                       </UserData>
                     </template>
 
@@ -4149,10 +4149,10 @@
                            keywords ="PerfTrackKeyword" opcode="ExecutionCheckpoint" task="ExecutionCheckpoint" symbol="ExecutionCheckpoint"
                            message="$(string.RuntimePublisher.ExecutionCheckpointEventMessage)"/>
 
-                    <!-- Native stubs events, 310-320 -->
-                    <event value="310" version="0" level="win:Verbose"  template="VSDStubCreated"
-                           keywords="NativeStubsKeyword" opcode="VSDStubCreated"
-                           task="NativeStubs"
+                    <!-- Stubs events, 310-320 -->
+                    <event value="310" version="0" level="win:Informational"  template="VSDStub"
+                           keywords="StubsKeyword" opcode="VSDStubCreated"
+                           task="Stubs"
                            symbol="VSDStubCreated"
                            message="$(string.RuntimePublisher.VSDStubCreatedEventMessage)"/>
                 </events>
@@ -8437,7 +8437,7 @@
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStartEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2" />
                 <string id="RuntimePublisher.TieredCompilationBackgroundJitStopEventMessage" value="ClrInstanceID=%1;%nPendingMethodCount=%2;%nJittedMethodCount=%3" />
                 <string id="RuntimePublisher.ExecutionCheckpointEventMessage" value="ClrInstanceID=%1;Checkpoint=%2;Timestamp=%3"/>
-                <string id="RuntimePublisher.VSDStubCreatedEventMessage" value="ClrInstanceID=%1;%nVSDStubKind=%2;%nStartAddress=%3;%nSize=%4;%nDeclaringTypeID=%5;%nDeclaredMethodID=%6;%nDeclaredMethodNamespace=%7;%nDeclaredMethodName=%8;%nDeclaredMethodSignature=%9;%nGuessedTypeID=%10" />
+                <string id="RuntimePublisher.VSDStubCreatedEventMessage" value="ClrInstanceID=%1;%nVSDStubKind=%2;%nStartAddress=%3;%nSize=%4;%nVirtualTypeID=%5;%nVirtualMethodID=%6;%nVirtualMethodNamespace=%7;%nVirtualMethodName=%8;%nVirtualMethodSignature=%9;%nDispatchTypeID=%10" />
 
                 <string id="RundownPublisher.MethodDCStartEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6" />
                 <string id="RundownPublisher.MethodDCStart_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
@@ -8608,7 +8608,7 @@
                 <string id="RuntimePublisher.ExecutionCheckpointTaskMessage" value="ExecutionCheckpoint" />
                 <string id="RuntimePublisher.ProfilerTaskMessage" value="Profiler" />
                 <string id="RuntimePublisher.YieldProcessorMeasurementTaskMessage" value="YieldProcessorMeasurement" />
-                <string id="RuntimePublisher.NativeStubsTaskMessage" value="NativeStubs" />
+                <string id="RuntimePublisher.StubsTaskMessage" value="Stubs" />
 
                 <string id="RundownPublisher.GCTaskMessage" value="GC" />
                 <string id="RundownPublisher.EEStartupTaskMessage" value="Runtime" />
@@ -8798,9 +8798,9 @@
                 <string id="RuntimePublisher.ResolutionAttempted.Failure" value="Failure" />
                 <string id="RuntimePublisher.ResolutionAttempted.Exception" value="Exception" />
                 <string id="RuntimePublisher.VSDStubKind.Lookup" value="Lookup" />
-                <string id="RuntimePublisher.VSDStubKind.Dispatch" value="Lookup" />
-                <string id="RuntimePublisher.VSDStubKind.Resolve" value="Lookup" />
-                <string id="RuntimePublisher.VSDStubKind.VTableCall" value="Lookup" />
+                <string id="RuntimePublisher.VSDStubKind.Dispatch" value="Dispatch" />
+                <string id="RuntimePublisher.VSDStubKind.Resolve" value="Resolve" />
+                <string id="RuntimePublisher.VSDStubKind.VTableCall" value="VTableCall" />
 
                 <string id="RundownPublisher.AppDomain.ExecutableMapMessage" value="Executable" />
                 <string id="RundownPublisher.AppDomain.SharedMapMessage" value="Shared" />
@@ -8952,7 +8952,7 @@
                 <string id="RuntimePublisher.TypeDiagnosticKeywordMessage" value="TypeDiagnostic" />
                 <string id="RuntimePublisher.JitInstrumentationDataKeywordMessage" value="JitInstrumentationData" />
                 <string id="RuntimePublisher.ProfilerKeywordMessage" value="Profiler" />
-                <string id="RuntimePublisher.NativeStubsKeywordMessage" value="NativeStubs" />
+                <string id="RuntimePublisher.StubsKeywordMessage" value="Stubs" />
                 <string id="RuntimePublisher.GenAwareBeginEventMessage" value="NONE" />
                 <string id="RuntimePublisher.GenAwareEndEventMessage" value="NONE" />
                 <string id="RundownPublisher.GCKeywordMessage" value="GC" />
@@ -9101,7 +9101,7 @@
 
                 <string id="RuntimePublisher.ProfilerOpcodeMessage" value="ProfilerMessage" />
 
-                <string id="RuntimePublisher.VSDStubCreatedMessage" value="VSDStubCreated" />
+                <string id="RuntimePublisher.VSDStubCreatedOpcodeMessage" value="VSDStubCreated" />
 
                 <string id="RundownPublisher.GCSettingsOpcodeMessage" value="GCSettingsRundown" />
 

--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -317,6 +317,11 @@ nostack:TieredCompilation:::TieredCompilationBackgroundJitStart
 nomac:TieredCompilation:::TieredCompilationBackgroundJitStop
 nostack:TieredCompilation:::TieredCompilationBackgroundJitStop
 
+###########################
+# Stubs events
+###########################
+nostack:Stubs:::VSDStubCreated
+
 ##################################
 # Events from the rundown provider
 ##################################

--- a/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
+++ b/src/coreclr/vm/amd64/virtualcallstubcpu.hpp
@@ -393,7 +393,7 @@ struct ResolveStub
     inline UINT32 hashedToken()         { LIMITED_METHOD_CONTRACT; return _hashedToken >> LOG2_PTRSIZE;    }
     inline size_t cacheAddress()        { LIMITED_METHOD_CONTRACT; return _cacheAddress;   }
     inline size_t token()               { LIMITED_METHOD_CONTRACT; return _token;          }
-    inline size_t size()                { LIMITED_METHOD_CONTRACT; return sizeof(LookupStub); }
+    inline size_t size()                { LIMITED_METHOD_CONTRACT; return sizeof(ResolveStub); }
 
 private:
     friend struct ResolveHolder;

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -300,6 +300,11 @@ LPCUTF8 MethodDesc::GetName()
  */
 VOID MethodDesc::GetMethodInfoNoSig(SString &namespaceOrClassName, SString &methodName)
 {
+    CONTRACTL {
+        THROWS;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+
     static LPCWSTR pDynamicClassName = W("dynamicClass");
 
     // namespace
@@ -317,6 +322,11 @@ VOID MethodDesc::GetMethodInfoNoSig(SString &namespaceOrClassName, SString &meth
  */
 VOID MethodDesc::GetMethodInfo(SString &namespaceOrClassName, SString &methodName, SString &methodSignature)
 {
+    CONTRACTL {
+        THROWS;
+        GC_NOTRIGGER;
+    } CONTRACTL_END;
+
     GetMethodInfoNoSig(namespaceOrClassName, methodName);
 
     // signature

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2644,7 +2644,7 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
             }
             else
             {
-                pCode = pMgr->GetVTableCallStub(slot);
+                pCode = pMgr->GetVTableCallStub(pMT, slot);
                 *(TADDR *)pIndirection = pCode;
             }
             _ASSERTE(pCode != NULL);

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -2616,10 +2616,7 @@ void VirtualCallStubManager::FireVSDStubCreatedEvent(
         SString virtualMethodNamespaceOrClassName;
         SString virtualMethodName;
         SString virtualMethodSignature;
-        if (pVirtualMD != NULL)
-        {
-            pVirtualMD->GetMethodInfo(virtualMethodNamespaceOrClassName, virtualMethodName, virtualMethodSignature);
-        }
+        pVirtualMD->GetMethodInfo(virtualMethodNamespaceOrClassName, virtualMethodName, virtualMethodSignature);
 
         FireEtwVSDStubCreated(
             GetClrInstanceId(),

--- a/src/coreclr/vm/virtualcallstub.h
+++ b/src/coreclr/vm/virtualcallstub.h
@@ -492,7 +492,7 @@ private:
     bool ShouldFireVSDStubCreatedEvents()
     {
         LIMITED_METHOD_CONTRACT;
-        return !m_loaderAllocator->IsCollectible() && EventEnabledVSDStubCreated();
+        return EventEnabledVSDStubCreated();
     }
 
     // Fire a VSDStubCreated ETW event.
@@ -501,9 +501,9 @@ private:
         EtwStubKind kind,
         PCODE addr,
         size_t size,
-        MethodTable* pDeclaringMT,
-        MethodDesc* pDeclaredMD,
-        MethodTable* pGuessedMT);
+        MethodTable* pVirtualMT,
+        MethodDesc* pVirtualMD,
+        MethodTable* pDispatchMT);
 
     // Given a dispatch token and a method table for a derived or implementing
     // class, return the method table and method desc of the declaration that the


### PR DESCRIPTION
Add a new Stubs keyword and task, and under this new category add
a VSDStubCreated ETW event. This event is fired when we create a new VSD
stub (lookup, dispatch, resolve, vtable call). For all the stubs we
include the target base method, and for the dispatch stub we furthermore
include the type ID that we are guessing for.