### PR TITLE
Remove explicit Exe output types from tests without Main

### DIFF
--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTests.csproj
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTests.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="IlasmPortablePdbTester.cs" />
     <Compile Include="IlasmPortablePdbTesterCommon.cs" />

--- a/src/tests/ilverify/ILVerificationTests.csproj
+++ b/src/tests/ilverify/ILVerificationTests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <OutputPath>$(BaseOutputPathWithConfig)ilverify\</OutputPath>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- The test uses xunit directly and it fails to find the test assembly for some reason -->

--- a/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
+++ b/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' != 'coreclr'">true</DisableProjectBuild>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
     <!-- The test is lengthy as it scans the entire System.Private.CoreLib so that it times out in GC stress runs. -->
     <!-- The purpose of the test is functional testing of the R2R reader, not runtime stress testing. -->


### PR DESCRIPTION
These three projects apparently already use the [Fact] model;
this causes trouble in the switch-over to support new-style merged
test wrappers as the system believes these are standalone tests
due to the explicit Exe output type specification and and they fail
to provide a Main method. Thanks to Jeremy's source generation
change we can now tag them as "new-style tests".

Thanks

Tomas