### PR TITLE
Move the remainder of X509Certificates and TestUtilities use GeneratedDllImport

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
@@ -12,26 +12,26 @@ internal static partial class Interop
 {
     internal static partial class AndroidCrypto
     {
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainCreateContext")]
-        internal static extern SafeX509ChainContextHandle X509ChainCreateContext(
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainCreateContext")]
+        internal static partial SafeX509ChainContextHandle X509ChainCreateContext(
             SafeX509Handle cert,
             IntPtr[] extraStore,
             int extraStoreLen);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainDestroyContext")]
-        internal static extern void X509ChainDestroyContext(IntPtr ctx);
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainDestroyContext")]
+        internal static partial void X509ChainDestroyContext(IntPtr ctx);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainBuild")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainBuild")]
         [return: MarshalAs(UnmanagedType.U1)]
-        internal static extern bool X509ChainBuild(
+        internal static partial bool X509ChainBuild(
             SafeX509ChainContextHandle ctx,
             long timeInMsFromUnixEpoch);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetCertificateCount")]
-        private static extern int X509ChainGetCertificateCount(SafeX509ChainContextHandle ctx);
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetCertificateCount")]
+        private static partial int X509ChainGetCertificateCount(SafeX509ChainContextHandle ctx);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetCertificates")]
-        private static extern int X509ChainGetCertificates(
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetCertificates")]
+        private static partial int X509ChainGetCertificates(
             SafeX509ChainContextHandle ctx,
             IntPtr[] certs,
             int certsLen);
@@ -69,13 +69,13 @@ internal static partial class Interop
             public int Status;
         }
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetErrorCount")]
-        private static extern int X509ChainGetErrorCount(SafeX509ChainContextHandle ctx);
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetErrorCount")]
+        private static partial int X509ChainGetErrorCount(SafeX509ChainContextHandle ctx);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetErrors")]
-        private static unsafe extern int X509ChainGetErrors(
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainGetErrors")]
+        private static unsafe partial int X509ChainGetErrors(
             SafeX509ChainContextHandle ctx,
-            [Out] ValidationError[] errors,
+            ValidationError[] errors,
             int errorsLen);
 
         internal static ValidationError[] X509ChainGetErrors(SafeX509ChainContextHandle ctx)
@@ -92,18 +92,18 @@ internal static partial class Interop
             return errors;
         }
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainSetCustomTrustStore")]
-        internal static extern int X509ChainSetCustomTrustStore(
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainSetCustomTrustStore")]
+        internal static partial int X509ChainSetCustomTrustStore(
             SafeX509ChainContextHandle ctx,
             IntPtr[] customTrustStore,
             int customTrustStoreLen);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainSupportsRevocationOptions")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainSupportsRevocationOptions")]
         [return:MarshalAs(UnmanagedType.U1)]
-        internal static extern bool X509ChainSupportsRevocationOptions();
+        internal static partial bool X509ChainSupportsRevocationOptions();
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainValidate")]
-        internal static extern int X509ChainValidate(
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainValidate")]
+        internal static partial int X509ChainValidate(
             SafeX509ChainContextHandle ctx,
             X509RevocationMode revocationMode,
             X509RevocationFlag revocationFlag,

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Store.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Store.cs
@@ -11,49 +11,49 @@ internal static partial class Interop
 {
     internal static partial class AndroidCrypto
     {
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreAddCertificate")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreAddCertificate", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool X509StoreAddCertificate(
+        internal static unsafe partial bool X509StoreAddCertificate(
             SafeX509StoreHandle store,
             SafeX509Handle cert,
             string hashString);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreAddCertificateWithPrivateKey")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreAddCertificateWithPrivateKey", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool X509StoreAddCertificateWithPrivateKey(
+        internal static unsafe partial bool X509StoreAddCertificateWithPrivateKey(
             SafeX509StoreHandle store,
             SafeX509Handle cert,
             SafeKeyHandle key,
             PAL_KeyAlgorithm algorithm,
             string hashString);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreContainsCertificate")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreContainsCertificate", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool X509StoreContainsCertificate(
+        internal static unsafe partial bool X509StoreContainsCertificate(
             SafeX509StoreHandle store,
             SafeX509Handle cert,
             string hashString);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreEnumerateCertificates")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreEnumerateCertificates")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool X509StoreEnumerateCertificates(
+        internal static unsafe partial bool X509StoreEnumerateCertificates(
             SafeX509StoreHandle storeHandle,
             delegate* unmanaged<void*, void*, Interop.AndroidCrypto.PAL_KeyAlgorithm, void*, void> callback,
             void *callbackContext);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreEnumerateTrustedCertificates")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreEnumerateTrustedCertificates")]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool X509StoreEnumerateTrustedCertificates(
+        internal static unsafe partial bool X509StoreEnumerateTrustedCertificates(
             byte systemOnly,
             delegate* unmanaged<void*, void*, void> callback,
             void *callbackContext);
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreOpenDefault")]
-        internal static extern unsafe SafeX509StoreHandle X509StoreOpenDefault();
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreOpenDefault")]
+        internal static unsafe partial SafeX509StoreHandle X509StoreOpenDefault();
 
-        [DllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreRemoveCertificate")]
+        [GeneratedDllImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509StoreRemoveCertificate", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern unsafe bool X509StoreRemoveCertificate(
+        internal static unsafe partial bool X509StoreRemoveCertificate(
             SafeX509StoreHandle store,
             SafeX509Handle cert,
             string hashString);

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.iOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Keychain.iOS.cs
@@ -15,20 +15,20 @@ internal static partial class Interop
 {
     internal static partial class AppleCrypto
     {
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_SecKeychainEnumerateCerts(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_SecKeychainEnumerateCerts(
             out SafeCFArrayHandle matches);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_SecKeychainEnumerateIdentities(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_SecKeychainEnumerateIdentities(
             out SafeCFArrayHandle matches);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_X509StoreAddCertificate(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_X509StoreAddCertificate(
             SafeHandle certOrIdentity);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_X509StoreRemoveCertificate(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_X509StoreRemoveCertificate(
             SafeHandle certOrIdentity,
             bool isReadOnlyMode);
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.iOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.iOS.cs
@@ -33,8 +33,8 @@ internal static partial class Interop
                 out pPrivateKeyOut);
         }
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_X509ImportCertificate(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_X509ImportCertificate(
             ref byte pbKeyBlob,
             int cbKeyBlob,
             X509ContentType contentType,
@@ -42,8 +42,8 @@ internal static partial class Interop
             out SafeSecCertificateHandle pCertOut,
             out SafeSecIdentityHandle pPrivateKeyOut);
 
-        [DllImport(Libraries.AppleCryptoNative)]
-        private static extern int AppleCryptoNative_X509ImportCollection(
+        [GeneratedDllImport(Libraries.AppleCryptoNative)]
+        private static partial int AppleCryptoNative_X509ImportCollection(
             ref byte pbKeyBlob,
             int cbKeyBlob,
             X509ContentType contentType,

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslGetProtocolSupport.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSslGetProtocolSupport.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class OpenSsl
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslGetProtocolSupport")]
-        internal static extern int OpenSslGetProtocolSupport(int protocol);
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OpenSslGetProtocolSupport")]
+        internal static partial int OpenSslGetProtocolSupport(int protocol);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation_void.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetTokenInformation_void.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true)]
-        internal static extern unsafe bool GetTokenInformation(
+        [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true)]
+        internal static unsafe partial bool GetTokenInformation(
             SafeAccessTokenHandle TokenHandle,
             TOKEN_INFORMATION_CLASS TokenInformationClass,
             void* TokenInformation,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
@@ -15,10 +15,8 @@ internal static partial class Interop
         private const int FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100;
         private const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
 
-#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-                                                // Disabled since FormatMessage is a QCall in some scenarios and DllImportGenerator doesn't support QCalls.
-        [DllImport(Libraries.Kernel32, EntryPoint = "FormatMessageW", BestFitMapping = true, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        private static extern unsafe int FormatMessage(
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "FormatMessageW", ExactSpelling = true, SetLastError = true)]
+        private static unsafe partial int FormatMessage(
             int dwFlags,
             IntPtr lpSource,
             uint dwMessageId,
@@ -26,7 +24,6 @@ internal static partial class Interop
             void* lpBuffer,
             int nSize,
             IntPtr arguments);
-#pragma warning restore DLLIMPORTGENANALYZER015
 
         /// <summary>
         ///     Returns a string message for the specified Win32 error code.

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
@@ -287,41 +287,41 @@ namespace System.Buffers
                 UnsafeNativeMethods.VirtualFree(handle, IntPtr.Zero, VirtualAllocAllocationType.MEM_RELEASE);
         }
 
-        private static class UnsafeNativeMethods
+        private static partial class UnsafeNativeMethods
         {
             private const string KERNEL32_LIB = "kernel32.dll";
 
             // https://msdn.microsoft.com/en-us/library/windows/desktop/aa366887(v=vs.85).aspx
-            [DllImport(KERNEL32_LIB, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
-            public static extern VirtualAllocHandle VirtualAlloc(
-                [In] IntPtr lpAddress,
-                [In] IntPtr dwSize,
-                [In] VirtualAllocAllocationType flAllocationType,
-                [In] VirtualAllocProtection flProtect);
+            [GeneratedDllImport(KERNEL32_LIB, SetLastError = true)]
+            public static partial VirtualAllocHandle VirtualAlloc(
+                IntPtr lpAddress,
+                IntPtr dwSize,
+                VirtualAllocAllocationType flAllocationType,
+                VirtualAllocProtection flProtect);
 
             // https://msdn.microsoft.com/en-us/library/windows/desktop/aa366892(v=vs.85).aspx
-            [DllImport(KERNEL32_LIB, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+            [GeneratedDllImport(KERNEL32_LIB, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool VirtualFree(
-                [In] IntPtr lpAddress,
-                [In] IntPtr dwSize,
-                [In] VirtualAllocAllocationType dwFreeType);
+            public static partial bool VirtualFree(
+                IntPtr lpAddress,
+                IntPtr dwSize,
+                VirtualAllocAllocationType dwFreeType);
 
             // https://msdn.microsoft.com/en-us/library/windows/desktop/aa366898(v=vs.85).aspx
-            [DllImport(KERNEL32_LIB, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+            [GeneratedDllImport(KERNEL32_LIB, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool VirtualProtect(
-                [In] IntPtr lpAddress,
-                [In] IntPtr dwSize,
-                [In] VirtualAllocProtection flNewProtect,
-                [Out] out VirtualAllocProtection lpflOldProtect);
+            public static partial bool VirtualProtect(
+                IntPtr lpAddress,
+                IntPtr dwSize,
+                VirtualAllocProtection flNewProtect,
+                out VirtualAllocProtection lpflOldProtect);
 
             // https://msdn.microsoft.com/en-us/library/windows/desktop/aa366902(v=vs.85).aspx
-            [DllImport(KERNEL32_LIB, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
-            public static extern IntPtr VirtualQuery(
-                [In] IntPtr lpAddress,
-                [Out] out MEMORY_BASIC_INFORMATION lpBuffer,
-                [In] IntPtr dwLength);
+            [GeneratedDllImport(KERNEL32_LIB, SetLastError = true)]
+            public static partial IntPtr VirtualQuery(
+                IntPtr lpAddress,
+                out MEMORY_BASIC_INFORMATION lpBuffer,
+                IntPtr dwLength);
         }
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -317,16 +317,16 @@ namespace System
             public Version VersionId { get; set; }
         }
 
-        private static class libc
+        private static partial class libc
         {
-            [DllImport("libc", SetLastError = true)]
-            public static extern unsafe uint geteuid();
+            [GeneratedDllImport("libc", SetLastError = true)]
+            public static unsafe partial uint geteuid();
 
-            [DllImport("libc", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr gnu_get_libc_release();
+            [GeneratedDllImport("libc")]
+            public static partial IntPtr gnu_get_libc_release();
 
-            [DllImport("libc", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
-            public static extern IntPtr gnu_get_libc_version();
+            [GeneratedDllImport("libc")]
+            public static partial IntPtr gnu_get_libc_version();
         }
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -140,8 +140,8 @@ namespace System
         private const int PRODUCT_HOME_PREMIUM = 0x00000003;
         private const int PRODUCT_HOME_PREMIUM_N = 0x0000001A;
 
-        [DllImport("kernel32.dll", SetLastError = false)]
-        private static extern bool GetProductInfo(
+        [GeneratedDllImport("kernel32.dll", SetLastError = false)]
+        private static partial bool GetProductInfo(
             int dwOSMajorVersion,
             int dwOSMinorVersion,
             int dwSpMajorVersion,
@@ -149,8 +149,8 @@ namespace System
             out int pdwReturnedProductType
         );
 
-        [DllImport("kernel32.dll", ExactSpelling = true)]
-        private static extern int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
+        [GeneratedDllImport("kernel32.dll", ExactSpelling = true)]
+        private static partial int GetCurrentApplicationUserModelId(ref uint applicationUserModelIdLength, byte[] applicationUserModelId);
 
         private static volatile Version s_windowsVersionObject;
         internal static Version GetWindowsVersionObject()

--- a/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
@@ -28,7 +28,7 @@ namespace System
         }
     }
 
-    public sealed class WindowsTestAccount : IDisposable
+    public sealed partial class WindowsTestAccount : IDisposable
     {
         private readonly string _userName;
         private SafeAccessTokenHandle _accountTokenHandle;
@@ -102,14 +102,18 @@ namespace System
             }
         }
 
-        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        private static extern bool LogonUser(string userName, string domain, string password, int logonType, int logonProvider, out SafeAccessTokenHandle safeAccessTokenHandle);
+        [GeneratedDllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static partial bool LogonUser(string userName, string domain, string password, int logonType, int logonProvider, out SafeAccessTokenHandle safeAccessTokenHandle);
 
+
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we add support for non-blittable struct marshalling.
         [DllImport("netapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern uint NetUserAdd([MarshalAs(UnmanagedType.LPWStr)]string servername, uint level, ref USER_INFO_1 buf, out uint parm_err);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport("netapi32.dll")]
-        internal static extern uint NetUserDel([MarshalAs(UnmanagedType.LPWStr)]string servername, [MarshalAs(UnmanagedType.LPWStr)]string username);
+        [GeneratedDllImport("netapi32.dll")]
+        internal static partial uint NetUserDel([MarshalAs(UnmanagedType.LPWStr)]string servername, [MarshalAs(UnmanagedType.LPWStr)]string username);
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         internal struct USER_INFO_1


### PR DESCRIPTION
Now that the X509Certificates interop code was refactored to follow the interop guidelines, migrate what is still using DllImport to use GeneratedDllImport