### PR TITLE
Small fix for Crossgen2 execution on Windows

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -193,8 +193,8 @@ if defined RunCrossGen2 (
         call :CompileOneFileCrossgen2
         IF NOT !CrossGen2Status!==0 goto :DoneCrossgen2Operations
     ) else (
+        set ExtraCrossGen2Args=!ExtraCrossGen2Args! -r:!scriptPath!IL-CG2\*.dll
         for %%I in (!scriptPath!\*.dll) do (
-            set ExtraCrossGen2Args=!ExtraCrossGen2Args! -r:!scriptPath!IL-CG2\*.dll
             set __OutputFile=!scriptPath!\%%~nI.dll
             set __InputFile=!scriptPath!IL-CG2\%%~nI.dll
             call :CompileOneFileCrossgen2


### PR DESCRIPTION
During my work on runtime test refactoring I noticed that when
CG2-compiling the merged test, the component assemblies end up
with an ever-increasing reference list. I tracked it down to this
poorly placed environment variable update.

Thanks

Tomas