### PR TITLE
Add missing return in LoopsToProcess test

### DIFF
--- a/src/tests/JIT/Directed/LoopAlignment/LoopsToProcess.cs
+++ b/src/tests/JIT/Directed/LoopAlignment/LoopsToProcess.cs
@@ -134,8 +134,9 @@ public class TestClass_Loops
             return;
         }
     }
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
         new TestClass_Loops().Method0();
+        return 100;
     }
 }


### PR DESCRIPTION
Forgot to add `return 100` needed for test harness to consider that the test passed. It was not detected during PR CI because the test is marked as P1.

Fixes: #62260