### PR TITLE
Use GeneratedDllImport throughout System.Private.CoreLib.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
@@ -21,8 +21,8 @@ namespace System
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "Buffer_Clear")]
-        private static extern unsafe void __ZeroMemory(void* b, nuint byteLength);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "Buffer_Clear")]
+        private static unsafe partial void __ZeroMemory(void* b, nuint byteLength);
 
         // The maximum block size to for __BulkMoveWithWriteBarrier FCall. This is required to avoid GC starvation.
 #if DEBUG // Stress the mechanism in debug builds
@@ -77,8 +77,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern void __BulkMoveWithWriteBarrier(ref byte destination, ref byte source, nuint byteCount);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "Buffer_MemMove")]
-        private static extern unsafe void __Memmove(byte* dest, byte* src, nuint len);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "Buffer_MemMove")]
+        private static unsafe partial void __Memmove(byte* dest, byte* src, nuint len);
 
         // Used by ilmarshalers.cpp
         internal static unsafe void Memcpy(byte* dest, byte* src, int len)

--- a/src/coreclr/System.Private.CoreLib/src/System/CLRConfig.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/CLRConfig.cs
@@ -10,7 +10,7 @@ namespace System
     // one example, is using the context switch in the globalization code which require to read the switch very
     // early even before the appdomain get initialized.
     // In general AppContext should be used instead of CLRConfig if there is no reason prevent that.
-    internal static class CLRConfig
+    internal static partial class CLRConfig
     {
         internal static bool GetBoolValue(string switchName, out bool exist)
         {
@@ -50,7 +50,7 @@ namespace System
             return defaultValue;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ClrConfig_GetConfigBoolValue", CharSet = CharSet.Unicode)]
-        private static extern bool GetConfigBoolValue(string configSwitchName, out bool exist);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ClrConfig_GetConfigBoolValue", CharSet = CharSet.Unicode)]
+        private static partial bool GetConfigBoolValue(string configSwitchName, out bool exist);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
@@ -51,7 +51,7 @@ namespace System.Diagnostics
             }
         }
 
-        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint ="DebugDebugger_Launch")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "DebugDebugger_Launch")]
         private static partial bool LaunchInternal();
 
         // Returns whether or not a debugger is attached to the process.

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Debugger.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Diagnostics
 {
-    public static class Debugger
+    public static partial class Debugger
     {
         // Break causes a breakpoint to be signalled to an attached debugger.  If no debugger
         // is attached, the user is asked if they want to attach a debugger. If yes, then the
@@ -51,8 +51,8 @@ namespace System.Diagnostics
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint="DebugDebugger_Launch")]
-        private static extern bool LaunchInternal();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint ="DebugDebugger_Launch")]
+        private static partial bool LaunchInternal();
 
         // Returns whether or not a debugger is attached to the process.
         //
@@ -77,8 +77,8 @@ namespace System.Diagnostics
         // report the message depending on its settings.
         public static void Log(int level, string? category, string? message) => LogInternal(level, category, message);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint="DebugDebugger_Log", CharSet = CharSet.Unicode)]
-        private static extern void LogInternal(int level, string? category, string? message);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "DebugDebugger_Log", CharSet = CharSet.Unicode)]
+        private static partial void LogInternal(int level, string? category, string? message);
 
         // Checks to see if an attached debugger has logging enabled
         //

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/EventPipe.CoreCLR.cs
@@ -14,49 +14,52 @@ namespace System.Diagnostics.Tracing
         //
         // These PInvokes are used by the configuration APIs to interact with EventPipe.
         //
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_Enable")]
-        private static unsafe extern ulong Enable(
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_Enable")]
+        private static unsafe partial ulong Enable(
             char* outputFile,
             EventPipeSerializationFormat format,
             uint circularBufferSizeInMB,
             EventPipeProviderConfigurationNative* providers,
             uint numProviders);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_Disable")]
-        internal static extern void Disable(ulong sessionID);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_Disable")]
+        internal static partial void Disable(ulong sessionID);
 
         //
         // These PInvokes are used by EventSource to interact with the EventPipe.
         //
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_CreateProvider", CharSet = CharSet.Unicode)]
-        internal static extern IntPtr CreateProvider(string providerName, Interop.Advapi32.EtwEnableCallback callbackFunc);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_CreateProvider", CharSet = CharSet.Unicode)]
+        internal static partial IntPtr CreateProvider(string providerName, Interop.Advapi32.EtwEnableCallback callbackFunc);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_DefineEvent")]
-        internal static extern unsafe IntPtr DefineEvent(IntPtr provHandle, uint eventID, long keywords, uint eventVersion, uint level, void *pMetadata, uint metadataLength);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_DefineEvent")]
+        internal static unsafe partial IntPtr DefineEvent(IntPtr provHandle, uint eventID, long keywords, uint eventVersion, uint level, void *pMetadata, uint metadataLength);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetProvider", CharSet = CharSet.Unicode)]
-        internal static extern IntPtr GetProvider(string providerName);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetProvider", CharSet = CharSet.Unicode)]
+        internal static partial IntPtr GetProvider(string providerName);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_DeleteProvider")]
-        internal static extern void DeleteProvider(IntPtr provHandle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_DeleteProvider")]
+        internal static partial void DeleteProvider(IntPtr provHandle);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
         [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_EventActivityIdControl")]
         internal static extern int EventActivityIdControl(uint controlCode, ref Guid activityId);
+#pragma warning restore DLLIMPORTGENANALYZER015
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_WriteEventData")]
-        internal static extern unsafe void WriteEventData(IntPtr eventHandle, EventProvider.EventData* pEventData, uint dataCount, Guid* activityId, Guid* relatedActivityId);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_WriteEventData")]
+        internal static unsafe partial void WriteEventData(IntPtr eventHandle, EventProvider.EventData* pEventData, uint dataCount, Guid* activityId, Guid* relatedActivityId);
 
         //
         // These PInvokes are used as part of the EventPipeEventDispatcher.
         //
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetSessionInfo")]
-        internal static extern unsafe bool GetSessionInfo(ulong sessionID, EventPipeSessionInfo* pSessionInfo);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetSessionInfo")]
+        internal static unsafe partial bool GetSessionInfo(ulong sessionID, EventPipeSessionInfo* pSessionInfo);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetNextEvent")]
-        internal static extern unsafe bool GetNextEvent(ulong sessionID, EventPipeEventInstanceData* pInstance);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetNextEvent")]
+        internal static unsafe partial bool GetNextEvent(ulong sessionID, EventPipeEventInstanceData* pInstance);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetWaitHandle")]
-        internal static extern unsafe IntPtr GetWaitHandle(ulong sessionID);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetWaitHandle")]
+        internal static unsafe partial IntPtr GetWaitHandle(ulong sessionID);
     }
 }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/NativeRuntimeEventSource.PortableThreadPool.NativeSinks.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/Eventing/NativeRuntimeEventSource.PortableThreadPool.NativeSinks.CoreCLR.cs
@@ -14,28 +14,28 @@ namespace System.Diagnostics.Tracing
     internal sealed partial class NativeRuntimeEventSource : EventSource
     {
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolWorkerThreadStart(uint ActiveWorkerThreadCount, uint RetiredWorkerThreadCount, ushort ClrInstanceID);
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolWorkerThreadStart(uint ActiveWorkerThreadCount, uint RetiredWorkerThreadCount, ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolWorkerThreadStop(uint ActiveWorkerThreadCount, uint RetiredWorkerThreadCount, ushort ClrInstanceID);
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolWorkerThreadStop(uint ActiveWorkerThreadCount, uint RetiredWorkerThreadCount, ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolWorkerThreadWait(uint ActiveWorkerThreadCount, uint RetiredWorkerThreadCount, ushort ClrInstanceID);
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolWorkerThreadWait(uint ActiveWorkerThreadCount, uint RetiredWorkerThreadCount, ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolWorkerThreadAdjustmentSample(double Throughput, ushort ClrInstanceID);
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolWorkerThreadAdjustmentSample(double Throughput, ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolWorkerThreadAdjustmentAdjustment(double AverageThroughput, uint NewWorkerThreadCount, NativeRuntimeEventSource.ThreadAdjustmentReasonMap Reason, ushort ClrInstanceID);
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolWorkerThreadAdjustmentAdjustment(double AverageThroughput, uint NewWorkerThreadCount, NativeRuntimeEventSource.ThreadAdjustmentReasonMap Reason, ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolWorkerThreadAdjustmentStats(
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolWorkerThreadAdjustmentStats(
             double Duration,
             double Throughput,
             double ThreadPoolWorkerThreadWait,
@@ -49,23 +49,23 @@ namespace System.Diagnostics.Tracing
             ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolIOEnqueue(
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolIOEnqueue(
             IntPtr NativeOverlapped,
             IntPtr Overlapped,
             bool MultiDequeues,
             ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolIODequeue(
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolIODequeue(
             IntPtr NativeOverlapped,
             IntPtr Overlapped,
             ushort ClrInstanceID);
 
         [NonEvent]
-        [DllImport(RuntimeHelpers.QCall)]
-        internal static extern void LogThreadPoolWorkingThreadCount(
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        internal static partial void LogThreadPoolWorkingThreadCount(
             uint Count,
             ushort ClrInstanceID
         );

--- a/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreCLR.cs
@@ -54,8 +54,8 @@ namespace System.Diagnostics
 
         private static bool AppendStackFrameWithoutMethodBase(StringBuilder sb) => false;
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "StackFrame_GetMethodDescFromNativeIP")]
-        private static extern RuntimeMethodHandleInternal GetMethodDescFromNativeIP(IntPtr ip);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "StackFrame_GetMethodDescFromNativeIP")]
+        private static partial RuntimeMethodHandleInternal GetMethodDescFromNativeIP(IntPtr ip);
 
         /// <summary>
         /// Returns the MethodBase instance for the managed code IP address.

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -10,8 +10,8 @@ namespace System
 {
     public abstract partial class Enum
     {
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "Enum_GetValuesAndNames")]
-        private static extern void GetEnumValuesAndNames(QCallTypeHandle enumType, ObjectHandleOnStack values, ObjectHandleOnStack names, Interop.BOOL getNames);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "Enum_GetValuesAndNames")]
+        private static partial void GetEnumValuesAndNames(QCallTypeHandle enumType, ObjectHandleOnStack values, ObjectHandleOnStack names, Interop.BOOL getNames);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern object InternalBoxEnum(RuntimeType enumType, long value);

--- a/src/coreclr/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
@@ -18,9 +18,9 @@ namespace System
         }
 
         // Terminates this process with the given exit code.
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "Environment_Exit")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "Environment_Exit")]
         [DoesNotReturn]
-        private static extern void _Exit(int exitCode);
+        private static partial void _Exit(int exitCode);
 
         [DoesNotReturn]
         public static void Exit(int exitCode) => _Exit(exitCode);
@@ -84,8 +84,8 @@ namespace System
                 GetCommandLineArgsNative();
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "Environment_GetProcessorCount")]
-        private static extern int GetProcessorCount();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "Environment_GetProcessorCount")]
+        private static partial int GetProcessorCount();
 
         // Used by VM
         internal static string? GetResourceStringLocal(string key) => SR.GetResourceString(key);

