### PR TITLE
Lock MemeoryMappedFile CreateViewAccesssor call

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs
@@ -160,7 +160,13 @@ namespace System.Reflection.Internal
                 }
             }
 
-            MemoryMappedViewAccessor accessor = _lazyMemoryMap.CreateViewAccessor(start, size, MemoryMappedFileAccess.Read);
+            MemoryMappedViewAccessor accessor;
+
+            lock (_streamGuard)
+            {
+                accessor = _lazyMemoryMap.CreateViewAccessor(start, size, MemoryMappedFileAccess.Read);
+            }
+
             if (accessor == null)
             {
                 block = null;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/60545

There is a concurrency [bug reported](https://github.com/dotnet/runtime/issues/60545) in PEReader when loading from FileStream

The bug is only reproducible on Linux with .Net 5.0 or below, after investigating it we discovered that `_lazyMemoryMap.CreateViewAccesssor(...)` call needs a lock:
https://github.com/dotnet/runtime/blob/3e704ae3bbc59822f1ab06f530d955ee2afd4c78/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/MemoryBlocks/StreamMemoryBlockProvider.cs#L163

The bug is not reproducible in 6.0 or above, the fix is tested manually with 5.0 code and Linux env.
look into the [issue](https://github.com/dotnet/runtime/issues/60545) for more details

CC @danmoseley @adamsitnik 
