### PR TITLE
Mark static boxes as invariant

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9382,6 +9382,11 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                         chars += printf("[ICON_BBC_PTR]");
                         break;
 
+                    case GTF_ICON_STATIC_BOX_PTR:
+
+                        chars += printf("[GTF_ICON_STATIC_BOX_PTR]");
+                        break;
+
                     case GTF_ICON_FIELD_OFF:
 
                         chars += printf("[ICON_FIELD_OFF]");

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -10454,6 +10454,9 @@ void Compiler::gtDispConst(GenTree* tree)
                         case GTF_ICON_BBC_PTR:
                             printf(" bbc");
                             break;
+                        case GTF_ICON_STATIC_BOX_PTR:
+                            printf(" static box ptr");
+                            break;
                         default:
                             printf(" UNKNOWN");
                             break;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -542,27 +542,28 @@ enum GenTreeFlags : unsigned int
 
     GTF_BOX_VALUE               = 0x80000000, // GT_BOX -- "box" is on a value type
 
-    GTF_ICON_HDL_MASK           = 0xF0000000, // Bits used by handle types below
-    GTF_ICON_SCOPE_HDL          = 0x10000000, // GT_CNS_INT -- constant is a scope handle
-    GTF_ICON_CLASS_HDL          = 0x20000000, // GT_CNS_INT -- constant is a class handle
-    GTF_ICON_METHOD_HDL         = 0x30000000, // GT_CNS_INT -- constant is a method handle
-    GTF_ICON_FIELD_HDL          = 0x40000000, // GT_CNS_INT -- constant is a field handle
-    GTF_ICON_STATIC_HDL         = 0x50000000, // GT_CNS_INT -- constant is a handle to static data
-    GTF_ICON_STR_HDL            = 0x60000000, // GT_CNS_INT -- constant is a string handle
-    GTF_ICON_CONST_PTR          = 0x70000000, // GT_CNS_INT -- constant is a pointer to immutable data, (e.g. IAT_PPVALUE)
-    GTF_ICON_GLOBAL_PTR         = 0x80000000, // GT_CNS_INT -- constant is a pointer to mutable data (e.g. from the VM state)
-    GTF_ICON_VARG_HDL           = 0x90000000, // GT_CNS_INT -- constant is a var arg cookie handle
-    GTF_ICON_PINVKI_HDL         = 0xA0000000, // GT_CNS_INT -- constant is a pinvoke calli handle
-    GTF_ICON_TOKEN_HDL          = 0xB0000000, // GT_CNS_INT -- constant is a token handle (other than class, method or field)
-    GTF_ICON_TLS_HDL            = 0xC0000000, // GT_CNS_INT -- constant is a TLS ref with offset
-    GTF_ICON_FTN_ADDR           = 0xD0000000, // GT_CNS_INT -- constant is a function address
-    GTF_ICON_CIDMID_HDL         = 0xE0000000, // GT_CNS_INT -- constant is a class ID or a module ID
-    GTF_ICON_BBC_PTR            = 0xF0000000, // GT_CNS_INT -- constant is a basic block count pointer
+    GTF_ICON_HDL_MASK           = 0xFF000000, // Bits used by handle types below
+    GTF_ICON_SCOPE_HDL          = 0x01000000, // GT_CNS_INT -- constant is a scope handle
+    GTF_ICON_CLASS_HDL          = 0x02000000, // GT_CNS_INT -- constant is a class handle
+    GTF_ICON_METHOD_HDL         = 0x03000000, // GT_CNS_INT -- constant is a method handle
+    GTF_ICON_FIELD_HDL          = 0x04000000, // GT_CNS_INT -- constant is a field handle
+    GTF_ICON_STATIC_HDL         = 0x05000000, // GT_CNS_INT -- constant is a handle to static data
+    GTF_ICON_STR_HDL            = 0x06000000, // GT_CNS_INT -- constant is a string handle
+    GTF_ICON_CONST_PTR          = 0x07000000, // GT_CNS_INT -- constant is a pointer to immutable data, (e.g. IAT_PPVALUE)
+    GTF_ICON_GLOBAL_PTR         = 0x08000000, // GT_CNS_INT -- constant is a pointer to mutable data (e.g. from the VM state)
+    GTF_ICON_VARG_HDL           = 0x09000000, // GT_CNS_INT -- constant is a var arg cookie handle
+    GTF_ICON_PINVKI_HDL         = 0x0A000000, // GT_CNS_INT -- constant is a pinvoke calli handle
+    GTF_ICON_TOKEN_HDL          = 0x0B000000, // GT_CNS_INT -- constant is a token handle (other than class, method or field)
+    GTF_ICON_TLS_HDL            = 0x0C000000, // GT_CNS_INT -- constant is a TLS ref with offset
+    GTF_ICON_FTN_ADDR           = 0x0D000000, // GT_CNS_INT -- constant is a function address
+    GTF_ICON_CIDMID_HDL         = 0x0E000000, // GT_CNS_INT -- constant is a class ID or a module ID
+    GTF_ICON_BBC_PTR            = 0x0F000000, // GT_CNS_INT -- constant is a basic block count pointer
+    GTF_ICON_STATIC_BOX_PTR     = 0x10000000, // GT_CNS_INT -- constant is an address of the box for a STATIC_IN_HEAP field
 
-    GTF_ICON_FIELD_OFF          = 0x08000000, // GT_CNS_INT -- constant is a field offset
-    GTF_ICON_SIMD_COUNT         = 0x04000000, // GT_CNS_INT -- constant is Vector<T>.Count
-
-    GTF_ICON_INITCLASS          = 0x02000000, // GT_CNS_INT -- Constant is used to access a static that requires preceding
+ // GTF_ICON_REUSE_REG_VAL      = 0x00800000  // GT_CNS_INT -- GTF_REUSE_REG_VAL, defined above
+    GTF_ICON_FIELD_OFF          = 0x00400000, // GT_CNS_INT -- constant is a field offset
+    GTF_ICON_SIMD_COUNT         = 0x00200000, // GT_CNS_INT -- constant is Vector<T>.Count
+    GTF_ICON_INITCLASS          = 0x00100000, // GT_CNS_INT -- Constant is used to access a static that requires preceding
                                               //               class/static init helper.  In some cases, the constant is
                                               //               the address of the static field itself, and in other cases
                                               //               there's an extra layer of indirection and it is the address

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8808,6 +8808,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             vnStore->VNPUnpackExc(addr->gtVNPair, &addrNvnp, &addrXvnp);
 
             // Is the dereference immutable?  If so, model it as referencing the read-only heap.