--- a/src/coreclr/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -248,8 +248,8 @@ namespace System
             return retMesg!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ExceptionNative_GetMessageFromNativeResources")]
-        private static extern void GetMessageFromNativeResources(ExceptionMessageKind kind, StringHandleOnStack retMesg);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ExceptionNative_GetMessageFromNativeResources")]
+        private static partial void GetMessageFromNativeResources(ExceptionMessageKind kind, StringHandleOnStack retMesg);
 
         internal readonly struct DispatchState
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.cs
@@ -50,7 +50,7 @@ namespace System
         NotApplicable = 4
     }
 
-    public static class GC
+    public static partial class GC
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern void GetMemoryInfo(GCMemoryInfoData data, int kind);
@@ -78,11 +78,11 @@ namespace System
             return new GCMemoryInfo(data);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_StartNoGCRegion")]
-        internal static extern int _StartNoGCRegion(long totalSize, bool lohSizeKnown, long lohSize, bool disallowFullBlockingGC);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_StartNoGCRegion")]
+        internal static partial int _StartNoGCRegion(long totalSize, bool lohSizeKnown, long lohSize, bool disallowFullBlockingGC);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_EndNoGCRegion")]
-        internal static extern int _EndNoGCRegion();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_EndNoGCRegion")]
+        internal static partial int _EndNoGCRegion();
 
         // keep in sync with GC_ALLOC_FLAGS in gcinterface.h
         internal enum GC_ALLOC_FLAGS
@@ -98,11 +98,11 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern int GetGenerationWR(IntPtr handle);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_GetTotalMemory")]
-        private static extern long GetTotalMemory();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_GetTotalMemory")]
+        private static partial long GetTotalMemory();
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_Collect")]
-        private static extern void _Collect(int generation, int mode);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_Collect")]
+        private static partial void _Collect(int generation, int mode);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern int GetMaxGeneration();
@@ -119,11 +119,11 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern ulong GetGenerationSize(int gen);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_AddMemoryPressure")]
-        private static extern void _AddMemoryPressure(ulong bytesAllocated);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_AddMemoryPressure")]
+        private static partial void _AddMemoryPressure(ulong bytesAllocated);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_RemoveMemoryPressure")]
-        private static extern void _RemoveMemoryPressure(ulong bytesAllocated);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_RemoveMemoryPressure")]
+        private static partial void _RemoveMemoryPressure(ulong bytesAllocated);
 
         public static void AddMemoryPressure(long bytesAllocated)
         {
@@ -289,8 +289,8 @@ namespace System
         //
         public static int MaxGeneration => GetMaxGeneration();
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_WaitForPendingFinalizers")]
-        private static extern void _WaitForPendingFinalizers();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_WaitForPendingFinalizers")]
+        private static partial void _WaitForPendingFinalizers();
 
         public static void WaitForPendingFinalizers()
         {
@@ -352,11 +352,11 @@ namespace System
             return newSize;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_RegisterFrozenSegment")]
-        private static extern IntPtr _RegisterFrozenSegment(IntPtr sectionAddress, nint sectionSize);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_RegisterFrozenSegment")]
+        private static partial IntPtr _RegisterFrozenSegment(IntPtr sectionAddress, nint sectionSize);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_UnregisterFrozenSegment")]
-        private static extern void _UnregisterFrozenSegment(IntPtr segmentHandle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_UnregisterFrozenSegment")]
+        private static partial void _UnregisterFrozenSegment(IntPtr segmentHandle);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern long GetAllocatedBytesForCurrentThread();

--- a/src/coreclr/System.Private.CoreLib/src/System/IO/FileLoadException.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/IO/FileLoadException.CoreCLR.cs
@@ -31,10 +31,10 @@ namespace System.IO
             return string.Format(format!, fileName, message);
         }
 
-        [DllImport(RuntimeHelpers.QCall)]
-        private static extern void GetFileLoadExceptionMessage(int hResult, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        private static partial void GetFileLoadExceptionMessage(int hResult, StringHandleOnStack retString);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "FileLoadException_GetMessageForHR")]
-        private static extern void GetMessageForHR(int hresult, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "FileLoadException_GetMessageForHR")]
+        private static partial void GetMessageForHR(int hresult, StringHandleOnStack retString);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -54,8 +54,8 @@ namespace System.Reflection
             return RuntimeAssembly.InternalLoad(assemblyRef, ref stackMark, AssemblyLoadContext.CurrentContextualReflectionContext);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetExecutingAssembly")]
