### PR TITLE
[Android] Prevent potential out of bounds write on Android

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -585,13 +585,15 @@ AndroidCryptoNative_SSLStreamRead(SSLStream* sslStream, uint8_t* buffer, int32_t
 
     if (rem > 0)
     {
-        data = make_java_byte_array(env, rem);
+        int32_t bytes_to_read = rem < length ? rem : length;
+        assert(bytes_to_read == rem && "buffer is not large enough");
+        data = make_java_byte_array(env, bytes_to_read);
         IGNORE_RETURN((*env)->CallObjectMethod(env, sslStream->appInBuffer, g_ByteBufferGet, data));
         ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
         IGNORE_RETURN((*env)->CallObjectMethod(env, sslStream->appInBuffer, g_ByteBufferCompact));
         ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
-        (*env)->GetByteArrayRegion(env, data, 0, rem, (jbyte*)buffer);
-        *read = rem;
+        (*env)->GetByteArrayRegion(env, data, 0, bytes_to_read, (jbyte*)buffer);
+        *read = bytes_to_read;
         ret = SSLStreamStatus_OK;
     }
     else

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -586,7 +586,7 @@ AndroidCryptoNative_SSLStreamRead(SSLStream* sslStream, uint8_t* buffer, int32_t
     if (rem > 0)
     {
         int32_t bytes_to_read = rem < length ? rem : length;
-        assert(bytes_to_read == rem && "buffer is not large enough");
+        assert(bytes_to_read == rem && "destination buffer is not large enough");
         data = make_java_byte_array(env, bytes_to_read);
         IGNORE_RETURN((*env)->CallObjectMethod(env, sslStream->appInBuffer, g_ByteBufferGet, data));
         ON_EXCEPTION_PRINT_AND_GOTO(cleanup);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -586,7 +586,6 @@ AndroidCryptoNative_SSLStreamRead(SSLStream* sslStream, uint8_t* buffer, int32_t
     if (rem > 0)
     {
         int32_t bytes_to_read = rem < length ? rem : length;
-        assert(bytes_to_read == rem && "destination buffer is not large enough");
         data = make_java_byte_array(env, bytes_to_read);
         IGNORE_RETURN((*env)->CallObjectMethod(env, sslStream->appInBuffer, g_ByteBufferGet, data));
         ON_EXCEPTION_PRINT_AND_GOTO(cleanup);


### PR DESCRIPTION
This PR makes sure we never write more bytes into the destination buffer than we allocated. The way we currently use this function always is safe because we ensure that the destination buffer is large enough beforehand but it could be a problem if we reused this function somewhere else in the future.

If there's too much data in the input buffer to fit into the destination buffer we read only as much as we can and we leave the rest of the data intact for future reads.