### PR TITLE
Fix soundplayer assertion failure

### DIFF
--- a/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
@@ -308,8 +308,7 @@ namespace System.Media
 
         private void LoadStream(bool loadSync)
         {
-            Debug.Assert(_stream != null);
-            if (loadSync && _stream.CanSeek)
+            if (loadSync && _stream!.CanSeek)
             {
                 int streamLen = (int)_stream.Length;
                 _currentPos = 0;


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/62305

Recent nullable annotations inadvertently added an invalid assert.
Removed assert. Verified that if `loadSync` is true, then `_stream` is non null, and add null forgiving operator.
Verified all tests now pass including. outer loop 