### PR TITLE
Move FabricBot rules to Config-As-Code

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,6871 @@
+[
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "taskName": "Area-owners",
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "area-System.Security"
+          ],
+          "mentionees": [
+            "bartonjs",
+            "vcsjones",
+            "krwq",
+            "GrabYourPitchForks"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Drawing"
+          ],
+          "mentionees": [
+            "safern"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Diagnostics.Tracing"
+          ],
+          "mentionees": [
+            "tarekgh",
+            "tommcdon",
+            "pjanotti"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Linq.Parallel"
+          ],
+          "mentionees": [
+            "tarekgh",
+            "dotnet/area-system-linq-parallel"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Text.Encoding"
+          ],
+          "mentionees": [
+            "tarekgh",
+            "dotnet/area-system-text-encoding"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Text.Encodings.Web"
+          ],
+          "mentionees": [
+            "tarekgh",
+            "dotnet/area-system-text-encodings-web"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Threading.Channels"
+          ],
+          "mentionees": [
+            "dotnet/area-system-threading-channels"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Threading.Tasks"
+          ],
+          "mentionees": [
+            "dotnet/area-system-threading-tasks"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Text.RegularExpressions"
+          ],
+          "mentionees": [
+            "dotnet/area-system-text-regularexpressions"
+          ]
+        },
+        {
+          "labels": [
+            "area-GC-mono"
+          ],
+          "mentionees": [
+            "brzvlad"
+          ]
+        },
+        {
+          "labels": [
+            "area-Codegen-Interpreter-mono"
+          ],
+          "mentionees": [
+            "brzvlad"
+          ]
+        },
+        {
+          "labels": [
+            "area-Infrastructure-mono"
+          ],
+          "mentionees": [
+            "directhex"
+          ]
+        },
+        {
+          "labels": [
+            "area-AssemblyLoader-mono"
+          ],
+          "mentionees": []
+        },
+        {
+          "labels": [
+            "area-Debugger-mono"
+          ],
+          "mentionees": [
+            "thaystg"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Collections"
+          ],
+          "mentionees": [
+            "dotnet/area-system-collections"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Linq"
+          ],
+          "mentionees": [
+            "dotnet/area-system-linq"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Numerics.Tensors"
+          ],
+          "mentionees": [
+            "dotnet/area-system-numerics-tensors"
+          ]
+        },
+        {
+          "labels": [
+            "area-Host"
+          ],
+          "mentionees": [
+            "vitek-karas",
+            "agocke",
+            "vsadov"
+          ]
+        },
+        {
+          "labels": [
+            "area-HostModel"
+          ],
+          "mentionees": [
+            "vitek-karas",
+            "agocke"
+          ]
+        },
+        {
+          "labels": [
+            "area-Single-File"
+          ],
+          "mentionees": [
+            "agocke",
+            "vitek-karas",
+            "vsadov"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Buffers"
+          ],
+          "mentionees": [
+            "GrabYourPitchForks",
+            "dotnet/area-system-buffers"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Numerics"
+          ],
+          "mentionees": [
+            "dotnet/area-system-numerics"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Runtime.Intrinsics"
+          ],
+          "mentionees": [
+            "dotnet/area-system-runtime-intrinsics"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.CodeDom"
+          ],
+          "mentionees": [
+            "buyaa-n"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Xml"
+          ],
+          "mentionees": [
+            "dotnet/area-system-xml"
+          ]
+        },
+        {
+          "labels": [
+            "area-AssemblyLoader-coreclr"
+          ],
+          "mentionees": [
+            "vitek-karas",
+            "agocke",
+            "vsadov"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Dynamic.Runtime"
+          ],
+          "mentionees": [
+            "cston"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Linq.Expressions"
+          ],
+          "mentionees": [
+            "cston"
+          ]
+        },
+        {
+          "labels": [
+            "area-Microsoft.CSharp"
+          ],
+          "mentionees": [
+            "cston"
+          ]
+        },
+        {
+          "labels": [
+            "area-Microsoft.VisualBasic"
+          ],
+          "mentionees": [
+            "cston"
+          ]
+        },
+        {
+          "labels": [
+            "area-Infrastructure-libraries"
+          ],
+          "mentionees": [
+            "safern"
+          ]
+        },
+        {
+          "labels": [
+            "area-Infrastructure"
+          ],
+          "mentionees": [
+            "dotnet/runtime-infrastructure"
+          ]
+        },
+        {
+          "labels": [
+            "area-GC-coreclr"
+          ],
+          "mentionees": [
+            "dotnet/gc"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Net"
+          ],
+          "mentionees": [
+            "dotnet/ncl"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Net.Http"
+          ],
+          "mentionees": [
+            "dotnet/ncl"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Net.Security"
+          ],
+          "mentionees": [
+            "dotnet/ncl",
+            "vcsjones"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Net.Sockets"
+          ],
+          "mentionees": [
+            "dotnet/ncl"
+          ]
+        },
+        {
+          "labels": [
+            "area-Diagnostics-coreclr"
+          ],
+          "mentionees": [
+            "tommcdon"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Diagnostics"
+          ],
+          "mentionees": [
+            "tommcdon"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Data"
+          ],
+          "mentionees": [
+            "roji",
+            "ajcvickers"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Data.OleDB"
+          ],
+          "mentionees": [
+            "roji",
+            "ajcvickers"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Data.Odbc"
+          ],
+          "mentionees": [
+            "roji",
+            "ajcvickers"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Data.SqlClient"
+          ],
+          "mentionees": [
+            "cheenamalhotra",
+            "david-engel"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.ComponentModel.DataAnnotations"
+          ],
+          "mentionees": [
+            "ajcvickers",
+            "bricelam",
+            "roji"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-FileSystem"
+          ],
+          "mentionees": [
+            "maryamariyan",
+            "dotnet/area-extensions-filesystem"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-HttpClientFactory"
+          ],
+          "mentionees": [
+            "dotnet/ncl"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Net.Quic"
+          ],
+          "mentionees": [
+            "dotnet/ncl"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Formats.Cbor"
+          ],
+          "mentionees": [
+            "bartonjs",
+            "dotnet/area-system-formats-cbor"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Formats.Asn1"
+          ],
+          "mentionees": [
+            "bartonjs",
+            "vcsjones"
+          ]
+        },
+        {
+          "labels": [
+            "area-Codegen-JIT-Mono"
+          ],
+          "mentionees": [
+            "SamMonoRT",
+            "vargaz"
+          ]
+        },
+        {
+          "labels": [
+            "area-CodeGen-LLVM-Mono"
+          ],
+          "mentionees": [
+            "SamMonoRT",
+            "vargaz",
+            "imhameed"
+          ]
+        },
+        {
+          "labels": [
+            "area-CodeGen-meta-Mono"
+          ],
+          "mentionees": [
+            "SamMonoRT",
+            "vargaz",
+            "lambdageek"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Text.Json"
+          ],
+          "mentionees": [
+            "dotnet/area-system-text-json"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Memory"
+          ],
+          "mentionees": [
+            "GrabYourPitchForks",
+            "dotnet/area-system-memory"
+          ]
+        },
+        {
+          "labels": [
+            "area-Infrastructure-coreclr"
+          ],
+          "mentionees": [
+            "hoyosjs"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.IO"
+          ],
+          "mentionees": [
+            "dotnet/area-system-io"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.IO.Compression"
+          ],
+          "mentionees": [
+            "dotnet/area-system-io-compression"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Diagnostics.Process"
+          ],
+          "mentionees": [
+            "dotnet/area-system-diagnostics-process"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Console"
+          ],
+          "mentionees": [
+            "dotnet/area-system-console"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Runtime"
+          ],
+          "mentionees": [
+            "dotnet/area-system-runtime"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Threading"
+          ],
+          "mentionees": [
+            "mangod9"
+          ]
+        },
+        {
+          "labels": [
+            "area-vm-coreclr"
+          ],
+          "mentionees": [
+            "mangod9"
+          ]
+        },
+        {
+          "labels": [
+            "area-CodeGen-coreclr"
+          ],
+          "mentionees": [
+            "JulieLeeMSFT"
+          ]
+        },
+        {
+          "labels": [
+            "area-ILTools-coreclr"
+          ],
+          "mentionees": [
+            "JulieLeeMSFT"
+          ]
+        },
+        {
+          "labels": [
+            "area-ILVerification"
+          ],
+          "mentionees": [
+            "JulieLeeMSFT"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.DirectoryServices"
+          ],
+          "mentionees": [
+            "jay98014"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Speech"
+          ],
+          "mentionees": [
+            "danmoseley"
+          ]
+        },
+        {
+          "labels": [
+            "area-Meta"
+          ],
+          "mentionees": [
+            "dotnet/area-meta"
+          ]
+        },
+        {
+          "labels": [
+            "area-DependencyModel"
+          ],
+          "mentionees": [
+            "dotnet/area-dependencymodel"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-Caching"
+          ],
+          "mentionees": [
+            "dotnet/area-extensions-caching"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-Configuration"
+          ],
+          "mentionees": [
+            "dotnet/area-extensions-configuration"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-DependencyInjection"
+          ],
+          "mentionees": [
+            "dotnet/area-extensions-dependencyinjection"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-Hosting"
+          ],
+          "mentionees": [
+            "dotnet/area-extensions-hosting"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-Logging"
+          ],
+          "mentionees": [
+            "dotnet/area-extensions-logging"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-Options"
+          ],
+          "mentionees": [
+            "dotnet/area-extensions-options"
+          ]
+        },
+        {
+          "labels": [
+            "area-Extensions-Primitives"
+          ],
+          "mentionees": [
+            "dotnet/area-extensions-primitives"
+          ]
+        },
+        {
+          "labels": [
+            "area-Microsoft.Extensions"
+          ],
+          "mentionees": [
+            "dotnet/area-microsoft-extensions"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.ComponentModel"
+          ],
+          "mentionees": [
+            "dotnet/area-system-componentmodel"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.ComponentModel.Composition"
+          ],
+          "mentionees": [
+            "dotnet/area-system-componentmodel-composition"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Composition"
+          ],
+          "mentionees": [
+            "dotnet/area-system-composition"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Diagnostics.Activity"
+          ],
+          "mentionees": [
+            "dotnet/area-system-diagnostics-activity"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Globalization"
+          ],
+          "mentionees": [
+            "dotnet/area-system-globalization"
+          ]
+        }
+      ],
+      "replyTemplate": "Tagging subscribers to this area: ${mentionees}\nSee info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.",
+      "enableForPullRequests": true
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "breaking-change"
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "",
+                "parameters": {}
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "needs-breaking-change-doc-created"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Added `needs-breaking-change-doc-created` label because this issue has the `breaking-change` label. \n\n1. [ ] Create and link to this issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+), then remove this `needs-breaking-change-doc-created` label.\n\nTagging @dotnet/compat for awareness of the breaking change."
+          }
+        }
+      ],
+      "taskName": "Add breaking change doc label to issue"
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "breaking-change"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "needs-breaking-change-doc-created"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Added `needs-breaking-change-doc-created` label because this PR has the `breaking-change` label. \n\nWhen you commit this breaking change:\n\n1. [ ] Create and link to this PR and the issue a matching issue in the dotnet/docs repo using the [breaking change documentation template](https://github.com/dotnet/docs/issues/new?assignees=gewarren&labels=breaking-change%2CPri1%2Cdoc-idea&template=breaking-change.yml&title=%5BBreaking+change%5D%3A+), then remove this `needs-breaking-change-doc-created` label.\n2. [ ] Ask a committer to mail the `.NET Breaking Change Notification` DL.\n\nTagging @dotnet/compat for awareness of the breaking change."
+          }
+        }
+      ],
+      "taskName": "Add breaking change doc label to PR"
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            1,
+            7,
+            13,
+            19
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            1,
+            7,
+            13,
+            19
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            1,
+            7,
+            13,
+            19
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            1,
+            7,
+            13,
+            19
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            1,
+            7,
+            13,
+            19
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            1,
+            7,
+            13,
+            19
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            1,
+            7,
+            13,
+            19
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isClosed",
+          "parameters": {}
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 30
+          }
+        },
+        {
+          "name": "isUnlocked",
+          "parameters": {}
+        }
+      ],
+      "actions": [
+        {
+          "name": "lockIssue",
+          "parameters": {
+            "reason": "resolved",
+            "label": "will_lock_this"
+          }
+        }
+      ],
+      "taskName": "Lock stale issues and PR's"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Replace `needs more info` label with `needs further triage` label when the author comments on an issue",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs more info"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "needs further triage"
+          }
+        },
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "needs more info"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove `no recent activity` label from issues when issue is modified",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no recent activity"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "no recent activity"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove `no recent activity` label when an issue is commented on",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no recent activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        }
+      ],
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Close issues with no recent activity",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 14
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue will now be closed since it had been marked `no recent activity` but received no further activity in the past 14 days. It is still possible to reopen or comment on the issue, but please note that the issue will be locked if it remains inactive for another 30 days."
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Add no recent activity label to issues",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isIssue",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "needs more info"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 14
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been automatically marked `no recent activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no recent activity`."
+          }
+        }
+      ]
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "InPrLabel",
+    "subCapability": "InPrLabel",
+    "version": "1.0",
+    "config": {
+      "taskName": "Add 'In-PR' label on issue when an open pull request is targeting it",
+      "inPrLabelText": "Status: In PR",
+      "fixedLabelText": "Status: Fixed",
+      "fixedLabelEnabled": false,
+      "label_inPr": "in pr"
+    }
+  },
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "taskName": "@Mention for linkable-framework",
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "linkable-framework"
+          ],
+          "mentionees": [
+            "eerhardt",
+            "vitek-karas",
+            "LakshanF",
+            "sbomer",
+            "joperezr"
+          ]
+        }
+      ],
+      "replyTemplate": "Tagging subscribers to 'linkable-framework': ${mentionees}\nSee info in area-owners.md if you want to be subscribed.",
+      "enableForPullRequests": true
+    }
+  },
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "taskName": "@Mention for size-reduction",
+      "replyTemplate": "Tagging subscribers to 'size-reduction': ${mentionees}\nSee info in area-owners.md if you want to be subscribed.",
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "size-reduction"
+          ],
+          "mentionees": [
+            "eerhardt",
+            "SamMonoRT",
+            "marek-safar"
+          ]
+        }
+      ],
+      "enableForPullRequests": true
+    }
+  },
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "taskName": "@Mention for wasm",
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "arch-wasm"
+          ],
+          "mentionees": [
+            "lewing"
+          ]
+        }
+      ],
+      "replyTemplate": "Tagging subscribers to 'arch-wasm': ${mentionees}\nSee info in area-owners.md if you want to be subscribed.",
+      "enableForPullRequests": true
+    }
+  },
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "taskName": "@Mention for ios",
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "os-ios"
+          ],
+          "mentionees": [
+            "steveisok",
+            "akoeplinger"
+          ]
+        }
+      ],
+      "enableForPullRequests": true,
+      "replyTemplate": "Tagging subscribers to 'os-ios': ${mentionees}\nSee info in area-owners.md if you want to be subscribed."
+    }
+  },
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "taskName": "@Mention for android",
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "os-android"
+          ],
+          "mentionees": [
+            "steveisok",
+            "akoeplinger"
+          ]
+        }
+      ],
+      "enableForPullRequests": true,
+      "replyTemplate": "Tagging subscribers to 'arch-android': ${mentionees}\nSee info in area-owners.md if you want to be subscribed."
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            5,
+            11,
+            17,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            5,
+            11,
+            17,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            5,
+            11,
+            17,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            5,
+            11,
+            17,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            5,
+            11,
+            17,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            5,
+            11,
+            17,
+            23
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            5,
+            11,
+            17,
+            23
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isDraftPr",
+          "parameters": {
+            "value": "true"
+          }
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 30
+          }
+        }
+      ],
+      "taskName": "Close inactive Draft PRs",
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Draft Pull Request was automatically closed for inactivity. Please [let us know](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you'd like to reopen it."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "label": "area-System.DirectoryServices",
+                  "projectName": "Triage POD for Meta, Reflection, etc"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Meta"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.CodeDom"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.ComponentModel.Composition"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Composition"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Configuration"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Reflection"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Reflection.Emit"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Reflection.Metadata"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Resources"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Runtime.CompilerServices"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.DirectoryServices"
+                }
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[joperezr Pod Triage] Move issue to our pod project when a label from our area is added.",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Triage POD for Meta, Reflection, etc",
+            "columnName": "Needs triage"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "ML, Extensions, Globalization, etc, POD."
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-DependencyModel"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Caching"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Configuration"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-DependencyInjection"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Hosting"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Logging"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Options"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Primitives"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.ComponentModel"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Drawing"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Globalization"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[safern/maryamariyan Pod triage] Add issues to POD project",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD.",
+            "columnName": "Untriaged"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "ML, Extensions, Globalization, etc, POD.",
+              "columnName": "Untriaged"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[safern/maryamariyan Pod triage] Move issues to 6.0.0 column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD.",
+            "columnName": "6.0.0"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "ML, Extensions, Globalization, etc, POD."
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProjectColumn",
+                    "parameters": {
+                      "projectName": "ML, Extensions, Globalization, etc, POD.",
+                      "columnName": "Active PRs"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-DependencyModel"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Caching"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Configuration"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-DependencyInjection"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Hosting"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Logging"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Options"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Extensions-Primitives"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Drawing"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.ComponentModel"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Globalization"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[safern/maryamariyan Pod triage] Add PRs to project board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD.",
+            "columnName": "Active PRs"
+          }
+        },
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD.",
+            "columnName": "Active PRs"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "ML, Extensions, Globalization, etc, POD."
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[safern/maryamariyan Pod triage] Move issues to future milestone column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD.",
+            "columnName": "Future"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "ML, Extensions, Globalization, etc, POD."
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "ML, Extensions, Globalization, etc, POD.",
+                  "columnName": "Untriaged"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "untriaged"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "needs further triage"
+                }
+              },
+              {
+                "name": "removedFromMilestone",
+                "parameters": {
+                  "milestoneName": ""
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[safern/maryamariyan Pod triage] Move issues to untriaged column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD.",
+            "columnName": "Untriaged"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "ML, Extensions, Globalization, etc, POD."
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-DependencyModel"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Extensions-Caching"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Extensions-Configuration"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Extensions-DependencyInjection"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Extensions-Hosting"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Extensions-Logging"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Extensions-Options"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Extensions-Primitives"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.ComponentModel"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.Drawing"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.Globalization"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-DependencyModel"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Extensions-Caching"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Extensions-Configuration"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Extensions-DependencyInjection"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Extensions-Hosting"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Extensions-Logging"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Extensions-Options"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Extensions-Primitives"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.ComponentModel"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Drawing"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Globalization"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[safern/maryamariyan Pod triage] Remove from project",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Triage POD for Meta, Reflection, etc",
+              "columnName": "Future"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[joperezr Pod Triage] Move issues from Future column to Needs triage when commented on.",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Triage POD for Meta, Reflection, etc",
+            "columnName": "Needs triage"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "needs further triage"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Triage POD for Meta, Reflection, etc",
+              "columnName": "Future"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "labeled"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "unlabeled"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[joperezr Pod Triage] Move issues from Future column to Needs triage when issue is changed.",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Triage POD for Meta, Reflection, etc",
+            "columnName": "Needs triage"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "needs further triage"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Infrastructure Backlog"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-coreclr"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-installer"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-libraries"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-mono"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Add issues to infra POD project",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Infrastructure Backlog",
+            "columnName": "Untriaged"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Infrastructure Backlog"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Add infrastructure issues to future column in project board",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Infrastructure Backlog",
+            "columnName": "Future"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Infrastructure Backlog"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Add to 6.0.0 column in infrastructure project board",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Infrastructure Backlog",
+            "columnName": "6.0.0"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Infrastructure Backlog"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "untriaged"
+                }
+              },
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "needs further triage"
+                }
+              },
+              {
+                "name": "addedToMilestone",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInMilestone",
+                "parameters": {}
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "7.0.0"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Move to servicing column in infrastructure project",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Infrastructure Backlog",
+            "columnName": "Servicing"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Infrastructure Backlog"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-coreclr"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-installer"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-libraries"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Infrastructure-mono"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Add infrastructure PRs to Active project column",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Infrastructure Backlog",
+            "columnName": "In Progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Infrastructure Backlog"
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Infrastructure"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Infrastructure-coreclr"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Infrastructure-installer"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Infrastructure-libraries"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Infrastructure-mono"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Infrastructure"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Infrastructure-coreclr"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Infrastructure-installer"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Infrastructure-libraries"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Infrastructure-mono"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Remove PRs from Infrastructure project",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Infrastructure Backlog"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Infrastructure Backlog"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "area-Infrastructure"
+                }
+              },
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "area-Infrastructure-coreclr"
+                }
+              },
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "area-Infrastructure-installer"
+                }
+              },
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "area-Infrastructure-libraries"
+                }
+              },
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "area-Infrastructure-mono"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Infrastructure"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Infrastructure-coreclr"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Infrastructure-installer"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Infrastructure-libraries"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Infrastructure-mono"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Remove issues from infrastructure project board",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Infrastructure Backlog"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Infrastructure Backlog"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Infrastructure Backlog",
+                  "columnName": "Untriaged"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "untriaged"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "needs further triage"
+                }
+              },
+              {
+                "name": "removedFromMilestone",
+                "parameters": {}
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Move issues to Untriaged column in infrastructure project",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Infrastructure Backlog",
+            "columnName": "Untriaged"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Microsoft.Win32"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Diagnostics.EventLog"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Diagnostics.PerformanceCounter"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Diagnostics.Tracing"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Management"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.ServiceProcess"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Anirudh\\Viktor Pod Triage] Add untriaged issues to the pod",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI",
+            "columnName": "Untriaged"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": []
+              },
+              {
+                "name": "labelRemoved",
+                "parameters": {
+                  "label": "untriaged"
+                }
+              },
+              {
+                "name": "isInMilestone",
+                "parameters": {
+                  "milestoneName": "6.0.0"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "6.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Anirudh/Viktor Pod triage] Move issues to 6.0.0 milestone column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI",
+            "columnName": "6.0.0"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProjectColumn",
+                    "parameters": {
+                      "columnName": "Active Prs",
+                      "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-Microsoft.Win32"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.EventLog"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.PerformanceCounter"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.Tracing"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Management"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.ServiceProcess"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Anirudh/Viktor Pod triage] Add PRs to project board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI",
+            "columnName": "Active PRs"
+          }
+        },
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI",
+            "columnName": "Active PRs"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI",
+                  "columnName": "Untriaged"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "needs further triage"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "untriaged"
+                }
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "removedFromMilestone",
+                        "parameters": {
+                          "milestoneName": "Future"
+                        }
+                      },
+                      {
+                        "name": "removedFromMilestone",
+                        "parameters": {
+                          "milestoneName": "6.0.0"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "isInMilestone",
+                        "parameters": {
+                          "milestoneName": "Future"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "isInMilestone",
+                        "parameters": {
+                          "milestoneName": "6.0.0"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Anirudh/Viktor Pod triage] Move issues to untriaged column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI",
+            "columnName": "Untriaged"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "Future"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Anirudh/Viktor Pod triage] Move issues to future milestone column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI",
+            "columnName": "Future"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-Microsoft.Win32"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.EventLog"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.PerformanceCounter"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.Tracing"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.Management"
+                    }
+                  },
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "area-System.ServiceProcess"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Microsoft.Win32"
+                    }
+                  },
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.EventLog"
+                    }
+                  },
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.PerformanceCounter"
+                    }
+                  },
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Diagnostics.Tracing"
+                    }
+                  },
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Management"
+                    }
+                  },
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.ServiceProcess"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Anirudh/ViktorPod triage] Remove from project",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Issue Triage Pod for EventLog, PerformanceCounter , Tracing, ServiceProcess and WMI"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Triage POD for Meta, Reflection, etc"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-Meta"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.CodeDom"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.ComponentModel.Composition"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Composition"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Configuration"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Reflection"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Reflection.Emit"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Reflection.Metadata"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Resources"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.Runtime.CompilerServices"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "area-System.DirectoryServices"
+                }
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[joperezr Pod Triage] Move PRs to our pod project when a label from our area is added",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Triage POD for Meta, Reflection, etc",
+            "columnName": "Needs triage"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "prMatchesPattern",
+                "parameters": {
+                  "matchRegex": ".*ILLink.*"
+                }
+              },
+              {
+                "name": "prMatchesPattern",
+                "parameters": {
+                  "matchRegex": ".*illink.*"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "linkable-framework"
+                }
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Linkable-framework workgroup] Add linkable-framework label to new Prs that touch files with *ILLink* that not have it already",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "linkable-framework"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "prMatchesPattern",
+                "parameters": {
+                  "matchRegex": ".*ILLink.*"
+                }
+              },
+              {
+                "name": "prMatchesPattern",
+                "parameters": {
+                  "matchRegex": ".*illink.*"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "linkable-framework"
+                }
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "synchronize"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Linkable-framework workgroup] Add linkable-framework label to Prs that get changes pushed where they touch *ILLInk* files",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "linkable-framework"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dotnet-maestro[bot]"
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "name": "titleContains",
+            "parameters": {
+              "titlePattern": "dotnet-optimization"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Auto-approve maestro PRs",
+      "actions": [
+        {
+          "name": "approvePullRequest",
+          "parameters": {
+            "comment": "Auto-approve dotnet-optimization PR"
+          }
+        }
+      ]
+    },
+    "disabled": true
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "activitySenderHasPermissions",
+                    "parameters": {
+                      "association": "OWNER",
+                      "permissions": "admin"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "activitySenderHasPermissions",
+                    "parameters": {
+                      "association": "MEMBER",
+                      "permissions": "write"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "github-actions[bot]"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dotnet-maestro[bot]"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dotnet-maestro-bot[bot]"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dotnet-maestro-bot"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dotnet-maestro"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "github-actions"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Label community PRs",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "community-contribution"
+          }
+        }
+      ]
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": ".NET Core Diagnostics ",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Diagnostics"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-Diagnostics-coreclr"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-Tracing-coreclr"
+                }
+              }
+            ]
+          },
+          {
+            "name": "isInMilestone",
+            "parameters": {
+              "milestoneName": "6.0.0"
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "User Story"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "enhancement"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "feature request"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[hoyosjs/tommcdon] Add diagnostics 6.0 issues to project",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": ".NET Core Diagnostics",
+            "columnName": "6.0.0",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "ML, Extensions, Globalization, etc, POD."
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "7.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "7.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "7.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[safern/maryamariyan Pod Triage] Move issues to 7.0.0 column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "ML, Extensions, Globalization, etc, POD.",
+            "columnName": "7.0.0"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Infrastructure Backlog"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "addedToMilestone",
+                    "parameters": {
+                      "milestoneName": "7.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "untriaged"
+                    }
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "7.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "needs further triage"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "labelRemoved",
+                    "parameters": {
+                      "label": "needs further triage"
+                    }
+                  },
+                  {
+                    "name": "isInMilestone",
+                    "parameters": {
+                      "milestoneName": "7.0.0"
+                    }
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "untriaged"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Viktor/safern] Add infrastructure issue to 7.0.0 column",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Infrastructure Backlog",
+            "columnName": "7.0.0"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "no recent activity"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Issue cleanup notification",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "Due to lack of recent activity, this issue has been marked as a candidate for backlog cleanup.  It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will undo this process.\n\nThis process is part of the experimental [issue cleanup initiative](https://github.com/dotnet/runtime/issues/60288) we are currently trialing in a limited number of areas. Please share any feedback you might have in the linked issue."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": "needs more info"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Needs more info notification",
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This issue has been marked `needs more info` since it may be missing important information. Please refer to our [contribution guidelines](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md#writing-a-good-bug-report) for tips on how to report issues effectively."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "taskName": "@Mention for tvos",
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "os-tvos"
+          ],
+          "mentionees": [
+            "steveisok",
+            "akoeplinger"
+          ]
+        }
+      ],
+      "enableForPullRequests": true,
+      "replyTemplate": "Tagging subscribers to 'os-tvos': ${mentionees}\nSee info in area-owners.md if you want to be subscribed."
+    }
+  },
+  {
+    "taskType": "scheduledAndTrigger",
+    "capabilityId": "IssueRouting",
+    "subCapability": "@Mention",
+    "version": "1.0",
+    "config": {
+      "labelsAndMentions": [
+        {
+          "labels": [
+            "os-maccatalyst"
+          ],
+          "mentionees": [
+            "steveisok",
+            "akoeplinger"
+          ]
+        }
+      ],
+      "replyTemplate": "Tagging subscribers to 'os-maccatalyst': ${mentionees}\nSee info in area-owners.md if you want to be subscribed.",
+      "enableForPullRequests": true,
+      "taskName": "@Mention for maccatalyst"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "activitySenderHasPermissions",
+            "parameters": {
+              "state": "changes_requested",
+              "permissions": "write"
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "submitted"
+            }
+          },
+          {
+            "name": "isReviewState",
+            "parameters": {
+              "state": "changes_requested"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ],
+      "taskName": "PR reviews with \"changes requested\" applies the needs-author-action label",
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "synchronize"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs-author-action"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Pushing changes to PR branch removes the needs-author-action label",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "created"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs-author-action"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "Author commenting in PR removes the needs-author-action label",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ]
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Author responding to a pull request review comment removes the needs-author-action label",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs-author-action"
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "submitted"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-Meta"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
+                        }
+                      },
+                      {
+                        "operator": "not",
+                        "operands": [
+                          {
+                            "name": "isInMilestone",
+                            "parameters": {}
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-Meta"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+                  "isOrgProject": true,
+                  "columnName": "Triaged"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Add new issue to Board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-Meta"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "write"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+                  "columnName": "Triaged",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Further Triage",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "columnName": "Needs Triage",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Meta"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Remove relabeled issues",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+                  "columnName": "Triaged"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "addedToMilestone",
+                "parameters": {}
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "needs more info"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "api-ready-for-review"
+                }
+              },
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Move to Triaged Column",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triaged",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Collections"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Linq"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Text.Json"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Xml"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProject",
+                "parameters": {
+                  "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - PRs] Add new PR to Board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
+            "columnName": "Needs Champion",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - PRs",
+              "columnName": "Needs Champion",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-Meta"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - PRs] Remove relabeled PRs",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - PRs",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.CodeDom"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Configuration"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Reflection"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Reflection.Emit"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Reflection.Metadata"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Resources"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Runtime.CompilerServices"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Text.RegularExpressions"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Threading.Channels"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Threading.Tasks"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.DirectoryServices"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
+                        }
+                      },
+                      {
+                        "operator": "not",
+                        "operands": [
+                          {
+                            "name": "isInMilestone",
+                            "parameters": {}
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.CodeDom"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Configuration"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Reflection"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Reflection.Emit"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Reflection.Metadata"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Resources"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Runtime.CompilerServices"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Text.RegularExpressions"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Threading.Channels"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Threading.Tasks"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.DirectoryServices"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+                  "isOrgProject": true,
+                  "columnName": "Triaged"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Add new issue to Board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.CodeDom"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Configuration"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Reflection"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Reflection.Emit"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Reflection.Metadata"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Resources"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Runtime.CompilerServices"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Text.RegularExpressions"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Threading.Channels"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Threading.Tasks"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DirectoryServices"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "write"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+                  "columnName": "Triaged",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Needs Further Triage",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "columnName": "Needs Triage",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.CodeDom"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Configuration"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Reflection"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Reflection.Emit"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Reflection.Metadata"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Resources"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Runtime.CompilerServices"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Text.RegularExpressions"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Threading.Channels"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Threading.Tasks"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.DirectoryServices"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Remove relabeled issues",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+                  "columnName": "Triaged"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "addedToMilestone",
+                "parameters": {}
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "needs more info"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "api-ready-for-review"
+                }
+              },
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Move to Triaged Column",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Triaged",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
+              "columnName": "Needs Champion",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.CodeDom"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Configuration"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Reflection"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Reflection.Emit"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Reflection.Metadata"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Resources"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Runtime.CompilerServices"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Text.RegularExpressions"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Threading.Channels"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Threading.Tasks"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.DirectoryServices"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - PRs] Remove relabeled PRs",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Collections"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Linq"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Text.Json"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
+                          "label": "area-System.Xml"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
+                        }
+                      },
+                      {
+                        "operator": "not",
+                        "operands": [
+                          {
+                            "name": "isInMilestone",
+                            "parameters": {}
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "operator": "or",
+                "operands": [
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Collections"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Linq"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Text.Json"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.Xml"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+                  "isOrgProject": true,
+                  "columnName": "Triaged"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Add new issue to Board",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Collections"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Linq"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Text.Json"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.Xml"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isCloseAndComment",
+                "parameters": {}
+              }
+            ]
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "write"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "isInProject",
+                    "parameters": {
+                      "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+                      "isOrgProject": true
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+                  "columnName": "Triaged",
+                  "isOrgProject": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Needs Further Triage",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "columnName": "Needs Triage",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Collections"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Linq"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Text.Json"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Xml"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Remove relabeled issues",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProject",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isInProjectColumn",
+                "parameters": {
+                  "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+                  "columnName": "Triaged"
+                }
+              }
+            ]
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "addedToMilestone",
+                "parameters": {}
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "needs more info"
+                }
+              },
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "api-ready-for-review"
+                }
+              },
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Move to Triaged Column",
+      "actions": [
+        {
+          "name": "addToProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Triaged",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
+              "columnName": "Needs Champion",
+              "isOrgProject": true
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Collections"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Linq"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Text.Json"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
+                      "label": "area-System.Xml"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - PRs] Remove relabeled PRs",
+      "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  }
+]

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -12,18 +12,9 @@
             "area-System.Security"
           ],
           "mentionees": [
-            "bartonjs",
+            "dotnet/area-system-security",
             "vcsjones",
-            "krwq",
-            "GrabYourPitchForks"
-          ]
-        },
-        {
-          "labels": [
-            "area-System.Drawing"
-          ],
-          "mentionees": [
-            "safern"
+            "krwq"
           ]
         },
         {
@@ -33,7 +24,8 @@
           "mentionees": [
             "tarekgh",
             "tommcdon",
-            "pjanotti"
+            "pjanotti",
+            "safern"
           ]
         },
         {
@@ -41,8 +33,8 @@
             "area-System.Linq.Parallel"
           ],
           "mentionees": [
-            "tarekgh",
-            "dotnet/area-system-linq-parallel"
+            "dotnet/area-system-linq-parallel",
+            "tarekgh"
           ]
         },
         {
@@ -50,8 +42,8 @@
             "area-System.Text.Encoding"
           ],
           "mentionees": [
-            "tarekgh",
-            "dotnet/area-system-text-encoding"
+            "dotnet/area-system-text-encoding",
+            "tarekgh"
           ]
         },
         {
@@ -59,8 +51,8 @@
             "area-System.Text.Encodings.Web"
           ],
           "mentionees": [
-            "tarekgh",
-            "dotnet/area-system-text-encodings-web"
+            "dotnet/area-system-text-encodings-web",
+            "tarekgh"
           ]
         },
         {
@@ -183,8 +175,8 @@
             "area-System.Buffers"
           ],
           "mentionees": [
-            "GrabYourPitchForks",
-            "dotnet/area-system-buffers"
+            "dotnet/area-system-buffers",
+            "GrabYourPitchforks"
           ]
         },
         {
@@ -208,7 +200,7 @@
             "area-System.CodeDom"
           ],
           "mentionees": [
-            "buyaa-n"
+            "dotnet/area-system-codedom"
           ]
         },
         {
@@ -266,7 +258,7 @@
             "area-Infrastructure-libraries"
           ],
           "mentionees": [
-            "safern"
+            "dotnet/area-infrastructure-libraries"
           ]
         },
         {
@@ -385,8 +377,8 @@
             "area-Extensions-FileSystem"
           ],
           "mentionees": [
-            "maryamariyan",
-            "dotnet/area-extensions-filesystem"
+            "dotnet/area-extensions-filesystem",
+            "maryamariyan"
           ]
         },
         {
@@ -410,7 +402,6 @@
             "area-System.Formats.Cbor"
           ],
           "mentionees": [
-            "bartonjs",
             "dotnet/area-system-formats-cbor"
           ]
         },
