### PR TITLE
[wasm][debugger] View object attributes - DebugType=full

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -534,7 +534,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal int PdbAge { get; }
         internal System.Guid PdbGuid { get; }
         internal string PdbName { get; }
-
+        internal bool PdbInformationAvailable { get; }
         public bool TriedToLoadSymbolsOnDemand { get; set; }
 
         public unsafe AssemblyInfo(MonoProxy monoProxy, SessionId sessionId, string url, byte[] assembly, byte[] pdb, CancellationToken token)
@@ -550,6 +550,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 PdbAge = codeViewData.Age;
                 PdbGuid = codeViewData.Guid;
                 PdbName = codeViewData.Path;
+                PdbInformationAvailable = true;
             }
             asmMetadataReader = PEReaderExtensions.GetMetadataReader(peReader);
             var asmDef = asmMetadataReader.GetAssemblyDefinition();

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -537,11 +537,11 @@ namespace Microsoft.WebAssembly.Diagnostics
         public unsafe AssemblyInfo(string url, byte[] assembly, byte[] pdb)
         {
             this.id = Interlocked.Increment(ref next_id);
-            var asmStream = new MemoryStream(assembly);
-            var peReader = new PEReader(asmStream);
-            var entries = peReader.ReadDebugDirectory();
+            using var asmStream = new MemoryStream(assembly);
+            using var peReader = new PEReader(asmStream);
+            ImmutableArray<DebugDirectoryEntry> entries = peReader.ReadDebugDirectory();
             var codeView = entries[0];
-            var codeViewData = peReader.ReadCodeViewDebugDirectoryData(codeView);
+            CodeViewDebugDirectoryData codeViewData = peReader.ReadCodeViewDebugDirectoryData(codeView);
             PdbAge = codeViewData.Age;
             PdbGuid = codeViewData.Guid;
             PdbName = codeViewData.Path;
@@ -554,6 +554,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var pdbStream = new MemoryStream(pdb);
                 try
                 {
+                    // MetadataReaderProvider.FromPortablePdbStream takes ownership of the stream
                     pdbMetadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
                 }
                 catch (BadImageFormatException)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -541,10 +541,19 @@ namespace Microsoft.WebAssembly.Diagnostics
             asmStream = new MemoryStream(assembly);
             peReader = new PEReader(asmStream);
             asmMetadataReader = PEReaderExtensions.GetMetadataReader(peReader);
+            Name = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
+            AssemblyNameUnqualified = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
             if (pdb != null)
             {
                 pdbStream = new MemoryStream(pdb);
-                pdbMetadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
+                try
+                {
+                    pdbMetadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
+                }
+                catch (BadImageFormatException)
+                {
+                    Console.WriteLine($"Warning: Unable to read debug information of: {Name} (use DebugType=Portable/Embedded)");
+                }
             }
             else
             {
@@ -555,8 +564,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                     pdbMetadataReader = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embeddedPdbEntry).GetMetadataReader();
                 }
             }
-            Name = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
-            AssemblyNameUnqualified = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
             Populate();
         }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -964,7 +964,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             ExecutionContext context = GetContext(sessionId);
             if (urlSymbolServerList.Count == 0)
                 return null;
-            if (asm.TriedToLoadSymbolsOnDemand)
+            if (asm.TriedToLoadSymbolsOnDemand || !asm.PdbInformationAvailable)
                 return null;
             asm.TriedToLoadSymbolsOnDemand = true;
             var pdbName = Path.GetFileName(asm.PdbName);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1057,7 +1057,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var store = await LoadStore(sessionId, token);
                 var assembly_name = eventArgs?["assembly_name"]?.Value<string>();
 