-        private static extern void GetExecutingAssemblyNative(StackCrawlMarkHandle stackMark, ObjectHandleOnStack retAssembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetExecutingAssembly")]
+        private static partial void GetExecutingAssemblyNative(StackCrawlMarkHandle stackMark, ObjectHandleOnStack retAssembly);
 
         internal static RuntimeAssembly GetExecutingAssembly(ref StackCrawlMark stackMark)
         {
@@ -82,8 +82,8 @@ namespace System.Reflection
             return GetExecutingAssembly(ref stackMark);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetEntryAssembly")]
-        private static extern void GetEntryAssemblyNative(ObjectHandleOnStack retAssembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetEntryAssembly")]
+        private static partial void GetEntryAssemblyNative(ObjectHandleOnStack retAssembly);
 
         private static Assembly? GetEntryAssemblyInternal()
         {
@@ -92,8 +92,8 @@ namespace System.Reflection
             return entryAssembly;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetAssemblyCount")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetAssemblyCount")]
         [SuppressGCTransition]
-        internal static extern uint GetAssemblyCount();
+        internal static partial uint GetAssemblyCount();
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -268,8 +268,8 @@ namespace System.Reflection.Emit
                                                  assemblyAttributes);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomain_CreateDynamicAssembly")]
-        private static extern void CreateDynamicAssembly(ObjectHandleOnStack name,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomain_CreateDynamicAssembly")]
+        private static partial void CreateDynamicAssembly(ObjectHandleOnStack name,
                                                          StackCrawlMarkHandle stackMark,
                                                          int access,
                                                          ObjectHandleOnStack assemblyLoadContext,

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.Emit
 {
-    internal sealed class InternalModuleBuilder : RuntimeModule
+    internal sealed partial class InternalModuleBuilder : RuntimeModule
     {
         // InternalModuleBuilder should not contain any data members as its reflectbase is the same as Module.
 
@@ -36,7 +36,7 @@ namespace System.Reflection.Emit
     }
 
     // deliberately not [serializable]
-    public class ModuleBuilder : Module
+    public partial class ModuleBuilder : Module
     {
         internal static string UnmangleTypeName(string typeName)
         {
@@ -118,11 +118,11 @@ namespace System.Reflection.Emit
             return SymbolType.FormCompoundType(strFormat, baseType, 0);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetTypeRef", CharSet = CharSet.Unicode)]
-        private static extern int GetTypeRef(QCallModule module, string strFullName, QCallModule refedModule, string? strRefedModuleFileName, int tkResolution);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetTypeRef", CharSet = CharSet.Unicode)]
+        private static partial int GetTypeRef(QCallModule module, string strFullName, QCallModule refedModule, string? strRefedModuleFileName, int tkResolution);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRef")]
-        private static extern int GetMemberRef(QCallModule module, QCallModule refedModule, int tr, int defToken);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRef")]
+        private static partial int GetMemberRef(QCallModule module, QCallModule refedModule, int tr, int defToken);
 
         private int GetMemberRef(Module? refedModule, int tr, int defToken)
         {
@@ -132,8 +132,8 @@ namespace System.Reflection.Emit
             return GetMemberRef(new QCallModule(ref thisModule), new QCallModule(ref refedRuntimeModule), tr, defToken);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRefFromSignature", CharSet = CharSet.Unicode)]
-        private static extern int GetMemberRefFromSignature(QCallModule module, int tr, string methodName, byte[] signature, int length);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRefFromSignature", CharSet = CharSet.Unicode)]
+        private static partial int GetMemberRefFromSignature(QCallModule module, int tr, string methodName, byte[] signature, int length);
 
         private int GetMemberRefFromSignature(int tr, string methodName, byte[] signature, int length)
         {
@@ -141,8 +141,8 @@ namespace System.Reflection.Emit
             return GetMemberRefFromSignature(new QCallModule(ref thisModule), tr, methodName, signature, length);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRefOfMethodInfo")]
-        private static extern int GetMemberRefOfMethodInfo(QCallModule module, int tr, RuntimeMethodHandleInternal method);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRefOfMethodInfo")]
+        private static partial int GetMemberRefOfMethodInfo(QCallModule module, int tr, RuntimeMethodHandleInternal method);
 
         private int GetMemberRefOfMethodInfo(int tr, RuntimeMethodInfo method)
         {
@@ -164,8 +164,8 @@ namespace System.Reflection.Emit
             return result;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRefOfFieldInfo")]
-        private static extern int GetMemberRefOfFieldInfo(QCallModule module, int tkType, QCallTypeHandle declaringType, int tkField);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetMemberRefOfFieldInfo")]
+        private static partial int GetMemberRefOfFieldInfo(QCallModule module, int tkType, QCallTypeHandle declaringType, int tkField);
 
         private int GetMemberRefOfFieldInfo(int tkType, RuntimeTypeHandle declaringType, RuntimeFieldInfo runtimeField)
         {
@@ -175,8 +175,8 @@ namespace System.Reflection.Emit
             return GetMemberRefOfFieldInfo(new QCallModule(ref thisModule), tkType, new QCallTypeHandle(ref declaringType), runtimeField.MetadataToken);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetTokenFromTypeSpec")]
-        private static extern int GetTokenFromTypeSpec(QCallModule pModule, byte[] signature, int length);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetTokenFromTypeSpec")]
+        private static partial int GetTokenFromTypeSpec(QCallModule pModule, byte[] signature, int length);
 
         private int GetTokenFromTypeSpec(byte[] signature, int length)
         {
@@ -184,14 +184,14 @@ namespace System.Reflection.Emit
             return GetTokenFromTypeSpec(new QCallModule(ref thisModule), signature, length);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetArrayMethodToken", CharSet = CharSet.Unicode)]
-        private static extern int GetArrayMethodToken(QCallModule module, int tkTypeSpec, string methodName, byte[] signature, int sigLength);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetArrayMethodToken", CharSet = CharSet.Unicode)]
+        private static partial int GetArrayMethodToken(QCallModule module, int tkTypeSpec, string methodName, byte[] signature, int sigLength);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetStringConstant", CharSet = CharSet.Unicode)]
-        private static extern int GetStringConstant(QCallModule module, string str, int length);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_GetStringConstant", CharSet = CharSet.Unicode)]
+        private static partial int GetStringConstant(QCallModule module, string str, int length);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_SetFieldRVAContent")]
-        internal static extern void SetFieldRVAContent(QCallModule module, int fdToken, byte[]? data, int length);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleBuilder_SetFieldRVAContent")]
+        internal static partial void SetFieldRVAContent(QCallModule module, int fdToken, byte[]? data, int length);
 
         #endregion
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -10,7 +10,7 @@ using CultureInfo = System.Globalization.CultureInfo;
 
 namespace System.Reflection.Emit
 {
-    public sealed class TypeBuilder : TypeInfo
+    public sealed partial class TypeBuilder : TypeInfo
     {
         public override bool IsAssignableFrom([NotNullWhen(true)] TypeInfo? typeInfo)
         {
@@ -149,35 +149,35 @@ namespace System.Reflection.Emit
         #endregion
 
         #region Private Static FCalls
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetParentType")]
-        private static extern void SetParentType(QCallModule module, int tdTypeDef, int tkParent);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetParentType")]
+        private static partial void SetParentType(QCallModule module, int tdTypeDef, int tkParent);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_AddInterfaceImpl")]
-        private static extern void AddInterfaceImpl(QCallModule module, int tdTypeDef, int tkInterface);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_AddInterfaceImpl")]
+        private static partial void AddInterfaceImpl(QCallModule module, int tdTypeDef, int tkInterface);
         #endregion
 
         #region Internal Static FCalls
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethod", CharSet = CharSet.Unicode)]
-        internal static extern int DefineMethod(QCallModule module, int tkParent, string name, byte[] signature, int sigLength,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethod", CharSet = CharSet.Unicode)]
+        internal static partial int DefineMethod(QCallModule module, int tkParent, string name, byte[] signature, int sigLength,
             MethodAttributes attributes);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethodSpec")]
-        internal static extern int DefineMethodSpec(QCallModule module, int tkParent, byte[] signature, int sigLength);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethodSpec")]
+        internal static partial int DefineMethodSpec(QCallModule module, int tkParent, byte[] signature, int sigLength);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineField", CharSet = CharSet.Unicode)]
-        internal static extern int DefineField(QCallModule module, int tkParent, string name, byte[] signature, int sigLength,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineField", CharSet = CharSet.Unicode)]
+        internal static partial int DefineField(QCallModule module, int tkParent, string name, byte[] signature, int sigLength,
             FieldAttributes attributes);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetMethodIL")]
-        private static extern void SetMethodIL(QCallModule module, int tk, bool isInitLocals,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetMethodIL")]
+        private static partial void SetMethodIL(QCallModule module, int tk, bool isInitLocals,
             byte[]? body, int bodyLength,
             byte[] LocalSig, int sigLength,
             int maxStackSize,
             ExceptionHandler[]? exceptions, int numExceptions,
             int[]? tokenFixups, int numTokenFixups);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineCustomAttribute")]
-        private static extern void DefineCustomAttribute(QCallModule module, int tkAssociate, int tkConstructor,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineCustomAttribute")]
+        private static partial void DefineCustomAttribute(QCallModule module, int tkAssociate, int tkConstructor,
             byte[]? attr, int attrLength);
 
         internal static void DefineCustomAttribute(ModuleBuilder module, int tkAssociate, int tkConstructor,
@@ -195,41 +195,41 @@ namespace System.Reflection.Emit
                 localAttr, (localAttr != null) ? localAttr.Length : 0);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineProperty", CharSet = CharSet.Unicode)]
-        internal static extern int DefineProperty(QCallModule module, int tkParent, string name, PropertyAttributes attributes,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineProperty", CharSet = CharSet.Unicode)]
+        internal static partial int DefineProperty(QCallModule module, int tkParent, string name, PropertyAttributes attributes,
             byte[] signature, int sigLength);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineEvent", CharSet = CharSet.Unicode)]
-        internal static extern int DefineEvent(QCallModule module, int tkParent, string name, EventAttributes attributes, int tkEventType);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineEvent", CharSet = CharSet.Unicode)]
+        internal static partial int DefineEvent(QCallModule module, int tkParent, string name, EventAttributes attributes, int tkEventType);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethodSemantics")]
-        internal static extern void DefineMethodSemantics(QCallModule module, int tkAssociation,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethodSemantics")]
+        internal static partial void DefineMethodSemantics(QCallModule module, int tkAssociation,
             MethodSemanticsAttributes semantics, int tkMethod);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethodImpl")]
-        internal static extern void DefineMethodImpl(QCallModule module, int tkType, int tkBody, int tkDecl);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineMethodImpl")]
+        internal static partial void DefineMethodImpl(QCallModule module, int tkType, int tkBody, int tkDecl);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetMethodImpl")]
-        internal static extern void SetMethodImpl(QCallModule module, int tkMethod, MethodImplAttributes MethodImplAttributes);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetMethodImpl")]
+        internal static partial void SetMethodImpl(QCallModule module, int tkMethod, MethodImplAttributes MethodImplAttributes);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetParamInfo", CharSet = CharSet.Unicode)]
-        internal static extern int SetParamInfo(QCallModule module, int tkMethod, int iSequence,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetParamInfo", CharSet = CharSet.Unicode)]
+        internal static partial int SetParamInfo(QCallModule module, int tkMethod, int iSequence,
             ParameterAttributes iParamAttributes, string? strParamName);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_GetTokenFromSig")]
-        internal static extern int GetTokenFromSig(QCallModule module, byte[] signature, int sigLength);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_GetTokenFromSig")]
+        internal static partial int GetTokenFromSig(QCallModule module, byte[] signature, int sigLength);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetFieldLayoutOffset")]
-        internal static extern void SetFieldLayoutOffset(QCallModule module, int fdToken, int iOffset);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetFieldLayoutOffset")]
+        internal static partial void SetFieldLayoutOffset(QCallModule module, int fdToken, int iOffset);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetClassLayout")]
-        internal static extern void SetClassLayout(QCallModule module, int tk, PackingSize iPackingSize, int iTypeSize);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetClassLayout")]
+        internal static partial void SetClassLayout(QCallModule module, int tk, PackingSize iPackingSize, int iTypeSize);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetConstantValue")]
-        private static extern unsafe void SetConstantValue(QCallModule module, int tk, int corType, void* pValue);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetConstantValue")]
+        private static unsafe partial void SetConstantValue(QCallModule module, int tk, int corType, void* pValue);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetPInvokeData", CharSet = CharSet.Unicode)]
-        private static extern void SetPInvokeData(QCallModule module, string DllName, string name, int token, int linkFlags);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetPInvokeData", CharSet = CharSet.Unicode)]
+        private static partial void SetPInvokeData(QCallModule module, string DllName, string name, int token, int linkFlags);
 
         #endregion
         #region Internal\Private Static Members
@@ -655,16 +655,16 @@ namespace System.Reflection.Emit
         #endregion
 
         #region FCalls
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineType", CharSet = CharSet.Unicode)]
-        private static extern int DefineType(QCallModule module,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineType", CharSet = CharSet.Unicode)]
+        private static partial int DefineType(QCallModule module,
             string fullname, int tkParent, TypeAttributes attributes, int tkEnclosingType, int[] interfaceTokens);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineGenericParam", CharSet = CharSet.Unicode)]
-        private static extern int DefineGenericParam(QCallModule module,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_DefineGenericParam", CharSet = CharSet.Unicode)]
+        private static partial int DefineGenericParam(QCallModule module,
             string name, int tkParent, GenericParameterAttributes attributes, int position, int[] constraints);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_TermCreateClass")]
-        private static extern void TermCreateClass(QCallModule module, int tk, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_TermCreateClass")]
+        private static partial void TermCreateClass(QCallModule module, int tk, ObjectHandleOnStack type);
         #endregion
 
         #region Internal Methods

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
@@ -20,13 +20,13 @@ namespace System.Reflection
     // The finalization does not have to be done using CriticalFinalizerObject. We have to go over all LoaderAllocators
     // during AppDomain shutdown anyway to avoid leaks e.g. if somebody stores reference to LoaderAllocator in a static.
     //
-    internal sealed class LoaderAllocatorScout
+    internal sealed partial class LoaderAllocatorScout
     {
         // This field is set by the VM to atomically transfer the ownership to the managed loader allocator
         internal IntPtr m_nativeLoaderAllocator;
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "LoaderAllocator_Destroy")]
-        private static extern bool Destroy(IntPtr nativeLoaderAllocator);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "LoaderAllocator_Destroy")]
+        private static partial bool Destroy(IntPtr nativeLoaderAllocator);
 
         ~LoaderAllocatorScout()
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.Metadata
 {
-    public static class AssemblyExtensions
+    public static partial class AssemblyExtensions
     {
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InternalTryGetRawMetadata")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InternalTryGetRawMetadata")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern unsafe bool InternalTryGetRawMetadata(QCallAssembly assembly, ref byte* blob, ref int length);
+        private static unsafe partial bool InternalTryGetRawMetadata(QCallAssembly assembly, ref byte* blob, ref int length);
 
         // Retrieves the metadata section of the assembly, for use with System.Reflection.Metadata.MetadataReader.
         //   - Returns false upon failure. Metadata might not be available for some assemblies, such as AssemblyBuilder, .NET

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
@@ -7,13 +7,13 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.Metadata
 {
-    public static class MetadataUpdater
+    public static partial class MetadataUpdater
     {
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_ApplyUpdate")]
-        private static extern unsafe void ApplyUpdate(QCallAssembly assembly, byte* metadataDelta, int metadataDeltaLength, byte* ilDelta, int ilDeltaLength, byte* pdbDelta, int pdbDeltaLength);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_ApplyUpdate")]
+        private static unsafe partial void ApplyUpdate(QCallAssembly assembly, byte* metadataDelta, int metadataDeltaLength, byte* ilDelta, int ilDeltaLength, byte* pdbDelta, int pdbDeltaLength);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_IsApplyUpdateSupported")]
-        private static extern unsafe bool IsApplyUpdateSupported();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_IsApplyUpdateSupported")]
+        private static unsafe partial bool IsApplyUpdateSupported();
 
         /// <summary>
         /// Updates the specified assembly using the provided metadata, IL and PDB deltas.

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -16,7 +16,7 @@ using System.Threading;
 
 namespace System.Reflection
 {
-    internal class RuntimeAssembly : Assembly
+    internal partial class RuntimeAssembly : Assembly
     {
         internal RuntimeAssembly() { throw new NotSupportedException(); }
 
@@ -68,8 +68,8 @@ namespace System.Reflection
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetCodeBase")]
-        private static extern bool GetCodeBase(QCallAssembly assembly,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetCodeBase")]
+        private static partial bool GetCodeBase(QCallAssembly assembly,
                                                StringHandleOnStack retString);
 
         internal string? GetCodeBase()
@@ -126,8 +126,8 @@ namespace System.Reflection
             return an;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetFullName")]
-        private static extern void GetFullName(QCallAssembly assembly, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetFullName")]
+        private static partial void GetFullName(QCallAssembly assembly, StringHandleOnStack retString);
 
         public override string? FullName
         {
@@ -146,8 +146,8 @@ namespace System.Reflection
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetEntryPoint")]
-        private static extern void GetEntryPoint(QCallAssembly assembly, ObjectHandleOnStack retMethod);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetEntryPoint")]
+        private static partial void GetEntryPoint(QCallAssembly assembly, ObjectHandleOnStack retMethod);
 
         public override MethodInfo? EntryPoint
         {
@@ -164,8 +164,8 @@ namespace System.Reflection
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetType", CharSet = CharSet.Unicode)]
-        private static extern void GetType(QCallAssembly assembly,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetType", CharSet = CharSet.Unicode)]
+        private static partial void GetType(QCallAssembly assembly,
                                             string name,
                                             bool throwOnError,
                                             bool ignoreCase,
@@ -197,8 +197,8 @@ namespace System.Reflection
             return type;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetExportedTypes")]
-        private static extern void GetExportedTypes(QCallAssembly assembly, ObjectHandleOnStack retTypes);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetExportedTypes")]
+        private static partial void GetExportedTypes(QCallAssembly assembly, ObjectHandleOnStack retTypes);
 
         [RequiresUnreferencedCode("Types might be removed")]
         public override Type[] GetExportedTypes()
@@ -231,8 +231,8 @@ namespace System.Reflection
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetIsCollectible")]
-        internal static extern Interop.BOOL GetIsCollectible(QCallAssembly assembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetIsCollectible")]
+        internal static partial Interop.BOOL GetIsCollectible(QCallAssembly assembly);
 
         public override bool IsCollectible
         {
@@ -244,8 +244,8 @@ namespace System.Reflection
         }
 
         // GetResource will return a pointer to the resources in memory.
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetResource", CharSet = CharSet.Unicode)]
-        private static extern unsafe byte* GetResource(QCallAssembly assembly,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetResource", CharSet = CharSet.Unicode)]
+        private static unsafe partial byte* GetResource(QCallAssembly assembly,
                                                        string resourceName,
                                                        out uint length);
 
@@ -343,8 +343,8 @@ namespace System.Reflection
             return retAssembly!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InternalLoad")]
-        private static extern void InternalLoad(ObjectHandleOnStack assemblyName,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InternalLoad")]
+        private static partial void InternalLoad(ObjectHandleOnStack assemblyName,
                                                 ObjectHandleOnStack requestingAssembly,
                                                 StackCrawlMarkHandle stackMark,
                                                 bool throwOnFileNotFound,
@@ -355,8 +355,8 @@ namespace System.Reflection
 
         // Returns the module in this assembly with name 'name'
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetModule", CharSet = CharSet.Unicode)]
-        private static extern void GetModule(QCallAssembly assembly, string name, ObjectHandleOnStack retModule);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetModule", CharSet = CharSet.Unicode)]
+        private static partial void GetModule(QCallAssembly assembly, string name, ObjectHandleOnStack retModule);
 
         public override Module? GetModule(string name)
         {
@@ -428,8 +428,8 @@ namespace System.Reflection
             return GetReferencedAssemblies(GetNativeHandle());
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetManifestResourceInfo", CharSet = CharSet.Unicode)]
-        private static extern int GetManifestResourceInfo(QCallAssembly assembly,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetManifestResourceInfo", CharSet = CharSet.Unicode)]
+        private static partial int GetManifestResourceInfo(QCallAssembly assembly,
                                                           string resourceName,
                                                           ObjectHandleOnStack assemblyRef,
                                                           StringHandleOnStack retFileName);
@@ -450,8 +450,8 @@ namespace System.Reflection
                                                 (ResourceLocation)location);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetLocation")]
-        private static extern void GetLocation(QCallAssembly assembly, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetLocation")]
+        private static partial void GetLocation(QCallAssembly assembly, StringHandleOnStack retString);
 
         public override string Location
         {
@@ -466,8 +466,8 @@ namespace System.Reflection
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetImageRuntimeVersion")]
-        private static extern void GetImageRuntimeVersion(QCallAssembly assembly, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetImageRuntimeVersion")]
+        private static partial void GetImageRuntimeVersion(QCallAssembly assembly, StringHandleOnStack retString);
 
         public override string ImageRuntimeVersion
         {
@@ -485,8 +485,8 @@ namespace System.Reflection
 
         public override long HostContext => 0;
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetVersion")]
-        private static extern void GetVersion(QCallAssembly assembly,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetVersion")]
+        private static partial void GetVersion(QCallAssembly assembly,
                                               out int majVer,
                                               out int minVer,
                                               out int buildNum,
@@ -499,8 +499,8 @@ namespace System.Reflection
             return new Version(majorVer, minorVer, build, revision);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetLocale")]
-        private static extern void GetLocale(QCallAssembly assembly, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetLocale")]
+        private static partial void GetLocale(QCallAssembly assembly, StringHandleOnStack retString);
 
         internal CultureInfo GetLocale()
         {
@@ -520,8 +520,8 @@ namespace System.Reflection
 
         public override bool IsDynamic => FCallIsDynamic(GetNativeHandle());
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetSimpleName")]
-        private static extern void GetSimpleName(QCallAssembly assembly, StringHandleOnStack retSimpleName);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetSimpleName")]
+        private static partial void GetSimpleName(QCallAssembly assembly, StringHandleOnStack retSimpleName);
 
         internal string? GetSimpleName()
         {
@@ -531,8 +531,8 @@ namespace System.Reflection
             return name;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetHashAlgorithm")]
-        private static extern AssemblyHashAlgorithm GetHashAlgorithm(QCallAssembly assembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetHashAlgorithm")]
+        private static partial AssemblyHashAlgorithm GetHashAlgorithm(QCallAssembly assembly);
 
         private AssemblyHashAlgorithm GetHashAlgorithm()
         {
@@ -540,8 +540,8 @@ namespace System.Reflection
             return GetHashAlgorithm(new QCallAssembly(ref runtimeAssembly));
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetFlags")]
-        private static extern AssemblyNameFlags GetFlags(QCallAssembly assembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetFlags")]
+        private static partial AssemblyNameFlags GetFlags(QCallAssembly assembly);
 
         private AssemblyNameFlags GetFlags()
         {
@@ -549,8 +549,8 @@ namespace System.Reflection
             return GetFlags(new QCallAssembly(ref runtimeAssembly));
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetPublicKey")]
-        private static extern void GetPublicKey(QCallAssembly assembly, ObjectHandleOnStack retPublicKey);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetPublicKey")]
+        private static partial void GetPublicKey(QCallAssembly assembly, ObjectHandleOnStack retPublicKey);
 
         internal byte[]? GetPublicKey()
         {
@@ -604,8 +604,8 @@ namespace System.Reflection
             return retAssembly;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetModules")]
-        private static extern void GetModules(QCallAssembly assembly,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetModules")]
+        private static partial void GetModules(QCallAssembly assembly,
                                               bool loadIfNotFound,
                                               bool getResourceModules,
                                               ObjectHandleOnStack retModuleHandles);
@@ -709,7 +709,7 @@ namespace System.Reflection
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetForwardedType")]
-        private static extern void GetForwardedType(QCallAssembly assembly, MetadataToken mdtExternalType, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetForwardedType")]
+        private static partial void GetForwardedType(QCallAssembly assembly, MetadataToken mdtExternalType, ObjectHandleOnStack type);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -9,19 +9,19 @@ using System.Runtime.CompilerServices;
 
 namespace System.Reflection
 {
-    internal class RuntimeModule : Module
+    internal partial class RuntimeModule : Module
     {
         internal RuntimeModule() { throw new NotSupportedException(); }
 
         #region FCalls
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetType", CharSet = CharSet.Unicode)]
-        private static extern void GetType(QCallModule module, string className, bool throwOnError, bool ignoreCase, ObjectHandleOnStack type, ObjectHandleOnStack keepAlive);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetType", CharSet = CharSet.Unicode)]
+        private static partial void GetType(QCallModule module, string className, bool throwOnError, bool ignoreCase, ObjectHandleOnStack type, ObjectHandleOnStack keepAlive);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetScopeName")]
-        private static extern void GetScopeName(QCallModule module, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetScopeName")]
+        private static partial void GetScopeName(QCallModule module, StringHandleOnStack retString);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetFullyQualifiedName")]
-        private static extern void GetFullyQualifiedName(QCallModule module, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeModule_GetFullyQualifiedName")]
+        private static partial void GetFullyQualifiedName(QCallModule module, StringHandleOnStack retString);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern RuntimeType[] GetTypes(RuntimeModule module);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -48,8 +48,8 @@ namespace System.Runtime.CompilerServices
         // This call will generate an exception if the specified class constructor threw an
         // exception when it ran.
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_RunClassConstructor")]
-        private static extern void RunClassConstructor(QCallTypeHandle type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_RunClassConstructor")]
+        private static partial void RunClassConstructor(QCallTypeHandle type);
 
         [RequiresUnreferencedCode("Trimmer can't guarantee existence of class constructor")]
         public static void RunClassConstructor(RuntimeTypeHandle type)
@@ -69,8 +69,8 @@ namespace System.Runtime.CompilerServices
         // This call will generate an exception if the specified module constructor threw an
         // exception when it ran.
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_RunModuleConstructor")]
-        private static extern void RunModuleConstructor(QCallModule module);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_RunModuleConstructor")]
+        private static partial void RunModuleConstructor(QCallModule module);
 
         public static void RunModuleConstructor(ModuleHandle module)
         {
@@ -81,11 +81,11 @@ namespace System.Runtime.CompilerServices
             RunModuleConstructor(new QCallModule(ref rm));
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_CompileMethod")]
-        internal static extern void CompileMethod(RuntimeMethodHandleInternal method);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_CompileMethod")]
+        internal static partial void CompileMethod(RuntimeMethodHandleInternal method);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_PrepareMethod")]
-        private static extern unsafe void PrepareMethod(RuntimeMethodHandleInternal method, IntPtr* pInstantiation, int cInstantiation);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_PrepareMethod")]
+        private static unsafe partial void PrepareMethod(RuntimeMethodHandleInternal method, IntPtr* pInstantiation, int cInstantiation);
 
         public static void PrepareMethod(RuntimeMethodHandle method) => PrepareMethod(method, null);
 
@@ -173,8 +173,8 @@ namespace System.Runtime.CompilerServices
             return obj!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionSerialization_GetUninitializedObject")]
-        private static extern void GetUninitializedObject(QCallTypeHandle type, ObjectHandleOnStack retObject);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionSerialization_GetUninitializedObject")]
+        private static partial void GetUninitializedObject(QCallTypeHandle type, ObjectHandleOnStack retObject);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern object AllocateUninitializedClone(object obj);
@@ -305,8 +305,8 @@ namespace System.Runtime.CompilerServices
             return AllocateTypeAssociatedMemory(new QCallTypeHandle(ref rt), (uint)size);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_AllocateTypeAssociatedMemory")]
-        private static extern IntPtr AllocateTypeAssociatedMemory(QCallTypeHandle type, uint size);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_AllocateTypeAssociatedMemory")]
+        private static partial IntPtr AllocateTypeAssociatedMemory(QCallTypeHandle type, uint size);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern IntPtr AllocTailCallArgBuffer(int size, IntPtr gcDesc);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -103,8 +103,8 @@ namespace System.Runtime.InteropServices
             return TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack.Create(ref impl), impl.id, ObjectHandleOnStack.Create(ref instance), flags, out retValue);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetOrCreateComInterfaceForObject")]
-        private static extern bool TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, ObjectHandleOnStack instance, CreateComInterfaceFlags flags, out IntPtr retValue);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetOrCreateComInterfaceForObject")]
+        private static partial bool TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, ObjectHandleOnStack instance, CreateComInterfaceFlags flags, out IntPtr retValue);
 
         // Called by the runtime to execute the abstract instance function
         internal static unsafe void* CallComputeVtables(ComWrappersScenario scenario, ComWrappers? comWrappersImpl, object obj, CreateComInterfaceFlags flags, out int count)
@@ -251,8 +251,8 @@ namespace System.Runtime.InteropServices
             return TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack.Create(ref impl), impl.id, externalComObject, innerMaybe, flags, ObjectHandleOnStack.Create(ref wrapperMaybeLocal), ObjectHandleOnStack.Create(ref retValue));
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetOrCreateObjectForComInstance")]
-        private static extern bool TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, IntPtr externalComObject, IntPtr innerMaybe, CreateObjectFlags flags, ObjectHandleOnStack wrapper, ObjectHandleOnStack retValue);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_TryGetOrCreateObjectForComInstance")]
+        private static partial bool TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, IntPtr externalComObject, IntPtr innerMaybe, CreateObjectFlags flags, ObjectHandleOnStack wrapper, ObjectHandleOnStack retValue);
 
         // Call to execute the virtual instance function
         internal static void CallReleaseObjects(ComWrappers? comWrappersImpl, IEnumerable objects)
@@ -283,9 +283,9 @@ namespace System.Runtime.InteropServices
         }
 
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_SetGlobalInstanceRegisteredForTrackerSupport")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_SetGlobalInstanceRegisteredForTrackerSupport")]
         [SuppressGCTransition]
-        private static extern void SetGlobalInstanceRegisteredForTrackerSupport(long id);
+        private static partial void SetGlobalInstanceRegisteredForTrackerSupport(long id);
 
         /// <summary>
         /// Register a <see cref="ComWrappers" /> instance to be used as the global instance for marshalling in the runtime.
@@ -317,9 +317,9 @@ namespace System.Runtime.InteropServices
             SetGlobalInstanceRegisteredForMarshalling(instance.id);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_SetGlobalInstanceRegisteredForMarshalling")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_SetGlobalInstanceRegisteredForMarshalling")]
         [SuppressGCTransition]
-        private static extern void SetGlobalInstanceRegisteredForMarshalling(long id);
+        private static partial void SetGlobalInstanceRegisteredForMarshalling(long id);
 
         /// <summary>
         /// Get the runtime provided IUnknown implementation.
@@ -330,8 +330,8 @@ namespace System.Runtime.InteropServices
         protected static void GetIUnknownImpl(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease)
             => GetIUnknownImplInternal(out fpQueryInterface, out fpAddRef, out fpRelease);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_GetIUnknownImpl")]
-        private static extern void GetIUnknownImplInternal(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_GetIUnknownImpl")]
+        private static partial void GetIUnknownImplInternal(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease);
 
         internal static int CallICustomQueryInterface(object customQueryInterfaceMaybe, ref Guid iid, out IntPtr ppObject)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -192,8 +192,8 @@ namespace System.Runtime.InteropServices
             GC.KeepAlive(rmi);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_Prelink")]
-        private static extern void InternalPrelink(RuntimeMethodHandleInternal m);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_Prelink")]
+        private static partial void InternalPrelink(RuntimeMethodHandleInternal m);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern /* struct _EXCEPTION_POINTERS* */ IntPtr GetExceptionPointers();
@@ -228,8 +228,8 @@ namespace System.Runtime.InteropServices
 #if TARGET_WINDOWS
         internal static bool IsBuiltInComSupported { get; } = IsBuiltInComSupportedInternal();
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_IsBuiltInComSupported")]
-        private static extern bool IsBuiltInComSupportedInternal();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_IsBuiltInComSupported")]
+        private static partial bool IsBuiltInComSupportedInternal();
 
         /// <summary>
         /// Returns the HInstance for this module.  Returns -1 if the module doesn't have
@@ -250,8 +250,8 @@ namespace System.Runtime.InteropServices
             return (IntPtr)(-1);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_GetHINSTANCE")]
-        private static extern IntPtr GetHINSTANCE(QCallModule m);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_GetHINSTANCE")]
+        private static partial IntPtr GetHINSTANCE(QCallModule m);
 
 #endif // TARGET_WINDOWS
 
@@ -298,9 +298,11 @@ namespace System.Runtime.InteropServices
             GetTypeFromCLSID(clsid, server, ObjectHandleOnStack.Create(ref type));
             return type;
         }
-
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
         [DllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_GetTypeFromCLSID", CharSet = CharSet.Unicode)]
         private static extern void GetTypeFromCLSID(in Guid clsid, string? server, ObjectHandleOnStack retType);
+#pragma warning restore DLLIMPORTGENANALYZER015
 
         /// <summary>
         /// Return the IUnknown* for an Object if the current context is the one
@@ -777,6 +779,8 @@ namespace System.Runtime.InteropServices
 
             return obj;
         }
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // These methods use built-in COM interop, which is not supported by the source generator.
 
         // Revist after https://github.com/mono/linker/issues/1989 is fixed
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2050:UnrecognizedReflectionPattern",
@@ -793,6 +797,7 @@ namespace System.Runtime.InteropServices
             Justification = "The calling method is annotated with RequiresUnreferencedCode")]
         [DllImport(Interop.Libraries.Ole32, PreserveSig = false)]
         private static extern void BindMoniker(IMoniker pmk, uint grfOpt, ref Guid iidResult, [MarshalAs(UnmanagedType.Interface)] out object ppvResult);
+#pragma warning restore DLLIMPORTGENANALYZER015
 
         [SupportedOSPlatform("windows")]
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -806,8 +811,8 @@ namespace System.Runtime.InteropServices
         internal static extern IntPtr GetFunctionPointerForDelegateInternal(Delegate d);
 
 #if DEBUG // Used for testing in Checked or Debug
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_GetIsInCooperativeGCModeFunctionPointer")]
-        internal static unsafe extern delegate* unmanaged<int> GetIsInCooperativeGCModeFunctionPointer();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_GetIsInCooperativeGCModeFunctionPointer")]
+        internal static unsafe partial delegate* unmanaged<int> GetIsInCooperativeGCModeFunctionPointer();
 #endif
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreCLR.cs
@@ -20,18 +20,18 @@ namespace System.Runtime.InteropServices
 
         /// External functions that implement the NativeLibrary interface
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_LoadFromPath", CharSet = CharSet.Unicode)]
-        internal static extern IntPtr LoadFromPath(string libraryName, bool throwOnError);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_LoadFromPath", CharSet = CharSet.Unicode)]
+        internal static partial IntPtr LoadFromPath(string libraryName, bool throwOnError);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_LoadByName", CharSet = CharSet.Unicode)]
-        internal static extern IntPtr LoadByName(string libraryName, QCallAssembly callingAssembly,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_LoadByName", CharSet = CharSet.Unicode)]
+        internal static partial IntPtr LoadByName(string libraryName, QCallAssembly callingAssembly,
                                                  bool hasDllImportSearchPathFlag, uint dllImportSearchPathFlag,
                                                  bool throwOnError);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_FreeLib")]
-        internal static extern void FreeLib(IntPtr handle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_FreeLib")]
+        internal static partial void FreeLib(IntPtr handle);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_GetSymbol", CharSet = CharSet.Unicode)]
-        internal static extern IntPtr GetSymbol(IntPtr handle, string symbolName, bool throwOnError);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "NativeLibrary_GetSymbol", CharSet = CharSet.Unicode)]
+        internal static partial IntPtr GetSymbol(IntPtr handle, string symbolName, bool throwOnError);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
@@ -21,19 +21,19 @@ namespace System.Runtime.InteropServices.ObjectiveC
             System.StubHelpers.StubHelpers.SetPendingExceptionObject(exception);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_TrySetGlobalMessageSendCallback")]
-        private static extern bool TrySetGlobalMessageSendCallback(
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_TrySetGlobalMessageSendCallback")]
+        private static partial bool TrySetGlobalMessageSendCallback(
             MessageSendFunction msgSendFunction,
             IntPtr func);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_TryInitializeReferenceTracker")]
-        private static unsafe extern bool TryInitializeReferenceTracker(
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_TryInitializeReferenceTracker")]
+        private static unsafe partial bool TryInitializeReferenceTracker(
             delegate* unmanaged<void> beginEndCallback,
             delegate* unmanaged<IntPtr, int> isReferencedCallback,
             delegate* unmanaged<IntPtr, void> trackedObjectEnteredFinalization);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_CreateReferenceTrackingHandle")]
-        private static extern IntPtr CreateReferenceTrackingHandleInternal(
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ObjCMarshal_CreateReferenceTrackingHandle")]
+        private static partial IntPtr CreateReferenceTrackingHandleInternal(
             ObjectHandleOnStack obj,
             out int memInSizeT,
             out IntPtr mem);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.CoreCLR.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.Intrinsics.X86
 {
     public abstract partial class X86Base
     {
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "X86BaseCpuId")]
-        private static extern unsafe void __cpuidex(int* cpuInfo, int functionId, int subFunctionId);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "X86BaseCpuId")]
+        private static unsafe partial void __cpuidex(int* cpuInfo, int functionId, int subFunctionId);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -11,25 +11,25 @@ namespace System.Runtime.Loader
 {
     public partial class AssemblyLoadContext
     {
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InitializeAssemblyLoadContext")]
-        private static extern IntPtr InitializeAssemblyLoadContext(IntPtr ptrAssemblyLoadContext, bool fRepresentsTPALoadContext, bool isCollectible);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InitializeAssemblyLoadContext")]
+        private static partial IntPtr InitializeAssemblyLoadContext(IntPtr ptrAssemblyLoadContext, bool fRepresentsTPALoadContext, bool isCollectible);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_PrepareForAssemblyLoadContextRelease")]
-        private static extern void PrepareForAssemblyLoadContextRelease(IntPtr ptrNativeAssemblyBinder, IntPtr ptrAssemblyLoadContextStrong);
-
-        [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed")]
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_LoadFromStream")]
-        private static extern void LoadFromStream(IntPtr ptrNativeAssemblyBinder, IntPtr ptrAssemblyArray, int iAssemblyArrayLen, IntPtr ptrSymbols, int iSymbolArrayLen, ObjectHandleOnStack retAssembly);
-
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MultiCoreJIT_InternalSetProfileRoot", CharSet = CharSet.Unicode)]
-        internal static extern void InternalSetProfileRoot(string directoryPath);
-
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MultiCoreJIT_InternalStartProfile", CharSet = CharSet.Unicode)]
-        internal static extern void InternalStartProfile(string? profile, IntPtr ptrNativeAssemblyBinder);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_PrepareForAssemblyLoadContextRelease")]
+        private static partial void PrepareForAssemblyLoadContextRelease(IntPtr ptrNativeAssemblyBinder, IntPtr ptrAssemblyLoadContextStrong);
 
         [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed")]
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_LoadFromPath", CharSet = CharSet.Unicode)]
-        private static extern void LoadFromPath(IntPtr ptrNativeAssemblyBinder, string? ilPath, string? niPath, ObjectHandleOnStack retAssembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_LoadFromStream")]
+        private static partial void LoadFromStream(IntPtr ptrNativeAssemblyBinder, IntPtr ptrAssemblyArray, int iAssemblyArrayLen, IntPtr ptrSymbols, int iSymbolArrayLen, ObjectHandleOnStack retAssembly);
+
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MultiCoreJIT_InternalSetProfileRoot", CharSet = CharSet.Unicode)]
+        internal static partial void InternalSetProfileRoot(string directoryPath);
+
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MultiCoreJIT_InternalStartProfile", CharSet = CharSet.Unicode)]
+        internal static partial void InternalStartProfile(string? profile, IntPtr ptrNativeAssemblyBinder);
+
+        [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_LoadFromPath", CharSet = CharSet.Unicode)]
+        private static partial void LoadFromPath(IntPtr ptrNativeAssemblyBinder, string? ilPath, string? niPath, ObjectHandleOnStack retAssembly);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern Assembly[] GetLoadedAssemblies();
@@ -37,17 +37,17 @@ namespace System.Runtime.Loader
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsTracingEnabled();
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceResolvingHandlerInvoked", CharSet = CharSet.Unicode)]
-        internal static extern bool TraceResolvingHandlerInvoked(string assemblyName, string handlerName, string? alcName, string? resultAssemblyName, string? resultAssemblyPath);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceResolvingHandlerInvoked", CharSet = CharSet.Unicode)]
+        internal static partial bool TraceResolvingHandlerInvoked(string assemblyName, string handlerName, string? alcName, string? resultAssemblyName, string? resultAssemblyPath);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceAssemblyResolveHandlerInvoked", CharSet = CharSet.Unicode)]
-        internal static extern bool TraceAssemblyResolveHandlerInvoked(string assemblyName, string handlerName, string? resultAssemblyName, string? resultAssemblyPath);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceAssemblyResolveHandlerInvoked", CharSet = CharSet.Unicode)]
+        internal static partial bool TraceAssemblyResolveHandlerInvoked(string assemblyName, string handlerName, string? resultAssemblyName, string? resultAssemblyPath);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceAssemblyLoadFromResolveHandlerInvoked", CharSet = CharSet.Unicode)]
-        internal static extern bool TraceAssemblyLoadFromResolveHandlerInvoked(string assemblyName, bool isTrackedAssembly, string requestingAssemblyPath, string? requestedAssemblyPath);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceAssemblyLoadFromResolveHandlerInvoked", CharSet = CharSet.Unicode)]
+        internal static partial bool TraceAssemblyLoadFromResolveHandlerInvoked(string assemblyName, bool isTrackedAssembly, string requestingAssemblyPath, string? requestedAssemblyPath);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceSatelliteSubdirectoryPathProbed", CharSet = CharSet.Unicode)]
-        internal static extern bool TraceSatelliteSubdirectoryPathProbed(string filePath, int hResult);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_TraceSatelliteSubdirectoryPathProbed", CharSet = CharSet.Unicode)]
+        internal static partial bool TraceSatelliteSubdirectoryPathProbed(string filePath, int hResult);
 
         [RequiresUnreferencedCode("Types and members the loaded assembly depends on might be removed")]
         private Assembly InternalLoadFromPath(string? assemblyPath, string? nativeImagePath)
@@ -72,8 +72,8 @@ namespace System.Runtime.Loader
         }
 
 #if TARGET_WINDOWS
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_LoadFromInMemoryModule")]
-        private static extern IntPtr LoadFromInMemoryModuleInternal(IntPtr ptrNativeAssemblyBinder, IntPtr hModule, ObjectHandleOnStack retAssembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_LoadFromInMemoryModule")]
+        private static partial IntPtr LoadFromInMemoryModuleInternal(IntPtr ptrNativeAssemblyBinder, IntPtr hModule, ObjectHandleOnStack retAssembly);
 
 
         /// <summary>
@@ -134,8 +134,8 @@ namespace System.Runtime.Loader
             return context.ResolveUsingEvent(assemblyName);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetLoadContextForAssembly")]
-        private static extern IntPtr GetLoadContextForAssembly(QCallAssembly assembly);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetLoadContextForAssembly")]
+        private static partial IntPtr GetLoadContextForAssembly(QCallAssembly assembly);
 
         // Returns the load context in which the specified assembly has been loaded
         public static AssemblyLoadContext? GetLoadContext(Assembly assembly)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -15,7 +15,7 @@ using Internal.Runtime.CompilerServices;
 namespace System
 {
     [NonVersionable]
-    public unsafe struct RuntimeTypeHandle : ISerializable
+    public unsafe partial struct RuntimeTypeHandle : ISerializable
     {
         // Returns handle for interop with EE. The handle is guaranteed to be non-null.
         internal RuntimeTypeHandle GetNativeHandle()
@@ -260,8 +260,8 @@ namespace System
             return instantiatedObject!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter")]
-        private static extern void CreateInstanceForAnotherGenericParameter(
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter")]
+        private static partial void CreateInstanceForAnotherGenericParameter(
             QCallTypeHandle baseType,
             IntPtr* pTypeHandles,
             int cTypeHandles,
@@ -297,8 +297,8 @@ namespace System
             ctorIsPublic = fCtorIsPublicTemp != Interop.BOOL.FALSE;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetActivationInfo")]
-        private static extern void GetActivationInfo(
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetActivationInfo")]
+        private static partial void GetActivationInfo(
             ObjectHandleOnStack pRuntimeType,
             delegate*<void*, object>* ppfnAllocator,
             void** pvAllocatorFirstArg,
@@ -403,8 +403,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern Type[]? GetInterfaces(RuntimeType type);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetConstraints")]
-        private static extern void GetConstraints(QCallTypeHandle handle, ObjectHandleOnStack types);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetConstraints")]
+        private static partial void GetConstraints(QCallTypeHandle handle, ObjectHandleOnStack types);
 
         internal Type[] GetConstraints()
         {
@@ -416,8 +416,8 @@ namespace System
             return types!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "QCall_GetGCHandleForTypeHandle")]
-        private static extern IntPtr GetGCHandle(QCallTypeHandle handle, GCHandleType type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "QCall_GetGCHandleForTypeHandle")]
+        private static partial IntPtr GetGCHandle(QCallTypeHandle handle, GCHandleType type);
 
         internal IntPtr GetGCHandle(GCHandleType type)
         {
@@ -425,8 +425,8 @@ namespace System
             return GetGCHandle(new QCallTypeHandle(ref nativeHandle), type);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "QCall_FreeGCHandleForTypeHandle")]
-        private static extern IntPtr FreeGCHandle(QCallTypeHandle typeHandle, IntPtr objHandle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "QCall_FreeGCHandleForTypeHandle")]
+        private static partial IntPtr FreeGCHandle(QCallTypeHandle typeHandle, IntPtr objHandle);
 
         internal IntPtr FreeGCHandle(IntPtr objHandle)
         {
@@ -440,8 +440,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern int GetNumVirtualsAndStaticVirtuals(RuntimeType type);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_VerifyInterfaceIsImplemented")]
-        private static extern void VerifyInterfaceIsImplemented(QCallTypeHandle handle, QCallTypeHandle interfaceHandle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_VerifyInterfaceIsImplemented")]
+        private static partial void VerifyInterfaceIsImplemented(QCallTypeHandle handle, QCallTypeHandle interfaceHandle);
 
         internal void VerifyInterfaceIsImplemented(RuntimeTypeHandle interfaceHandle)
         {
@@ -450,8 +450,8 @@ namespace System
             VerifyInterfaceIsImplemented(new QCallTypeHandle(ref nativeHandle), new QCallTypeHandle(ref nativeInterfaceHandle));
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetInterfaceMethodImplementation")]
-        private static extern RuntimeMethodHandleInternal GetInterfaceMethodImplementation(QCallTypeHandle handle, QCallTypeHandle interfaceHandle, RuntimeMethodHandleInternal interfaceMethodHandle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetInterfaceMethodImplementation")]
+        private static partial RuntimeMethodHandleInternal GetInterfaceMethodImplementation(QCallTypeHandle handle, QCallTypeHandle interfaceHandle, RuntimeMethodHandleInternal interfaceMethodHandle);
 
         internal RuntimeMethodHandleInternal GetInterfaceMethodImplementation(RuntimeTypeHandle interfaceHandle, RuntimeMethodHandleInternal interfaceMethodHandle)
         {
@@ -479,9 +479,9 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsByRefLike(RuntimeType type);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_IsVisible")]
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_IsVisible")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool _IsVisible(QCallTypeHandle typeHandle);
+        private static partial bool _IsVisible(QCallTypeHandle typeHandle);
 
         internal static bool IsVisible(RuntimeType type)
         {
@@ -491,8 +491,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsValueType(RuntimeType type);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_ConstructName")]
-        private static extern void ConstructName(QCallTypeHandle handle, TypeNameFormatFlags formatFlags, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_ConstructName")]
+        private static partial void ConstructName(QCallTypeHandle handle, TypeNameFormatFlags formatFlags, StringHandleOnStack retString);
 
         internal string ConstructName(TypeNameFormatFlags formatFlags)
         {
@@ -519,8 +519,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern IRuntimeMethodInfo GetDeclaringMethod(RuntimeType type);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetTypeByName", CharSet = CharSet.Unicode)]
-        private static extern void GetTypeByName(string name, bool throwOnError, bool ignoreCase, StackCrawlMarkHandle stackMark,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetTypeByName", CharSet = CharSet.Unicode)]
+        private static partial void GetTypeByName(string name, bool throwOnError, bool ignoreCase, StackCrawlMarkHandle stackMark,
             ObjectHandleOnStack assemblyLoadContext,
             ObjectHandleOnStack type, ObjectHandleOnStack keepalive);
 
@@ -553,8 +553,8 @@ namespace System
             return type;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetTypeByNameUsingCARules", CharSet = CharSet.Unicode)]
-        private static extern void GetTypeByNameUsingCARules(string name, QCallModule scope, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetTypeByNameUsingCARules", CharSet = CharSet.Unicode)]
+        private static partial void GetTypeByNameUsingCARules(string name, QCallModule scope, ObjectHandleOnStack type);
 
         internal static RuntimeType GetTypeByNameUsingCARules(string name, RuntimeModule scope)
         {
@@ -567,8 +567,8 @@ namespace System
             return type!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetInstantiation")]
-        internal static extern void GetInstantiation(QCallTypeHandle type, ObjectHandleOnStack types, Interop.BOOL fAsRuntimeTypeArray);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetInstantiation")]
+        internal static partial void GetInstantiation(QCallTypeHandle type, ObjectHandleOnStack types, Interop.BOOL fAsRuntimeTypeArray);
 
         internal RuntimeType[] GetInstantiationInternal()
         {
@@ -586,8 +586,8 @@ namespace System
             return types!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_Instantiate")]
-        private static extern void Instantiate(QCallTypeHandle handle, IntPtr* pInst, int numGenericArgs, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_Instantiate")]
+        private static partial void Instantiate(QCallTypeHandle handle, IntPtr* pInst, int numGenericArgs, ObjectHandleOnStack type);
 
         internal RuntimeType Instantiate(RuntimeType inst)
         {
@@ -614,8 +614,8 @@ namespace System
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakeArray")]
-        private static extern void MakeArray(QCallTypeHandle handle, int rank, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakeArray")]
+        private static partial void MakeArray(QCallTypeHandle handle, int rank, ObjectHandleOnStack type);
 
         internal RuntimeType MakeArray(int rank)
         {
@@ -625,8 +625,8 @@ namespace System
             return type!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakeSZArray")]
-        private static extern void MakeSZArray(QCallTypeHandle handle, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakeSZArray")]
+        private static partial void MakeSZArray(QCallTypeHandle handle, ObjectHandleOnStack type);
 
         internal RuntimeType MakeSZArray()
         {
@@ -636,8 +636,8 @@ namespace System
             return type!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakeByRef")]
-        private static extern void MakeByRef(QCallTypeHandle handle, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakeByRef")]
+        private static partial void MakeByRef(QCallTypeHandle handle, ObjectHandleOnStack type);
 
         internal RuntimeType MakeByRef()
         {
@@ -647,8 +647,8 @@ namespace System
             return type!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakePointer")]
-        private static extern void MakePointer(QCallTypeHandle handle, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakePointer")]
+        private static partial void MakePointer(QCallTypeHandle handle, ObjectHandleOnStack type);
 
         internal RuntimeType MakePointer()
         {
@@ -658,14 +658,14 @@ namespace System
             return type!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_IsCollectible")]
-        internal static extern Interop.BOOL IsCollectible(QCallTypeHandle handle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_IsCollectible")]
+        internal static partial Interop.BOOL IsCollectible(QCallTypeHandle handle);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool HasInstantiation(RuntimeType type);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetGenericTypeDefinition")]
-        private static extern void GetGenericTypeDefinition(QCallTypeHandle type, ObjectHandleOnStack retType);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetGenericTypeDefinition")]
+        private static partial void GetGenericTypeDefinition(QCallTypeHandle type, ObjectHandleOnStack retType);
 
         internal static RuntimeType GetGenericTypeDefinition(RuntimeType type)
         {
@@ -814,7 +814,7 @@ namespace System
     }
 
     [NonVersionable]
-    public unsafe struct RuntimeMethodHandle : ISerializable
+    public unsafe partial struct RuntimeMethodHandle : ISerializable
     {
         // Returns handle for interop with EE. The handle is guaranteed to be non-null.
         internal static IRuntimeMethodInfo EnsureNonNullMethodInfo(IRuntimeMethodInfo method)
@@ -879,8 +879,8 @@ namespace System
             return m_value == null;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetFunctionPointer")]
-        internal static extern IntPtr GetFunctionPointer(RuntimeMethodHandleInternal handle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetFunctionPointer")]
+        internal static partial IntPtr GetFunctionPointer(RuntimeMethodHandleInternal handle);
 
         public IntPtr GetFunctionPointer()
         {
@@ -889,11 +889,11 @@ namespace System
             return ptr;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetIsCollectible")]
-        internal static extern Interop.BOOL GetIsCollectible(RuntimeMethodHandleInternal handle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetIsCollectible")]
+        internal static partial Interop.BOOL GetIsCollectible(RuntimeMethodHandleInternal handle);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_IsCAVisibleFromDecoratedType")]
-        internal static extern Interop.BOOL IsCAVisibleFromDecoratedType(
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_IsCAVisibleFromDecoratedType")]
+        internal static partial Interop.BOOL IsCAVisibleFromDecoratedType(
             QCallTypeHandle attrTypeHandle,
             RuntimeMethodHandleInternal attrCtor,
             QCallTypeHandle sourceTypeHandle,
@@ -919,8 +919,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern MethodImplAttributes GetImplAttributes(IRuntimeMethodInfo method);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_ConstructInstantiation")]
-        private static extern void ConstructInstantiation(RuntimeMethodHandleInternal method, TypeNameFormatFlags format, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_ConstructInstantiation")]
+        private static partial void ConstructInstantiation(RuntimeMethodHandleInternal method, TypeNameFormatFlags format, StringHandleOnStack retString);
 
         internal static string ConstructInstantiation(IRuntimeMethodInfo method, TypeNameFormatFlags format)
         {
@@ -982,8 +982,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern object? InvokeMethod(object? target, in Span<object?> arguments, Signature sig, bool constructor, bool wrapExceptions);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetMethodInstantiation")]
-        private static extern void GetMethodInstantiation(RuntimeMethodHandleInternal method, ObjectHandleOnStack types, Interop.BOOL fAsRuntimeTypeArray);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetMethodInstantiation")]
+        private static partial void GetMethodInstantiation(RuntimeMethodHandleInternal method, ObjectHandleOnStack types, Interop.BOOL fAsRuntimeTypeArray);
 
         internal static RuntimeType[] GetMethodInstantiationInternal(IRuntimeMethodInfo method)
         {
@@ -1037,8 +1037,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsTypicalMethodDefinition(IRuntimeMethodInfo method);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetTypicalMethodDefinition")]
-        private static extern void GetTypicalMethodDefinition(RuntimeMethodHandleInternal method, ObjectHandleOnStack outMethod);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetTypicalMethodDefinition")]
+        private static partial void GetTypicalMethodDefinition(RuntimeMethodHandleInternal method, ObjectHandleOnStack outMethod);
 
         internal static IRuntimeMethodInfo GetTypicalMethodDefinition(IRuntimeMethodInfo method)
         {
@@ -1056,8 +1056,8 @@ namespace System
 
         internal static int GetGenericParameterCount(IRuntimeMethodInfo method) => GetGenericParameterCount(method.Value);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_StripMethodInstantiation")]
-        private static extern void StripMethodInstantiation(RuntimeMethodHandleInternal method, ObjectHandleOnStack outMethod);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_StripMethodInstantiation")]
+        private static partial void StripMethodInstantiation(RuntimeMethodHandleInternal method, ObjectHandleOnStack outMethod);
 
         internal static IRuntimeMethodInfo StripMethodInstantiation(IRuntimeMethodInfo method)
         {
@@ -1072,8 +1072,8 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsDynamicMethod(RuntimeMethodHandleInternal method);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_Destroy")]
-        internal static extern void Destroy(RuntimeMethodHandleInternal method);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_Destroy")]
+        internal static partial void Destroy(RuntimeMethodHandleInternal method);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern Resolver GetResolver(RuntimeMethodHandleInternal method);
@@ -1246,7 +1246,7 @@ namespace System
         }
     }
 
-    public unsafe struct ModuleHandle
+    public unsafe partial struct ModuleHandle
     {
         #region Public Static Members
         public static readonly ModuleHandle EmptyHandle;
@@ -1362,8 +1362,8 @@ namespace System
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveType")]
-        private static extern void ResolveType(QCallModule module,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveType")]
+        private static partial void ResolveType(QCallModule module,
                                                             int typeToken,
                                                             IntPtr* typeInstArgs,
                                                             int typeInstCount,
@@ -1414,8 +1414,8 @@ namespace System
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveMethod")]
-        private static extern RuntimeMethodHandleInternal ResolveMethod(QCallModule module,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveMethod")]
+        private static partial RuntimeMethodHandleInternal ResolveMethod(QCallModule module,
                                                         int methodToken,
                                                         IntPtr* typeInstArgs,
                                                         int typeInstCount,
@@ -1470,8 +1470,8 @@ namespace System
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveField")]
-        private static extern void ResolveField(QCallModule module,
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveField")]
+        private static partial void ResolveField(QCallModule module,
                                                       int fieldToken,
                                                       IntPtr* typeInstArgs,
                                                       int typeInstCount,
@@ -1479,8 +1479,8 @@ namespace System
                                                       int methodInstCount,
                                                       ObjectHandleOnStack retField);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_GetModuleType")]
-        internal static extern void GetModuleType(QCallModule handle, ObjectHandleOnStack type);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_GetModuleType")]
+        internal static partial void GetModuleType(QCallModule handle, ObjectHandleOnStack type);
 
         internal static RuntimeType GetModuleType(RuntimeModule module)
         {
@@ -1489,8 +1489,8 @@ namespace System
             return type!;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_GetPEKind")]
-        private static extern void GetPEKind(QCallModule handle, int* peKind, int* machine);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_GetPEKind")]
+        private static partial void GetPEKind(QCallModule handle, int* peKind, int* machine);
 
         // making this internal, used by Module.GetPEKind
         internal static void GetPEKind(RuntimeModule module, out PortableExecutableKinds peKind, out ImageFileMachine machine)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -4001,13 +4001,13 @@ namespace System
     }
 
     #region Library
-    internal readonly unsafe struct MdUtf8String
+    internal readonly unsafe partial struct MdUtf8String
     {
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MdUtf8String_EqualsCaseInsensitive")]
-        private static extern bool EqualsCaseInsensitive(void* szLhs, void* szRhs, int cSz);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MdUtf8String_EqualsCaseInsensitive")]
+        private static partial bool EqualsCaseInsensitive(void* szLhs, void* szRhs, int cSz);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "MdUtf8String_HashCaseInsensitive")]
-        private static extern uint HashCaseInsensitive(void* sz, int cSz);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "MdUtf8String_HashCaseInsensitive")]
+        private static partial uint HashCaseInsensitive(void* sz, int cSz);
 
         private readonly byte* m_pStringHeap;        // This is the raw UTF8 string.
         private readonly int m_StringHeapByteLength;

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -578,7 +578,7 @@ namespace System.StubHelpers
     }  // class DateMarshaler
 
 #if FEATURE_COMINTEROP
-    internal static class InterfaceMarshaler
+    internal static partial class InterfaceMarshaler
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern IntPtr ConvertToNative(object objSrc, IntPtr itfMT, IntPtr classMT, int flags);
@@ -586,8 +586,8 @@ namespace System.StubHelpers
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern object ConvertToManaged(ref IntPtr ppUnk, IntPtr itfMT, IntPtr classMT, int flags);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "InterfaceMarshaler__ClearNative")]
-        internal static extern void ClearNative(IntPtr pUnk);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "InterfaceMarshaler__ClearNative")]
+        internal static partial void ClearNative(IntPtr pUnk);
     }  // class InterfaceMarshaler
 #endif // FEATURE_COMINTEROP
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Interlocked.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Interlocked.CoreCLR.cs
@@ -226,8 +226,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern void ReadMemoryBarrier();
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "Interlocked_MemoryBarrierProcessWide")]
-        private static extern void _MemoryBarrierProcessWide();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "Interlocked_MemoryBarrierProcessWide")]
+        private static partial void _MemoryBarrierProcessWide();
 
         /// <summary>Provides a process-wide memory barrier that ensures that reads and writes from any CPU cannot move across the barrier.</summary>
         public static void MemoryBarrierProcessWide() => _MemoryBarrierProcessWide();

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.Unix.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.Unix.cs
@@ -31,8 +31,8 @@ namespace System.Threading
             return waitResult == WaitHandle.WaitSuccess;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "WaitHandle_CorWaitOnePrioritizedNative")]
-        private static extern int WaitNative(SafeWaitHandle handle, int timeoutMs);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "WaitHandle_CorWaitOnePrioritizedNative")]
+        private static partial int WaitNative(SafeWaitHandle handle, int timeoutMs);
 
         public void ReleaseCore(int count)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
@@ -197,7 +197,7 @@ namespace System.Threading
         /// </summary>
         public static long LockContentionCount => GetLockContentionCount();
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ObjectNative_GetMonitorLockContentionCount")]
-        private static extern long GetLockContentionCount();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ObjectNative_GetMonitorLockContentionCount")]
+        private static partial long GetLockContentionCount();
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -92,8 +92,8 @@ namespace System.Threading
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_Start")]
-        private static extern unsafe void StartInternal(ThreadHandle t, int stackSize, int priority, char* pThreadName);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_Start")]
+        private static unsafe partial void StartInternal(ThreadHandle t, int stackSize, int priority, char* pThreadName);
 
         // Called from the runtime
         private void StartCallback()
@@ -119,8 +119,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern void SleepInternal(int millisecondsTimeout);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_UninterruptibleSleep0")]
-        internal static extern void UninterruptibleSleep0();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_UninterruptibleSleep0")]
+        internal static partial void UninterruptibleSleep0();
 
         /// <summary>
         /// Wait for a length of time proportional to 'iterations'.  Each iteration is should
@@ -132,8 +132,8 @@ namespace System.Threading
 
         public static void SpinWait(int iterations) => SpinWaitInternal(iterations);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_YieldThread")]
-        private static extern Interop.BOOL YieldInternal();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_YieldThread")]
+        private static partial Interop.BOOL YieldInternal();
 
         public static bool Yield() => YieldInternal() != Interop.BOOL.FALSE;
 
@@ -157,8 +157,8 @@ namespace System.Threading
             InformThreadNameChange(GetNativeHandle(), value, value?.Length ?? 0);
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_InformThreadNameChange", CharSet = CharSet.Unicode)]
-        private static extern void InformThreadNameChange(ThreadHandle t, string? name, int len);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_InformThreadNameChange", CharSet = CharSet.Unicode)]
+        private static partial void InformThreadNameChange(ThreadHandle t, string? name, int len);
 
         /// <summary>Returns true if the thread has been started and is not dead.</summary>
         public extern bool IsAlive
@@ -219,8 +219,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void SetPriorityNative(int priority);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_GetCurrentOSThreadId")]
-        private static extern ulong GetCurrentOSThreadId();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_GetCurrentOSThreadId")]
+        private static partial ulong GetCurrentOSThreadId();
 
         /// <summary>
         /// Return the thread state as a consistent set of bits.  This is more

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -342,8 +342,8 @@ namespace System.Threading
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadPool_GetCompletedWorkItemCount")]
-        private static extern long GetCompletedWorkItemCount();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadPool_GetCompletedWorkItemCount")]
+        private static partial long GetCompletedWorkItemCount();
 
         private static long PendingUnmanagedWorkItemCount => UsePortableThreadPool ? 0 : GetPendingUnmanagedWorkItemCount();
 
@@ -419,8 +419,8 @@ namespace System.Threading
             RequestWorkerThreadNative();
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadPool_RequestWorkerThread")]
-        private static extern Interop.BOOL RequestWorkerThreadNative();
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadPool_RequestWorkerThread")]
+        private static partial Interop.BOOL RequestWorkerThreadNative();
 
         // Entry point from unmanaged code
         private static void EnsureGateThreadRunning()
@@ -440,8 +440,8 @@ namespace System.Threading
             return PerformRuntimeSpecificGateActivitiesNative(cpuUtilization) != Interop.BOOL.FALSE;
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadPool_PerformGateActivities")]
-        private static extern Interop.BOOL PerformRuntimeSpecificGateActivitiesNative(int cpuUtilization);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "ThreadPool_PerformGateActivities")]
+        private static partial Interop.BOOL PerformRuntimeSpecificGateActivitiesNative(int cpuUtilization);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern unsafe bool PostQueuedCompletionStatus(NativeOverlapped* overlapped);

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Timer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Timer.CoreCLR.cs
@@ -59,14 +59,14 @@ namespace System.Threading
             Instances[id].FireNextTimers();
         }
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Create")]
-        private static extern AppDomainTimerSafeHandle CreateAppDomainTimer(uint dueTime, int id);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Create")]
+        private static partial AppDomainTimerSafeHandle CreateAppDomainTimer(uint dueTime, int id);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Change")]
-        private static extern bool ChangeAppDomainTimer(AppDomainTimerSafeHandle handle, uint dueTime);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Change")]
+        private static partial bool ChangeAppDomainTimer(AppDomainTimerSafeHandle handle, uint dueTime);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Delete")]
-        private static extern bool DeleteAppDomainTimer(IntPtr handle);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "AppDomainTimer_Delete")]
+        private static partial bool DeleteAppDomainTimer(IntPtr handle);
 
         #endregion
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/TypeLoadException.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/TypeLoadException.CoreCLR.cs
@@ -46,7 +46,7 @@ namespace System
             }
         }
 
-        [DllImport(RuntimeHelpers.QCall)]
-        private static extern void GetTypeLoadExceptionMessage(int resourceId, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        private static partial void GetTypeLoadExceptionMessage(int resourceId, StringHandleOnStack retString);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/TypeNameParser.cs
@@ -14,11 +14,11 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System
 {
-    internal sealed class SafeTypeNameParserHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed partial class SafeTypeNameParserHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         #region QCalls
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_ReleaseTypeNameParser")]
-        private static extern void Release(IntPtr pTypeNameParser);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_ReleaseTypeNameParser")]
+        private static partial void Release(IntPtr pTypeNameParser);
         #endregion
 
         public SafeTypeNameParserHandle()
@@ -34,23 +34,23 @@ namespace System
         }
     }
 
-    internal sealed class TypeNameParser : IDisposable
+    internal sealed partial class TypeNameParser : IDisposable
     {
         #region QCalls
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_CreateTypeNameParser", CharSet = CharSet.Unicode)]
-        private static extern void _CreateTypeNameParser(string typeName, ObjectHandleOnStack retHandle, bool throwOnError);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_CreateTypeNameParser", CharSet = CharSet.Unicode)]
+        private static partial void _CreateTypeNameParser(string typeName, ObjectHandleOnStack retHandle, bool throwOnError);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetNames")]
-        private static extern void _GetNames(SafeTypeNameParserHandle pTypeNameParser, ObjectHandleOnStack retArray);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetNames")]
+        private static partial void _GetNames(SafeTypeNameParserHandle pTypeNameParser, ObjectHandleOnStack retArray);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetTypeArguments")]
-        private static extern void _GetTypeArguments(SafeTypeNameParserHandle pTypeNameParser, ObjectHandleOnStack retArray);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetTypeArguments")]
+        private static partial void _GetTypeArguments(SafeTypeNameParserHandle pTypeNameParser, ObjectHandleOnStack retArray);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetModifiers")]
-        private static extern void _GetModifiers(SafeTypeNameParserHandle pTypeNameParser, ObjectHandleOnStack retArray);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetModifiers")]
+        private static partial void _GetModifiers(SafeTypeNameParserHandle pTypeNameParser, ObjectHandleOnStack retArray);
 
-        [DllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetAssemblyName")]
-        private static extern void _GetAssemblyName(SafeTypeNameParserHandle pTypeNameParser, StringHandleOnStack retString);
+        [GeneratedDllImport(RuntimeHelpers.QCall, EntryPoint = "TypeName_GetAssemblyName")]
+        private static partial void _GetAssemblyName(SafeTypeNameParserHandle pTypeNameParser, StringHandleOnStack retString);
         #endregion
 
         #region Static Members

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDefaultTimeZone.Android.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDefaultTimeZone.Android.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_GetDefaultTimeZone", CharSet = CharSet.Ansi, SetLastError = true)]
-        internal static extern string? GetDefaultTimeZone();
+        [GeneratedDllImport(Interop.Libraries.SystemNative, EntryPoint = "SystemNative_GetDefaultTimeZone", CharSet = CharSet.Ansi, SetLastError = true)]
+        internal static partial string? GetDefaultTimeZone();
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/XplatEventLogger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/XplatEventLogger.cs
@@ -14,7 +14,7 @@ using System.Runtime.Versioning;
 
 namespace System.Diagnostics.Tracing
 {
-    internal sealed class XplatEventLogger : EventListener
+    internal sealed partial class XplatEventLogger : EventListener
     {
         public XplatEventLogger() {}
 
@@ -38,11 +38,11 @@ namespace System.Diagnostics.Tracing
             return null;
         }
 
-        [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
-        private static extern bool IsEventSourceLoggingEnabled();
+        [GeneratedDllImport(RuntimeHelpers.QCall)]
+        private static partial bool IsEventSourceLoggingEnabled();
 
-        [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
-        private static extern void LogEventSource(int eventID, string? eventName, string eventSourceName, string payload);
+        [GeneratedDllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
+        private static partial void LogEventSource(int eventID, string? eventName, string eventSourceName, string payload);
 
         private static readonly List<char> escape_seq = new List<char> { '\b', '\f', '\n', '\r', '\t', '\"', '\\' };
         private static readonly Dictionary<char, string> seq_mapping = new Dictionary<char, string>()

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Interop
                 typeDeclaration.Kind(),
                 typeDeclaration.Identifier)
                 .WithTypeParameterList(typeDeclaration.TypeParameterList)
-                .WithModifiers(typeDeclaration.Modifiers);
+                .WithModifiers(StripTriviaFromModifiers(typeDeclaration.Modifiers));
         }
 
         private static MemberDeclarationSyntax PrintGeneratedSource(


### PR DESCRIPTION
Now that we can use `GeneratedDllImport` with QCalls, use `GeneratedDllImport` throughout CoreLib.