### PR TITLE
Fix superpmi.py collect script

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -3013,6 +3013,11 @@ def setup_args(args):
                             "Unable to set jitoption")
 
         coreclr_args.verify(args,
+                            "compile",  # The replay code checks this, so make sure it's set
+                            lambda unused: True,
+                            "Method context not valid")
+
+        coreclr_args.verify(args,
                             "collection_command",
                             lambda unused: True,
                             "Unable to set collection_command.")


### PR DESCRIPTION
Collect also does a replay, so needs all the replay arguments set to something.
Fixes this error: `'CoreclrArguments' object has no attribute 'compile'`