-                if (store.GetAssemblyByUnqualifiedName(assembly_name) != null)
+                if (store.GetAssemblyByName(assembly_name) != null)
                 {
                     Log("debug", $"Got AssemblyLoaded event for {assembly_name}, but skipping it as it has already been loaded.");
                     return true;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -50,6 +50,34 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         internal Task<Result> SendMonoCommand(SessionId id, MonoCommands cmd, CancellationToken token) => SendCommand(id, "Runtime.evaluate", JObject.FromObject(cmd), token);
 
+        internal void SendLog(SessionId sessionId, string message, CancellationToken token)
+        {
+            if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                return;
+            /*var o = JObject.FromObject(new
+            {
+                entry = JObject.FromObject(new
+                {
+                    source = "recommendation",
+                    level = "warning",
+                    text = message
+                })
+            });
+            SendEvent(id, "Log.enabled", null, token);
+            SendEvent(id, "Log.entryAdded", o, token);*/
+            var o = JObject.FromObject(new
+            {
+                type = "warning",
+                args = new JArray(JObject.FromObject(new
+                                {
+                                    type = "string",
+                                    value = message,
+                                })),
+                executionContextId = context.Id
+            });
+            SendEvent(sessionId, "Runtime.consoleAPICalled", o, token);
+        }
+
         protected override async Task<bool> AcceptEvent(SessionId sessionId, string method, JObject args, CancellationToken token)
         {
             switch (method)
@@ -1076,7 +1104,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 var pdb_data = string.IsNullOrEmpty(pdb_b64) ? null : Convert.FromBase64String(pdb_b64);
 
                 var context = GetContext(sessionId);
-                foreach (var source in store.Add(assembly_name, assembly_data, pdb_data))
+                foreach (var source in store.Add(sessionId, assembly_name, assembly_data, pdb_data, token))
                 {
                     await OnSourceFileAdded(sessionId, source, context, token);
                 }
@@ -1204,7 +1232,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         {
             ExecutionContext context = GetContext(sessionId);
 
-            if (Interlocked.CompareExchange(ref context.store, new DebugStore(logger), null) != null)
+            if (Interlocked.CompareExchange(ref context.store, new DebugStore(this, logger), null) != null)
                 return await context.Source.Task;
 
             try
@@ -1218,7 +1246,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
 
                 await
-                foreach (SourceFile source in context.store.Load(loaded_files, token).WithCancellation(token))
+                foreach (SourceFile source in context.store.Load(sessionId, loaded_files, token).WithCancellation(token))
                 {
                     await OnSourceFileAdded(sessionId, source, context, token);
                 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -939,18 +939,11 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (asm.TriedToLoadSymbolsOnDemand)
                 return null;
             asm.TriedToLoadSymbolsOnDemand = true;
-            var peReader = asm.peReader;
-            var entries = peReader.ReadDebugDirectory();
-            var codeView = entries[0];
-            var codeViewData = peReader.ReadCodeViewDebugDirectoryData(codeView);
-            int pdbAge = codeViewData.Age;
-            var pdbGuid = codeViewData.Guid;
-            string pdbName = codeViewData.Path;
-            pdbName = Path.GetFileName(pdbName);
+            var pdbName = Path.GetFileName(asm.PdbName);
 
             foreach (string urlSymbolServer in urlSymbolServerList)
             {
-                string downloadURL = $"{urlSymbolServer}/{pdbName}/{pdbGuid.ToString("N").ToUpper() + pdbAge}/{pdbName}";
+                string downloadURL = $"{urlSymbolServer}/{pdbName}/{asm.PdbGuid.ToString("N").ToUpper() + asm.PdbAge}/{pdbName}";
 
                 try
                 {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -916,7 +916,7 @@ namespace DebuggerTests
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() {" + expression + "; }, 1);",
-                "dotnet://debugger-test.dll/debugger-test.cs", 861, 8,
+                "dotnet://debugger-test.dll/debugger-test.cs", 860, 8,
                 "CallToEvaluateLocal",
                 wait_for_event_fn: async (pause_location) =>
                 {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -901,6 +901,35 @@ namespace DebuggerTests
                 }
             );
         }
+
+        [Fact]
+        public async Task InspectLocalsUsingClassFromLibraryUsingDebugTypeFull()
+        {
+            byte[] bytes = File.ReadAllBytes(Path.Combine(DebuggerTestAppPath, "debugger-test-with-full-debug-type.dll"));
+            string asm_base64 = Convert.ToBase64String(bytes);
+
+            string pdb_base64 = null;
+            bytes = File.ReadAllBytes(Path.Combine(DebuggerTestAppPath, "debugger-test-with-full-debug-type.pdb"));
+            pdb_base64 = Convert.ToBase64String(bytes);
+
+            var expression = $"{{ let asm_b64 = '{asm_base64}'; let pdb_b64 = '{pdb_base64}'; invoke_static_method('[debugger-test] DebugTypeFull:CallToEvaluateLocal', asm_b64, pdb_b64); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 861, 8,
+                "CallToEvaluateLocal",
+                wait_for_event_fn: async (pause_location) =>
+                {
+                    var a_props = await GetObjectOnFrame(pause_location["callFrames"][0], "a");
+                    await CheckProps(a_props, new
+                    {
+                        a = TNumber(10),
+                        b = TNumber(20),
+                        c = TNumber(30)
+                    }, "a");
+                }
+            );
+        }
         //TODO add tests covering basic stepping behavior as step in/out/over
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test-with-full-debug-type/debugger-test-with-full-debug-type.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-full-debug-type/debugger-test-with-full-debug-type.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+</Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-with-full-debug-type/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-full-debug-type/test.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace DebuggerTests
+{
+    public class ClassToInspectWithDebugTypeFull
+    {
+        int a;
+        int b;
+        int c;
+        public ClassToInspectWithDebugTypeFull()
+        {
+            a = 10;
+            b = 20;
+            c = 30;
+            Console.WriteLine(a);
+            Console.WriteLine(b);
+            Console.WriteLine(c);
+        }
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -849,3 +849,16 @@ public class DebuggerAttribute
         VisibleMethodDebuggerBreak();
     }
 }
+
+public class DebugTypeFull
+{
+    public static void CallToEvaluateLocal(string asm_base64, string pdb_base64)
+    {
+        var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-full-debug-type.dll");
+        var myType = asm.GetType("DebuggerTests.ClassToInspectWithDebugTypeFull");
+        var myMethod = myType.GetConstructor(new Type[] { });
+        var a = myMethod.Invoke(new object[]{});
+        Console.WriteLine(a);
+        System.Diagnostics.Debugger.Break();
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -858,7 +858,6 @@ public class DebugTypeFull
         var myType = asm.GetType("DebuggerTests.ClassToInspectWithDebugTypeFull");
         var myMethod = myType.GetConstructor(new Type[] { });
         var a = myMethod.Invoke(new object[]{});
-        Console.WriteLine(a);
         System.Diagnostics.Debugger.Break();
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" Private="true"/>
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" Private="true"/>
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
+    <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" Private="true"/>
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">
@@ -38,6 +39,7 @@
     <ItemGroup>
       <WasmAssembliesToBundle Include="$(OutDir)\$(TargetFileName)" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-full-debug-type.dll" />
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
 


### PR DESCRIPTION
Fix view object attributes from a class defined in an assembly with debugType = full.

Fix discussion on: https://github.com/mono/mono/issues/19942

Adding the Runtime.consoleAPICalled, I couldn't use the Log.entryAdded didn't work on VS.

in VS:
![image](https://user-images.githubusercontent.com/4503299/144918534-d1b89a42-90a6-43ca-8ea7-1de6d561b325.png)

in Chrome:
![image](https://user-images.githubusercontent.com/4503299/144920544-62381330-2750-470d-a38b-b45d170183ae.png)