@@ -419,8 +410,7 @@
             "area-System.Formats.Asn1"
           ],
           "mentionees": [
-            "bartonjs",
-            "vcsjones"
+            "dotnet/area-system-formats-asn1"
           ]
         },
         {
@@ -465,7 +455,6 @@
             "area-System.Memory"
           ],
           "mentionees": [
-            "GrabYourPitchForks",
             "dotnet/area-system-memory"
           ]
         },
@@ -562,6 +551,7 @@
             "area-System.DirectoryServices"
           ],
           "mentionees": [
+            "dotnet/area-system-directoryservices",
             "jay98014"
           ]
         },
@@ -691,6 +681,111 @@
           ],
           "mentionees": [
             "dotnet/area-system-globalization"
+          ]
+        },
+        {
+          "labels": [
+            "area-Microsoft.Win32"
+          ],
+          "mentionees": [
+            "dotnet/area-microsoft-win32"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Diagnostics.EventLog"
+          ],
+          "mentionees": [
+            "dotnet/area-system-diagnostics-eventlog"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Diagnostics.PerformanceCounter"
+          ],
+          "mentionees": [
+            "dotnet/area-system-diagnostics-performancecounter"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Diagnostics.TraceSource"
+          ],
+          "mentionees": [
+            "dotnet/area-system-diagnostics-tracesource"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Drawing"
+          ],
+          "mentionees": [
+            "dotnet/area-system-drawing"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Management"
+          ],
+          "mentionees": [
+            "dotnet/area-system-management"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.ServiceProcess"
+          ],
+          "mentionees": [
+            "dotnet/area-system-serviceprocess"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Configuration"
+          ],
+          "mentionees": [
+            "dotnet/area-system-configuration"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Reflection"
+          ],
+          "mentionees": [
+            "dotnet/area-system-reflection"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Reflection.Emit"
+          ],
+          "mentionees": [
+            "dotnet/area-system-reflection-emit"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Reflection.Metadata"
+          ],
+          "mentionees": [
+            "dotnet/area-system-reflection-metadata"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Resources"
+          ],
+          "mentionees": [
+            "dotnet/area-system-resources",
+            "tarekgh"
+          ]
+        },
+        {
+          "labels": [
+            "area-System.Runtime.CompilerServices"
+          ],
+          "mentionees": [
+            "dotnet/area-system-runtime-compilerservices"
           ]
         }
       ],
