### PR TITLE
Fixes #62167. WriteAsync may truncate data if called after .Advance(int)

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -1082,7 +1082,7 @@ namespace System.IO.Pipelines
                 }
 
                 // We filled the segment
-                _writingHead.End += writable;
+                _writingHead.End += _writingHeadBytesBuffered;
                 _writingHeadBytesBuffered = 0;
 
                 // This is optimized to use pooled memory. That's why we pass 0 instead of

--- a/src/libraries/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -277,5 +277,19 @@ namespace System.IO.Pipelines.Tests
             ReadResult result = await _pipe.Reader.ReadAsync();
             _pipe.Reader.AdvanceTo(default, default);
         }
+
+        [Fact]
+        public async Task AdvanceFollowedByWriteAsyncTest()
+        {
+            Memory<byte> buffer = new byte[26];
+            Pipe pipe = new(new PipeOptions(minimumSegmentSize: 1));
+
+            var mem = pipe.Writer.GetMemory(14)[..14];
+            buffer[..14].CopyTo(mem);
+            pipe.Writer.Advance(14);
+            await pipe.Writer.WriteAsync(buffer[14..]);
+            ReadResult res = await pipe.Reader.ReadAsync();
+            Assert.Equal(res.Buffer.Length, buffer.Length);
+        }
     }
 }


### PR DESCRIPTION
Fixes #62167. 
It took me way too much time to pinpoint where this issue came from ^^'.