### PR TITLE
[wasm] Work around `System.Diagnostics.Tests.StopwatchTests.GetTimestamp` failure

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -12,6 +12,7 @@ namespace System.Diagnostics.Tests
         private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/62021", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser)]
         public static void GetTimestamp()
         {
             long ts1 = Stopwatch.GetTimestamp();

--- a/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -12,11 +12,18 @@ namespace System.Diagnostics.Tests
         private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/62021", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public static void GetTimestamp()
         {
             long ts1 = Stopwatch.GetTimestamp();
-            Sleep();
+            if (PlatformDetection.IsBrowser)
+            {
+                // workaround for issue: https://github.com/dotnet/runtime/issues/62021
+                Sleep(5);
+            }
+            else
+            {
+                Sleep();
+            }
             long ts2 = Stopwatch.GetTimestamp();
             Assert.NotEqual(ts1, ts2);
         }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -12,7 +12,7 @@ namespace System.Diagnostics.Tests
         private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/62021", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/62021", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public static void GetTimestamp()
         {
             long ts1 = Stopwatch.GetTimestamp();


### PR DESCRIPTION
.. by sleeping for 5ms on wasm, instead of 1ms. Thanks to @danmoseley for the suggestion.

Issue: https://github.com/dotnet/runtime/issues/62021