### PR TITLE
Consistently use CreateProxyUri in WebProxy ctors

### DIFF
--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -35,7 +35,7 @@ namespace System.Net
         }
 
         public WebProxy(string Host, int Port)
-            : this(new Uri(string.Create(CultureInfo.InvariantCulture, $"http://{Host}:{Port}")), false, null, null)
+            : this(CreateProxyUri(Host, Port), false, null, null)
         {
         }
 
@@ -102,10 +102,27 @@ namespace System.Net
             return IsBypassed(destination) ? destination : Address;
         }
 
-        private static Uri? CreateProxyUri(string? address) =>
-            address == null ? null :
-            !address.Contains("://") ? new Uri("http://" + address) :
-            new Uri(address);
+        private static Uri? CreateProxyUri(string? address, int? port = null)
+        {
+            if (address is null)
+            {
+                return null;
+            }
+
+            if (!address.Contains("://", StringComparison.Ordinal))
+            {
+                address = "http://" + address;
+            }
+
+            var proxyUri = new Uri(address);
+
+            if (port.HasValue && proxyUri.IsAbsoluteUri)
+            {
+                proxyUri = new UriBuilder(proxyUri) { Port = port.Value }.Uri;
+            }
+
+            return proxyUri;
+        }
 
         private void UpdateRegexList(bool canThrow)
         {

--- a/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
+++ b/src/libraries/System.Net.WebProxy/tests/WebProxyTest.cs
@@ -16,7 +16,12 @@ namespace System.Net.Tests
             yield return new object[] { new WebProxy(), null, false, false, Array.Empty<string>(), null };
 
             yield return new object[] { new WebProxy("http://anything"), new Uri("http://anything"), false, false, Array.Empty<string>(), null };
+            yield return new object[] { new WebProxy("http://anything:42"), new Uri("http://anything:42"), false, false, Array.Empty<string>(), null };
+            yield return new object[] { new WebProxy("anything:42"), new Uri("http://anything:42"), false, false, Array.Empty<string>(), null };
             yield return new object[] { new WebProxy("anything", 42), new Uri("http://anything:42"), false, false, Array.Empty<string>(), null };
+            yield return new object[] { new WebProxy("http://anything", 42), new Uri("http://anything:42"), false, false, Array.Empty<string>(), null };
+            yield return new object[] { new WebProxy("http://anything:123", 42), new Uri("http://anything:42"), false, false, Array.Empty<string>(), null };
+            yield return new object[] { new WebProxy("socks5://anything", 42), new Uri("socks5://anything:42"), false, false, Array.Empty<string>(), null };
             yield return new object[] { new WebProxy(new Uri("http://anything")), new Uri("http://anything"), false, false, Array.Empty<string>(), null };
 
             yield return new object[] { new WebProxy("http://anything", true), new Uri("http://anything"), false, true, Array.Empty<string>(), null };


### PR DESCRIPTION
`WebProxy` has `new(Uri Address)`, `new(string Address)`, `new(string Host, int Port)` constructors that all behave differently.

The `new(string)` overload will check if the address is an absolute Uri and add a `"http://"` prefix otherwise.
The `new(string, int)` overload will blindly concat the host and port `$"http://{Host}:{Port}"`.

If you [happen](https://github.com/dotnet/core/issues/6099#issuecomment-858759926) [to](https://github.com/dotnet/runtime/issues/17740#issuecomment-775990056) [create](https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-5/#libraries-socks-proxy-support) a `WebProxy` object like `new WebProxy("socks5://127.0.0.1", 9050)`, what you actually end up with is a proxy to `"http://socks5://127.0.0.1:9050"` - an http proxy with the host `socks5` and a default port.

We should either check if the host is already an absolute Uri like we do for other overloads (this PR), or we should throw. `socks5://127.0.0.1` is not a valid host, it just happens to be interpreted as:
Host: `socks5`
Port: `:` (empty port is allowed and means "default for the scheme")
Path: `//127.0.0.1`

cc: @ManickaP who noticed our blog posts announcing `socks` support have broken code snippets.