@@ -3981,7 +4076,7 @@
                   {
                     "name": "labelRemoved",
                     "parameters": {
-                      "label": "area-Microsoft.Win32"
+                      "label": ""
                     }
                   },
                   {

--- a/docs/infra/automation.md
+++ b/docs/infra/automation.md
@@ -4,4 +4,4 @@
 
 This repository uses Fabric Bot to automate issue and pull request management. All automation rules are defined in the [`.github/fabricbot.json`](.github/fabricbot.json) file.
 
-At this moment Fabric Bot has not published a JSON schema for the configuration format. In order to make changes to the configuration file, you can use the [`Fabric Bot portal`](https://portal.fabricbot.ms/bot/) to load the configuration file via the "Import Configuration" option and make changes using the editor. You need to be signed out from the portal in order for this option to appear.
+At this moment Fabric Bot has not published a JSON schema for the configuration format. In order to make changes to the configuration file, you should use the [`Fabric Bot portal`](https://portal.fabricbot.ms/bot/) to load the configuration file via the "Import Configuration" option and make changes using the editor. You need to be signed out from the portal in order for this option to appear.

--- a/docs/infra/automation.md
+++ b/docs/infra/automation.md
@@ -1,0 +1,7 @@
+## Automation
+
+### Fabric Bot
+
+This repository uses Fabric Bot to automate issue and pull request management. All automation rules are defined in the [`.github/fabricbot.json`](.github/fabricbot.json) file.
+
+At this moment Fabric Bot has not published a JSON schema for the configuration format. In order to make changes to the configuration file, you can use the [`Fabric Bot portal`](https://portal.fabricbot.ms/bot/) to load the configuration file via the "Import Configuration" option and make changes using the editor. You need to be signed out from the portal in order for this option to appear.


### PR DESCRIPTION
Following [#7442](https://github.com/dotnet/dotnet-api-docs/pull/7442) this PR transfers our FabricBot automation rules to Config-as-Code. Also adds a bit of documentation pointing to the new rule editing workflow.