+            // TODO-VNTypes: this code needs to encode the types of the indirections.
             if (tree->gtFlags & GTF_IND_INVARIANT)
             {
                 assert(!isVolatile); // We don't expect both volatile and invariant
@@ -8830,22 +8831,13 @@ void Compiler::fgValueNumberTree(GenTree* tree)
 
                 if (!wasNewobj)
                 {
-
                     // Is this invariant indirect expected to always return a non-null value?
+                    // TODO-VNTypes: non-null indirects should only be used for TYP_REFs.
                     if ((tree->gtFlags & GTF_IND_NONNULL) != 0)
                     {
                         assert(tree->gtFlags & GTF_IND_NONFAULTING);
                         tree->gtVNPair = vnStore->VNPairForFunc(tree->TypeGet(), VNF_NonNullIndirect, addrNvnp);
-                        if (addr->IsCnsIntOrI())
-                        {
-                            assert(addrXvnp.BothEqual() &&
-                                   (addrXvnp.GetLiberal() == ValueNumStore::VNForEmptyExcSet()));
-                        }
-                        else
-                        {
-                            assert(false && "it's not expected to be hit at the moment, but can be allowed.");
-                            // tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, addrXvnp);
-                        }
+                        tree->gtVNPair = vnStore->VNPWithExc(tree->gtVNPair, addrXvnp);
                     }
                     else
                     {


### PR DESCRIPTION
This will be needed to make the upcoming changes to [how we parse the field sequences](https://github.com/dotnet/runtime/issues/58312#issuecomment-984559389) for boxed statics zero-diff - I need the box indirections to become invariant passthrough functions of their addresses.

It also happens to be a CQ improvement on its own...

...most of the time. Sometimes, CSE gets into an unfortunate position of not helping the RA a lot, and we end up with significant size regressions. Fortunately, those seems to be limited to R2R code and so are unlikely to show up on the performance radar, and in terms of PerfScore are not actually that bad (the worst one from the Win-x64 CG2 collection is a 13% PerfScore regression).

All the regressions I've looked at are because we now see CSEs live across calls, and that is not handled well. Those calls are most commonly the `GETSHARED_SOME_BASE` ones, attached to these statics.

<details>
<summary>Win-x64 diffs</summary>

## aspnet.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 13868297 (overridden on cmd)
Total bytes of diff: 13868054 (overridden on cmd)
Total bytes of delta: -243 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          96 : 28641.dasm (2.02% of base)
          40 : 16874.dasm (2.64% of base)
          16 : 39509.dasm (0.36% of base)

Top file improvements (bytes):
        -163 : 42592.dasm (-1.61% of base)
        -131 : 24038.dasm (-6.59% of base)
         -22 : 11800.dasm (-0.60% of base)
         -22 : 16418.dasm (-0.33% of base)
         -22 : 12787.dasm (-0.39% of base)
          -8 : 41925.dasm (-0.41% of base)
          -8 : 25211.dasm (-0.75% of base)
          -6 : 31505.dasm (-0.33% of base)
          -3 : 38568.dasm (-0.17% of base)
          -3 : 39570.dasm (-0.17% of base)
          -3 : 23677.dasm (-0.17% of base)
          -3 : 29839.dasm (-0.17% of base)
          -1 : 17430.dasm (-0.03% of base)

16 total files with Code Size differences (13 improved, 3 regressed), 0 unchanged.

Top method regressions (bytes):
          96 ( 2.02% of base) : 28641.dasm - SqlMapper:GenerateDeserializerFromMap(Type,IDataReader,int,int,bool,ILGenerator)
          40 ( 2.64% of base) : 16874.dasm - HttpConnectionPool:<CleanCacheAndDisposeIfUnused>g__IsUsableConnection|115_2(HttpConnectionBase,long,TimeSpan,TimeSpan):bool
          16 ( 0.36% of base) : 39509.dasm - SqlMapper:GenerateDeserializerFromMap(Type,IDataReader,int,int,bool,ILGenerator)

Top method improvements (bytes):
        -163 (-1.61% of base) : 42592.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
        -131 (-6.59% of base) : 24038.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
         -22 (-0.60% of base) : 11800.dasm - <CopyAsync>d__2:MoveNext():this
         -22 (-0.33% of base) : 16418.dasm - <CopyAsync>d__2:MoveNext():this
         -22 (-0.39% of base) : 12787.dasm - <CopyAsync>d__2:MoveNext():this
          -8 (-0.41% of base) : 41925.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -8 (-0.75% of base) : 25211.dasm - EventSource:WriteEventWithRelatedActivityIdCore(int,long,int,long):this
          -6 (-0.33% of base) : 31505.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -3 (-0.17% of base) : 38568.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -3 (-0.17% of base) : 39570.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -3 (-0.17% of base) : 23677.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -3 (-0.17% of base) : 29839.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -1 (-0.03% of base) : 17430.dasm - <CopyAsync>d__2:MoveNext():this

Top method regressions (percentages):
          40 ( 2.64% of base) : 16874.dasm - HttpConnectionPool:<CleanCacheAndDisposeIfUnused>g__IsUsableConnection|115_2(HttpConnectionBase,long,TimeSpan,TimeSpan):bool
          96 ( 2.02% of base) : 28641.dasm - SqlMapper:GenerateDeserializerFromMap(Type,IDataReader,int,int,bool,ILGenerator)
          16 ( 0.36% of base) : 39509.dasm - SqlMapper:GenerateDeserializerFromMap(Type,IDataReader,int,int,bool,ILGenerator)

Top method improvements (percentages):
        -131 (-6.59% of base) : 24038.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
        -163 (-1.61% of base) : 42592.dasm - ILEmitResolverBuilder:GenerateMethodBody(ServiceCallSite,ILGenerator):ILEmitResolverBuilderRuntimeContext:this
          -8 (-0.75% of base) : 25211.dasm - EventSource:WriteEventWithRelatedActivityIdCore(int,long,int,long):this
         -22 (-0.60% of base) : 11800.dasm - <CopyAsync>d__2:MoveNext():this
          -8 (-0.41% of base) : 41925.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
         -22 (-0.39% of base) : 12787.dasm - <CopyAsync>d__2:MoveNext():this
          -6 (-0.33% of base) : 31505.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
         -22 (-0.33% of base) : 16418.dasm - <CopyAsync>d__2:MoveNext():this
          -3 (-0.17% of base) : 38568.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -3 (-0.17% of base) : 39570.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -3 (-0.17% of base) : 23677.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -3 (-0.17% of base) : 29839.dasm - DynamicILGenerator:Emit(OpCode,MethodInfo):this
          -1 (-0.03% of base) : 17430.dasm - <CopyAsync>d__2:MoveNext():this

16 total methods with Code Size differences (13 improved, 3 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 12760187 (overridden on cmd)
Total bytes of diff: 12759786 (overridden on cmd)
Total bytes of delta: -401 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          89 : 8371.dasm (6.48% of base)
          25 : 8120.dasm (1.43% of base)
           6 : 38255.dasm (0.51% of base)
           4 : 6326.dasm (1.73% of base)
           2 : 12704.dasm (0.16% of base)
           1 : 36768.dasm (0.27% of base)

Top file improvements (bytes):
        -106 : 10415.dasm (-4.92% of base)
         -36 : 42192.dasm (-2.70% of base)
         -34 : 7264.dasm (-2.69% of base)
         -26 : 2932.dasm (-3.29% of base)
         -25 : 7958.dasm (-3.06% of base)
         -25 : 8118.dasm (-3.06% of base)
         -25 : 8134.dasm (-3.06% of base)
         -20 : 12561.dasm (-1.92% of base)
         -20 : 7974.dasm (-1.89% of base)
         -20 : 2922.dasm (-1.92% of base)
         -20 : 8023.dasm (-1.89% of base)
         -15 : 41802.dasm (-1.33% of base)
         -14 : 1157.dasm (-1.50% of base)
         -13 : 11803.dasm (-4.45% of base)
         -13 : 5874.dasm (-4.45% of base)
         -12 : 33101.dasm (-1.60% of base)
         -12 : 41272.dasm (-2.29% of base)
         -11 : 5706.dasm (-1.94% of base)
         -11 : 42126.dasm (-7.48% of base)
         -11 : 12570.dasm (-13.25% of base)

34 total files with Code Size differences (28 improved, 6 regressed), 1 unchanged.

Top method regressions (bytes):
          89 ( 6.48% of base) : 8371.dasm - System.Linq.Expressions.Compiler.CompilerScope:EmitNewHoistedLocals(System.Linq.Expressions.Compiler.LambdaCompiler):this
          25 ( 1.43% of base) : 8120.dasm - Sigil.Emit`1[__Canon][System.__Canon]:Switch(Sigil.Label[]):Sigil.Emit`1[__Canon]:this
           6 ( 0.51% of base) : 38255.dasm - BenchmarksGame.ReverseComplement_1:Bench(System.IO.Stream,System.IO.Stream)
           4 ( 1.73% of base) : 6326.dasm - System.TimeZoneInfo:ConvertUtcToTimeZone(long,System.TimeZoneInfo,byref):System.DateTime
           2 ( 0.16% of base) : 12704.dasm - System.Diagnostics.Tracing.EventSource:WriteEventWithRelatedActivityIdCore(int,long,int,long):this
           1 ( 0.27% of base) : 36768.dasm - HardwareIntrinsics.RayTracer.Packet256Tracer:MinIntersections(HardwareIntrinsics.RayTracer.RayPacket256,HardwareIntrinsics.RayTracer.Scene):HardwareIntrinsics.RayTracer.Intersections:this

Top method improvements (bytes):
        -106 (-4.92% of base) : 10415.dasm - Microsoft.Extensions.DependencyInjection.ServiceLookup.ILEmitResolverBuilder:GenerateMethodBody(Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceCallSite,System.Reflection.Emit.ILGenerator):ILEmitResolverBuilderRuntimeContext:this
         -36 (-2.70% of base) : 42192.dasm - System.Diagnostics.Tracing.EventSource:WriteEventVarargs(int,long,System.Object[]):this
         -34 (-2.69% of base) : 7264.dasm - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeIso(Newtonsoft.Json.Utilities.StringReference,int,byref):bool
         -26 (-3.29% of base) : 2932.dasm - Sigil.Emit`1[__Canon][System.__Canon]:Branch(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -25 (-3.06% of base) : 7958.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfGreater(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -25 (-3.06% of base) : 8118.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfGreaterOrEqual(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -25 (-3.06% of base) : 8134.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfLess(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -20 (-1.89% of base) : 7974.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfEqual(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -20 (-1.92% of base) : 12561.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfFalse(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -20 (-1.92% of base) : 2922.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfTrue(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -20 (-1.89% of base) : 8023.dasm - Sigil.Emit`1[__Canon][System.__Canon]:UnsignedBranchIfNotEqual(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -15 (-1.33% of base) : 41802.dasm - System.Diagnostics.Tracing.ActivityTracker:OnStart(System.String,System.String,int,byref,byref,int,bool):this
         -14 (-1.50% of base) : 1157.dasm - RuntimeTypeCache:GetGenericMethodInfo(long):System.Reflection.MethodInfo:this
         -13 (-4.45% of base) : 11803.dasm - System.Net.NetworkInformation.HostInformationPal:get_FixedInfo():byref
         -13 (-4.45% of base) : 5874.dasm - System.Net.NetworkInformation.HostInformationPal:get_FixedInfo():byref
         -12 (-1.60% of base) : 33101.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEParameterSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEModuleSymbol,Microsoft.CodeAnalysis.CSharp.Symbol,int,bool,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,System.Reflection.Metadata.ParameterHandle,int,byref):this
         -12 (-2.29% of base) : 41272.dasm - System.Linq.Expressions.Compiler.ILGen:TryEmitConstant(System.Reflection.Emit.ILGenerator,System.Object,System.Type,System.Linq.Expressions.Compiler.ILocalCache):bool
         -11 (-2.20% of base) : 16115.dasm - System.Net.WebSockets.Tests.SocketSendReceivePerfTest:Setup():this
         -11 (-14.29% of base) : 6335.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(long):this
         -11 (-1.94% of base) : 5706.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(System.Byte[],System.String,int):this

Top method regressions (percentages):
          89 ( 6.48% of base) : 8371.dasm - System.Linq.Expressions.Compiler.CompilerScope:EmitNewHoistedLocals(System.Linq.Expressions.Compiler.LambdaCompiler):this
           4 ( 1.73% of base) : 6326.dasm - System.TimeZoneInfo:ConvertUtcToTimeZone(long,System.TimeZoneInfo,byref):System.DateTime
          25 ( 1.43% of base) : 8120.dasm - Sigil.Emit`1[__Canon][System.__Canon]:Switch(Sigil.Label[]):Sigil.Emit`1[__Canon]:this
           6 ( 0.51% of base) : 38255.dasm - BenchmarksGame.ReverseComplement_1:Bench(System.IO.Stream,System.IO.Stream)
           1 ( 0.27% of base) : 36768.dasm - HardwareIntrinsics.RayTracer.Packet256Tracer:MinIntersections(HardwareIntrinsics.RayTracer.RayPacket256,HardwareIntrinsics.RayTracer.Scene):HardwareIntrinsics.RayTracer.Intersections:this
           2 ( 0.16% of base) : 12704.dasm - System.Diagnostics.Tracing.EventSource:WriteEventWithRelatedActivityIdCore(int,long,int,long):this

Top method improvements (percentages):
         -11 (-14.29% of base) : 6335.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(long):this
         -11 (-13.25% of base) : 12570.dasm - System.Xml.Schema.XmlSchemaParticle:.ctor():this
         -11 (-10.48% of base) : 6351.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:Reset():this
         -11 (-7.48% of base) : 42126.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(System.Security.Cryptography.X509Certificates.X509Certificate):this
        -106 (-4.92% of base) : 10415.dasm - Microsoft.Extensions.DependencyInjection.ServiceLookup.ILEmitResolverBuilder:GenerateMethodBody(Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceCallSite,System.Reflection.Emit.ILGenerator):ILEmitResolverBuilderRuntimeContext:this
         -13 (-4.45% of base) : 11803.dasm - System.Net.NetworkInformation.HostInformationPal:get_FixedInfo():byref
         -13 (-4.45% of base) : 5874.dasm - System.Net.NetworkInformation.HostInformationPal:get_FixedInfo():byref
          -9 (-3.73% of base) : 6045.dasm - System.Net.Http.HttpConnectionPoolManager:SetCleaningTimer(System.TimeSpan):this
         -26 (-3.29% of base) : 2932.dasm - Sigil.Emit`1[__Canon][System.__Canon]:Branch(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -25 (-3.06% of base) : 7958.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfGreater(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -25 (-3.06% of base) : 8118.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfGreaterOrEqual(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -25 (-3.06% of base) : 8134.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfLess(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -36 (-2.70% of base) : 42192.dasm - System.Diagnostics.Tracing.EventSource:WriteEventVarargs(int,long,System.Object[]):this
         -34 (-2.69% of base) : 7264.dasm - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeIso(Newtonsoft.Json.Utilities.StringReference,int,byref):bool
          -3 (-2.40% of base) : 11846.dasm - System.Numerics.Tests.Perf_Plane:EqualsBenchmark():bool:this
         -12 (-2.29% of base) : 41272.dasm - System.Linq.Expressions.Compiler.ILGen:TryEmitConstant(System.Reflection.Emit.ILGenerator,System.Object,System.Type,System.Linq.Expressions.Compiler.ILocalCache):bool
         -11 (-2.20% of base) : 16115.dasm - System.Net.WebSockets.Tests.SocketSendReceivePerfTest:Setup():this
         -11 (-1.94% of base) : 5706.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(System.Byte[],System.String,int):this
         -20 (-1.92% of base) : 12561.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfFalse(Sigil.Label):Sigil.Emit`1[__Canon]:this
         -20 (-1.92% of base) : 2922.dasm - Sigil.Emit`1[__Canon][System.__Canon]:BranchIfTrue(Sigil.Label):Sigil.Emit`1[__Canon]:this

34 total methods with Code Size differences (28 improved, 6 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 125643038 (overridden on cmd)
Total bytes of diff: 125566799 (overridden on cmd)
Total bytes of delta: -76239 (-0.06 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         313 : 217866.dasm (0.22% of base)
         303 : 217685.dasm (0.25% of base)
         299 : 217846.dasm (0.22% of base)
         283 : 217745.dasm (0.21% of base)
         224 : 217725.dasm (0.17% of base)
         222 : 217785.dasm (0.16% of base)
         219 : 217663.dasm (0.17% of base)
         191 : 217705.dasm (0.16% of base)
         168 : 217765.dasm (0.13% of base)
         159 : 217826.dasm (0.12% of base)
         154 : 217642.dasm (0.12% of base)
         108 : 237825.dasm (2.97% of base)
         108 : 237826.dasm (2.97% of base)
         101 : 217806.dasm (0.08% of base)
          67 : 163874.dasm (2.59% of base)
          64 : 152474.dasm (1.37% of base)
          64 : 154917.dasm (1.37% of base)
          57 : 250867.dasm (2.30% of base)
          49 : 192084.dasm (0.84% of base)
          43 : 192059.dasm (1.19% of base)

Top file improvements (bytes):
       -2005 : 218651.dasm (-3.22% of base)
       -2005 : 218656.dasm (-3.22% of base)
       -1199 : 218555.dasm (-14.08% of base)
       -1157 : 218527.dasm (-13.82% of base)
       -1125 : 218597.dasm (-13.38% of base)
       -1105 : 218250.dasm (-9.16% of base)
       -1097 : 218569.dasm (-12.90% of base)
       -1094 : 218509.dasm (-13.46% of base)
       -1088 : 217996.dasm (-12.60% of base)
       -1085 : 218638.dasm (-12.57% of base)
       -1079 : 218151.dasm (-8.90% of base)
       -1079 : 218380.dasm (-9.31% of base)
       -1049 : 217897.dasm (-12.37% of base)
       -1046 : 218610.dasm (-12.34% of base)
       -1043 : 218410.dasm (-12.61% of base)
       -1040 : 218281.dasm (-9.12% of base)
        -965 : 228104.dasm (-13.97% of base)
        -843 : 227186.dasm (-11.46% of base)
        -840 : 226181.dasm (-10.95% of base)
        -827 : 227156.dasm (-10.76% of base)

1298 total files with Code Size differences (1247 improved, 51 regressed), 5 unchanged.

Top method regressions (bytes):
         313 ( 0.22% of base) : 217866.dasm - u8rem:Main():int
         303 ( 0.25% of base) : 217685.dasm - r4div:Main():int
         299 ( 0.22% of base) : 217846.dasm - u4rem:Main():int
         283 ( 0.21% of base) : 217745.dasm - u8div:Main():int
         224 ( 0.17% of base) : 217725.dasm - u4div:Main():int
         222 ( 0.16% of base) : 217785.dasm - i8rem:Main():int
         219 ( 0.17% of base) : 217663.dasm - i8div:Main():int
         191 ( 0.16% of base) : 217705.dasm - r8div:Main():int
         168 ( 0.13% of base) : 217765.dasm - i4rem:Main():int
         159 ( 0.12% of base) : 217826.dasm - r8rem:Main():int
         154 ( 0.12% of base) : 217642.dasm - i4div:Main():int
         108 ( 2.97% of base) : 237825.dasm - intmm:Main():int
         108 ( 2.97% of base) : 237826.dasm - intmm:Main():int
         101 ( 0.08% of base) : 217806.dasm - r4rem:Main():int
          67 ( 2.59% of base) : 163874.dasm - ReliabilityFramework:ExecuteFromLog(System.String):this
          64 ( 1.37% of base) : 152474.dasm - testout1:Func_0_5_2_1_3():System.Decimal
          64 ( 1.37% of base) : 154917.dasm - testout1:Func_0_5_2_1_3():System.Decimal
          57 ( 2.30% of base) : 250867.dasm - Program:Main():int
          49 ( 0.84% of base) : 192084.dasm - ABIStress.Program:DoStubCall(int,bool,bool,int,int):bool
          43 ( 1.19% of base) : 192059.dasm - ABIStress.Program:DoPInvokes(int):bool

Top method improvements (bytes):
       -2005 (-3.22% of base) : 218651.dasm - testout1:Func_0():int
       -2005 (-3.22% of base) : 218656.dasm - testout1:Func_0():int
       -1199 (-14.08% of base) : 218555.dasm - TestApp:Main():int
       -1157 (-13.82% of base) : 218527.dasm - TestApp:Main():int
       -1125 (-13.38% of base) : 218597.dasm - TestApp:Main():int
       -1105 (-9.16% of base) : 218250.dasm - TestApp:Main():int
       -1097 (-12.90% of base) : 218569.dasm - TestApp:Main():int
       -1094 (-13.46% of base) : 218509.dasm - TestApp:Main():int
       -1088 (-12.60% of base) : 217996.dasm - TestApp:Main():int
       -1085 (-12.57% of base) : 218638.dasm - TestApp:Main():int
       -1079 (-8.90% of base) : 218151.dasm - TestApp:Main():int
       -1079 (-9.31% of base) : 218380.dasm - TestApp:Main():int
       -1049 (-12.37% of base) : 217897.dasm - TestApp:Main():int
       -1046 (-12.34% of base) : 218610.dasm - TestApp:Main():int
       -1043 (-12.61% of base) : 218410.dasm - TestApp:Main():int
       -1040 (-9.12% of base) : 218281.dasm - TestApp:Main():int
        -965 (-13.97% of base) : 228104.dasm - TestApp:Main():int
        -843 (-11.46% of base) : 227186.dasm - TestApp:Main():int
        -840 (-10.95% of base) : 226181.dasm - TestApp:Main():int
        -827 (-10.76% of base) : 227156.dasm - TestApp:Main():int

Top method regressions (percentages):
         108 ( 2.97% of base) : 237825.dasm - intmm:Main():int
         108 ( 2.97% of base) : 237826.dasm - intmm:Main():int
          67 ( 2.59% of base) : 163874.dasm - ReliabilityFramework:ExecuteFromLog(System.String):this
          57 ( 2.30% of base) : 250867.dasm - Program:Main():int
          38 ( 2.01% of base) : 154960.dasm - testout1:Func_0_5_2_3_1():System.Decimal
          17 ( 1.97% of base) : 151931.dasm - testout1:Func_0_2_1_6_6():float
          17 ( 1.97% of base) : 154540.dasm - testout1:Func_0_2_1_6_6():float
           6 ( 1.89% of base) : 192055.dasm - ABIStress.ConstantValue:EmitLoadBlittable(System.Reflection.Emit.ILGenerator,System.Numerics.Vector`1[Single])
          22 ( 1.88% of base) : 192079.dasm - ABIStress.Program:EmitDumpValues(System.String,System.Reflection.Emit.ILGenerator,System.Collections.Generic.IEnumerable`1[[ABIStress.Value, pinvokes_do, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]])
          29 ( 1.80% of base) : 152373.dasm - testout1:Func_0_4_5_3_2():System.Decimal
           6 ( 1.74% of base) : 260325.dasm - JitCrashPOC.ItemRunner:UpdateItem(float,int):this
          30 ( 1.50% of base) : 214641.dasm - testout1:Func_0_4_4_1():System.Decimal
          64 ( 1.37% of base) : 152474.dasm - testout1:Func_0_5_2_1_3():System.Decimal
          64 ( 1.37% of base) : 154917.dasm - testout1:Func_0_5_2_1_3():System.Decimal
          43 ( 1.19% of base) : 192059.dasm - ABIStress.Program:DoPInvokes(int):bool
          14 ( 1.07% of base) : 152769.dasm - testout1:Func_0_6_4_4_4():System.Decimal
           3 ( 1.06% of base) : 245439.dasm - My:EmitDynamicMethod(System.Reflection.MethodInfo):System.Reflection.Emit.DynamicMethod
          13 ( 0.96% of base) : 214621.dasm - testout1:Func_0_4_3():int
          13 ( 0.96% of base) : 214706.dasm - testout1:Func_0_4_3():int
          49 ( 0.84% of base) : 192084.dasm - ABIStress.Program:DoStubCall(int,bool,bool,int,int):bool

Top method improvements (percentages):
         -56 (-46.28% of base) : 154934.dasm - testout1:Func_0_5_3_2_1():float
         -56 (-46.28% of base) : 152498.dasm - testout1:Func_0_5_3_2_1():float
        -154 (-41.85% of base) : 152641.dasm - testout1:Func_0_5_6_4_5():double
        -215 (-37.92% of base) : 191677.dasm - testout1:Func_0_1_5():double
        -159 (-37.59% of base) : 191719.dasm - testout1:Func_0_4_3():double
        -138 (-37.00% of base) : 235508.dasm - NullableTest1:Run()
        -194 (-36.53% of base) : 191673.dasm - testout1:Func_0_1_9():long
         -30 (-35.71% of base) : 84899.dasm - ldloc_stloc:main(System.String[]):int
        -170 (-34.55% of base) : 191669.dasm - testout1:Func_0_2_4():double
        -138 (-31.94% of base) : 191701.dasm - testout1:Func_0_7_4():double
         -63 (-31.03% of base) : 191743.dasm - VT_0_6_1:.ctor(int):this
        -191 (-31.01% of base) : 191707.dasm - testout1:Func_0_6_3():long
        -129 (-30.86% of base) : 191698.dasm - testout1:Func_0_7_7():double
         -39 (-30.71% of base) : 82903.dasm - bug1:Main():int
         -45 (-30.61% of base) : 84509.dasm - Box_Unbox:main(System.String[]):int
        -142 (-30.21% of base) : 191712.dasm - testout1:Func_0_5_5():long
        -130 (-30.16% of base) : 191722.dasm - testout1:Func_0_3_8():long
         -60 (-30.15% of base) : 152744.dasm - testout1:Func_0_6_3_4_1():double
        -141 (-29.44% of base) : 191704.dasm - testout1:Func_0_7_1():float
        -150 (-29.13% of base) : 191715.dasm - testout1:Func_0_5_2():double

1298 total methods with Code Size differences (1247 improved, 51 regressed), 5 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 34402381 (overridden on cmd)
Total bytes of diff: 34411645 (overridden on cmd)
Total bytes of delta: 9264 (0.03 % of base)
    diff is a regression.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
        4439 : 16608.dasm (4.39% of base)
        3420 : 3477.dasm (22.41% of base)
        2799 : 14461.dasm (7.75% of base)
        1801 : 17539.dasm (10.69% of base)
        1136 : 16339.dasm (4.60% of base)
         880 : 16037.dasm (3.85% of base)
         623 : 4025.dasm (11.94% of base)
         340 : 8283.dasm (11.11% of base)
         337 : 13354.dasm (11.77% of base)
         211 : 8356.dasm (9.03% of base)
          72 : 14542.dasm (12.48% of base)
          72 : 14596.dasm (12.48% of base)
          60 : 17746.dasm (5.58% of base)
          49 : 14853.dasm (2.80% of base)
          41 : 128622.dasm (0.98% of base)
          23 : 8194.dasm (3.58% of base)
          23 : 14432.dasm (3.72% of base)
          18 : 38206.dasm (6.92% of base)
          17 : 113732.dasm (1.40% of base)
          16 : 17851.dasm (2.56% of base)

Top file improvements (bytes):
       -3154 : 19314.dasm (-6.79% of base)
       -2623 : 58169.dasm (-6.71% of base)
        -432 : 204662.dasm (-14.63% of base)
         -73 : 35518.dasm (-1.72% of base)
         -52 : 186306.dasm (-1.13% of base)
         -47 : 35517.dasm (-1.11% of base)
         -37 : 124966.dasm (-20.79% of base)
         -32 : 186414.dasm (-17.58% of base)
         -30 : 179809.dasm (-3.53% of base)
         -24 : 25900.dasm (-1.10% of base)
         -21 : 38142.dasm (-7.34% of base)
         -21 : 155951.dasm (-2.69% of base)
         -19 : 82943.dasm (-14.29% of base)
         -19 : 172734.dasm (-2.73% of base)
         -17 : 38204.dasm (-1.27% of base)
         -17 : 41612.dasm (-8.21% of base)
         -17 : 25947.dasm (-1.38% of base)
         -16 : 18339.dasm (-5.00% of base)
         -16 : 25962.dasm (-1.47% of base)
         -16 : 82944.dasm (-20.25% of base)

123 total files with Code Size differences (86 improved, 37 regressed), 2 unchanged.

Top method regressions (bytes):
        4439 ( 4.39% of base) : 16608.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        3420 (22.41% of base) : 3477.dasm - Microsoft.Diagnostics.Tracing.Parsers.AspNet.AspNetTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        2799 ( 7.75% of base) : 14461.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        1801 (10.69% of base) : 17539.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngineTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        1136 ( 4.60% of base) : 16339.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivateTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         880 ( 3.85% of base) : 16037.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         623 (11.94% of base) : 4025.dasm - Microsoft.Diagnostics.Tracing.Parsers.Clr.ClrRundownTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         340 (11.11% of base) : 8283.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.HeapTraceProviderTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         337 (11.77% of base) : 13354.dasm - Microsoft.Diagnostics.Tracing.Parsers.SymbolTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         211 ( 9.03% of base) : 8356.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.ThreadPoolTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          72 (12.48% of base) : 14596.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:add_MemoryPageAccess(System.Action`1[Microsoft.Diagnostics.Tracing.Parsers.Kernel.MemoryPageAccessTraceData]):this
          72 (12.48% of base) : 14542.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:add_PerfInfoISR(System.Action`1[Microsoft.Diagnostics.Tracing.Parsers.Kernel.ISRTraceData]):this
          60 ( 5.58% of base) : 17746.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareAMFilterTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          49 ( 2.80% of base) : 14853.dasm - Microsoft.Diagnostics.Tracing.Parsers.JSDumpHeapTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          41 ( 0.98% of base) : 128622.dasm - Microsoft.CodeAnalysis.VisualBasic.OverloadResolution:MatchArguments(Microsoft.CodeAnalysis.VisualBasic.BoundMethodOrPropertyGroup,byref,System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.VisualBasic.BoundExpression],System.Collections.Immutable.ImmutableArray`1[System.String],Microsoft.CodeAnalysis.VisualBasic.Binder,byref,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,bool,byref)
          23 ( 3.58% of base) : 8194.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.CritSecTraceProviderTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          23 ( 3.72% of base) : 14432.dasm - Microsoft.Diagnostics.Tracing.Parsers.LinuxKernelEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          18 ( 6.92% of base) : 38206.dasm - System.TimeZoneInfo:ConvertUtcToTimeZone(long,System.TimeZoneInfo,byref):System.DateTime
          17 ( 1.40% of base) : 113732.dasm - Microsoft.CodeAnalysis.CSharp.LocalRewriter:MakeSizeOfMultiplication(Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.Symbols.PointerTypeSymbol,bool):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
          16 ( 2.56% of base) : 17851.dasm - Microsoft.Diagnostics.Tracing.EventPipe.SampleProfilerTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this

Top method improvements (bytes):
       -3154 (-6.79% of base) : 19314.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[System.String, Microsoft.Diagnostics.Tracing.ETWMapping]
       -2623 (-6.71% of base) : 58169.dasm - Microsoft.CodeAnalysis.DesktopAssemblyIdentityComparer:.cctor()
        -432 (-14.63% of base) : 204662.dasm - System.ComponentModel.Design.StandardCommands:.cctor()
         -73 (-1.72% of base) : 35518.dasm - System.Globalization.TimeSpanParse:ProcessTerminal_HMS_F_D(byref,ubyte,byref):bool
         -52 (-1.13% of base) : 186306.dasm - Internal.TypeSystem.MetadataFieldLayoutAlgorithm:ComputeAutoFieldLayout(Internal.TypeSystem.MetadataType,int):Internal.TypeSystem.ComputedInstanceFieldLayout:this
         -47 (-1.11% of base) : 35517.dasm - System.Globalization.TimeSpanParse:ProcessTerminal_HM_S_D(byref,ubyte,byref):bool
         -37 (-20.79% of base) : 124966.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions:get_DefaultPreprocessorSymbols():System.Collections.Immutable.ImmutableArray`1[System.Collections.Generic.KeyValuePair`2[System.String, System.Object]]
         -32 (-17.58% of base) : 186414.dasm - Internal.TypeSystem.UniversalCanonLayoutAlgorithm:ComputeStaticFieldLayout(Internal.TypeSystem.DefType,int):Internal.TypeSystem.ComputedStaticFieldLayout:this
         -30 (-3.53% of base) : 179809.dasm - System.Runtime.Caching.UsageBucket:AddCacheEntry(System.Runtime.Caching.MemoryCacheEntry):this
         -24 (-1.10% of base) : 25900.dasm - System.Diagnostics.Tracing.EventSource:WriteImpl(System.String,byref,System.Object,long,long,System.Diagnostics.Tracing.TraceLoggingEventTypes):this
         -21 (-7.34% of base) : 38142.dasm - AdjustmentRule:AdjustDaylightDeltaToExpectedRange(byref,byref)
         -21 (-2.69% of base) : 155951.dasm - System.Data.SqlTypes.SqlDateTime:.cctor()
         -19 (-2.73% of base) : 172734.dasm - Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext:MatchPatternContexts(System.__Canon,System.Func`3[Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext, System.__Canon, Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult]):Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult:this
         -19 (-14.29% of base) : 82943.dasm - Newtonsoft.Json.Serialization.JsonTypeReflector:get_FullyTrusted():bool
         -17 (-8.21% of base) : 41612.dasm - System.DateTimeOffset:.cctor()
         -17 (-1.38% of base) : 25947.dasm - System.Diagnostics.Tracing.EventSource:WriteEventVarargs(int,long,System.Object[]):this
         -17 (-1.27% of base) : 38204.dasm - System.TimeZoneInfo:GetIsDaylightSavings(System.DateTime,System.TimeZoneInfo+AdjustmentRule,System.Globalization.DaylightTimeStruct):bool
         -16 (-5.00% of base) : 18339.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventProviderOptions:get_FilteringSupported():bool
         -16 (-20.25% of base) : 82944.dasm - Newtonsoft.Json.Serialization.JsonTypeReflector:get_DynamicCodeGeneration():bool
         -16 (-1.47% of base) : 25962.dasm - System.Diagnostics.Tracing.EventSource:WriteEventWithRelatedActivityIdCore(int,long,int,long):this

Top method regressions (percentages):
        3420 (22.41% of base) : 3477.dasm - Microsoft.Diagnostics.Tracing.Parsers.AspNet.AspNetTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          72 (12.48% of base) : 14596.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:add_MemoryPageAccess(System.Action`1[Microsoft.Diagnostics.Tracing.Parsers.Kernel.MemoryPageAccessTraceData]):this
          72 (12.48% of base) : 14542.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:add_PerfInfoISR(System.Action`1[Microsoft.Diagnostics.Tracing.Parsers.Kernel.ISRTraceData]):this
         623 (11.94% of base) : 4025.dasm - Microsoft.Diagnostics.Tracing.Parsers.Clr.ClrRundownTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         337 (11.77% of base) : 13354.dasm - Microsoft.Diagnostics.Tracing.Parsers.SymbolTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         340 (11.11% of base) : 8283.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.HeapTraceProviderTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        1801 (10.69% of base) : 17539.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngineTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         211 ( 9.03% of base) : 8356.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.ThreadPoolTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        2799 ( 7.75% of base) : 14461.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          18 ( 6.92% of base) : 38206.dasm - System.TimeZoneInfo:ConvertUtcToTimeZone(long,System.TimeZoneInfo,byref):System.DateTime
          60 ( 5.58% of base) : 17746.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareAMFilterTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        1136 ( 4.60% of base) : 16339.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivateTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
        4439 ( 4.39% of base) : 16608.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
         880 ( 3.85% of base) : 16037.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          23 ( 3.72% of base) : 14432.dasm - Microsoft.Diagnostics.Tracing.Parsers.LinuxKernelEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          23 ( 3.58% of base) : 8194.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.CritSecTraceProviderTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          49 ( 2.80% of base) : 14853.dasm - Microsoft.Diagnostics.Tracing.Parsers.JSDumpHeapTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
          16 ( 2.56% of base) : 17851.dasm - Microsoft.Diagnostics.Tracing.EventPipe.SampleProfilerTraceEventParser:EnumerateTemplates(System.Func`3[System.String, System.String, Microsoft.Diagnostics.Tracing.EventFilterResponse],System.Action`1[Microsoft.Diagnostics.Tracing.TraceEvent]):this
           3 ( 2.34% of base) : 155164.dasm - System.Data.SqlTypes.SqlByte:op_Explicit(System.Data.SqlTypes.SqlInt64):System.Data.SqlTypes.SqlByte
           3 ( 2.29% of base) : 155165.dasm - System.Data.SqlTypes.SqlByte:op_Explicit(System.Data.SqlTypes.SqlInt32):System.Data.SqlTypes.SqlByte

Top method improvements (percentages):
         -37 (-20.79% of base) : 124966.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions:get_DefaultPreprocessorSymbols():System.Collections.Immutable.ImmutableArray`1[System.Collections.Generic.KeyValuePair`2[System.String, System.Object]]
         -16 (-20.25% of base) : 82944.dasm - Newtonsoft.Json.Serialization.JsonTypeReflector:get_DynamicCodeGeneration():bool
         -32 (-17.58% of base) : 186414.dasm - Internal.TypeSystem.UniversalCanonLayoutAlgorithm:ComputeStaticFieldLayout(Internal.TypeSystem.DefType,int):Internal.TypeSystem.ComputedStaticFieldLayout:this
        -432 (-14.63% of base) : 204662.dasm - System.ComponentModel.Design.StandardCommands:.cctor()
         -19 (-14.29% of base) : 82943.dasm - Newtonsoft.Json.Serialization.JsonTypeReflector:get_FullyTrusted():bool
         -12 (-9.45% of base) : 186415.dasm - Internal.TypeSystem.UniversalCanonLayoutAlgorithm:ComputeInstanceLayout(Internal.TypeSystem.DefType,int):Internal.TypeSystem.ComputedInstanceFieldLayout:this
         -17 (-8.21% of base) : 41612.dasm - System.DateTimeOffset:.cctor()
         -14 (-7.37% of base) : 154587.dasm - System.Data.Common.DateTimeStorage:Compare(int,int):int:this
         -14 (-7.37% of base) : 153920.dasm - System.Data.Common.TimeSpanStorage:Compare(int,int):int:this
         -21 (-7.34% of base) : 38142.dasm - AdjustmentRule:AdjustDaylightDeltaToExpectedRange(byref,byref)
       -3154 (-6.79% of base) : 19314.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[System.String, Microsoft.Diagnostics.Tracing.ETWMapping]
       -2623 (-6.71% of base) : 58169.dasm - Microsoft.CodeAnalysis.DesktopAssemblyIdentityComparer:.cctor()
         -10 (-6.02% of base) : 153725.dasm - System.Data.Common.SqlBinaryStorage:.ctor(System.Data.DataColumn):this
         -10 (-6.02% of base) : 153825.dasm - System.Data.Common.SqlGuidStorage:.ctor(System.Data.DataColumn):this
          -8 (-5.84% of base) : 153797.dasm - System.Data.Common.SqlInt32Storage:.ctor(System.Data.DataColumn):this
          -8 (-5.84% of base) : 153755.dasm - System.Data.Common.SqlSingleStorage:.ctor(System.Data.DataColumn):this
          -8 (-5.56% of base) : 14595.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:remove_MemoryPageAccess(System.Action`1[Microsoft.Diagnostics.Tracing.Parsers.Kernel.MemoryPageAccessTraceData]):this
         -10 (-5.38% of base) : 153741.dasm - System.Data.Common.SqlStringStorage:.ctor(System.Data.DataColumn):this
          -8 (-5.23% of base) : 153867.dasm - System.Data.Common.SqlDateTimeStorage:.ctor(System.Data.DataColumn):this
          -7 (-5.19% of base) : 153811.dasm - System.Data.Common.SqlInt16Storage:.ctor(System.Data.DataColumn):this

123 total methods with Code Size differences (86 improved, 37 regressed), 2 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 45297619 (overridden on cmd)
Total bytes of diff: 45283751 (overridden on cmd)
Total bytes of delta: -13868 (-0.03 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         783 : 85859.dasm (0.67% of base)
          91 : 121525.dasm (6.43% of base)
          52 : 143415.dasm (4.46% of base)
          47 : 137866.dasm (2.12% of base)
          41 : 225090.dasm (1.05% of base)
          39 : 137793.dasm (1.01% of base)
          39 : 137867.dasm (2.26% of base)
          34 : 114611.dasm (4.90% of base)
          31 : 103286.dasm (2.11% of base)
          29 : 177573.dasm (0.62% of base)
          28 : 109958.dasm (0.85% of base)
          21 : 137890.dasm (0.91% of base)
          20 : 137157.dasm (0.87% of base)
          13 : 193937.dasm (0.47% of base)
          12 : 109827.dasm (0.13% of base)
          11 : 185919.dasm (0.99% of base)
          10 : 214328.dasm (0.34% of base)
           9 : 215985.dasm (0.62% of base)
           9 : 137170.dasm (0.52% of base)
           8 : 137950.dasm (0.21% of base)

Top file improvements (bytes):
       -5441 : 84095.dasm (-10.27% of base)
       -1639 : 85673.dasm (-10.34% of base)
       -1447 : 86799.dasm (-4.99% of base)
       -1371 : 99680.dasm (-9.18% of base)
       -1197 : 87068.dasm (-4.46% of base)
        -262 : 99255.dasm (-4.92% of base)
        -188 : 85034.dasm (-6.23% of base)
        -165 : 24958.dasm (-7.78% of base)
        -134 : 95074.dasm (-4.42% of base)
        -132 : 90040.dasm (-4.43% of base)
        -128 : 88550.dasm (-0.30% of base)
        -106 : 163093.dasm (-4.92% of base)
         -99 : 49948.dasm (-5.70% of base)
         -92 : 95003.dasm (-3.96% of base)
         -81 : 166233.dasm (-6.42% of base)
         -71 : 88539.dasm (-3.87% of base)
         -71 : 202816.dasm (-1.83% of base)
         -71 : 217539.dasm (-1.93% of base)
         -60 : 106105.dasm (-4.78% of base)
         -53 : 84300.dasm (-1.10% of base)

246 total files with Code Size differences (206 improved, 40 regressed), 2 unchanged.

Top method regressions (bytes):
         783 ( 0.67% of base) : 85859.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
          91 ( 6.43% of base) : 121525.dasm - System.Linq.Expressions.Compiler.CompilerScope:EmitNewHoistedLocals(System.Linq.Expressions.Compiler.LambdaCompiler):this
          52 ( 4.46% of base) : 143415.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:VisitChoice(System.Xml.Xsl.Qil.QilChoice):System.Xml.Xsl.Qil.QilNode:this
          47 ( 2.12% of base) : 137866.dasm - System.Xml.Schema.SchemaCollectionCompiler:CannonicalizeChoice(System.Xml.Schema.XmlSchemaChoice,bool,bool):System.Xml.Schema.XmlSchemaParticle:this
          41 ( 1.05% of base) : 225090.dasm - System.ServiceModel.Syndication.Rss20FeedFormatter:WriteItemContents(System.Xml.XmlWriter,System.ServiceModel.Syndication.SyndicationItem,System.Uri):this
          39 ( 1.01% of base) : 137793.dasm - System.Xml.Schema.Preprocessor:PreprocessParticle(System.Xml.Schema.XmlSchemaParticle):this
          39 ( 2.26% of base) : 137867.dasm - System.Xml.Schema.SchemaCollectionCompiler:CannonicalizeSequence(System.Xml.Schema.XmlSchemaSequence,bool,bool):System.Xml.Schema.XmlSchemaParticle:this
          34 ( 4.90% of base) : 114611.dasm - System.Data.Common.DecimalStorage:Compare(int,int):int:this
          31 ( 2.11% of base) : 103286.dasm - Microsoft.VisualBasic.CompilerServices.IDOUtils:CreateInvoker(int):System.Func`4[[System.Runtime.CompilerServices.CallSiteBinder, System.Linq.Expressions, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a],[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object[], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
          29 ( 0.62% of base) : 177573.dasm - System.ComponentModel.Composition.MetadataViewGenerator:GenerateInterfaceViewProxyType(System.Type):System.Type
          28 ( 0.85% of base) : 109958.dasm - System.Data.XSDSchema:HandleDataSet(System.Xml.Schema.XmlSchemaElement,bool):this
          21 ( 0.91% of base) : 137890.dasm - System.Xml.Schema.SchemaCollectionCompiler:CompileComplexContent(System.Xml.Schema.XmlSchemaComplexType):System.Xml.Schema.ContentValidator:this
          20 ( 0.87% of base) : 137157.dasm - System.Xml.Schema.Compiler:CompileComplexContent(System.Xml.Schema.XmlSchemaComplexType):System.Xml.Schema.ContentValidator:this
          13 ( 0.47% of base) : 193937.dasm - System.Formats.Asn1.AsnDecoder:ProcessConstructedBitString(System.ReadOnlySpan`1[Byte],int,System.Span`1[Byte],BitStringCopyAction,bool,byref,byref):int
          12 ( 0.13% of base) : 109827.dasm - System.Data.XmlTreeGen:SchemaTree(System.Xml.XmlDocument,System.Xml.XmlWriter,System.Data.DataSet,System.Data.DataTable,bool):this
          11 ( 0.99% of base) : 185919.dasm - System.Data.OleDb.OleDbCommand:ExecuteTableDirect(int,byref):int:this
          10 ( 0.34% of base) : 214328.dasm - ProxyBuilder:AddMethodImpl(System.Reflection.MethodInfo,int):System.Reflection.Emit.MethodBuilder:this
           9 ( 0.62% of base) : 215985.dasm - System.Runtime.Caching.ExpiresBucket:FlushExpiredItems(System.DateTime,bool):int:this
           9 ( 0.52% of base) : 137170.dasm - System.Xml.Schema.Compiler:CannonicalizeSequence(System.Xml.Schema.XmlSchemaSequence,bool):System.Xml.Schema.XmlSchemaParticle:this
           8 ( 1.57% of base) : 163643.dasm - Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext:MatchPatternContexts(short,System.Func`3[[Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext, Microsoft.Extensions.FileSystemGlobbing, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Int16, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult, Microsoft.Extensions.FileSystemGlobbing, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]]):Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult:this

Top method improvements (bytes):
       -5441 (-10.27% of base) : 84095.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.ETWMapping, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
       -1639 (-10.34% of base) : 85673.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngineTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -1447 (-4.99% of base) : 86799.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivateTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -1371 (-9.18% of base) : 99680.dasm - Microsoft.Diagnostics.Tracing.Parsers.AspNet.AspNetTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -1197 (-4.46% of base) : 87068.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -262 (-4.92% of base) : 99255.dasm - Microsoft.Diagnostics.Tracing.Parsers.Clr.ClrRundownTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -188 (-6.23% of base) : 85034.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventSession:SetStackTraceIds(int,long,int):int
        -165 (-7.78% of base) : 24958.dasm - Microsoft.CodeAnalysis.CSharp.BuiltInOperators:GetSimpleBuiltInOperators(int,Microsoft.CodeAnalysis.ArrayBuilder`1[BinaryOperatorSignature]):this
        -134 (-4.42% of base) : 95074.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.HeapTraceProviderTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -132 (-4.43% of base) : 90040.dasm - Microsoft.Diagnostics.Tracing.Parsers.SymbolTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -128 (-0.30% of base) : 88550.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -106 (-4.92% of base) : 163093.dasm - Microsoft.Extensions.DependencyInjection.ServiceLookup.ILEmitResolverBuilder:GenerateMethodBody(Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceCallSite,System.Reflection.Emit.ILGenerator):ILEmitResolverBuilderRuntimeContext:this
         -99 (-5.70% of base) : 49948.dasm - Microsoft.CodeAnalysis.VisualBasic.MemberSemanticModel:GetCollectionRangeVariableSymbolInfoWorker(Microsoft.CodeAnalysis.VisualBasic.Syntax.CollectionRangeVariableSyntax,System.Threading.CancellationToken):Microsoft.CodeAnalysis.VisualBasic.CollectionRangeVariableSymbolInfo:this
         -92 (-3.96% of base) : 95003.dasm - Microsoft.Diagnostics.Tracing.Parsers.Kernel.ThreadPoolTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
         -81 (-6.42% of base) : 166233.dasm - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeIso(System.String,int,byref):bool
         -71 (-3.87% of base) : 88539.dasm - Microsoft.Diagnostics.Tracing.Parsers.JSDumpHeapTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
         -71 (-1.83% of base) : 202816.dasm - System.Management.ManagementDateTimeConverter:ToDateTime(System.String):System.DateTime
         -71 (-1.93% of base) : 217539.dasm - System.Security.AccessControl.CommonAcl:RemoveQualifiedAces(System.Security.Principal.SecurityIdentifier,int,int,ubyte,bool,int,System.Guid,System.Guid):bool:this
         -60 (-4.78% of base) : 106105.dasm - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeIso(Newtonsoft.Json.Utilities.StringReference,int,byref):bool
         -53 (-1.10% of base) : 84300.dasm - Microsoft.Diagnostics.Tracing.TraceEvent:Dump(bool,bool):System.String:this

Top method regressions (percentages):
          91 ( 6.43% of base) : 121525.dasm - System.Linq.Expressions.Compiler.CompilerScope:EmitNewHoistedLocals(System.Linq.Expressions.Compiler.LambdaCompiler):this
          34 ( 4.90% of base) : 114611.dasm - System.Data.Common.DecimalStorage:Compare(int,int):int:this
          52 ( 4.46% of base) : 143415.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:VisitChoice(System.Xml.Xsl.Qil.QilChoice):System.Xml.Xsl.Qil.QilNode:this
           7 ( 4.40% of base) : 44834.dasm - QueryTranslationState:RangeVariableMap(Microsoft.CodeAnalysis.CSharp.Symbols.RangeVariableSymbol[]):RangeVariableMap
          39 ( 2.26% of base) : 137867.dasm - System.Xml.Schema.SchemaCollectionCompiler:CannonicalizeSequence(System.Xml.Schema.XmlSchemaSequence,bool,bool):System.Xml.Schema.XmlSchemaParticle:this
          47 ( 2.12% of base) : 137866.dasm - System.Xml.Schema.SchemaCollectionCompiler:CannonicalizeChoice(System.Xml.Schema.XmlSchemaChoice,bool,bool):System.Xml.Schema.XmlSchemaParticle:this
          31 ( 2.11% of base) : 103286.dasm - Microsoft.VisualBasic.CompilerServices.IDOUtils:CreateInvoker(int):System.Func`4[[System.Runtime.CompilerServices.CallSiteBinder, System.Linq.Expressions, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a],[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object[], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
           8 ( 1.57% of base) : 163643.dasm - Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext:MatchPatternContexts(short,System.Func`3[[Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext, Microsoft.Extensions.FileSystemGlobbing, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Int16, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult, Microsoft.Extensions.FileSystemGlobbing, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]]):Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult:this
           8 ( 1.57% of base) : 163642.dasm - Microsoft.Extensions.FileSystemGlobbing.Internal.MatcherContext:MatchPatternContexts(ubyte,System.Func`3[[Microsoft.Extensions.FileSystemGlobbing.Internal.IPatternContext, Microsoft.Extensions.FileSystemGlobbing, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[System.Byte, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult, Microsoft.Extensions.FileSystemGlobbing, Version=7.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]]):Microsoft.Extensions.FileSystemGlobbing.Internal.PatternTestResult:this
           3 ( 1.40% of base) : 191955.dasm - System.DirectoryServices.ActiveDirectoryAccessRule:.ctor(System.Security.Principal.IdentityReference,int,int,int):this
           3 ( 1.40% of base) : 191992.dasm - System.DirectoryServices.ActiveDirectoryAuditRule:.ctor(System.Security.Principal.IdentityReference,int,int,int):this
           3 ( 1.35% of base) : 191977.dasm - System.DirectoryServices.PropertyAccessRule:.ctor(System.Security.Principal.IdentityReference,int,int,int):this
          41 ( 1.05% of base) : 225090.dasm - System.ServiceModel.Syndication.Rss20FeedFormatter:WriteItemContents(System.Xml.XmlWriter,System.ServiceModel.Syndication.SyndicationItem,System.Uri):this
          39 ( 1.01% of base) : 137793.dasm - System.Xml.Schema.Preprocessor:PreprocessParticle(System.Xml.Schema.XmlSchemaParticle):this
          11 ( 0.99% of base) : 185919.dasm - System.Data.OleDb.OleDbCommand:ExecuteTableDirect(int,byref):int:this
          21 ( 0.91% of base) : 137890.dasm - System.Xml.Schema.SchemaCollectionCompiler:CompileComplexContent(System.Xml.Schema.XmlSchemaComplexType):System.Xml.Schema.ContentValidator:this
          20 ( 0.87% of base) : 137157.dasm - System.Xml.Schema.Compiler:CompileComplexContent(System.Xml.Schema.XmlSchemaComplexType):System.Xml.Schema.ContentValidator:this
          28 ( 0.85% of base) : 109958.dasm - System.Data.XSDSchema:HandleDataSet(System.Xml.Schema.XmlSchemaElement,bool):this
         783 ( 0.67% of base) : 85859.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
           8 ( 0.62% of base) : 143292.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:NestedVisitEnsureCache(System.Xml.Xsl.Qil.QilNode,System.Type):this

Top method improvements (percentages):
         -11 (-25.58% of base) : 221402.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor():this
         -11 (-20.75% of base) : 221411.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(Internal.Cryptography.ICertificatePalCore):this
         -14 (-17.07% of base) : 107043.dasm - Newtonsoft.Json.Serialization.JsonTypeReflector:get_DynamicCodeGeneration():bool
         -14 (-17.07% of base) : 107044.dasm - Newtonsoft.Json.Serialization.JsonTypeReflector:get_FullyTrusted():bool
         -11 (-14.29% of base) : 221410.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(long):this
         -33 (-14.04% of base) : 158348.dasm - Internal.TypeSystem.UniversalCanonLayoutAlgorithm:ComputeStaticFieldLayout(Internal.TypeSystem.DefType,int):Internal.TypeSystem.ComputedStaticFieldLayout:this
         -23 (-13.69% of base) : 230812.dasm - System.Transactions.TransactionManager:ValidateTimeout(System.TimeSpan):System.TimeSpan
         -11 (-13.25% of base) : 138706.dasm - System.Xml.Schema.XmlSchemaParticle:.ctor():this
         -11 (-10.48% of base) : 221389.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:Reset():this
         -29 (-10.43% of base) : 217835.dasm - System.Security.AccessControl.ObjectAccessRule:.ctor(System.Security.Principal.IdentityReference,int,bool,int,int,System.Guid,System.Guid,int):this
         -29 (-10.43% of base) : 217839.dasm - System.Security.AccessControl.ObjectAuditRule:.ctor(System.Security.Principal.IdentityReference,int,bool,int,int,System.Guid,System.Guid,int):this
       -1639 (-10.34% of base) : 85673.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngineTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -5441 (-10.27% of base) : 84095.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.ETWMapping, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
         -26 (-9.67% of base) : 216039.dasm - System.Runtime.Caching.UsageBucket:AddUsageEntryToFreeList(System.Runtime.Caching.UsageEntryRef):this
       -1371 (-9.18% of base) : 99680.dasm - Microsoft.Diagnostics.Tracing.Parsers.AspNet.AspNetTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
         -11 (-9.02% of base) : 209172.dasm - System.Net.Cache.HttpRequestCachePolicy:.ctor(int):this
         -11 (-8.09% of base) : 217563.dasm - System.Security.AccessControl.CommonAcl:GetObjectTypesForSplit(System.Security.AccessControl.ObjectAce,int,ubyte,byref,byref,byref):this
        -165 (-7.78% of base) : 24958.dasm - Microsoft.CodeAnalysis.CSharp.BuiltInOperators:GetSimpleBuiltInOperators(int,Microsoft.CodeAnalysis.ArrayBuilder`1[BinaryOperatorSignature]):this
         -20 (-7.60% of base) : 74805.dasm - Microsoft.VisualStudio.Shell.Interop.SqmServiceProvider:TryGetSqmServiceDelegate(System.String):QueryServiceDelegate
         -11 (-7.48% of base) : 221418.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:.ctor(System.Security.Cryptography.X509Certificates.X509Certificate):this

246 total methods with Code Size differences (206 improved, 40 regressed), 2 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 114292847 (overridden on cmd)
Total bytes of diff: 114274194 (overridden on cmd)
Total bytes of delta: -18653 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
         327 : 180364.dasm (5.14% of base)
         238 : 205470.dasm (1.75% of base)
         225 : 204796.dasm (3.84% of base)
         178 : 282804.dasm (3.91% of base)
         170 : 205252.dasm (2.95% of base)
         170 : 205259.dasm (2.95% of base)
         162 : 204522.dasm (1.44% of base)
         156 : 154821.dasm (2.48% of base)
         143 : 154877.dasm (2.26% of base)
         116 : 205601.dasm (2.00% of base)
         113 : 204617.dasm (0.80% of base)
          92 : 205627.dasm (0.54% of base)
          82 : 154824.dasm (3.89% of base)
          80 : 282795.dasm (1.30% of base)
          80 : 205503.dasm (1.29% of base)
          79 : 154880.dasm (3.59% of base)
          79 : 282798.dasm (2.28% of base)
          64 : 328413.dasm (1.94% of base)
          64 : 52042.dasm (0.81% of base)
          63 : 308348.dasm (1.05% of base)

Top file improvements (bytes):
       -8238 : 328444.dasm (-18.04% of base)
        -503 : 72877.dasm (-15.09% of base)
        -500 : 328821.dasm (-9.27% of base)
        -359 : 154715.dasm (-4.49% of base)
        -352 : 154719.dasm (-3.99% of base)
        -286 : 154707.dasm (-7.14% of base)
        -276 : 154706.dasm (-5.05% of base)
        -245 : 136583.dasm (-1.56% of base)
        -245 : 136593.dasm (-1.64% of base)
        -245 : 177142.dasm (-4.81% of base)
        -245 : 177141.dasm (-4.51% of base)
        -241 : 272102.dasm (-7.74% of base)
        -205 : 35634.dasm (-11.47% of base)
        -205 : 35484.dasm (-11.47% of base)
        -191 : 35694.dasm (-10.99% of base)
        -191 : 35769.dasm (-10.99% of base)
        -191 : 35544.dasm (-10.99% of base)
        -191 : 35619.dasm (-10.99% of base)
        -174 : 316334.dasm (-9.28% of base)
        -172 : 35649.dasm (-3.50% of base)

494 total files with Code Size differences (418 improved, 76 regressed), 6 unchanged.

Top method regressions (bytes):
         327 ( 5.14% of base) : 180364.dasm - System.Net.Http.Tests.HttpHeadersTest:AddHeaders_SourceAndDestinationStoreHaveMultipleHeaders_OnlyHeadersNotInDestinationAreCopiedFromSource():this
         238 ( 1.75% of base) : 205470.dasm - <>c__DisplayClass20_0:<ReadFrom_FullItem_ReturnsExpected>b__0(System.ServiceModel.Syndication.SyndicationItem):this
         225 ( 3.84% of base) : 204796.dasm - System.ServiceModel.Syndication.Tests.SyndicationFeedTests:Ctor_SyndicationFeed_Full(bool):this
         178 ( 3.91% of base) : 282804.dasm - System.Diagnostics.Metrics.Tests.MetricEventSourceTests:EventSourceWorksWithSequentialListeners():this
         170 ( 2.95% of base) : 205259.dasm - System.ServiceModel.Syndication.Tests.SyndicationItemTests:Clone_Full_ReturnsExpected():this
         170 ( 2.95% of base) : 205252.dasm - System.ServiceModel.Syndication.Tests.SyndicationItemTests:Ctor_SyndicationItem_Full():this
         162 ( 1.44% of base) : 204522.dasm - System.ServiceModel.Syndication.Tests.Rss20FeedFormatterTests:Read_TryParseTrue_ReturnsExpected(bool,bool):this
         156 ( 2.48% of base) : 154821.dasm - System.Data.Tests.SqlTypes.SqlInt16Test:Conversions():this
         143 ( 2.26% of base) : 154877.dasm - System.Data.Tests.SqlTypes.SqlInt64Test:Conversions():this
         116 ( 2.00% of base) : 205601.dasm - <WriteTo_TestData>d__9:MoveNext():bool:this
         113 ( 0.80% of base) : 204617.dasm - System.ServiceModel.Syndication.Tests.Atom10FeedFormatterTests:Read_TryParseTrue_ReturnsExpected(bool,bool):this
          92 ( 0.54% of base) : 205627.dasm - <>c__DisplayClass28_0:<Read_FullItem_ReturnsExpected>b__0(System.ServiceModel.Syndication.SyndicationFeed):this
          82 ( 3.89% of base) : 154824.dasm - System.Data.Tests.SqlTypes.SqlInt16Test:BitwiseOperators():this
          80 ( 1.29% of base) : 205503.dasm - <WriteTo_TestData>d__11:MoveNext():bool:this
          80 ( 1.30% of base) : 282795.dasm - System.Diagnostics.Metrics.Tests.MetricEventSourceTests:EventSourceFiltersInstruments():this
          79 ( 3.59% of base) : 154880.dasm - System.Data.Tests.SqlTypes.SqlInt64Test:BitwiseOperators():this
          79 ( 2.28% of base) : 282798.dasm - System.Diagnostics.Metrics.Tests.MetricEventSourceTests:EventSourcePublishesEndEventsOnMeterDispose():this
          64 ( 0.81% of base) : 52042.dasm - System.Linq.Expressions.Tests.Compiler_Tests:UnaryOperators(bool)
          64 ( 1.94% of base) : 328413.dasm - System.Numerics.Tests.BigIntegerConstructorTest:VerifyCtorDecimal(System.Decimal)
          63 ( 1.05% of base) : 308348.dasm - <Alpn_TestData>d__15:MoveNext():bool:this

Top method improvements (bytes):
       -8238 (-18.04% of base) : 328444.dasm - System.Numerics.Tests.Driver:RunTests()
        -503 (-15.09% of base) : 72877.dasm - System.Tests.TimeZoneInfoTests:ConvertTime_DateTimeOffset_NearMinMaxValue()
        -500 (-9.27% of base) : 328821.dasm - System.Numerics.Tests.ComplexTests:EqualsTest()
        -359 (-4.49% of base) : 154715.dasm - System.Data.Tests.SqlTypes.SqlDateTimeTest:Parse():this
        -352 (-3.99% of base) : 154719.dasm - System.Data.Tests.SqlTypes.SqlDateTimeTest:SqlStringToSqlDateTime():this
        -286 (-7.14% of base) : 154707.dasm - System.Data.Tests.SqlTypes.SqlDateTimeTest:PublicFields():this
        -276 (-5.05% of base) : 154706.dasm - System.Data.Tests.SqlTypes.SqlDateTimeTest:Create():this
        -245 (-1.56% of base) : 136583.dasm - <DateAdd_DateInterval_TestData>d__2:MoveNext():bool:this
        -245 (-1.64% of base) : 136593.dasm - <DateAdd_StringInterval_TestData>d__6:MoveNext():bool:this
        -245 (-4.51% of base) : 177141.dasm - System.Buffers.Binary.Tests.BinaryReaderUnitTests:SpanWriteAndReadBigEndianHeterogeneousStruct():this
        -245 (-4.81% of base) : 177142.dasm - System.Buffers.Binary.Tests.BinaryReaderUnitTests:SpanWriteAndReadLittleEndianHeterogeneousStruct():this
        -241 (-7.74% of base) : 272102.dasm - System.Collections.Immutable.Tests.ImmutableArrayExtensionsTest:SequenceEqual():this
        -205 (-11.47% of base) : 35484.dasm - Dynamic.Operator.Tests.AndEqualLiftTests:Decimal()
        -205 (-11.47% of base) : 35634.dasm - Dynamic.Operator.Tests.AndEqualTypeTests:Decimal()
        -191 (-10.99% of base) : 35544.dasm - Dynamic.Operator.Tests.OrEqualLiftTests:Decimal()
        -191 (-10.99% of base) : 35694.dasm - Dynamic.Operator.Tests.OrEqualTypeTests:Decimal()
        -191 (-10.99% of base) : 35619.dasm - Dynamic.Operator.Tests.XorEqualLiftTests:Decimal()
        -191 (-10.99% of base) : 35769.dasm - Dynamic.Operator.Tests.XorEqualTypeTests:Decimal()
        -174 (-9.28% of base) : 316334.dasm - System.Reflection.Emit.Tests.ILGeneratorEmit3:PosTest1():this
        -172 (-3.50% of base) : 35649.dasm - Dynamic.Operator.Tests.DivideEqualTypeTests:Decimal()

Top method regressions (percentages):
          56 ( 5.33% of base) : 239574.dasm - EmittingVisitor:EmitNewArray(System.Object,System.Type,System.Object[],System.Reflection.Emit.ILGenerator,ClosureInfo):bool
         327 ( 5.14% of base) : 180364.dasm - System.Net.Http.Tests.HttpHeadersTest:AddHeaders_SourceAndDestinationStoreHaveMultipleHeaders_OnlyHeadersNotInDestinationAreCopiedFromSource():this
         178 ( 3.91% of base) : 282804.dasm - System.Diagnostics.Metrics.Tests.MetricEventSourceTests:EventSourceWorksWithSequentialListeners():this
          82 ( 3.89% of base) : 154824.dasm - System.Data.Tests.SqlTypes.SqlInt16Test:BitwiseOperators():this
         225 ( 3.84% of base) : 204796.dasm - System.ServiceModel.Syndication.Tests.SyndicationFeedTests:Ctor_SyndicationFeed_Full(bool):this
          79 ( 3.59% of base) : 154880.dasm - System.Data.Tests.SqlTypes.SqlInt64Test:BitwiseOperators():this
          18 ( 3.23% of base) : 268512.dasm - EmittingVisitor:EmitNewArray(System.Linq.Expressions.NewArrayExpression,System.Collections.Generic.IList`1[[System.Linq.Expressions.ParameterExpression, System.Linq.Expressions, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Reflection.Emit.ILGenerator,ClosureInfo):bool
          19 ( 3.20% of base) : 239575.dasm - EmittingVisitor:EmitNewArrayInfo(LamarCompiler.Util.NewArrayExpressionInfo,System.Type,System.Object[],System.Reflection.Emit.ILGenerator,ClosureInfo):bool
          22 ( 3.13% of base) : 331965.dasm - System.Security.Cryptography.Rsa.Tests.RSAImportExportCspBlobTests:RSAParametersToBlob_PublicOnly()
         170 ( 2.95% of base) : 205259.dasm - System.ServiceModel.Syndication.Tests.SyndicationItemTests:Clone_Full_ReturnsExpected():this
         170 ( 2.95% of base) : 205252.dasm - System.ServiceModel.Syndication.Tests.SyndicationItemTests:Ctor_SyndicationItem_Full():this
          24 ( 2.58% of base) : 241188.dasm - LightInject.ServiceContainer:EmitConstructorDependencies(LightInject.ConstructionInfo,LightInject.IEmitter,System.Action`1[[LightInject.IEmitter, LightInject, Version=6.3.2.0, Culture=neutral, PublicKeyToken=null]]):this
         156 ( 2.48% of base) : 154821.dasm - System.Data.Tests.SqlTypes.SqlInt16Test:Conversions():this
          18 ( 2.37% of base) : 231728.dasm - EmittingVisitor:EmitNewArray(FastExpressionCompiler.LightExpression.NewArrayExpression,System.Collections.Generic.IReadOnlyList`1[[FastExpressionCompiler.LightExpression.ParameterExpression, DryIoc, Version=4.1.4.0, Culture=neutral, PublicKeyToken=dfbf2bd50fcf7768]],System.Reflection.Emit.ILGenerator,byref,int):bool
          79 ( 2.28% of base) : 282798.dasm - System.Diagnostics.Metrics.Tests.MetricEventSourceTests:EventSourcePublishesEndEventsOnMeterDispose():this
         143 ( 2.26% of base) : 154877.dasm - System.Data.Tests.SqlTypes.SqlInt64Test:Conversions():this
          34 ( 2.17% of base) : 282803.dasm - System.Diagnostics.Metrics.Tests.MetricEventSourceTests:EventSourceHandlesObservableCallbackException():this
         116 ( 2.00% of base) : 205601.dasm - <WriteTo_TestData>d__9:MoveNext():bool:this
          64 ( 1.94% of base) : 328413.dasm - System.Numerics.Tests.BigIntegerConstructorTest:VerifyCtorDecimal(System.Decimal)
          48 ( 1.92% of base) : 282790.dasm - System.Diagnostics.Metrics.Tests.MetricEventSourceTests:EventSourcePublishesTimeSeriesWithEmptyMetadata():this

Top method improvements (percentages):
         -24 (-22.43% of base) : 302018.dasm - System.Net.Http.WinHttpHandlerUnitTests.APICallHistory:set_RequestProxySettings(ProxyInfo)
         -24 (-22.43% of base) : 179685.dasm - System.Net.Http.WinHttpHandlerUnitTests.APICallHistory:set_RequestProxySettings(ProxyInfo)
         -24 (-22.43% of base) : 179683.dasm - System.Net.Http.WinHttpHandlerUnitTests.APICallHistory:set_SessionProxySettings(ProxyInfo)
         -24 (-22.43% of base) : 302016.dasm - System.Net.Http.WinHttpHandlerUnitTests.APICallHistory:set_SessionProxySettings(ProxyInfo)
         -38 (-19.69% of base) : 286028.dasm - System.DirectoryServices.Protocols.Tests.DirectoryServicesTestHelpers:get_IsLibLdapInstalled():bool
       -8238 (-18.04% of base) : 328444.dasm - System.Numerics.Tests.Driver:RunTests()
         -52 (-17.57% of base) : 139596.dasm - NuGet.Packaging.PackageExtraction.PackageExtractionBehavior:get_XmlDocFileSaveMode():int
        -503 (-15.09% of base) : 72877.dasm - System.Tests.TimeZoneInfoTests:ConvertTime_DateTimeOffset_NearMinMaxValue()
         -50 (-12.63% of base) : 287087.dasm - System.Formats.Asn1.Tests.Asn1TagTests:EqualsIsExact()
        -110 (-11.84% of base) : 175057.dasm - System.TestHelpers:GetSpanLE():System.Span`1[Byte]
        -205 (-11.47% of base) : 35484.dasm - Dynamic.Operator.Tests.AndEqualLiftTests:Decimal()
        -205 (-11.47% of base) : 35634.dasm - Dynamic.Operator.Tests.AndEqualTypeTests:Decimal()
        -110 (-11.27% of base) : 175056.dasm - System.TestHelpers:GetSpanBE():System.Span`1[Byte]
        -191 (-10.99% of base) : 35544.dasm - Dynamic.Operator.Tests.OrEqualLiftTests:Decimal()
        -191 (-10.99% of base) : 35694.dasm - Dynamic.Operator.Tests.OrEqualTypeTests:Decimal()
        -191 (-10.99% of base) : 35619.dasm - Dynamic.Operator.Tests.XorEqualLiftTests:Decimal()
        -191 (-10.99% of base) : 35769.dasm - Dynamic.Operator.Tests.XorEqualTypeTests:Decimal()
         -39 (-10.86% of base) : 330346.dasm - DataContractJsonSerializerTests:DCJS_TimeSpanAsRoot()
         -39 (-10.86% of base) : 194616.dasm - DataContractSerializerTests:DCS_TimeSpanAsRoot()
         -36 (-10.71% of base) : 123138.dasm - Microsoft.Build.Shared.NativeMethodsShared:get_IsMono():bool

494 total methods with Code Size differences (418 improved, 76 regressed), 6 unchanged.

```

</details>

--------------------------------------------------------------------------------
</details>

I have also checked diffs with CSE disabled, there were just a few, arising from propagating the non-nullness of the boxed static's address.

Part of #58312.

[Full diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1494464&view=ms.vss-build-web.run-extensions-tab).