### PR TITLE
Convert System.DirectoryServices.Protocols and System.Drawing.Common to use GeneratedDllImport

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ber.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ber.cs
@@ -12,14 +12,17 @@ internal static partial class Interop
     {
         public const int ber_default_successful_return_code = 0;
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_alloc_t", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ber_alloc(int option);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_alloc_t", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ber_alloc(int option);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
         [DllImport(Libraries.OpenLdap, EntryPoint = "ber_init", CharSet = CharSet.Ansi)]
         public static extern IntPtr ber_init(berval value);
+#pragma warning restore DLLIMPORTGENANALYZER015
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_free", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ber_free([In] IntPtr berelement, int option);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_free", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ber_free(IntPtr berelement, int option);
 
         public static int ber_printf_emptyarg(SafeBerHandle berElement, string format, nuint tag)
         {
@@ -46,20 +49,20 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_start_seq", CharSet = CharSet.Ansi)]
-        public static extern int ber_start_seq(SafeBerHandle berElement, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_start_seq", CharSet = CharSet.Ansi)]
+        public static partial int ber_start_seq(SafeBerHandle berElement, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_start_set", CharSet = CharSet.Ansi)]
-        public static extern int ber_start_set(SafeBerHandle berElement, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_start_set", CharSet = CharSet.Ansi)]
+        public static partial int ber_start_set(SafeBerHandle berElement, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_seq", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_seq(SafeBerHandle berElement, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_seq", CharSet = CharSet.Ansi)]
+        public static partial int ber_put_seq(SafeBerHandle berElement, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_set", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_set(SafeBerHandle berElement, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_set", CharSet = CharSet.Ansi)]
+        public static partial int ber_put_set(SafeBerHandle berElement, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_null", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_null(SafeBerHandle berElement, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_null", CharSet = CharSet.Ansi)]
+        public static partial int ber_put_null(SafeBerHandle berElement, nuint tag);
 
         public static int ber_printf_int(SafeBerHandle berElement, string format, int value, nuint tag)
         {
@@ -78,14 +81,14 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_int", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_int(SafeBerHandle berElement, int value, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_int", CharSet = CharSet.Ansi)]
+        public static partial int ber_put_int(SafeBerHandle berElement, int value, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_enum", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_enum(SafeBerHandle berElement, int value, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_enum", CharSet = CharSet.Ansi)]
+        public static partial int ber_put_enum(SafeBerHandle berElement, int value, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_boolean", CharSet = CharSet.Ansi)]
-        public static extern int ber_put_boolean(SafeBerHandle berElement, int value, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_boolean", CharSet = CharSet.Ansi)]
+        public static partial int ber_put_boolean(SafeBerHandle berElement, int value, nuint tag);
 
         public static int ber_printf_bytearray(SafeBerHandle berElement, string format, HGlobalMemHandle value, nuint length, nuint tag)
         {
@@ -104,23 +107,23 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_ostring", CharSet = CharSet.Ansi)]
-        private static extern int ber_put_ostring(SafeBerHandle berElement, HGlobalMemHandle value, nuint length, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_ostring", CharSet = CharSet.Ansi)]
+        private static partial int ber_put_ostring(SafeBerHandle berElement, HGlobalMemHandle value, nuint length, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_string", CharSet = CharSet.Ansi)]
-        private static extern int ber_put_string(SafeBerHandle berElement, HGlobalMemHandle value, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_string", CharSet = CharSet.Ansi)]
+        private static partial int ber_put_string(SafeBerHandle berElement, HGlobalMemHandle value, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_put_bitstring", CharSet = CharSet.Ansi)]
-        private static extern int ber_put_bitstring(SafeBerHandle berElement, HGlobalMemHandle value, nuint length, nuint tag);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_put_bitstring", CharSet = CharSet.Ansi)]
+        private static partial int ber_put_bitstring(SafeBerHandle berElement, HGlobalMemHandle value, nuint length, nuint tag);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_flatten", CharSet = CharSet.Ansi)]
-        public static extern int ber_flatten(SafeBerHandle berElement, ref IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_flatten", CharSet = CharSet.Ansi)]
+        public static partial int ber_flatten(SafeBerHandle berElement, ref IntPtr value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_bvfree", CharSet = CharSet.Ansi)]
-        public static extern int ber_bvfree(IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_bvfree", CharSet = CharSet.Ansi)]
+        public static partial int ber_bvfree(IntPtr value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_bvecfree", CharSet = CharSet.Ansi)]
-        public static extern int ber_bvecfree(IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_bvecfree", CharSet = CharSet.Ansi)]
+        public static partial int ber_bvecfree(IntPtr value);
 
         public static int ber_scanf_emptyarg(SafeBerHandle berElement, string format)
         {
@@ -141,11 +144,11 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_skip_tag", CharSet = CharSet.Ansi)]
-        private static extern int ber_skip_tag(SafeBerHandle berElement, ref nuint len);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_skip_tag", CharSet = CharSet.Ansi)]
+        private static partial int ber_skip_tag(SafeBerHandle berElement, ref nuint len);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_null", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_null(SafeBerHandle berElement);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_get_null", CharSet = CharSet.Ansi)]
+        private static partial int ber_get_null(SafeBerHandle berElement);
 
         public static int ber_scanf_int(SafeBerHandle berElement, string format, ref int value)
         {
@@ -164,14 +167,14 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_int", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_int(SafeBerHandle berElement, ref int value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_get_int", CharSet = CharSet.Ansi)]
+        private static partial int ber_get_int(SafeBerHandle berElement, ref int value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_enum", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_enum(SafeBerHandle berElement, ref int value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_get_enum", CharSet = CharSet.Ansi)]
+        private static partial int ber_get_enum(SafeBerHandle berElement, ref int value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_boolean", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_boolean(SafeBerHandle berElement, ref int value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_get_boolean", CharSet = CharSet.Ansi)]
+        private static partial int ber_get_boolean(SafeBerHandle berElement, ref int value);
 
         public static int ber_scanf_bitstring(SafeBerHandle berElement, string format, ref IntPtr value, ref uint bitLength)
         {
@@ -182,8 +185,8 @@ internal static partial class Interop
             return res;
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_stringb", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_stringb(SafeBerHandle berElement, ref IntPtr value, ref nuint bitLength);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_get_stringb", CharSet = CharSet.Ansi)]
+        private static partial int ber_get_stringb(SafeBerHandle berElement, ref IntPtr value, ref nuint bitLength);
 
         public static int ber_scanf_ptr(SafeBerHandle berElement, string format, ref IntPtr value)
         {
@@ -191,8 +194,8 @@ internal static partial class Interop
             return ber_get_stringal(berElement, ref value);
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ber_get_stringal", CharSet = CharSet.Ansi)]
-        private static extern int ber_get_stringal(SafeBerHandle berElement, ref IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ber_get_stringal", CharSet = CharSet.Ansi)]
+        private static partial int ber_get_stringal(SafeBerHandle berElement, ref IntPtr value);
 
         public static int ber_printf_berarray(SafeBerHandle berElement, string format, IntPtr value, nuint tag)
         {

--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -76,149 +76,167 @@ internal static partial class Interop
             ldap_get_option_int(IntPtr.Zero, LdapOption.LDAP_OPT_DEBUG_LEVEL, ref unused);
         }
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_initialize", CharSet = CharSet.Ansi, SetLastError = true)]
-        public static extern int ldap_initialize(out IntPtr ld, string uri);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_initialize", CharSet = CharSet.Ansi, SetLastError = true)]
+        public static partial int ldap_initialize(out IntPtr ld, string uri);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_unbind_ext_s", CharSet = CharSet.Ansi)]
-        public static extern int ldap_unbind_ext_s(IntPtr ld, ref IntPtr serverctrls, ref IntPtr clientctrls);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_unbind_ext_s", CharSet = CharSet.Ansi)]
+        public static partial int ldap_unbind_ext_s(IntPtr ld, ref IntPtr serverctrls, ref IntPtr clientctrls);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_dn", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_get_dn([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_dn", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_get_dn(ConnectionHandle ldapHandle, IntPtr result);
 
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_get_option_bool(ConnectionHandle ldapHandle, LdapOption option, ref bool outValue);
+
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] We need to manually convert SecurityPackageContextConnectionInformation to marshal differently as layout classes are not supported in generated interop.
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_get_option_bool([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref bool outValue);
+        public static extern int ldap_get_option_secInfo(ConnectionHandle ldapHandle, LdapOption option, [In, Out] SecurityPackageContextConnectionInformation outValue);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_get_option_secInfo([In] ConnectionHandle ldapHandle, [In] LdapOption option, [In, Out] SecurityPackageContextConnectionInformation outValue);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_get_option_sechandle(ConnectionHandle ldapHandle, LdapOption option, ref SecurityHandle outValue);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_get_option_sechandle([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref SecurityHandle outValue);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
+        private static partial int ldap_get_option_int(IntPtr ldapHandle, LdapOption option, ref int outValue);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
-        private static extern int ldap_get_option_int([In] IntPtr ldapHandle, [In] LdapOption option, ref int outValue);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_get_option_int(ConnectionHandle ldapHandle, LdapOption option, ref int outValue);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_get_option_int([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref int outValue);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_get_option_ptr(ConnectionHandle ldapHandle, LdapOption option, ref IntPtr outValue);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_get_option_ptr([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref IntPtr outValue);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_values_len", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_get_values_len(ConnectionHandle ldapHandle, IntPtr result, string name);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_values_len", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_get_values_len([In] ConnectionHandle ldapHandle, [In] IntPtr result, string name);
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_result", CharSet = CharSet.Ansi, SetLastError = true)]
+        public static extern int ldap_result(ConnectionHandle ldapHandle, int messageId, int all, LDAP_TIMEVAL timeout, ref IntPtr Mesage);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_result", SetLastError = true, CharSet = CharSet.Ansi)]
-        public static extern int ldap_result([In] ConnectionHandle ldapHandle, int messageId, int all, LDAP_TIMEVAL timeout, ref IntPtr Mesage);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_result2error", CharSet = CharSet.Ansi)]
+        public static partial int ldap_result2error(ConnectionHandle ldapHandle, IntPtr result, int freeIt);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_result2error", CharSet = CharSet.Ansi)]
-        public static extern int ldap_result2error([In] ConnectionHandle ldapHandle, [In] IntPtr result, int freeIt);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_search_ext", CharSet = CharSet.Ansi)]
+        public static partial int ldap_search(ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_search_ext", CharSet = CharSet.Ansi)]
-        public static extern int ldap_search([In] ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi, SetLastError = true)]
+        public static partial int ldap_set_option_bool(ConnectionHandle ld, LdapOption option, bool value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi, SetLastError = true)]
-        public static extern int ldap_set_option_bool([In] ConnectionHandle ld, [In] LdapOption option, bool value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_set_option_clientcert(ConnectionHandle ldapHandle, LdapOption option, QUERYCLIENTCERT outValue);
 
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_set_option_servercert(ConnectionHandle ldapHandle, LdapOption option, VERIFYSERVERCERT outValue);
+
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi, SetLastError = true)]
+        public static partial int ldap_set_option_int(ConnectionHandle ld, LdapOption option, ref int inValue);
+
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_set_option_ptr(ConnectionHandle ldapHandle, LdapOption option, ref IntPtr inValue);
+
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
+        public static partial int ldap_set_option_string(ConnectionHandle ldapHandle, LdapOption option, string inValue);
+
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_set_option_clientcert([In] ConnectionHandle ldapHandle, [In] LdapOption option, QUERYCLIENTCERT outValue);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_set_option_servercert([In] ConnectionHandle ldapHandle, [In] LdapOption option, VERIFYSERVERCERT outValue);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi, SetLastError = true)]
-        public static extern int ldap_set_option_int([In] ConnectionHandle ld, [In] LdapOption option, ref int inValue);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_set_option_ptr([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref IntPtr inValue);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_set_option_string([In] ConnectionHandle ldapHandle, [In] LdapOption option, string inValue);
-
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
-        public static extern int ldap_set_option_referral([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref LdapReferralCallback outValue);
+        public static extern int ldap_set_option_referral(ConnectionHandle ldapHandle, LdapOption option, ref LdapReferralCallback outValue);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
         // Note that ldap_start_tls_s has a different signature across Windows LDAP and OpenLDAP
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_start_tls_s", CharSet = CharSet.Ansi)]
-        public static extern int ldap_start_tls(ConnectionHandle ldapHandle, IntPtr serverControls, IntPtr clientControls);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_start_tls_s", CharSet = CharSet.Ansi)]
+        public static partial int ldap_start_tls(ConnectionHandle ldapHandle, IntPtr serverControls, IntPtr clientControls);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_result", CharSet = CharSet.Ansi)]
-        public static extern int ldap_parse_result([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref int serverError, ref IntPtr dn, ref IntPtr message, ref IntPtr referral, ref IntPtr control, byte freeIt);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_result", CharSet = CharSet.Ansi)]
+        public static partial int ldap_parse_result(ConnectionHandle ldapHandle, IntPtr result, ref int serverError, ref IntPtr dn, ref IntPtr message, ref IntPtr referral, ref IntPtr control, byte freeIt);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_result", CharSet = CharSet.Ansi)]
-        public static extern int ldap_parse_result_referral([In] ConnectionHandle ldapHandle, [In] IntPtr result, IntPtr serverError, IntPtr dn, IntPtr message, ref IntPtr referral, IntPtr control, byte freeIt);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_result", CharSet = CharSet.Ansi)]
+        public static partial int ldap_parse_result_referral(ConnectionHandle ldapHandle, IntPtr result, IntPtr serverError, IntPtr dn, IntPtr message, ref IntPtr referral, IntPtr control, byte freeIt);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_extended_result", CharSet = CharSet.Ansi)]
-        public static extern int ldap_parse_extended_result([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_extended_result", CharSet = CharSet.Ansi)]
+        public static partial int ldap_parse_extended_result(ConnectionHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_reference", CharSet = CharSet.Ansi)]
-        public static extern int ldap_parse_reference([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref IntPtr referrals, IntPtr ServerControls, byte freeIt);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_parse_reference", CharSet = CharSet.Ansi)]
+        public static partial int ldap_parse_reference(ConnectionHandle ldapHandle, IntPtr result, ref IntPtr referrals, IntPtr ServerControls, byte freeIt);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_sasl_bind_s", CharSet = CharSet.Ansi)]
-        internal static extern int ldap_sasl_bind([In] ConnectionHandle ld, string dn, string mechanism, berval cred, IntPtr serverctrls, IntPtr clientctrls, IntPtr servercredp);
+        internal static extern int ldap_sasl_bind(ConnectionHandle ld, string dn, string mechanism, berval cred, IntPtr serverctrls, IntPtr clientctrls, IntPtr servercredp);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_sasl_interactive_bind_s", CharSet = CharSet.Ansi)]
-        internal static extern int ldap_sasl_interactive_bind([In] ConnectionHandle ld, string dn, string mechanism, IntPtr serverctrls, IntPtr clientctrls, uint flags, [MarshalAs(UnmanagedType.FunctionPtr)] LDAP_SASL_INTERACT_PROC proc, IntPtr defaults);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_sasl_interactive_bind_s", CharSet = CharSet.Ansi)]
+        internal static partial int ldap_sasl_interactive_bind(ConnectionHandle ld, string dn, string mechanism, IntPtr serverctrls, IntPtr clientctrls, uint flags, LDAP_SASL_INTERACT_PROC proc, IntPtr defaults);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_err2string", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_err2string(int err);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_err2string", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_err2string(int err);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_extended_operation", CharSet = CharSet.Ansi)]
-        public static extern int ldap_extended_operation([In] ConnectionHandle ldapHandle, string oid, berval data, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        public static extern int ldap_extended_operation(ConnectionHandle ldapHandle, string oid, berval data, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_first_attribute", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_first_attribute([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref IntPtr address);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_first_attribute", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_first_attribute(ConnectionHandle ldapHandle, IntPtr result, ref IntPtr address);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_first_entry", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_first_entry([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_first_entry", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_first_entry(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_first_reference", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_first_reference([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_first_reference", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_first_reference(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_create_sort_control", CharSet = CharSet.Ansi)]
-        public static extern int ldap_create_sort_control(ConnectionHandle handle, IntPtr keys, byte critical, ref IntPtr control);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_create_sort_control", CharSet = CharSet.Ansi)]
+        public static partial int ldap_create_sort_control(ConnectionHandle handle, IntPtr keys, byte critical, ref IntPtr control);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_control_free", CharSet = CharSet.Ansi)]
-        public static extern int ldap_control_free(IntPtr control);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_control_free", CharSet = CharSet.Ansi)]
+        public static partial int ldap_control_free(IntPtr control);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_controls_free", CharSet = CharSet.Ansi)]
-        public static extern int ldap_controls_free([In] IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_controls_free", CharSet = CharSet.Ansi)]
+        public static partial int ldap_controls_free(IntPtr value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_value_free", CharSet = CharSet.Ansi)]
-        public static extern int ldap_value_free([In] IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_value_free", CharSet = CharSet.Ansi)]
+        public static partial int ldap_value_free(IntPtr value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_value_free_len", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_value_free_len([In] IntPtr berelement);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_value_free_len", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_value_free_len(IntPtr berelement);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_memfree", CharSet = CharSet.Ansi)]
-        public static extern void ldap_memfree([In] IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_memfree", CharSet = CharSet.Ansi)]
+        public static partial void ldap_memfree(IntPtr value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_msgfree", CharSet = CharSet.Ansi)]
-        public static extern void ldap_msgfree([In] IntPtr value);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_msgfree", CharSet = CharSet.Ansi)]
+        public static partial void ldap_msgfree(IntPtr value);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_modify_ext", CharSet = CharSet.Ansi)]
-        public static extern int ldap_modify([In] ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_modify_ext", CharSet = CharSet.Ansi)]
+        public static partial int ldap_modify(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_next_attribute", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_next_attribute([In] ConnectionHandle ldapHandle, [In] IntPtr result, [In, Out] IntPtr address);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_next_attribute", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_next_attribute(ConnectionHandle ldapHandle, IntPtr result, IntPtr address);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_next_entry", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_next_entry([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_next_entry", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_next_entry(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_next_reference", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ldap_next_reference([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_next_reference", CharSet = CharSet.Ansi)]
+        public static partial IntPtr ldap_next_reference(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_abandon", CharSet = CharSet.Ansi)]
-        public static extern int ldap_abandon([In] ConnectionHandle ldapHandle, [In] int messagId);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_abandon", CharSet = CharSet.Ansi)]
+        public static partial int ldap_abandon(ConnectionHandle ldapHandle, int messagId);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_add_ext", CharSet = CharSet.Ansi)]
-        public static extern int ldap_add([In] ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_add_ext", CharSet = CharSet.Ansi)]
+        public static partial int ldap_add(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_delete_ext", CharSet = CharSet.Ansi)]
-        public static extern int ldap_delete_ext([In] ConnectionHandle ldapHandle, string dn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_delete_ext", CharSet = CharSet.Ansi)]
+        public static partial int ldap_delete_ext(ConnectionHandle ldapHandle, string dn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
-        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_rename", CharSet = CharSet.Ansi)]
-        public static extern int ldap_rename([In] ConnectionHandle ldapHandle, string dn, string newRdn, string newParentDn, int deleteOldRdn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.OpenLdap, EntryPoint = "ldap_rename", CharSet = CharSet.Ansi)]
+        public static partial int ldap_rename(ConnectionHandle ldapHandle, string dn, string newRdn, string newParentDn, int deleteOldRdn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_compare_ext", CharSet = CharSet.Ansi)]
-        public static extern int ldap_compare([In] ConnectionHandle ldapHandle, string dn, string attributeName, berval binaryValue, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        public static extern int ldap_compare(ConnectionHandle ldapHandle, string dn, string attributeName, berval binaryValue, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.BitBlt.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.BitBlt.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
-        public static extern int BitBlt(IntPtr hdc, int x, int y, int cx, int cy,
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
+        public static partial int BitBlt(IntPtr hdc, int x, int y, int cx, int cy,
                                         IntPtr hdcSrc, int x1, int y1, RasterOp rop);
 
         public static int BitBlt(HandleRef hdc, int x, int y, int cx, int cy,

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.BitBlt.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.BitBlt.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Gdi32, SetLastError = true)]
         public static partial int BitBlt(IntPtr hdc, int x, int y, int cx, int cy,
                                         IntPtr hdcSrc, int x1, int y1, RasterOp rop);
 

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CombineRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CombineRgn.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             RGN_DIFF = 4,
         }
 
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Gdi32, SetLastError = true)]
         public static partial RegionType CombineRgn(IntPtr hrgnDst, IntPtr hrgnSrc1, IntPtr hrgnSrc2, CombineMode iMode);
 
         public static RegionType CombineRgn(HandleRef hrgnDst, HandleRef hrgnSrc1, HandleRef hrgnSrc2, CombineMode iMode)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CombineRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CombineRgn.cs
@@ -16,8 +16,8 @@ internal static partial class Interop
             RGN_DIFF = 4,
         }
 
-        [DllImport(Libraries.Gdi32, SetLastError = true, ExactSpelling = true)]
-        public static extern RegionType CombineRgn(IntPtr hrgnDst, IntPtr hrgnSrc1, IntPtr hrgnSrc2, CombineMode iMode);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
+        public static partial RegionType CombineRgn(IntPtr hrgnDst, IntPtr hrgnSrc1, IntPtr hrgnSrc2, CombineMode iMode);
 
         public static RegionType CombineRgn(HandleRef hrgnDst, HandleRef hrgnSrc1, HandleRef hrgnSrc2, CombineMode iMode)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateCompatibleDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateCompatibleDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial IntPtr CreateCompatibleDC(IntPtr hdc);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateCompatibleDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateCompatibleDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial IntPtr CreateCompatibleDC(IntPtr hdc);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr CreateDCW(string pwszDriver, string pwszDevice, string? pszPort, IntPtr pdm);
+        [GeneratedDllImport(Libraries.Gdi32, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static partial IntPtr CreateDCW(string pwszDriver, string pwszDevice, string? pszPort, IntPtr pdm);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateFontIndirect.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateFontIndirect.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr CreateFontIndirectW(ref User32.LOGFONT lplf);
+        [GeneratedDllImport(Libraries.Gdi32, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static partial IntPtr CreateFontIndirectW(ref User32.LOGFONT lplf);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateIC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateIC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr CreateICW(string pszDriver, string pszDevice, string? pszPort, IntPtr pdm);
+        [GeneratedDllImport(Libraries.Gdi32, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static partial IntPtr CreateICW(string pszDriver, string pszDevice, string? pszPort, IntPtr pdm);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateRectRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateRectRgn.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateRectRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateRectRgn.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteDC.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern bool DeleteDC(IntPtr hdc);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial bool DeleteDC(IntPtr hdc);
 
         public static bool DeleteDC(HandleRef hdc)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial bool DeleteDC(IntPtr hdc);
 
         public static bool DeleteDC(HandleRef hdc)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern bool DeleteObject(IntPtr ho);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial bool DeleteObject(IntPtr ho);
 
         public static bool DeleteObject(HandleRef ho)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial bool DeleteObject(IntPtr ho);
 
         public static bool DeleteObject(HandleRef ho)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetClipRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetClipRgn.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern int GetClipRgn(IntPtr hdc, IntPtr hrgn);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial int GetClipRgn(IntPtr hdc, IntPtr hrgn);
 
         public static int GetClipRgn(HandleRef hdc, IntPtr hrgn)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetClipRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetClipRgn.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial int GetClipRgn(IntPtr hdc, IntPtr hrgn);
 
         public static int GetClipRgn(HandleRef hdc, IntPtr hrgn)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetCurrentObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetCurrentObject.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern IntPtr GetCurrentObject(IntPtr hdc, ObjectType type);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial IntPtr GetCurrentObject(IntPtr hdc, ObjectType type);
 
         public static IntPtr GetCurrentObject(HandleRef hdc, ObjectType type)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetCurrentObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetCurrentObject.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial IntPtr GetCurrentObject(IntPtr hdc, ObjectType type);
 
         public static IntPtr GetCurrentObject(HandleRef hdc, ObjectType type)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetDeviceCaps.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetDeviceCaps.cs
@@ -30,8 +30,8 @@ internal static partial class Interop
             public const int DT_RASPRINTER = 2;
         }
 
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern int GetDeviceCaps(IntPtr hdc, DeviceCapability index);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial int GetDeviceCaps(IntPtr hdc, DeviceCapability index);
 
         public static int GetDeviceCaps(HandleRef hdc, DeviceCapability index)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetDeviceCaps.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetDeviceCaps.cs
@@ -30,7 +30,7 @@ internal static partial class Interop
             public const int DT_RASPRINTER = 2;
         }
 
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial int GetDeviceCaps(IntPtr hdc, DeviceCapability index);
 
         public static int GetDeviceCaps(HandleRef hdc, DeviceCapability index)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetObjectType.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetObjectType.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern ObjectType GetObjectType(IntPtr h);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial ObjectType GetObjectType(IntPtr h);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetObjectType.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetObjectType.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial ObjectType GetObjectType(IntPtr h);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetRgnBox.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetRgnBox.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern RegionType GetRgnBox(IntPtr hrgn, ref RECT lprc);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial RegionType GetRgnBox(IntPtr hrgn, ref RECT lprc);
 
         public static RegionType GetRgnBox(HandleRef hrgn, ref RECT lprc)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetRgnBox.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetRgnBox.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial RegionType GetRgnBox(IntPtr hrgn, ref RECT lprc);
 
         public static RegionType GetRgnBox(HandleRef hrgn, ref RECT lprc)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetStockObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetStockObject.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
             DEFAULT_GUI_FONT = 17
         }
 
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern IntPtr GetStockObject(StockObject i);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial IntPtr GetStockObject(StockObject i);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetStockObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetStockObject.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
             DEFAULT_GUI_FONT = 17
         }
 
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial IntPtr GetStockObject(StockObject i);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.OffsetViewportOrgEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.OffsetViewportOrgEx.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
     {
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
         // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [DllImport(Libraries.Gdi32)]
         public static extern bool OffsetViewportOrgEx(IntPtr hdc, int x, int y, ref Point lppt);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.OffsetViewportOrgEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.OffsetViewportOrgEx.cs
@@ -9,8 +9,11 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
         public static extern bool OffsetViewportOrgEx(IntPtr hdc, int x, int y, ref Point lppt);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
         public static bool OffsetViewportOrgEx(HandleRef hdc, int x, int y, ref Point lppt)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RestoreDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RestoreDC.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern bool RestoreDC(IntPtr hdc, int nSavedDC);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial bool RestoreDC(IntPtr hdc, int nSavedDC);
 
         public static bool RestoreDC(HandleRef hdc, int nSavedDC)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RestoreDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.RestoreDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial bool RestoreDC(IntPtr hdc, int nSavedDC);
 
         public static bool RestoreDC(HandleRef hdc, int nSavedDC)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SaveDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SaveDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Gdi32)]
         public static partial int SaveDC(IntPtr hdc);
 
         public static int SaveDC(HandleRef hdc)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SaveDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SaveDC.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern int SaveDC(IntPtr hdc);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true)]
+        public static partial int SaveDC(IntPtr hdc);
 
         public static int SaveDC(HandleRef hdc)
         {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Gdi32, SetLastError = true)]
         public static partial RegionType SelectClipRgn(IntPtr hdc, IntPtr hrgn);
 
         public static RegionType SelectClipRgn(HandleRef hdc, HandleRef hrgn)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.SelectClipRgn.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Gdi32
     {
-        [DllImport(Libraries.Gdi32, SetLastError = true, ExactSpelling = true)]
-        public static extern RegionType SelectClipRgn(IntPtr hdc, IntPtr hrgn);
+        [GeneratedDllImport(Libraries.Gdi32, ExactSpelling = true, SetLastError = true)]
+        public static partial RegionType SelectClipRgn(IntPtr hdc, IntPtr hrgn);
 
         public static RegionType SelectClipRgn(HandleRef hdc, HandleRef hrgn)
         {

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GlobalFree.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GlobalFree.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         public static partial IntPtr GlobalFree(IntPtr handle);
 
         public static IntPtr GlobalFree(HandleRef handle)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GlobalFree.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GlobalFree.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr GlobalFree(IntPtr handle);
+        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
+        public static partial IntPtr GlobalFree(IntPtr handle);
 
         public static IntPtr GlobalFree(HandleRef handle)
         {

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetDC.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetDC(IntPtr hWnd);
+        [GeneratedDllImport(Libraries.User32, ExactSpelling = true)]
+        public static partial IntPtr GetDC(IntPtr hWnd);
 
         public static IntPtr GetDC(HandleRef hWnd)
         {

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [GeneratedDllImport(Libraries.User32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.User32)]
         public static partial IntPtr GetDC(IntPtr hWnd);
 
         public static IntPtr GetDC(HandleRef hWnd)

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.ReleaseDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.ReleaseDC.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+        [GeneratedDllImport(Libraries.User32, ExactSpelling = true)]
+        public static partial int ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
         public static int ReleaseDC(HandleRef hWnd, IntPtr hDC)
         {

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.ReleaseDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.ReleaseDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [GeneratedDllImport(Libraries.User32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.User32)]
         public static partial int ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
         public static int ReleaseDC(HandleRef hWnd, IntPtr hDC)

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.SystemParametersInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.SystemParametersInfo.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
             SPI_GETNONCLIENTMETRICS = 0x29
         }
 
-        [DllImport(Libraries.User32, ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern unsafe bool SystemParametersInfoW(SystemParametersAction uiAction, uint uiParam, void* pvParam, uint fWinIni);
+        [GeneratedDllImport(Libraries.User32, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        public static unsafe partial bool SystemParametersInfoW(SystemParametersAction uiAction, uint uiParam, void* pvParam, uint fWinIni);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.WindowFromDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.WindowFromDC.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [GeneratedDllImport(Libraries.User32, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.User32)]
         public static partial IntPtr WindowFromDC(IntPtr hDC);
 
         public static IntPtr WindowFromDC(HandleRef hDC)

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.WindowFromDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.WindowFromDC.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr WindowFromDC(IntPtr hDC);
+        [GeneratedDllImport(Libraries.User32, ExactSpelling = true)]
+        public static partial IntPtr WindowFromDC(IntPtr hDC);
 
         public static IntPtr WindowFromDC(HandleRef hDC)
         {

--- a/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ber.cs
+++ b/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ber.cs
@@ -9,28 +9,43 @@ internal static partial class Interop
 {
     internal static partial class Ldap
     {
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_free", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ber_free([In] IntPtr berelement, int option);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ber_free", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ber_free(IntPtr berelement, int option);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_alloc_t", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ber_alloc(int option);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ber_alloc_t", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ber_alloc(int option);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_printf", CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Requires some varargs support mechanism in generated interop
+        [DllImport(Libraries.Wldap32, EntryPoint = "ber_printf", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         public static extern int ber_printf(SafeBerHandle berElement, string format, __arglist);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_flatten", CharSet = CharSet.Unicode)]
-        public static extern int ber_flatten(SafeBerHandle berElement, ref IntPtr value);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ber_flatten", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ber_flatten(SafeBerHandle berElement, ref IntPtr value);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_init", CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Wldap32, EntryPoint = "ber_init", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
         public static extern IntPtr ber_init(berval value);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_scanf", CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Requires some varargs support mechanism in generated interop
+        [DllImport(Libraries.Wldap32, EntryPoint = "ber_scanf", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         public static extern int ber_scanf(SafeBerHandle berElement, string format, __arglist);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_bvfree", CharSet = CharSet.Unicode)]
-        public static extern int ber_bvfree(IntPtr value);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ber_bvfree", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ber_bvfree(IntPtr value);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ber_bvecfree", CharSet = CharSet.Unicode)]
-        public static extern int ber_bvecfree(IntPtr value);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ber_bvecfree", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ber_bvecfree(IntPtr value);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Windows/Wldap32/Interop.Ldap.cs
@@ -9,148 +9,213 @@ internal static partial class Interop
 {
     internal static partial class Ldap
     {
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_bind_sW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_bind_s([In] ConnectionHandle ldapHandle, string dn, SEC_WINNT_AUTH_IDENTITY_EX credentials, BindMethod method);
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Wldap32, EntryPoint = "ldap_bind_sW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static extern int ldap_bind_s(ConnectionHandle ldapHandle, string dn, SEC_WINNT_AUTH_IDENTITY_EX credentials, BindMethod method);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_initW", SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_init(string hostName, int portNumber);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_initW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_init(string hostName, int portNumber);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "ldap_connect", CharSet = CharSet.Unicode)]
-        public static extern int ldap_connect([In] ConnectionHandle ldapHandle, LDAP_TIMEVAL timeout);
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Wldap32, EntryPoint = "ldap_connect", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static extern int ldap_connect(ConnectionHandle ldapHandle, LDAP_TIMEVAL timeout);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, ExactSpelling = true, EntryPoint = "ldap_unbind", CharSet = CharSet.Unicode)]
-        public static extern int ldap_unbind([In] IntPtr ldapHandle);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_unbind", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_unbind(IntPtr ldapHandle);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_get_option_int([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref int outValue);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_get_option_int(ConnectionHandle ldapHandle, LdapOption option, ref int outValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_set_option_int([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref int inValue);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_set_option_int(ConnectionHandle ldapHandle, LdapOption option, ref int inValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_get_option_ptr([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref IntPtr outValue);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_get_option_ptr(ConnectionHandle ldapHandle, LdapOption option, ref IntPtr outValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_set_option_ptr([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref IntPtr inValue);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_set_option_ptr(ConnectionHandle ldapHandle, LdapOption option, ref IntPtr inValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_get_option_sechandle([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref SecurityHandle outValue);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_get_option_sechandle(ConnectionHandle ldapHandle, LdapOption option, ref SecurityHandle outValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_get_option_secInfo([In] ConnectionHandle ldapHandle, [In] LdapOption option, [In, Out] SecurityPackageContextConnectionInformation outValue);
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Wldap32, EntryPoint = "ldap_get_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static extern int ldap_get_option_secInfo(ConnectionHandle ldapHandle, LdapOption option, [In, Out] SecurityPackageContextConnectionInformation outValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_set_option_referral([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref LdapReferralCallback outValue);
+        [DllImport(Libraries.Wldap32, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static extern int ldap_set_option_referral(ConnectionHandle ldapHandle, LdapOption option, ref LdapReferralCallback outValue);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_set_option_clientcert([In] ConnectionHandle ldapHandle, [In] LdapOption option, QUERYCLIENTCERT outValue);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_set_option_clientcert(ConnectionHandle ldapHandle, LdapOption option, QUERYCLIENTCERT outValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_set_option_servercert([In] ConnectionHandle ldapHandle, [In] LdapOption option, VERIFYSERVERCERT outValue);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_set_optionW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_set_option_servercert(ConnectionHandle ldapHandle, LdapOption option, VERIFYSERVERCERT outValue);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "LdapGetLastError")]
-        public static extern int LdapGetLastError();
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "LdapGetLastError")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int LdapGetLastError();
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "cldap_openW", SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern IntPtr cldap_open(string hostName, int portNumber);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "cldap_openW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr cldap_open(string hostName, int portNumber);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_simple_bind_sW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_simple_bind_s([In] ConnectionHandle ldapHandle, string distinguishedName, string password);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_simple_bind_sW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_simple_bind_s(ConnectionHandle ldapHandle, string distinguishedName, string password);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_delete_extW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_delete_ext([In] ConnectionHandle ldapHandle, string dn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_delete_extW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_delete_ext(ConnectionHandle ldapHandle, string dn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_result", SetLastError = true, CharSet = CharSet.Unicode)]
-        public static extern int ldap_result([In] ConnectionHandle ldapHandle, int messageId, int all, LDAP_TIMEVAL timeout, ref IntPtr Mesage);
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Wldap32, EntryPoint = "ldap_result", CharSet = CharSet.Unicode, SetLastError = true)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static extern int ldap_result(ConnectionHandle ldapHandle, int messageId, int all, LDAP_TIMEVAL timeout, ref IntPtr Mesage);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_parse_resultW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_parse_result([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref int serverError, ref IntPtr dn, ref IntPtr message, ref IntPtr referral, ref IntPtr control, byte freeIt);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_parse_resultW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_parse_result(ConnectionHandle ldapHandle, IntPtr result, ref int serverError, ref IntPtr dn, ref IntPtr message, ref IntPtr referral, ref IntPtr control, byte freeIt);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_parse_resultW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_parse_result_referral([In] ConnectionHandle ldapHandle, [In] IntPtr result, IntPtr serverError, IntPtr dn, IntPtr message, ref IntPtr referral, IntPtr control, byte freeIt);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_parse_resultW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_parse_result_referral(ConnectionHandle ldapHandle, IntPtr result, IntPtr serverError, IntPtr dn, IntPtr message, ref IntPtr referral, IntPtr control, byte freeIt);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_memfreeW", CharSet = CharSet.Unicode)]
-        public static extern void ldap_memfree([In] IntPtr value);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_memfreeW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial void ldap_memfree(IntPtr value);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_value_freeW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_value_free([In] IntPtr value);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_value_freeW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_value_free(IntPtr value);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_controls_freeW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_controls_free([In] IntPtr value);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_controls_freeW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_controls_free(IntPtr value);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_abandon", CharSet = CharSet.Unicode)]
-        public static extern int ldap_abandon([In] ConnectionHandle ldapHandle, [In] int messagId);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_abandon", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_abandon(ConnectionHandle ldapHandle, int messagId);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_start_tls_sW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_start_tls(ConnectionHandle ldapHandle, ref int ServerReturnValue, ref IntPtr Message, IntPtr ServerControls, IntPtr ClientControls);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_start_tls_sW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_start_tls(ConnectionHandle ldapHandle, ref int ServerReturnValue, ref IntPtr Message, IntPtr ServerControls, IntPtr ClientControls);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_stop_tls_s", CharSet = CharSet.Unicode)]
-        public static extern byte ldap_stop_tls(ConnectionHandle ldapHandle);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_stop_tls_s", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial byte ldap_stop_tls(ConnectionHandle ldapHandle);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_rename_extW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_rename([In] ConnectionHandle ldapHandle, string dn, string newRdn, string newParentDn, int deleteOldRdn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_rename_extW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_rename(ConnectionHandle ldapHandle, string dn, string newRdn, string newParentDn, int deleteOldRdn, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_compare_extW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_compare([In] ConnectionHandle ldapHandle, string dn, string attributeName, string strValue, berval binaryValue, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Wldap32, EntryPoint = "ldap_compare_extW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static extern int ldap_compare(ConnectionHandle ldapHandle, string dn, string attributeName, string strValue, berval binaryValue, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_add_extW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_add([In] ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_add_extW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_add(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_modify_extW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_modify([In] ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_modify_extW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_modify(ConnectionHandle ldapHandle, string dn, IntPtr attrs, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_extended_operationW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_extended_operation([In] ConnectionHandle ldapHandle, string oid, berval data, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Wldap32, EntryPoint = "ldap_extended_operationW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static extern int ldap_extended_operation(ConnectionHandle ldapHandle, string oid, berval data, IntPtr servercontrol, IntPtr clientcontrol, ref int messageNumber);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_parse_extended_resultW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_parse_extended_result([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_parse_extended_resultW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_parse_extended_result(ConnectionHandle ldapHandle, IntPtr result, ref IntPtr oid, ref IntPtr data, byte freeIt);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_msgfree", CharSet = CharSet.Unicode)]
-        public static extern int ldap_msgfree([In] IntPtr result);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_msgfree", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_msgfree(IntPtr result);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_search_extW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_search([In] ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_search_extW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_search(ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_first_entry", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_first_entry([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_first_entry", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_first_entry(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_next_entry", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_next_entry([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_next_entry", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_next_entry(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_first_reference", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_first_reference([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_first_reference", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_first_reference(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_next_reference", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_next_reference([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_next_reference", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_next_reference(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_get_dnW", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_get_dn([In] ConnectionHandle ldapHandle, [In] IntPtr result);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_get_dnW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_get_dn(ConnectionHandle ldapHandle, IntPtr result);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_first_attributeW", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_first_attribute([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref IntPtr address);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_first_attributeW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_first_attribute(ConnectionHandle ldapHandle, IntPtr result, ref IntPtr address);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_next_attributeW", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_next_attribute([In] ConnectionHandle ldapHandle, [In] IntPtr result, [In, Out] IntPtr address);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_next_attributeW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_next_attribute(ConnectionHandle ldapHandle, IntPtr result, IntPtr address);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_get_values_lenW", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_get_values_len([In] ConnectionHandle ldapHandle, [In] IntPtr result, string name);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_get_values_lenW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_get_values_len(ConnectionHandle ldapHandle, IntPtr result, string name);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_value_free_len", CharSet = CharSet.Unicode)]
-        public static extern IntPtr ldap_value_free_len([In] IntPtr berelement);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_value_free_len", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial IntPtr ldap_value_free_len(IntPtr berelement);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_parse_referenceW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_parse_reference([In] ConnectionHandle ldapHandle, [In] IntPtr result, ref IntPtr referrals);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_parse_referenceW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_parse_reference(ConnectionHandle ldapHandle, IntPtr result, ref IntPtr referrals);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_create_sort_controlW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_create_sort_control(ConnectionHandle handle, IntPtr keys, byte critical, ref IntPtr control);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_create_sort_controlW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_create_sort_control(ConnectionHandle handle, IntPtr keys, byte critical, ref IntPtr control);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_control_freeW", CharSet = CharSet.Unicode)]
-        public static extern int ldap_control_free(IntPtr control);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_control_freeW", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_control_free(IntPtr control);
 
-        [DllImport("Crypt32.dll", EntryPoint = "CertFreeCRLContext", CharSet = CharSet.Unicode)]
-        public static extern int CertFreeCRLContext(IntPtr certContext);
+        [GeneratedDllImport("Crypt32.dll", EntryPoint = "CertFreeCRLContext", CharSet = CharSet.Unicode)]
+        public static partial int CertFreeCRLContext(IntPtr certContext);
 
-        [DllImport(Libraries.Wldap32, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ldap_result2error", CharSet = CharSet.Unicode)]
-        public static extern int ldap_result2error([In] ConnectionHandle ldapHandle, [In] IntPtr result, int freeIt);
+        [GeneratedDllImport(Libraries.Wldap32, EntryPoint = "ldap_result2error", CharSet = CharSet.Unicode)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+        public static partial int ldap_result2error(ConnectionHandle ldapHandle, IntPtr result, int freeIt);
     }
 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
@@ -8,6 +8,8 @@
     <AddNETFrameworkPlaceholderFileToPackage>true</AddNETFrameworkPlaceholderFileToPackage>
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
     <PackageDescription>Provides the methods defined in the Lightweight Directory Access Protocol (LDAP) version 3 (V3) and Directory Services Markup Language (DSML) version 2.0 (V2) standards.</PackageDescription>
+    <!-- CS3016: Arrays as attribute arguments is not CLS-compliant -->
+    <NoWarn>CS3016</NoWarn>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -9,7 +9,7 @@
     <AddNETFrameworkAssemblyReferenceToPackage>true</AddNETFrameworkAssemblyReferenceToPackage>
     <PackageDescription>Provides the methods defined in the Lightweight Directory Access Protocol (LDAP) version 3 (V3) and Directory Services Markup Language (DSML) version 2.0 (V2) standards.</PackageDescription>
     <!-- CS3016: Arrays as attribute arguments is not CLS-compliant -->
-    <NoWarn>CS3016</NoWarn>
+    <NoWarn>$(NoWarn);CS3016</NoWarn>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Comdlg32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Comdlg32.cs
@@ -8,11 +8,14 @@ internal static partial class Interop
 {
     internal static partial class Comdlg32
     {
-        [DllImport(Libraries.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+        // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
+        [DllImport(Libraries.Comdlg32, CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern bool PrintDlg([In, Out] PRINTDLG lppd);
 
-        [DllImport(Libraries.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
+        [DllImport(Libraries.Comdlg32, CharSet = CharSet.Auto, SetLastError = true)]
         internal static extern bool PrintDlg([In, Out] PRINTDLGX86 lppd);
+#pragma warning restore DLLIMPORTGENANALYZER015
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         internal sealed class PRINTDLG

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Gdi32.cs
@@ -42,8 +42,8 @@ internal static partial class Interop
         [DllImport(Libraries.Gdi32, SetLastError = true, CharSet = CharSet.Auto)]
         internal static extern IntPtr /*HDC*/ ResetDC(HandleRef hDC, HandleRef /*DEVMODE*/ lpDevMode);
 
-        [DllImport(Libraries.Gdi32, SetLastError = true, CharSet = CharSet.Auto)]
-        internal static extern int AddFontResourceEx(string lpszFilename, int fl, IntPtr pdv);
+        [GeneratedDllImport(Libraries.Gdi32, CharSet = CharSet.Auto, SetLastError = true)]
+        internal static partial int AddFontResourceEx(string lpszFilename, int fl, IntPtr pdv);
 
         internal static int AddFontFile(string fileName)
         {

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Kernel32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Kernel32.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
         public static partial int GetSystemDefaultLCID();
 
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GlobalAlloc", CharSet = CharSet.Auto, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GlobalAlloc", SetLastError = true)]
         internal static partial IntPtr IntGlobalAlloc(int uFlags, UIntPtr dwBytes); // size should be 32/64bits compatible
 
         internal static IntPtr GlobalAlloc(int uFlags, uint dwBytes)

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Kernel32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Kernel32.cs
@@ -8,11 +8,11 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, SetLastError = true)]
-        public static extern int GetSystemDefaultLCID();
+        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true)]
+        public static partial int GetSystemDefaultLCID();
 
-        [DllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true, EntryPoint = "GlobalAlloc", CharSet = CharSet.Auto)]
-        internal static extern IntPtr IntGlobalAlloc(int uFlags, UIntPtr dwBytes); // size should be 32/64bits compatible
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GlobalAlloc", CharSet = CharSet.Auto, ExactSpelling = true, SetLastError = true)]
+        internal static partial IntPtr IntGlobalAlloc(int uFlags, UIntPtr dwBytes); // size should be 32/64bits compatible
 
         internal static IntPtr GlobalAlloc(int uFlags, uint dwBytes)
         {

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.User32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.User32.cs
@@ -20,13 +20,13 @@ internal static partial class Interop
         [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
         internal static extern bool GetIconInfo(HandleRef hIcon, ref ICONINFO info);
 
-        [GeneratedDllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Libraries.User32, SetLastError = true)]
         public static partial int GetSystemMetrics(int nIndex);
 
         [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         internal static extern bool DrawIconEx(HandleRef hDC, int x, int y, HandleRef hIcon, int width, int height, int iStepIfAniCursor, HandleRef hBrushFlickerFree, int diFlags);
 
-        [GeneratedDllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        [GeneratedDllImport(Libraries.User32, SetLastError = true)]
         internal static unsafe partial IntPtr CreateIconFromResourceEx(byte* pbIconBits, uint cbIconBits, bool fIcon, int dwVersion, int csDesired, int cyDesired, int flags);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.User32.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.User32.cs
@@ -20,14 +20,14 @@ internal static partial class Interop
         [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
         internal static extern bool GetIconInfo(HandleRef hIcon, ref ICONINFO info);
 
-        [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
-        public static extern int GetSystemMetrics(int nIndex);
+        [GeneratedDllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static partial int GetSystemMetrics(int nIndex);
 
         [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         internal static extern bool DrawIconEx(HandleRef hDC, int x, int y, HandleRef hIcon, int width, int height, int iStepIfAniCursor, HandleRef hBrushFlickerFree, int diFlags);
 
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        internal static extern unsafe IntPtr CreateIconFromResourceEx(byte* pbIconBits, uint cbIconBits, bool fIcon, int dwVersion, int csDesired, int cyDesired, int flags);
+        [GeneratedDllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        internal static unsafe partial IntPtr CreateIconFromResourceEx(byte* pbIconBits, uint cbIconBits, bool fIcon, int dwVersion, int csDesired, int cyDesired, int flags);
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct ICONINFO

--- a/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Winspool.cs
+++ b/src/libraries/System.Drawing.Common/src/Interop/Windows/Interop.Winspool.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Winspool
     {
-        [DllImport(Libraries.Winspool, SetLastError = true, CharSet = CharSet.Auto)]
-        internal static extern int DeviceCapabilities(string pDevice, string pPort, short fwCapabilities, IntPtr pOutput, IntPtr /*DEVMODE*/ pDevMode);
+        [GeneratedDllImport(Libraries.Winspool, CharSet = CharSet.Auto, SetLastError = true)]
+        internal static partial int DeviceCapabilities(string pDevice, string pPort, short fwCapabilities, IntPtr pOutput, IntPtr /*DEVMODE*/ pDevMode);
 
         [DllImport(Libraries.Winspool, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
         internal static extern int DocumentProperties(HandleRef hwnd, HandleRef hPrinter, string pDeviceName, IntPtr /*DEVMODE*/ pDevModeOutput, HandleRef /*DEVMODE*/ pDevModeInput, int fMode);
@@ -17,7 +17,7 @@ internal static partial class Interop
         [DllImport(Libraries.Winspool, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
         internal static extern int DocumentProperties(HandleRef hwnd, HandleRef hPrinter, string pDeviceName, IntPtr /*DEVMODE*/ pDevModeOutput, IntPtr /*DEVMODE*/ pDevModeInput, int fMode);
 
-        [DllImport(Libraries.Winspool, SetLastError = true, CharSet = CharSet.Auto)]
-        internal static extern int EnumPrinters(int flags, string? name, int level, IntPtr pPrinterEnum/*buffer*/, int cbBuf, out int pcbNeeded, out int pcReturned);
+        [GeneratedDllImport(Libraries.Winspool, CharSet = CharSet.Auto, SetLastError = true)]
+        internal static partial int EnumPrinters(int flags, string? name, int level, IntPtr pPrinterEnum/*buffer*/, int cbBuf, out int pcbNeeded, out int pcReturned);
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -407,9 +407,11 @@ Unix support is disabled by default. See https://aka.ms/systemdrawingnonwindows 
     <Reference Include="System.ObjectModel" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.Primitives" />
     <Reference Include="System.ComponentModel.TypeConverter" />

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -70,38 +70,38 @@ namespace System.Drawing
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdiplusStartup(out IntPtr token, ref StartupInput input, out StartupOutput output);
 #pragma warning restore DLLIMPORTGENANALYZER015
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial void GdiplusShutdown(ref ulong token);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial IntPtr GdipAlloc(int size);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial void GdipFree(IntPtr ptr);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteBrush(HandleRef brush);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetBrushType(IntPtr brush, out BrushType type);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteGraphics(HandleRef graphics);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipRestoreGraphics(IntPtr graphics, uint graphicsState);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipReleaseDC(HandleRef graphics, HandleRef hdc);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipFillPath(IntPtr graphics, IntPtr brush, IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetNearestColor(IntPtr graphics, out int argb);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
@@ -113,28 +113,28 @@ namespace System.Drawing
             internal static extern int GdipAddPathStringI(IntPtr path, string s, int lenght, IntPtr family, int style, float emSize, ref Rectangle layoutRect, IntPtr format);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromHWND(IntPtr hwnd, out IntPtr graphics);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCloneImage(IntPtr image, out IntPtr imageclone);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImagePaletteSize(IntPtr image, out int size);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImagePalette(IntPtr image, IntPtr palette, int size);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetImagePalette(IntPtr image, IntPtr palette);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageBounds(IntPtr image, out RectangleF source, ref GraphicsUnit unit);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageThumbnail(IntPtr image, uint width, uint height, out IntPtr thumbImage, IntPtr callback, IntPtr callBackData);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
@@ -143,287 +143,287 @@ namespace System.Drawing
             internal static extern int GdipSaveImageToFile(IntPtr image, string filename, ref Guid encoderClsID, IntPtr encoderParameters);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSaveAdd(IntPtr image, IntPtr encoderParameters);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSaveAddImage(IntPtr image, IntPtr imagenew, IntPtr encoderParameters);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageGraphicsContext(IntPtr image, out IntPtr graphics);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreatePath(FillMode brushMode, out IntPtr path);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreatePath2(PointF[] points, byte[] types, int count, FillMode brushMode, out IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreatePath2I(Point[] points, byte[] types, int count, FillMode brushMode, out IntPtr path);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipClonePath(IntPtr path, out IntPtr clonePath);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeletePath(HandleRef path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipResetPath(IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetPointCount(IntPtr path, out int count);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetPathTypes(IntPtr path, byte[] types, int count);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathPoints(IntPtr path, [Out] PointF[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathPointsI(IntPtr path, [Out] Point[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetPathFillMode(IntPtr path, out FillMode fillMode);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetPathFillMode(IntPtr path, FillMode fillMode);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipStartPathFigure(IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipClosePathFigure(IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipClosePathFigures(IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetPathMarker(IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipClearPathMarkers(IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipReversePath(IntPtr path);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathLastPoint(IntPtr path, out PointF lastPoint);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathLine(IntPtr path, float x1, float y1, float x2, float y2);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathLine2(IntPtr path, PointF[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathLine2I(IntPtr path, Point[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathArc(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathBezier(IntPtr path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathBeziers(IntPtr path, PointF[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve(IntPtr path, PointF[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurveI(IntPtr path, Point[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve2(IntPtr path, PointF[] points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve2I(IntPtr path, Point[] points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve3(IntPtr path, PointF[] points, int count, int offset, int numberOfSegments, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve3I(IntPtr path, Point[] points, int count, int offset, int numberOfSegments, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurve(IntPtr path, PointF[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurveI(IntPtr path, Point[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurve2(IntPtr path, PointF[] points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurve2I(IntPtr path, Point[] points, int count, float tension);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathRectangle(IntPtr path, float x, float y, float width, float height);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathRectangles(IntPtr path, RectangleF[] rects, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathEllipse(IntPtr path, float x, float y, float width, float height);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathEllipseI(IntPtr path, int x, int y, int width, int height);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathPie(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathPieI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathPolygon(IntPtr path, PointF[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathPath(IntPtr path, IntPtr addingPath, bool connect);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathLineI(IntPtr path, int x1, int y1, int x2, int y2);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathArcI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathBezierI(IntPtr path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathBeziersI(IntPtr path, Point[] points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathPolygonI(IntPtr path, Point[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipAddPathRectangleI(IntPtr path, int x, int y, int width, int height);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathRectanglesI(IntPtr path, Rectangle[] rects, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipFlattenPath(IntPtr path, IntPtr matrix, float floatness);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipTransformPath(IntPtr path, IntPtr matrix);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipWarpPath(IntPtr path, IntPtr matrix, PointF[] points, int count, float srcx, float srcy, float srcwidth, float srcheight, WarpMode mode, float flatness);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipWidenPath(IntPtr path, IntPtr pen, IntPtr matrix, float flatness);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathWorldBounds(IntPtr path, out RectangleF bounds, IntPtr matrix, IntPtr pen);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathWorldBoundsI(IntPtr path, out Rectangle bounds, IntPtr matrix, IntPtr pen);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, out bool result);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisiblePathPointI(IntPtr path, int x, int y, IntPtr graphics, out bool result);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, IntPtr pen, IntPtr graphics, out bool result);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, IntPtr pen, IntPtr graphics, out bool result);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFontFromLogfont(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr ptr);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFontFromHfont(IntPtr hdc, out IntPtr font, ref Interop.User32.LOGFONT lf);
 
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static partial int GdipGetMetafileHeaderFromFile(string filename, IntPtr header);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetMetafileHeaderFromMetafile(IntPtr metafile, IntPtr header);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetMetafileHeaderFromEmf(IntPtr hEmf, IntPtr header);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetMetafileHeaderFromWmf(IntPtr hWmf, IntPtr wmfPlaceableFileHeader, IntPtr header);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetHemfFromMetafile(IntPtr metafile, out IntPtr hEmf);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetMetafileDownLevelRasterizationLimit(IntPtr metafile, ref uint metafileRasterizationLimitDpi);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipSetMetafileDownLevelRasterizationLimit(IntPtr metafile, uint metafileRasterizationLimitDpi);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromContext_macosx(IntPtr cgref, int width, int height, out IntPtr graphics);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetVisibleClip_linux(IntPtr graphics, ref Rectangle rect);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromXDrawable_linux(IntPtr drawable, IntPtr display, out IntPtr graphics);
 
             // Stream functions for non-Win32 (libgdiplus specific)
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipLoadImageFromDelegate_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, out IntPtr image);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in CoreLib (like Guid).
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSaveImageToDelegate_linux(IntPtr image, StreamGetBytesDelegate getBytes,
                 StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek, StreamCloseDelegate close,
                 StreamSizeDelegate size, ref Guid encoderClsID, IntPtr encoderParameters);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateMetafileFromDelegate_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, out IntPtr metafile);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetMetafileHeaderFromDelegate_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, IntPtr header);
@@ -443,12 +443,12 @@ namespace System.Drawing
                 MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetPostScriptGraphicsContext(
                 [MarshalAs(UnmanagedType.LPStr)] string filename,
                 int width, int height, double dpix, double dpiy, ref IntPtr graphics);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetPostScriptSavePage(IntPtr graphics);
         }
     }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -67,150 +67,177 @@ namespace System.Drawing
 
             // Imported functions
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdiplusStartup(out IntPtr token, ref StartupInput input, out StartupOutput output);
+#pragma warning restore DLLIMPORTGENANALYZER015
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern void GdiplusShutdown(ref ulong token);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial void GdiplusShutdown(ref ulong token);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern IntPtr GdipAlloc(int size);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial IntPtr GdipAlloc(int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern void GdipFree(IntPtr ptr);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial void GdipFree(IntPtr ptr);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeleteBrush(HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetBrushType(IntPtr brush, out BrushType type);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetBrushType(IntPtr brush, out BrushType type);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeleteGraphics(HandleRef graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipRestoreGraphics(IntPtr graphics, uint graphicsState);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipRestoreGraphics(IntPtr graphics, uint graphicsState);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipReleaseDC(HandleRef graphics, HandleRef hdc);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipFillPath(IntPtr graphics, IntPtr brush, IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipFillPath(IntPtr graphics, IntPtr brush, IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetNearestColor(IntPtr graphics, out int argb);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetNearestColor(IntPtr graphics, out int argb);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipAddPathString(IntPtr path, string s, int lenght, IntPtr family, int style, float emSize, ref RectangleF layoutRect, IntPtr format);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipAddPathStringI(IntPtr path, string s, int lenght, IntPtr family, int style, float emSize, ref Rectangle layoutRect, IntPtr format);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFromHWND(IntPtr hwnd, out IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFromHWND(IntPtr hwnd, out IntPtr graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCloneImage(IntPtr image, out IntPtr imageclone);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCloneImage(IntPtr image, out IntPtr imageclone);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImagePaletteSize(IntPtr image, out int size);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImagePaletteSize(IntPtr image, out int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImagePalette(IntPtr image, IntPtr palette, int size);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImagePalette(IntPtr image, IntPtr palette, int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipSetImagePalette(IntPtr image, IntPtr palette);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipSetImagePalette(IntPtr image, IntPtr palette);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetImageBounds(IntPtr image, out RectangleF source, ref GraphicsUnit unit);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImageThumbnail(IntPtr image, uint width, uint height, out IntPtr thumbImage, IntPtr callback, IntPtr callBackData);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImageThumbnail(IntPtr image, uint width, uint height, out IntPtr thumbImage, IntPtr callback, IntPtr callBackData);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in CoreLib (like Guid).
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipSaveImageToFile(IntPtr image, string filename, ref Guid encoderClsID, IntPtr encoderParameters);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipSaveAdd(IntPtr image, IntPtr encoderParameters);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipSaveAdd(IntPtr image, IntPtr encoderParameters);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipSaveAddImage(IntPtr image, IntPtr imagenew, IntPtr encoderParameters);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipSaveAddImage(IntPtr image, IntPtr imagenew, IntPtr encoderParameters);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImageGraphicsContext(IntPtr image, out IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImageGraphicsContext(IntPtr image, out IntPtr graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreatePath(FillMode brushMode, out IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreatePath(FillMode brushMode, out IntPtr path);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreatePath2(PointF[] points, byte[] types, int count, FillMode brushMode, out IntPtr path);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreatePath2I(Point[] points, byte[] types, int count, FillMode brushMode, out IntPtr path);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipClonePath(IntPtr path, out IntPtr clonePath);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipClonePath(IntPtr path, out IntPtr clonePath);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeletePath(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipResetPath(IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipResetPath(IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetPointCount(IntPtr path, out int count);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetPointCount(IntPtr path, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetPathTypes(IntPtr path, [Out] byte[] types, int count);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetPathTypes(IntPtr path, byte[] types, int count);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetPathPoints(IntPtr path, [Out] PointF[] points, int count);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetPathPointsI(IntPtr path, [Out] Point[] points, int count);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetPathFillMode(IntPtr path, out FillMode fillMode);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetPathFillMode(IntPtr path, out FillMode fillMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipSetPathFillMode(IntPtr path, FillMode fillMode);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipSetPathFillMode(IntPtr path, FillMode fillMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipStartPathFigure(IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipStartPathFigure(IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipClosePathFigure(IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipClosePathFigure(IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipClosePathFigures(IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipClosePathFigures(IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipSetPathMarker(IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipSetPathMarker(IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipClearPathMarkers(IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipClearPathMarkers(IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipReversePath(IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipReversePath(IntPtr path);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetPathLastPoint(IntPtr path, out PointF lastPoint);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathLine(IntPtr path, float x1, float y1, float x2, float y2);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathLine(IntPtr path, float x1, float y1, float x2, float y2);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathLine2(IntPtr path, PointF[] points, int count);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathLine2I(IntPtr path, Point[] points, int count);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathArc(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathArc(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathBezier(IntPtr path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathBezier(IntPtr path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathBeziers(IntPtr path, PointF[] points, int count);
 
@@ -243,158 +270,186 @@ namespace System.Drawing
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathClosedCurve2I(IntPtr path, Point[] points, int count, float tension);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathRectangle(IntPtr path, float x, float y, float width, float height);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathRectangle(IntPtr path, float x, float y, float width, float height);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathRectangles(IntPtr path, RectangleF[] rects, int count);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathEllipse(IntPtr path, float x, float y, float width, float height);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathEllipse(IntPtr path, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathEllipseI(IntPtr path, int x, int y, int width, int height);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathEllipseI(IntPtr path, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathPie(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathPie(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathPieI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathPieI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathPolygon(IntPtr path, PointF[] points, int count);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathPath(IntPtr path, IntPtr addingPath, bool connect);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathPath(IntPtr path, IntPtr addingPath, bool connect);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathLineI(IntPtr path, int x1, int y1, int x2, int y2);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathLineI(IntPtr path, int x1, int y1, int x2, int y2);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathArcI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathArcI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathBezierI(IntPtr path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathBezierI(IntPtr path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathBeziersI(IntPtr path, Point[] points, int count);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathPolygonI(IntPtr path, Point[] points, int count);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipAddPathRectangleI(IntPtr path, int x, int y, int width, int height);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipAddPathRectangleI(IntPtr path, int x, int y, int width, int height);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipAddPathRectanglesI(IntPtr path, Rectangle[] rects, int count);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipFlattenPath(IntPtr path, IntPtr matrix, float floatness);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipFlattenPath(IntPtr path, IntPtr matrix, float floatness);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipTransformPath(IntPtr path, IntPtr matrix);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipTransformPath(IntPtr path, IntPtr matrix);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipWarpPath(IntPtr path, IntPtr matrix, PointF[] points, int count, float srcx, float srcy, float srcwidth, float srcheight, WarpMode mode, float flatness);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipWidenPath(IntPtr path, IntPtr pen, IntPtr matrix, float flatness);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipWidenPath(IntPtr path, IntPtr pen, IntPtr matrix, float flatness);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetPathWorldBounds(IntPtr path, out RectangleF bounds, IntPtr matrix, IntPtr pen);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetPathWorldBoundsI(IntPtr path, out Rectangle bounds, IntPtr matrix, IntPtr pen);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, out bool result);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipIsVisiblePathPointI(IntPtr path, int x, int y, IntPtr graphics, out bool result);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipIsVisiblePathPointI(IntPtr path, int x, int y, IntPtr graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, IntPtr pen, IntPtr graphics, out bool result);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, IntPtr pen, IntPtr graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, IntPtr pen, IntPtr graphics, out bool result);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, IntPtr pen, IntPtr graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFontFromLogfont(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr ptr);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFontFromLogfont(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr ptr);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFontFromHfont(IntPtr hdc, out IntPtr font, ref Interop.User32.LOGFONT lf);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFontFromHfont(IntPtr hdc, out IntPtr font, ref Interop.User32.LOGFONT lf);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipGetMetafileHeaderFromFile(string filename, IntPtr header);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileHeaderFromFile(string filename, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetMetafileHeaderFromMetafile(IntPtr metafile, IntPtr header);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileHeaderFromMetafile(IntPtr metafile, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetMetafileHeaderFromEmf(IntPtr hEmf, IntPtr header);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileHeaderFromEmf(IntPtr hEmf, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetMetafileHeaderFromWmf(IntPtr hWmf, IntPtr wmfPlaceableFileHeader, IntPtr header);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileHeaderFromWmf(IntPtr hWmf, IntPtr wmfPlaceableFileHeader, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetHemfFromMetafile(IntPtr metafile, out IntPtr hEmf);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetHemfFromMetafile(IntPtr metafile, out IntPtr hEmf);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetMetafileDownLevelRasterizationLimit(IntPtr metafile, ref uint metafileRasterizationLimitDpi);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileDownLevelRasterizationLimit(IntPtr metafile, ref uint metafileRasterizationLimitDpi);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipSetMetafileDownLevelRasterizationLimit(IntPtr metafile, uint metafileRasterizationLimitDpi);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipSetMetafileDownLevelRasterizationLimit(IntPtr metafile, uint metafileRasterizationLimitDpi);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFromContext_macosx(IntPtr cgref, int width, int height, out IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFromContext_macosx(IntPtr cgref, int width, int height, out IntPtr graphics);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipSetVisibleClip_linux(IntPtr graphics, ref Rectangle rect);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFromXDrawable_linux(IntPtr drawable, IntPtr display, out IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFromXDrawable_linux(IntPtr drawable, IntPtr display, out IntPtr graphics);
 
             // Stream functions for non-Win32 (libgdiplus specific)
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipLoadImageFromDelegate_linux(StreamGetHeaderDelegate getHeader,
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipLoadImageFromDelegate_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, out IntPtr image);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in CoreLib (like Guid).
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipSaveImageToDelegate_linux(IntPtr image, StreamGetBytesDelegate getBytes,
                 StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek, StreamCloseDelegate close,
                 StreamSizeDelegate size, ref Guid encoderClsID, IntPtr encoderParameters);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateMetafileFromDelegate_linux(StreamGetHeaderDelegate getHeader,
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateMetafileFromDelegate_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, out IntPtr metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetMetafileHeaderFromDelegate_linux(StreamGetHeaderDelegate getHeader,
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileHeaderFromDelegate_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipRecordMetafileFromDelegate_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, IntPtr hdc, EmfType type, ref RectangleF frameRect,
                 MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipRecordMetafileFromDelegateI_linux(StreamGetHeaderDelegate getHeader,
                 StreamGetBytesDelegate getBytes, StreamPutBytesDelegate putBytes, StreamSeekDelegate doSeek,
                 StreamCloseDelegate close, StreamSizeDelegate size, IntPtr hdc, EmfType type, ref Rectangle frameRect,
                 MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetPostScriptGraphicsContext(
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetPostScriptGraphicsContext(
                 [MarshalAs(UnmanagedType.LPStr)] string filename,
                 int width, int height, double dpix, double dpiy, ref IntPtr graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetPostScriptSavePage(IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetPostScriptSavePage(IntPtr graphics);
         }
     }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -22,326 +22,326 @@ namespace System.Drawing
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             private static extern int GdiplusStartup(out IntPtr token, ref StartupInput input, out StartupOutput output);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreatePath(int brushMode, out IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreatePath2(PointF* points, byte* types, int count, int brushMode, out IntPtr path);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreatePath2I(Point* points, byte* types, int count, int brushMode, out IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipClonePath(HandleRef path, out IntPtr clonepath);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeletePath(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipResetPath(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPointCount(HandleRef path, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathTypes(HandleRef path, byte[] types, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathPoints(HandleRef path, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathFillMode(HandleRef path, out FillMode fillmode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathFillMode(HandleRef path, FillMode fillmode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathData(HandleRef path, GpPathData* pathData);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipStartPathFigure(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipClosePathFigure(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipClosePathFigures(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathMarker(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipClearPathMarkers(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipReversePath(HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathLastPoint(HandleRef path, out PointF lastPoint);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathLine(HandleRef path, float x1, float y1, float x2, float y2);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathLine2(HandleRef path, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathArc(HandleRef path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathBezier(HandleRef path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathBeziers(HandleRef path, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve(HandleRef path, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve2(HandleRef path, PointF* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve3(HandleRef path, PointF* points, int count, int offset, int numberOfSegments, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurve(HandleRef path, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurve2(HandleRef path, PointF* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathRectangle(HandleRef path, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathRectangles(HandleRef path, RectangleF* rects, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathEllipse(HandleRef path, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathPie(HandleRef path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathPolygon(HandleRef path, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathPath(HandleRef path, HandleRef addingPath, bool connect);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipAddPathString(HandleRef path, string s, int length, HandleRef fontFamily, int style, float emSize, ref RectangleF layoutRect, HandleRef format);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipAddPathStringI(HandleRef path, string s, int length, HandleRef fontFamily, int style, float emSize, ref Rectangle layoutRect, HandleRef format);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathLineI(HandleRef path, int x1, int y1, int x2, int y2);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathLine2I(HandleRef path, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathArcI(HandleRef path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathBezierI(HandleRef path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathBeziersI(HandleRef path, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurveI(HandleRef path, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve2I(HandleRef path, Point* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathCurve3I(HandleRef path, Point* points, int count, int offset, int numberOfSegments, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurveI(HandleRef path, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathClosedCurve2I(HandleRef path, Point* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathRectangleI(HandleRef path, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathRectanglesI(HandleRef path, Rectangle* rects, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathEllipseI(HandleRef path, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathPieI(HandleRef path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipAddPathPolygonI(HandleRef path, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipFlattenPath(HandleRef path, HandleRef matrixfloat, float flatness);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipWidenPath(HandleRef path, HandleRef pen, HandleRef matrix, float flatness);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipWarpPath(HandleRef path, HandleRef matrix, PointF* points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTransformPath(HandleRef path, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathWorldBounds(HandleRef path, out RectangleF gprectf, HandleRef matrix, HandleRef pen);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisiblePathPoint(HandleRef path, float x, float y, HandleRef graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisiblePathPointI(HandleRef path, int x, int y, HandleRef graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsOutlineVisiblePathPoint(HandleRef path, float x, float y, HandleRef pen, HandleRef graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsOutlineVisiblePathPointI(HandleRef path, int x, int y, HandleRef pen, HandleRef graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteBrush(HandleRef brush);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipLoadImageFromStream(IntPtr stream, IntPtr* image);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipLoadImageFromStreamICM(IntPtr stream, IntPtr* image);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneImage(HandleRef image, out IntPtr cloneimage);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipSaveImageToFile(HandleRef image, string filename, ref Guid classId, HandleRef encoderParams);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSaveImageToStream(HandleRef image, IntPtr stream, Guid* classId, HandleRef encoderParams);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSaveAdd(HandleRef image, HandleRef encoderParams);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSaveAddImage(HandleRef image, HandleRef newImage, HandleRef encoderParams);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageGraphicsContext(HandleRef image, out IntPtr graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageBounds(HandleRef image, out RectangleF gprectf, out GraphicsUnit unit);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageThumbnail(HandleRef image, int thumbWidth, int thumbHeight, out IntPtr thumbImage, Image.GetThumbnailImageAbort? callback, IntPtr callbackdata);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImagePalette(HandleRef image, IntPtr palette, int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImagePalette(HandleRef image, IntPtr palette);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImagePaletteSize(HandleRef image, out int size);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipImageForceValidation(IntPtr image);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromHDC2(IntPtr hdc, IntPtr hdevice, out IntPtr graphics);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromHWND(IntPtr hwnd, out IntPtr graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteGraphics(HandleRef graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipReleaseDC(HandleRef graphics, IntPtr hdc);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetNearestColor(HandleRef graphics, ref int color);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial IntPtr GdipCreateHalftonePalette();
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawBeziers(HandleRef graphics, HandleRef pen, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawBeziersI(HandleRef graphics, HandleRef pen, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillPath(HandleRef graphics, HandleRef brush, HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestPoint(HandleRef graphics, HandleRef metafile, ref PointF destPoint, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestPointI(HandleRef graphics, HandleRef metafile, ref Point destPoint, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestRect(HandleRef graphics, HandleRef metafile, ref RectangleF destRect, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestRectI(HandleRef graphics, HandleRef metafile, ref Rectangle destRect, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestPoints(HandleRef graphics, HandleRef metafile, PointF* destPoints, int count, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestPointsI(HandleRef graphics, HandleRef metafile, Point* destPoints, int count, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileSrcRectDestPoint(HandleRef graphics, HandleRef metafile, ref PointF destPoint, ref RectangleF srcRect, GraphicsUnit pageUnit, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileSrcRectDestPointI(HandleRef graphics, HandleRef metafile, ref Point destPoint, ref Rectangle srcRect, GraphicsUnit pageUnit, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileSrcRectDestRect(HandleRef graphics, HandleRef metafile, ref RectangleF destRect, ref RectangleF srcRect, GraphicsUnit pageUnit, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileSrcRectDestRectI(HandleRef graphics, HandleRef metafile, ref Rectangle destRect, ref Rectangle srcRect, GraphicsUnit pageUnit, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileSrcRectDestPoints(HandleRef graphics, HandleRef metafile, PointF* destPoints, int count, ref RectangleF srcRect, GraphicsUnit pageUnit, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileSrcRectDestPointsI(HandleRef graphics, HandleRef metafile, Point* destPoints, int count, ref Rectangle srcRect, GraphicsUnit pageUnit, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRestoreGraphics(HandleRef graphics, int state);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetMetafileHeaderFromWmf(IntPtr hMetafile, WmfPlaceableFileHeader wmfplaceable, [In] [Out] MetafileHeaderWmf metafileHeaderWmf);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetMetafileHeaderFromEmf(IntPtr hEnhMetafile, [In] [Out] MetafileHeaderEmf metafileHeaderEmf);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static partial int GdipGetMetafileHeaderFromFile(string filename, IntPtr header);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetMetafileHeaderFromStream(IntPtr stream, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetMetafileHeaderFromMetafile(HandleRef metafile, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetHemfFromMetafile(HandleRef metafile, out IntPtr hEnhMetafile);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateMetafileFromStream(IntPtr stream, IntPtr* metafile);
 
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
@@ -353,16 +353,16 @@ namespace System.Drawing
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static partial int GdipRecordMetafileStreamI(IntPtr stream, IntPtr referenceHdc, EmfType emfType, Rectangle* frameRect, MetafileFrameUnit frameUnit, string? description, IntPtr* metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipComment(HandleRef graphics, int sizeData, byte[] data);
 
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static partial int GdipCreateFontFromLogfontW(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr font);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateBitmapFromStream(IntPtr stream, IntPtr* bitmap);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateBitmapFromStreamICM(IntPtr stream, IntPtr* bitmap);
         }
     }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -20,17 +20,20 @@ namespace System.Drawing
 
             // Imported functions
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
             [DllImport(LibraryName, ExactSpelling = true)]
             private static extern int GdiplusStartup(out IntPtr token, ref StartupInput input, out StartupOutput output);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreatePath(int brushMode, out IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreatePath(int brushMode, out IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreatePath2(PointF* points, byte* types, int count, int brushMode, out IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreatePath2(PointF* points, byte* types, int count, int brushMode, out IntPtr path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreatePath2I(Point* points, byte* types, int count, int brushMode, out IntPtr path);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreatePath2I(Point* points, byte* types, int count, int brushMode, out IntPtr path);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipClonePath(HandleRef path, out IntPtr clonepath);
@@ -209,11 +212,11 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeleteBrush(HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipLoadImageFromStream(IntPtr stream, IntPtr* image);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipLoadImageFromStream(IntPtr stream, IntPtr* image);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipLoadImageFromStreamICM(IntPtr stream, IntPtr* image);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipLoadImageFromStreamICM(IntPtr stream, IntPtr* image);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCloneImage(HandleRef image, out IntPtr cloneimage);
@@ -248,14 +251,14 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetImagePaletteSize(HandleRef image, out int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipImageForceValidation(IntPtr image);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipImageForceValidation(IntPtr image);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFromHDC2(IntPtr hdc, IntPtr hdevice, out IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFromHDC2(IntPtr hdc, IntPtr hdevice, out IntPtr graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFromHWND(IntPtr hwnd, out IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFromHWND(IntPtr hwnd, out IntPtr graphics);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeleteGraphics(HandleRef graphics);
@@ -266,8 +269,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetNearestColor(HandleRef graphics, ref int color);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern IntPtr GdipCreateHalftonePalette();
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial IntPtr GdipCreateHalftonePalette();
 
             [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
             internal static extern int GdipDrawBeziers(HandleRef graphics, HandleRef pen, PointF* points, int count);
@@ -317,17 +320,20 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipRestoreGraphics(HandleRef graphics, int state);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetMetafileHeaderFromWmf(IntPtr hMetafile, WmfPlaceableFileHeader wmfplaceable, [In] [Out] MetafileHeaderWmf metafileHeaderWmf);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetMetafileHeaderFromEmf(IntPtr hEnhMetafile, [In] [Out] MetafileHeaderEmf metafileHeaderEmf);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipGetMetafileHeaderFromFile(string filename, IntPtr header);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileHeaderFromFile(string filename, IntPtr header);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetMetafileHeaderFromStream(IntPtr stream, IntPtr header);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetMetafileHeaderFromStream(IntPtr stream, IntPtr header);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetMetafileHeaderFromMetafile(HandleRef metafile, IntPtr header);
@@ -335,29 +341,29 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetHemfFromMetafile(HandleRef metafile, out IntPtr hEnhMetafile);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateMetafileFromStream(IntPtr stream, IntPtr* metafile);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateMetafileFromStream(IntPtr stream, IntPtr* metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipRecordMetafileStream(IntPtr stream, IntPtr referenceHdc, EmfType emfType, RectangleF* frameRect, MetafileFrameUnit frameUnit, string? description, IntPtr* metafile);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipRecordMetafileStream(IntPtr stream, IntPtr referenceHdc, EmfType emfType, RectangleF* frameRect, MetafileFrameUnit frameUnit, string? description, IntPtr* metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipRecordMetafileStream(IntPtr stream, IntPtr referenceHdc, EmfType emfType, IntPtr pframeRect, MetafileFrameUnit frameUnit, string? description, IntPtr* metafile);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipRecordMetafileStream(IntPtr stream, IntPtr referenceHdc, EmfType emfType, IntPtr pframeRect, MetafileFrameUnit frameUnit, string? description, IntPtr* metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipRecordMetafileStreamI(IntPtr stream, IntPtr referenceHdc, EmfType emfType, Rectangle* frameRect, MetafileFrameUnit frameUnit, string? description, IntPtr* metafile);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipRecordMetafileStreamI(IntPtr stream, IntPtr referenceHdc, EmfType emfType, Rectangle* frameRect, MetafileFrameUnit frameUnit, string? description, IntPtr* metafile);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipComment(HandleRef graphics, int sizeData, byte[] data);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipCreateFontFromLogfontW(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr font);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipCreateFontFromLogfontW(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr font);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateBitmapFromStream(IntPtr stream, IntPtr* bitmap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromStream(IntPtr stream, IntPtr* bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateBitmapFromStreamICM(IntPtr stream, IntPtr* bitmap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromStreamICM(IntPtr stream, IntPtr* bitmap);
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -27,8 +27,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipEndContainer(HandleRef graphics, int state);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateAdjustableArrowCap(float height, float width, bool isFilled, out IntPtr adjustableArrowCap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateAdjustableArrowCap(float height, float width, bool isFilled, out IntPtr adjustableArrowCap);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetAdjustableArrowCapHeight(HandleRef adjustableArrowCap, out float height);
@@ -54,14 +54,14 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetAdjustableArrowCapFillState(HandleRef adjustableArrowCap, out bool fillState);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetCustomLineCapType(IntPtr customCap, out CustomLineCapType capType);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetCustomLineCapType(IntPtr customCap, out CustomLineCapType capType);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateCustomLineCap(HandleRef fillpath, HandleRef strokepath, LineCap baseCap, float baseInset, out IntPtr customCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipDeleteCustomLineCap(IntPtr customCap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipDeleteCustomLineCap(IntPtr customCap);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeleteCustomLineCap(HandleRef customCap);
@@ -138,8 +138,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipPathIterCopyData(HandleRef pathIter, out int resultCount, PointF* points, byte* types, int startIndex, int endIndex);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateHatchBrush(int hatchstyle, int forecol, int backcol, out IntPtr brush);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateHatchBrush(int hatchstyle, int forecol, int backcol, out IntPtr brush);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetHatchStyle(HandleRef brush, out int hatchstyle);
@@ -153,6 +153,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCloneBrush(HandleRef brush, out IntPtr clonebrush);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateLineBrush(ref PointF point1, ref PointF point2, int color1, int color2, WrapMode wrapMode, out IntPtr lineGradient);
 
@@ -170,6 +172,7 @@ namespace System.Drawing
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateLineBrushFromRectWithAngleI(ref Rectangle rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipSetLineColors(HandleRef brush, int color1, int color2);
@@ -237,11 +240,11 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipRotateLineTransform(HandleRef brush, float angle, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreatePathGradient(PointF* points, int count, WrapMode wrapMode, out IntPtr brush);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreatePathGradient(PointF* points, int count, WrapMode wrapMode, out IntPtr brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreatePathGradientI(Point* points, int count, WrapMode wrapMode, out IntPtr brush);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreatePathGradientI(Point* points, int count, WrapMode wrapMode, out IntPtr brush);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreatePathGradientFromPath(HandleRef path, out IntPtr brush);
@@ -330,8 +333,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipSetPathGradientFocusScales(HandleRef brush, float xScale, float yScale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateImageAttributes(out IntPtr imageattr);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateImageAttributes(out IntPtr imageattr);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCloneImageAttributes(HandleRef imageattr, out IntPtr cloneImageattr);
@@ -369,20 +372,20 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetImageAttributesAdjustedPalette(HandleRef imageattr, IntPtr palette, ColorAdjustType type);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImageDecodersSize(out int numDecoders, out int size);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImageDecodersSize(out int numDecoders, out int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImageDecoders(int numDecoders, int size, IntPtr decoders);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImageDecoders(int numDecoders, int size, IntPtr decoders);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImageEncodersSize(out int numEncoders, out int size);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImageEncodersSize(out int numEncoders, out int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImageEncoders(int numEncoders, int size, IntPtr encoders);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImageEncoders(int numEncoders, int size, IntPtr encoders);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateSolidFill(int color, out IntPtr brush);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateSolidFill(int color, out IntPtr brush);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipSetSolidFillColor(HandleRef brush, int color);
@@ -442,20 +445,20 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetFontCollectionFamilyList(HandleRef fontCollection, int numSought, IntPtr[] gpfamilies, out int numFound);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCloneFontFamily(IntPtr fontfamily, out IntPtr clonefontfamily);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCloneFontFamily(IntPtr fontfamily, out IntPtr clonefontfamily);
 
             [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
             internal static extern int GdipCreateFontFamilyFromName(string name, HandleRef fontCollection, out IntPtr FontFamily);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetGenericFontFamilySansSerif(out IntPtr fontfamily);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetGenericFontFamilySansSerif(out IntPtr fontfamily);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetGenericFontFamilySerif(out IntPtr fontfamily);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetGenericFontFamilySerif(out IntPtr fontfamily);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetGenericFontFamilyMonospace(out IntPtr fontfamily);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetGenericFontFamilyMonospace(out IntPtr fontfamily);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeleteFontFamily(HandleRef fontFamily);
@@ -478,14 +481,14 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetLineSpacing(HandleRef family, FontStyle style, out int LineSpaceing);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipNewInstalledFontCollection(out IntPtr fontCollection);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipNewInstalledFontCollection(out IntPtr fontCollection);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipNewPrivateFontCollection(out IntPtr fontCollection);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipNewPrivateFontCollection(out IntPtr fontCollection);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipDeletePrivateFontCollection(ref IntPtr fontCollection);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipDeletePrivateFontCollection(ref IntPtr fontCollection);
 
             [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
             internal static extern int GdipPrivateAddFontFile(HandleRef fontCollection, string filename);
@@ -496,8 +499,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateFont(HandleRef fontFamily, float emSize, FontStyle style, GraphicsUnit unit, out IntPtr font);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFontFromDC(IntPtr hdc, ref IntPtr font);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFontFromDC(IntPtr hdc, ref IntPtr font);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCloneFont(HandleRef font, out IntPtr cloneFont);
@@ -526,8 +529,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetLogFontW(HandleRef font, HandleRef graphics, ref Interop.User32.LOGFONT lf);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreatePen1(int argb, float width, int unit, out IntPtr pen);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreatePen1(int argb, float width, int unit, out IntPtr pen);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreatePen2(HandleRef brush, float width, int unit, out IntPtr pen);
@@ -748,17 +751,20 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetDpiY(HandleRef graphics, out float dpi);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateMatrix(out IntPtr matrix);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateMatrix(out IntPtr matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateMatrix2(float m11, float m12, float m21, float m22, float dx, float dy, out IntPtr matrix);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateMatrix2(float m11, float m12, float m21, float m22, float dx, float dy, out IntPtr matrix);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateMatrix3(ref RectangleF rect, PointF* dstplg, out IntPtr matrix);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateMatrix3I(ref Rectangle rect, Point* dstplg, out IntPtr matrix);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCloneMatrix(HandleRef matrix, out IntPtr cloneMatrix);
@@ -811,23 +817,26 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipIsMatrixEqual(HandleRef matrix, HandleRef matrix2, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateRegion(out IntPtr region);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateRegion(out IntPtr region);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateRegionRect(ref RectangleF gprectf, out IntPtr region);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateRegionRectI(ref Rectangle gprect, out IntPtr region);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateRegionPath(HandleRef path, out IntPtr region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateRegionRgnData(byte[] rgndata, int size, out IntPtr region);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateRegionRgnData(byte[] rgndata, int size, out IntPtr region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateRegionHrgn(IntPtr hRgn, out IntPtr region);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateRegionHrgn(IntPtr hRgn, out IntPtr region);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCloneRegion(HandleRef region, out IntPtr cloneregion);
@@ -904,8 +913,8 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetRegionScans(HandleRef region, RectangleF* rects, out int count, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateFromHDC(IntPtr hdc, out IntPtr graphics);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateFromHDC(IntPtr hdc, out IntPtr graphics);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipSetClipGraphics(HandleRef graphics, HandleRef srcgraphics, CombineMode mode);
@@ -964,14 +973,14 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipSetStringFormatMeasurableCharacterRanges(HandleRef format, int rangeCount, [In] [Out] CharacterRange[] range);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateStringFormat(StringFormatFlags options, int language, out IntPtr format);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateStringFormat(StringFormatFlags options, int language, out IntPtr format);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipStringFormatGetGenericDefault(out IntPtr format);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipStringFormatGetGenericDefault(out IntPtr format);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipStringFormatGetGenericTypographic(out IntPtr format);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipStringFormatGetGenericTypographic(out IntPtr format);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDeleteStringFormat(HandleRef format);
@@ -1087,35 +1096,35 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetImageType(HandleRef image, out int type);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipGetImageType(IntPtr image, out int type);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipGetImageType(IntPtr image, out int type);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipDisposeImage(HandleRef image);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipDisposeImage(IntPtr image);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipDisposeImage(IntPtr image);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipCreateBitmapFromFile(string filename, out IntPtr bitmap);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromFile(string filename, out IntPtr bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipCreateBitmapFromFileICM(string filename, out IntPtr bitmap);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromFileICM(string filename, out IntPtr bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateBitmapFromScan0(int width, int height, int stride, int format, IntPtr scan0, out IntPtr bitmap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromScan0(int width, int height, int stride, int format, IntPtr scan0, out IntPtr bitmap);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateBitmapFromGraphics(int width, int height, HandleRef graphics, out IntPtr bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateBitmapFromHBITMAP(IntPtr hbitmap, IntPtr hpalette, out IntPtr bitmap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromHBITMAP(IntPtr hbitmap, IntPtr hpalette, out IntPtr bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateBitmapFromHICON(IntPtr hicon, out IntPtr bitmap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromHICON(IntPtr hicon, out IntPtr bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateBitmapFromResource(IntPtr hresource, IntPtr name, out IntPtr bitmap);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateBitmapFromResource(IntPtr hresource, IntPtr name, out IntPtr bitmap);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateHBITMAPFromBitmap(HandleRef nativeBitmap, out IntPtr hbitmap, int argbBackground);
@@ -1150,32 +1159,41 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipImageGetFrameDimensionsList(HandleRef image, Guid* dimensionIDs, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipCreateMetafileFromEmf(IntPtr hEnhMetafile, bool deleteEmf, out IntPtr metafile);
+            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            internal static partial int GdipCreateMetafileFromEmf(IntPtr hEnhMetafile, bool deleteEmf, out IntPtr metafile);
 
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipCreateMetafileFromWmf(IntPtr hMetafile, bool deleteWmf, WmfPlaceableFileHeader wmfplacealbeHeader, out IntPtr metafile);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipCreateMetafileFromFile(string file, out IntPtr metafile);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipCreateMetafileFromFile(string file, out IntPtr metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
-            internal static extern int GdipRecordMetafile(IntPtr referenceHdc, EmfType emfType, IntPtr pframeRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipRecordMetafile(IntPtr referenceHdc, EmfType emfType, IntPtr pframeRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipRecordMetafile(IntPtr referenceHdc, EmfType emfType, ref RectangleF frameRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipRecordMetafileI(IntPtr referenceHdc, EmfType emfType, ref Rectangle frameRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipRecordMetafileFileName(string fileName, IntPtr referenceHdc, EmfType emfType, ref RectangleF frameRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipRecordMetafileFileName(string fileName, IntPtr referenceHdc, EmfType emfType, IntPtr pframeRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipRecordMetafileFileName(string fileName, IntPtr referenceHdc, EmfType emfType, IntPtr pframeRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static extern int GdipRecordMetafileFileNameI(string fileName, IntPtr referenceHdc, EmfType emfType, ref Rectangle frameRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
+#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipPlayMetafileRecord(HandleRef metafile, EmfPlusRecordType recordType, int flags, int dataSize, byte[] data);
@@ -1363,11 +1381,11 @@ namespace System.Drawing
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipTransformPointsI(HandleRef graphics, int destSpace, int srcSpace, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipLoadImageFromFileICM(string filename, out IntPtr image);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipLoadImageFromFileICM(string filename, out IntPtr image);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
-            internal static extern int GdipLoadImageFromFile(string filename, out IntPtr image);
+            [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
+            internal static partial int GdipLoadImageFromFile(string filename, out IntPtr image);
 
             [DllImport(LibraryName, ExactSpelling = true)]
             internal static extern int GdipGetEncoderParameterListSize(HandleRef image, ref Guid encoder, out int size);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -15,1094 +15,1094 @@ namespace System.Drawing
         internal static unsafe partial class Gdip
         {
             // Shared function imports (all platforms)
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBeginContainer(HandleRef graphics, ref RectangleF dstRect, ref RectangleF srcRect, GraphicsUnit unit, out int state);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBeginContainer2(HandleRef graphics, out int state);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBeginContainerI(HandleRef graphics, ref Rectangle dstRect, ref Rectangle srcRect, GraphicsUnit unit, out int state);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipEndContainer(HandleRef graphics, int state);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateAdjustableArrowCap(float height, float width, bool isFilled, out IntPtr adjustableArrowCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetAdjustableArrowCapHeight(HandleRef adjustableArrowCap, out float height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetAdjustableArrowCapHeight(HandleRef adjustableArrowCap, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetAdjustableArrowCapWidth(HandleRef adjustableArrowCap, float width);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetAdjustableArrowCapWidth(HandleRef adjustableArrowCap, out float width);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetAdjustableArrowCapMiddleInset(HandleRef adjustableArrowCap, float middleInset);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetAdjustableArrowCapMiddleInset(HandleRef adjustableArrowCap, out float middleInset);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetAdjustableArrowCapFillState(HandleRef adjustableArrowCap, bool fillState);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetAdjustableArrowCapFillState(HandleRef adjustableArrowCap, out bool fillState);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetCustomLineCapType(IntPtr customCap, out CustomLineCapType capType);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateCustomLineCap(HandleRef fillpath, HandleRef strokepath, LineCap baseCap, float baseInset, out IntPtr customCap);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipDeleteCustomLineCap(IntPtr customCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteCustomLineCap(HandleRef customCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneCustomLineCap(HandleRef customCap, out IntPtr clonedCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetCustomLineCapStrokeCaps(HandleRef customCap, LineCap startCap, LineCap endCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCustomLineCapStrokeCaps(HandleRef customCap, out LineCap startCap, out LineCap endCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetCustomLineCapStrokeJoin(HandleRef customCap, LineJoin lineJoin);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCustomLineCapStrokeJoin(HandleRef customCap, out LineJoin lineJoin);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetCustomLineCapBaseCap(HandleRef customCap, LineCap baseCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCustomLineCapBaseCap(HandleRef customCap, out LineCap baseCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetCustomLineCapBaseInset(HandleRef customCap, float inset);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCustomLineCapBaseInset(HandleRef customCap, out float inset);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetCustomLineCapWidthScale(HandleRef customCap, float widthScale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCustomLineCapWidthScale(HandleRef customCap, out float widthScale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreatePathIter(out IntPtr pathIter, HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeletePathIter(HandleRef pathIter);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextSubpath(HandleRef pathIter, out int resultCount, out int startIndex, out int endIndex, out bool isClosed);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextSubpathPath(HandleRef pathIter, out int resultCount, HandleRef path, out bool isClosed);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextPathType(HandleRef pathIter, out int resultCount, out byte pathType, out int startIndex, out int endIndex);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextMarker(HandleRef pathIter, out int resultCount, out int startIndex, out int endIndex);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextMarkerPath(HandleRef pathIter, out int resultCount, HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterGetCount(HandleRef pathIter, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterGetSubpathCount(HandleRef pathIter, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterHasCurve(HandleRef pathIter, out bool hasCurve);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterRewind(HandleRef pathIter);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterEnumerate(HandleRef pathIter, out int resultCount, PointF* points, byte* types, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPathIterCopyData(HandleRef pathIter, out int resultCount, PointF* points, byte* types, int startIndex, int endIndex);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateHatchBrush(int hatchstyle, int forecol, int backcol, out IntPtr brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetHatchStyle(HandleRef brush, out int hatchstyle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetHatchForegroundColor(HandleRef brush, out int forecol);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetHatchBackgroundColor(HandleRef brush, out int backcol);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneBrush(HandleRef brush, out IntPtr clonebrush);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateLineBrush(ref PointF point1, ref PointF point2, int color1, int color2, WrapMode wrapMode, out IntPtr lineGradient);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateLineBrushI(ref Point point1, ref Point point2, int color1, int color2, WrapMode wrapMode, out IntPtr lineGradient);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateLineBrushFromRect(ref RectangleF rect, int color1, int color2, LinearGradientMode lineGradientMode, WrapMode wrapMode, out IntPtr lineGradient);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateLineBrushFromRectI(ref Rectangle rect, int color1, int color2, LinearGradientMode lineGradientMode, WrapMode wrapMode, out IntPtr lineGradient);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateLineBrushFromRectWithAngle(ref RectangleF rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateLineBrushFromRectWithAngleI(ref Rectangle rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLineColors(HandleRef brush, int color1, int color2);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineColors(HandleRef brush, int[] colors);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineRect(HandleRef brush, out RectangleF gprectf);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineGammaCorrection(HandleRef brush, out bool useGammaCorrection);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLineGammaCorrection(HandleRef brush, bool useGammaCorrection);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLineSigmaBlend(HandleRef brush, float focus, float scale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLineLinearBlend(HandleRef brush, float focus, float scale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineBlendCount(HandleRef brush, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLineBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLinePresetBlendCount(HandleRef brush, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLinePresetBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLinePresetBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLineWrapMode(HandleRef brush, int wrapMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineWrapMode(HandleRef brush, out int wrapMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipResetLineTransform(HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipMultiplyLineTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineTransform(HandleRef brush, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetLineTransform(HandleRef brush, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslateLineTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipScaleLineTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRotateLineTransform(HandleRef brush, float angle, MatrixOrder order);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreatePathGradient(PointF* points, int count, WrapMode wrapMode, out IntPtr brush);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreatePathGradientI(Point* points, int count, WrapMode wrapMode, out IntPtr brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreatePathGradientFromPath(HandleRef path, out IntPtr brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientCenterColor(HandleRef brush, out int color);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientCenterColor(HandleRef brush, int color);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientSurroundColorsWithCount(HandleRef brush, int[] color, ref int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientSurroundColorsWithCount(HandleRef brush, int[] argb, ref int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientCenterPoint(HandleRef brush, out PointF point);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientCenterPoint(HandleRef brush, ref PointF point);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientRect(HandleRef brush, out RectangleF gprectf);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientPointCount(HandleRef brush, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientSurroundColorCount(HandleRef brush, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientBlendCount(HandleRef brush, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientBlend(HandleRef brush, float[] blend, float[] positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientPresetBlendCount(HandleRef brush, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientPresetBlend(HandleRef brush, int[] blend, float[] positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientPresetBlend(HandleRef brush, int[] blend, float[] positions, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientSigmaBlend(HandleRef brush, float focus, float scale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientLinearBlend(HandleRef brush, float focus, float scale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientWrapMode(HandleRef brush, int wrapmode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientWrapMode(HandleRef brush, out int wrapmode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientTransform(HandleRef brush, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientTransform(HandleRef brush, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipResetPathGradientTransform(HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipMultiplyPathGradientTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslatePathGradientTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipScalePathGradientTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRotatePathGradientTransform(HandleRef brush, float angle, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientFocusScales(HandleRef brush, float[] xScale, float[] yScale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPathGradientFocusScales(HandleRef brush, float xScale, float yScale);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateImageAttributes(out IntPtr imageattr);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneImageAttributes(HandleRef imageattr, out IntPtr cloneImageattr);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDisposeImageAttributes(HandleRef imageattr);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesColorMatrix(HandleRef imageattr, ColorAdjustType type, bool enableFlag, ColorMatrix? colorMatrix, ColorMatrix? grayMatrix, ColorMatrixFlag flags);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesThreshold(HandleRef imageattr, ColorAdjustType type, bool enableFlag, float threshold);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesGamma(HandleRef imageattr, ColorAdjustType type, bool enableFlag, float gamma);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesNoOp(HandleRef imageattr, ColorAdjustType type, bool enableFlag);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesColorKeys(HandleRef imageattr, ColorAdjustType type, bool enableFlag, int colorLow, int colorHigh);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesOutputChannel(HandleRef imageattr, ColorAdjustType type, bool enableFlag, ColorChannelFlag flags);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipSetImageAttributesOutputChannelColorProfile(HandleRef imageattr, ColorAdjustType type, bool enableFlag, string colorProfileFilename);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesRemapTable(HandleRef imageattr, ColorAdjustType type, bool enableFlag, int mapSize, IntPtr map);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetImageAttributesWrapMode(HandleRef imageattr, int wrapmode, int argb, bool clamp);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageAttributesAdjustedPalette(HandleRef imageattr, IntPtr palette, ColorAdjustType type);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageDecodersSize(out int numDecoders, out int size);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageDecoders(int numDecoders, int size, IntPtr decoders);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageEncodersSize(out int numEncoders, out int size);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageEncoders(int numEncoders, int size, IntPtr encoders);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateSolidFill(int color, out IntPtr brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetSolidFillColor(HandleRef brush, int color);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetSolidFillColor(HandleRef brush, out int color);
 
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateTexture(HandleRef bitmap, int wrapmode, out IntPtr texture);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateTexture2(HandleRef bitmap, int wrapmode, float x, float y, float width, float height, out IntPtr texture);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateTextureIA(HandleRef bitmap, HandleRef imageAttrib, float x, float y, float width, float height, out IntPtr texture);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateTexture2I(HandleRef bitmap, int wrapmode, int x, int y, int width, int height, out IntPtr texture);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateTextureIAI(HandleRef bitmap, HandleRef imageAttrib, int x, int y, int width, int height, out IntPtr texture);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetTextureTransform(HandleRef brush, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetTextureTransform(HandleRef brush, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipResetTextureTransform(HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipMultiplyTextureTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslateTextureTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipScaleTextureTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRotateTextureTransform(HandleRef brush, float angle, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetTextureWrapMode(HandleRef brush, int wrapMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetTextureWrapMode(HandleRef brush, out int wrapMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetTextureImage(HandleRef brush, out IntPtr image);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFontCollectionFamilyCount(HandleRef fontCollection, out int numFound);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFontCollectionFamilyList(HandleRef fontCollection, int numSought, IntPtr[] gpfamilies, out int numFound);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCloneFontFamily(IntPtr fontfamily, out IntPtr clonefontfamily);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipCreateFontFamilyFromName(string name, HandleRef fontCollection, out IntPtr FontFamily);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetGenericFontFamilySansSerif(out IntPtr fontfamily);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetGenericFontFamilySerif(out IntPtr fontfamily);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetGenericFontFamilyMonospace(out IntPtr fontfamily);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteFontFamily(HandleRef fontFamily);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipGetFamilyName(HandleRef family, char* name, int language);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsStyleAvailable(HandleRef family, FontStyle style, out int isStyleAvailable);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetEmHeight(HandleRef family, FontStyle style, out int EmHeight);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCellAscent(HandleRef family, FontStyle style, out int CellAscent);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCellDescent(HandleRef family, FontStyle style, out int CellDescent);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLineSpacing(HandleRef family, FontStyle style, out int LineSpaceing);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipNewInstalledFontCollection(out IntPtr fontCollection);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipNewPrivateFontCollection(out IntPtr fontCollection);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipDeletePrivateFontCollection(ref IntPtr fontCollection);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipPrivateAddFontFile(HandleRef fontCollection, string filename);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPrivateAddMemoryFont(HandleRef fontCollection, IntPtr memory, int length);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateFont(HandleRef fontFamily, float emSize, FontStyle style, GraphicsUnit unit, out IntPtr font);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFontFromDC(IntPtr hdc, ref IntPtr font);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneFont(HandleRef font, out IntPtr cloneFont);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteFont(HandleRef font);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFamily(HandleRef font, out IntPtr family);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFontStyle(HandleRef font, out FontStyle style);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFontSize(HandleRef font, out float size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFontHeight(HandleRef font, HandleRef graphics, out float size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFontHeightGivenDPI(HandleRef font, float dpi, out float size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetFontUnit(HandleRef font, out GraphicsUnit unit);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetLogFontW(HandleRef font, HandleRef graphics, ref Interop.User32.LOGFONT lf);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreatePen1(int argb, float width, int unit, out IntPtr pen);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreatePen2(HandleRef brush, float width, int unit, out IntPtr pen);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipClonePen(HandleRef pen, out IntPtr clonepen);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeletePen(HandleRef Pen);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenMode(HandleRef pen, PenAlignment penAlign);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenMode(HandleRef pen, out PenAlignment penAlign);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenWidth(HandleRef pen, float width);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenWidth(HandleRef pen, float[] width);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenLineCap197819(HandleRef pen, int startCap, int endCap, int dashCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenStartCap(HandleRef pen, int startCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenEndCap(HandleRef pen, int endCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenStartCap(HandleRef pen, out int startCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenEndCap(HandleRef pen, out int endCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenDashCap197819(HandleRef pen, out int dashCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenDashCap197819(HandleRef pen, int dashCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenLineJoin(HandleRef pen, int lineJoin);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenLineJoin(HandleRef pen, out int lineJoin);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenCustomStartCap(HandleRef pen, HandleRef customCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenCustomStartCap(HandleRef pen, out IntPtr customCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenCustomEndCap(HandleRef pen, HandleRef customCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenCustomEndCap(HandleRef pen, out IntPtr customCap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenMiterLimit(HandleRef pen, float miterLimit);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenMiterLimit(HandleRef pen, float[] miterLimit);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenTransform(HandleRef pen, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenTransform(HandleRef pen, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipResetPenTransform(HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipMultiplyPenTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslatePenTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipScalePenTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRotatePenTransform(HandleRef brush, float angle, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenColor(HandleRef pen, int argb);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenColor(HandleRef pen, out int argb);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenBrushFill(HandleRef pen, HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenBrushFill(HandleRef pen, out IntPtr brush);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenFillType(HandleRef pen, out int pentype);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenDashStyle(HandleRef pen, out int dashstyle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenDashStyle(HandleRef pen, int dashstyle);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenDashArray(HandleRef pen, HandleRef memorydash, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenDashOffset(HandleRef pen, float[] dashoffset);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenDashOffset(HandleRef pen, float dashoffset);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenDashCount(HandleRef pen, out int dashcount);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenDashArray(HandleRef pen, float[] memorydash, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenCompoundCount(HandleRef pen, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPenCompoundArray(HandleRef pen, float[] array, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPenCompoundArray(HandleRef pen, float[] array, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetWorldTransform(HandleRef graphics, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipResetWorldTransform(HandleRef graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipMultiplyWorldTransform(HandleRef graphics, HandleRef matrix, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslateWorldTransform(HandleRef graphics, float dx, float dy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipScaleWorldTransform(HandleRef graphics, float sx, float sy, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRotateWorldTransform(HandleRef graphics, float angle, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetWorldTransform(HandleRef graphics, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetCompositingMode(HandleRef graphics, CompositingMode compositingMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetTextRenderingHint(HandleRef graphics, TextRenderingHint textRenderingHint);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetTextContrast(HandleRef graphics, int textContrast);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetInterpolationMode(HandleRef graphics, InterpolationMode interpolationMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCompositingMode(HandleRef graphics, out CompositingMode compositingMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetRenderingOrigin(HandleRef graphics, int x, int y);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetRenderingOrigin(HandleRef graphics, out int x, out int y);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetCompositingQuality(HandleRef graphics, CompositingQuality quality);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetCompositingQuality(HandleRef graphics, out CompositingQuality quality);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetSmoothingMode(HandleRef graphics, SmoothingMode smoothingMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetSmoothingMode(HandleRef graphics, out SmoothingMode smoothingMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPixelOffsetMode(HandleRef graphics, PixelOffsetMode pixelOffsetMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPixelOffsetMode(HandleRef graphics, out PixelOffsetMode pixelOffsetMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetTextRenderingHint(HandleRef graphics, out TextRenderingHint textRenderingHint);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetTextContrast(HandleRef graphics, out int textContrast);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetInterpolationMode(HandleRef graphics, out InterpolationMode interpolationMode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPageUnit(HandleRef graphics, out GraphicsUnit unit);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPageScale(HandleRef graphics, out float scale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPageUnit(HandleRef graphics, GraphicsUnit unit);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPageScale(HandleRef graphics, float scale);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetDpiX(HandleRef graphics, out float dpi);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetDpiY(HandleRef graphics, out float dpi);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateMatrix(out IntPtr matrix);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateMatrix2(float m11, float m12, float m21, float m22, float dx, float dy, out IntPtr matrix);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateMatrix3(ref RectangleF rect, PointF* dstplg, out IntPtr matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateMatrix3I(ref Rectangle rect, Point* dstplg, out IntPtr matrix);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneMatrix(HandleRef matrix, out IntPtr cloneMatrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteMatrix(HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetMatrixElements(HandleRef matrix, float m11, float m12, float m21, float m22, float dx, float dy);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipMultiplyMatrix(HandleRef matrix, HandleRef matrix2, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslateMatrix(HandleRef matrix, float offsetX, float offsetY, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipScaleMatrix(HandleRef matrix, float scaleX, float scaleY, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRotateMatrix(HandleRef matrix, float angle, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipShearMatrix(HandleRef matrix, float shearX, float shearY, MatrixOrder order);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipInvertMatrix(HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTransformMatrixPoints(HandleRef matrix, PointF* pts, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTransformMatrixPointsI(HandleRef matrix, Point* pts, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipVectorTransformMatrixPoints(HandleRef matrix, PointF* pts, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipVectorTransformMatrixPointsI(HandleRef matrix, Point* pts, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern unsafe int GdipGetMatrixElements(HandleRef matrix, float* m);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsMatrixInvertible(HandleRef matrix, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsMatrixIdentity(HandleRef matrix, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsMatrixEqual(HandleRef matrix, HandleRef matrix2, out int boolean);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateRegion(out IntPtr region);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateRegionRect(ref RectangleF gprectf, out IntPtr region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateRegionRectI(ref Rectangle gprect, out IntPtr region);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateRegionPath(HandleRef path, out IntPtr region);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateRegionRgnData(byte[] rgndata, int size, out IntPtr region);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateRegionHrgn(IntPtr hRgn, out IntPtr region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneRegion(HandleRef region, out IntPtr cloneregion);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteRegion(HandleRef region);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillRegion(HandleRef graphics, HandleRef brush, HandleRef region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetInfinite(HandleRef region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetEmpty(HandleRef region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCombineRegionRect(HandleRef region, ref RectangleF gprectf, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCombineRegionRectI(HandleRef region, ref Rectangle gprect, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCombineRegionPath(HandleRef region, HandleRef path, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCombineRegionRegion(HandleRef region, HandleRef region2, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslateRegion(HandleRef region, float dx, float dy);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslateRegionI(HandleRef region, int dx, int dy);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTransformRegion(HandleRef region, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetRegionBounds(HandleRef region, HandleRef graphics, out RectangleF gprectf);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetRegionHRgn(HandleRef region, HandleRef graphics, out IntPtr hrgn);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsEmptyRegion(HandleRef region, HandleRef graphics, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsInfiniteRegion(HandleRef region, HandleRef graphics, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsEqualRegion(HandleRef region, HandleRef region2, HandleRef graphics, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetRegionDataSize(HandleRef region, out int bufferSize);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetRegionData(HandleRef region, byte[] regionData, int bufferSize, out int sizeFilled);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisibleRegionPoint(HandleRef region, float X, float Y, HandleRef graphics, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisibleRegionPointI(HandleRef region, int X, int Y, HandleRef graphics, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisibleRegionRect(HandleRef region, float X, float Y, float width, float height, HandleRef graphics, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisibleRegionRectI(HandleRef region, int X, int Y, int width, int height, HandleRef graphics, out int boolean);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetRegionScansCount(HandleRef region, out int count, HandleRef matrix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetRegionScans(HandleRef region, RectangleF* rects, out int count, HandleRef matrix);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromHDC(IntPtr hdc, out IntPtr graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetClipGraphics(HandleRef graphics, HandleRef srcgraphics, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetClipRect(HandleRef graphics, float x, float y, float width, float height, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetClipRectI(HandleRef graphics, int x, int y, int width, int height, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetClipPath(HandleRef graphics, HandleRef path, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetClipRegion(HandleRef graphics, HandleRef region, CombineMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipResetClip(HandleRef graphics);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTranslateClip(HandleRef graphics, float dx, float dy);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetClip(HandleRef graphics, HandleRef region);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetClipBounds(HandleRef graphics, out RectangleF rect);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsClipEmpty(HandleRef graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetVisibleClipBounds(HandleRef graphics, out RectangleF rect);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisibleClipEmpty(HandleRef graphics, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisiblePoint(HandleRef graphics, float x, float y, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisiblePointI(HandleRef graphics, int x, int y, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisibleRect(HandleRef graphics, float x, float y, float width, float height, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipIsVisibleRectI(HandleRef graphics, int x, int y, int width, int height, out bool result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipFlush(HandleRef graphics, FlushIntention intention);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetDC(HandleRef graphics, out IntPtr hdc);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatMeasurableCharacterRanges(HandleRef format, int rangeCount, [In] [Out] CharacterRange[] range);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateStringFormat(StringFormatFlags options, int language, out IntPtr format);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipStringFormatGetGenericDefault(out IntPtr format);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipStringFormatGetGenericTypographic(out IntPtr format);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDeleteStringFormat(HandleRef format);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneStringFormat(HandleRef format, out IntPtr newFormat);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatFlags(HandleRef format, StringFormatFlags options);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatFlags(HandleRef format, out StringFormatFlags result);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatAlign(HandleRef format, StringAlignment align);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatAlign(HandleRef format, out StringAlignment align);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatLineAlign(HandleRef format, StringAlignment align);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatLineAlign(HandleRef format, out StringAlignment align);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatHotkeyPrefix(HandleRef format, HotkeyPrefix hotkeyPrefix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatHotkeyPrefix(HandleRef format, out HotkeyPrefix hotkeyPrefix);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatTabStops(HandleRef format, float firstTabOffset, int count, float[] tabStops);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatTabStops(HandleRef format, int count, out float firstTabOffset, [In] [Out] float[] tabStops);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatTabStopCount(HandleRef format, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatMeasurableCharacterRangeCount(HandleRef format, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatTrimming(HandleRef format, StringTrimming trimming);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatTrimming(HandleRef format, out StringTrimming trimming);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetStringFormatDigitSubstitution(HandleRef format, int langID, StringDigitSubstitute sds);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetStringFormatDigitSubstitution(HandleRef format, out int langID, out StringDigitSubstitute sds);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageDimension(HandleRef image, out float width, out float height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageWidth(HandleRef image, out int width);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageHeight(HandleRef image, out int height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageHorizontalResolution(HandleRef image, out float horzRes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageVerticalResolution(HandleRef image, out float vertRes);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageFlags(HandleRef image, out int flags);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageRawFormat(HandleRef image, ref Guid format);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImagePixelFormat(HandleRef image, out PixelFormat format);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipImageGetFrameCount(HandleRef image, ref Guid dimensionID, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipImageSelectActiveFrame(HandleRef image, ref Guid dimensionID, int frameIndex);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipImageRotateFlip(HandleRef image, int rotateFlipType);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetAllPropertyItems(HandleRef image, uint totalBufferSize, uint numProperties, PropertyItemInternal* allItems);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPropertyCount(HandleRef image, out uint numOfProperty);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPropertyIdList(HandleRef image, uint numOfProperty, int* list);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPropertyItem(HandleRef image, int propid, uint propSize, PropertyItemInternal* buffer);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPropertyItemSize(HandleRef image, int propid, out uint size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetPropertySize(HandleRef image, out uint totalBufferSize, out uint numProperties);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipRemovePropertyItem(HandleRef image, int propid);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSetPropertyItem(HandleRef image, PropertyItemInternal* item);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetImageType(HandleRef image, out int type);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetImageType(IntPtr image, out int type);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipDisposeImage(HandleRef image);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipDisposeImage(IntPtr image);
 
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
@@ -1111,60 +1111,60 @@ namespace System.Drawing
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static partial int GdipCreateBitmapFromFileICM(string filename, out IntPtr bitmap);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateBitmapFromScan0(int width, int height, int stride, int format, IntPtr scan0, out IntPtr bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateBitmapFromGraphics(int width, int height, HandleRef graphics, out IntPtr bitmap);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateBitmapFromHBITMAP(IntPtr hbitmap, IntPtr hpalette, out IntPtr bitmap);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateBitmapFromHICON(IntPtr hicon, out IntPtr bitmap);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateBitmapFromResource(IntPtr hresource, IntPtr name, out IntPtr bitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateHBITMAPFromBitmap(HandleRef nativeBitmap, out IntPtr hbitmap, int argbBackground);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateHICONFromBitmap(HandleRef nativeBitmap, out IntPtr hicon);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneBitmapArea(float x, float y, float width, float height, int format, HandleRef srcbitmap, out IntPtr dstbitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCloneBitmapAreaI(int x, int y, int width, int height, int format, HandleRef srcbitmap, out IntPtr dstbitmap);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBitmapLockBits(HandleRef bitmap, ref Rectangle rect, ImageLockMode flags, PixelFormat format, [In] [Out] BitmapData lockedBitmapData);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBitmapUnlockBits(HandleRef bitmap, BitmapData lockedBitmapData);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBitmapGetPixel(HandleRef bitmap, int x, int y, out int argb);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBitmapSetPixel(HandleRef bitmap, int x, int y, int argb);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipBitmapSetResolution(HandleRef bitmap, float dpix, float dpiy);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipImageGetFrameDimensionsCount(HandleRef image, out int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipImageGetFrameDimensionsList(HandleRef image, Guid* dimensionIDs, int count);
 
-            [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+            [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateMetafileFromEmf(IntPtr hEnhMetafile, bool deleteEmf, out IntPtr metafile);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support non-blittable structs.
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipCreateMetafileFromWmf(IntPtr hMetafile, bool deleteWmf, WmfPlaceableFileHeader wmfplacealbeHeader, out IntPtr metafile);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
@@ -1195,190 +1195,190 @@ namespace System.Drawing
             internal static extern int GdipRecordMetafileFileNameI(string fileName, IntPtr referenceHdc, EmfType emfType, ref Rectangle frameRect, MetafileFrameUnit frameUnit, string? description, out IntPtr metafile);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipPlayMetafileRecord(HandleRef metafile, EmfPlusRecordType recordType, int flags, int dataSize, byte[] data);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipSaveGraphics(HandleRef graphics, out int state);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawArc(HandleRef graphics, HandleRef pen, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawArcI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawLinesI(HandleRef graphics, HandleRef pen, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawBezier(HandleRef graphics, HandleRef pen, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawEllipse(HandleRef graphics, HandleRef pen, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawEllipseI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawLine(HandleRef graphics, HandleRef pen, float x1, float y1, float x2, float y2);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawLineI(HandleRef graphics, HandleRef pen, int x1, int y1, int x2, int y2);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawLines(HandleRef graphics, HandleRef pen, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawPath(HandleRef graphics, HandleRef pen, HandleRef path);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawPie(HandleRef graphics, HandleRef pen, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawPieI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawPolygon(HandleRef graphics, HandleRef pen, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawPolygonI(HandleRef graphics, HandleRef pen, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillEllipse(HandleRef graphics, HandleRef brush, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillEllipseI(HandleRef graphics, HandleRef brush, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillPolygon(HandleRef graphics, HandleRef brush, PointF* points, int count, FillMode brushMode);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillPolygonI(HandleRef graphics, HandleRef brush, Point* points, int count, FillMode brushMode);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillRectangle(HandleRef graphics, HandleRef brush, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillRectangleI(HandleRef graphics, HandleRef brush, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillRectangles(HandleRef graphics, HandleRef brush, RectangleF* rects, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillRectanglesI(HandleRef graphics, HandleRef brush, Rectangle* rects, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode, SetLastError = true)]
             internal static extern int GdipDrawString(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, HandleRef brush);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImageRectI(HandleRef graphics, HandleRef image, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGraphicsClear(HandleRef graphics, int argb);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawClosedCurve(HandleRef graphics, HandleRef pen, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawClosedCurveI(HandleRef graphics, HandleRef pen, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawClosedCurve2(HandleRef graphics, HandleRef pen, PointF* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawClosedCurve2I(HandleRef graphics, HandleRef pen, Point* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawCurve(HandleRef graphics, HandleRef pen, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawCurveI(HandleRef graphics, HandleRef pen, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawCurve2(HandleRef graphics, HandleRef pen, PointF* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawCurve2I(HandleRef graphics, HandleRef pen, Point* points, int count, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawCurve3(HandleRef graphics, HandleRef pen, PointF* points, int count, int offset, int numberOfSegments, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawCurve3I(HandleRef graphics, HandleRef pen, Point* points, int count, int offset, int numberOfSegments, float tension);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillClosedCurve(HandleRef graphics, HandleRef brush, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillClosedCurveI(HandleRef graphics, HandleRef brush, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillClosedCurve2(HandleRef graphics, HandleRef brush, PointF* points, int count, float tension, FillMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillClosedCurve2I(HandleRef graphics, HandleRef brush, Point* points, int count, float tension, FillMode mode);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillPie(HandleRef graphics, HandleRef brush, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillPieI(HandleRef graphics, HandleRef brush, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipMeasureString(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, ref RectangleF boundingBox, out int codepointsFitted, out int linesFilled);
 
-            [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipMeasureCharacterRanges(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, int characterCount, [In] [Out] IntPtr[] region);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImageI(HandleRef graphics, HandleRef image, int x, int y);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImage(HandleRef graphics, HandleRef image, float x, float y);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImagePoints(HandleRef graphics, HandleRef image, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImagePointsI(HandleRef graphics, HandleRef image, Point* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImageRectRectI(HandleRef graphics, HandleRef image, int dstx, int dsty, int dstwidth, int dstheight, int srcx, int srcy, int srcwidth, int srcheight, GraphicsUnit srcunit, HandleRef imageAttributes, Graphics.DrawImageAbort? callback, HandleRef callbackdata);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImagePointsRect(HandleRef graphics, HandleRef image, PointF* points, int count, float srcx, float srcy, float srcwidth, float srcheight, GraphicsUnit srcunit, HandleRef imageAttributes, Graphics.DrawImageAbort? callback, HandleRef callbackdata);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImageRectRect(HandleRef graphics, HandleRef image, float dstx, float dsty, float dstwidth, float dstheight, float srcx, float srcy, float srcwidth, float srcheight, GraphicsUnit srcunit, HandleRef imageAttributes, Graphics.DrawImageAbort? callback, HandleRef callbackdata);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImagePointsRectI(HandleRef graphics, HandleRef image, Point* points, int count, int srcx, int srcy, int srcwidth, int srcheight, GraphicsUnit srcunit, HandleRef imageAttributes, Graphics.DrawImageAbort? callback, HandleRef callbackdata);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImageRect(HandleRef graphics, HandleRef image, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImagePointRect(HandleRef graphics, HandleRef image, float x, float y, float srcx, float srcy, float srcwidth, float srcheight, int srcunit);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImagePointRectI(HandleRef graphics, HandleRef image, int x, int y, int srcx, int srcy, int srcwidth, int srcheight, int srcunit);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawRectangle(HandleRef graphics, HandleRef pen, float x, float y, float width, float height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawRectangleI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawRectangles(HandleRef graphics, HandleRef pen, RectangleF* rects, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true, SetLastError = true)]
+            [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawRectanglesI(HandleRef graphics, HandleRef pen, Rectangle* rects, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTransformPoints(HandleRef graphics, int destSpace, int srcSpace, PointF* points, int count);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipTransformPointsI(HandleRef graphics, int destSpace, int srcSpace, Point* points, int count);
 
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
@@ -1387,10 +1387,10 @@ namespace System.Drawing
             [GeneratedDllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
             internal static partial int GdipLoadImageFromFile(string filename, out IntPtr image);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetEncoderParameterListSize(HandleRef image, ref Guid encoder, out int size);
 
-            [DllImport(LibraryName, ExactSpelling = true)]
+            [DllImport(LibraryName)]
             internal static extern int GdipGetEncoderParameterList(HandleRef image, ref Guid encoder, int size, IntPtr buffer);
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.COMWrappers.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Icon.Windows.COMWrappers.cs
@@ -61,8 +61,8 @@ namespace System.Drawing
             }
         }
 
-        [DllImport(Interop.Libraries.Oleaut32)]
-        private static unsafe extern int OleCreatePictureIndirect(PICTDESC* pictdesc, Guid* refiid, int fOwn, IntPtr* lplpvObj);
+        [GeneratedDllImport(Interop.Libraries.Oleaut32)]
+        private static unsafe partial int OleCreatePictureIndirect(PICTDESC* pictdesc, Guid* refiid, int fOwn, IntPtr* lplpvObj);
 
         [StructLayout(LayoutKind.Sequential)]
         private readonly struct PICTDESC

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/LibX11Functions.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/LibX11Functions.cs
@@ -7,44 +7,44 @@ using System.Runtime.InteropServices;
 
 namespace System.Drawing
 {
-    internal static class LibX11Functions
+    internal static partial class LibX11Functions
     {
         // Some special X11 stuff
-        [DllImport("libX11", EntryPoint = "XOpenDisplay")]
-        internal static extern IntPtr XOpenDisplay(IntPtr display);
+        [GeneratedDllImport("libX11", EntryPoint = "XOpenDisplay")]
+        internal static partial IntPtr XOpenDisplay(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XCloseDisplay")]
-        internal static extern int XCloseDisplay(IntPtr display);
+        [GeneratedDllImport("libX11", EntryPoint = "XCloseDisplay")]
+        internal static partial int XCloseDisplay(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XRootWindow")]
-        internal static extern IntPtr XRootWindow(IntPtr display, int screen);
+        [GeneratedDllImport("libX11", EntryPoint = "XRootWindow")]
+        internal static partial IntPtr XRootWindow(IntPtr display, int screen);
 
-        [DllImport("libX11", EntryPoint = "XDefaultScreen")]
-        internal static extern int XDefaultScreen(IntPtr display);
+        [GeneratedDllImport("libX11", EntryPoint = "XDefaultScreen")]
+        internal static partial int XDefaultScreen(IntPtr display);
 
-        [DllImport("libX11", EntryPoint = "XDefaultDepth")]
-        internal static extern uint XDefaultDepth(IntPtr display, int screen);
+        [GeneratedDllImport("libX11", EntryPoint = "XDefaultDepth")]
+        internal static partial uint XDefaultDepth(IntPtr display, int screen);
 
-        [DllImport("libX11", EntryPoint = "XGetImage")]
-        internal static extern IntPtr XGetImage(IntPtr display, IntPtr drawable, int src_x, int src_y, int width, int height, int pane, int format);
+        [GeneratedDllImport("libX11", EntryPoint = "XGetImage")]
+        internal static partial IntPtr XGetImage(IntPtr display, IntPtr drawable, int src_x, int src_y, int width, int height, int pane, int format);
 
-        [DllImport("libX11", EntryPoint = "XGetPixel")]
-        internal static extern int XGetPixel(IntPtr image, int x, int y);
+        [GeneratedDllImport("libX11", EntryPoint = "XGetPixel")]
+        internal static partial int XGetPixel(IntPtr image, int x, int y);
 
-        [DllImport("libX11", EntryPoint = "XDestroyImage")]
-        internal static extern int XDestroyImage(IntPtr image);
+        [GeneratedDllImport("libX11", EntryPoint = "XDestroyImage")]
+        internal static partial int XDestroyImage(IntPtr image);
 
-        [DllImport("libX11", EntryPoint = "XDefaultVisual")]
-        internal static extern IntPtr XDefaultVisual(IntPtr display, int screen);
+        [GeneratedDllImport("libX11", EntryPoint = "XDefaultVisual")]
+        internal static partial IntPtr XDefaultVisual(IntPtr display, int screen);
 
-        [DllImport("libX11", EntryPoint = "XGetVisualInfo")]
-        internal static extern IntPtr XGetVisualInfo(IntPtr display, int vinfo_mask, ref XVisualInfo vinfo_template, ref int nitems);
+        [GeneratedDllImport("libX11", EntryPoint = "XGetVisualInfo")]
+        internal static partial IntPtr XGetVisualInfo(IntPtr display, int vinfo_mask, ref XVisualInfo vinfo_template, ref int nitems);
 
-        [DllImport("libX11", EntryPoint = "XVisualIDFromVisual")]
-        internal static extern IntPtr XVisualIDFromVisual(IntPtr visual);
+        [GeneratedDllImport("libX11", EntryPoint = "XVisualIDFromVisual")]
+        internal static partial IntPtr XVisualIDFromVisual(IntPtr visual);
 
-        [DllImport("libX11", EntryPoint = "XFree")]
-        internal static extern void XFree(IntPtr data);
+        [GeneratedDllImport("libX11", EntryPoint = "XFree")]
+        internal static partial void XFree(IntPtr data);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
@@ -26,39 +26,39 @@ namespace System.Drawing.Printing
             return lib;
         }
 
-        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName)]
         internal static partial int cupsGetDests(ref IntPtr dests);
 
-        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName)]
         internal static partial void cupsFreeDests(int num_dests, IntPtr dests);
 
-        [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
+        [DllImport(LibraryName, CharSet = CharSet.Ansi)]
 #pragma warning disable CA1838 // not hot-path enough to worry about the overheads of StringBuilder marshaling
         internal static extern IntPtr cupsTempFd([Out] StringBuilder sb, int len);
 #pragma warning restore CA1838
 
-        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName)]
         internal static partial IntPtr cupsGetDefault();
 
-        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi)]
         internal static partial int cupsPrintFile(string printer, string filename, string title, int num_options, IntPtr options);
 
-        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi)]
         internal static partial IntPtr cupsGetPPD(string printer);
 
-        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi)]
         internal static partial IntPtr ppdOpenFile(string filename);
 
-        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi)]
         internal static partial IntPtr ppdFindOption(IntPtr ppd_file, string keyword);
 
-        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi)]
         internal static partial void ppdClose(IntPtr ppd);
 
-        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi)]
         internal static partial int cupsParseOptions(string arg, int number_of_options, ref IntPtr options);
 
-        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        [GeneratedDllImport(LibraryName)]
         internal static partial void cupsFreeOptions(int number_options, IntPtr options);
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace System.Drawing.Printing
 {
-    internal static class LibcupsNative
+    internal static partial class LibcupsNative
     {
         internal const string LibraryName = "libcups";
 
@@ -26,39 +26,39 @@ namespace System.Drawing.Printing
             return lib;
         }
 
-        [DllImport(LibraryName, ExactSpelling = true)]
-        internal static extern int cupsGetDests(ref IntPtr dests);
+        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        internal static partial int cupsGetDests(ref IntPtr dests);
 
-        [DllImport(LibraryName, ExactSpelling = true)]
-        internal static extern void cupsFreeDests(int num_dests, IntPtr dests);
+        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        internal static partial void cupsFreeDests(int num_dests, IntPtr dests);
 
         [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
 #pragma warning disable CA1838 // not hot-path enough to worry about the overheads of StringBuilder marshaling
         internal static extern IntPtr cupsTempFd([Out] StringBuilder sb, int len);
 #pragma warning restore CA1838
 
-        [DllImport(LibraryName, ExactSpelling = true)]
-        internal static extern IntPtr cupsGetDefault();
+        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        internal static partial IntPtr cupsGetDefault();
 
-        [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        internal static extern int cupsPrintFile(string printer, string filename, string title, int num_options, IntPtr options);
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        internal static partial int cupsPrintFile(string printer, string filename, string title, int num_options, IntPtr options);
 
-        [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        internal static extern IntPtr cupsGetPPD(string printer);
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        internal static partial IntPtr cupsGetPPD(string printer);
 
-        [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        internal static extern IntPtr ppdOpenFile(string filename);
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        internal static partial IntPtr ppdOpenFile(string filename);
 
-        [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        internal static extern IntPtr ppdFindOption(IntPtr ppd_file, string keyword);
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        internal static partial IntPtr ppdFindOption(IntPtr ppd_file, string keyword);
 
-        [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        internal static extern void ppdClose(IntPtr ppd);
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        internal static partial void ppdClose(IntPtr ppd);
 
-        [DllImport(LibraryName, ExactSpelling = true, CharSet = CharSet.Ansi)]
-        internal static extern int cupsParseOptions(string arg, int number_of_options, ref IntPtr options);
+        [GeneratedDllImport(LibraryName, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        internal static partial int cupsParseOptions(string arg, int number_of_options, ref IntPtr options);
 
-        [DllImport(LibraryName, ExactSpelling = true)]
-        internal static extern void cupsFreeOptions(int number_options, IntPtr options);
+        [GeneratedDllImport(LibraryName, ExactSpelling = true)]
+        internal static partial void cupsFreeOptions(int number_options, IntPtr options);
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
@@ -34,7 +34,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Drawing
 {
-    internal static class MacSupport
+    internal static partial class MacSupport
     {
         internal static readonly Hashtable contextReference = new Hashtable();
         internal static readonly object lockobj = new object();
@@ -151,84 +151,84 @@ namespace System.Drawing
         }
 
         #region Cocoa Methods
-        [DllImport("libobjc.dylib")]
-        public static extern IntPtr objc_getClass(string className);
-        [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
-        public static extern IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector);
-        [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend_stret")]
-        public static extern void Rect_objc_msgSend_stret(out Rect arect, IntPtr basePtr, IntPtr selector);
-        [DllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+        [GeneratedDllImport("libobjc.dylib", CharSet = CharSet.Ansi)]
+        public static partial IntPtr objc_getClass(string className);
+        [GeneratedDllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+        public static partial IntPtr intptr_objc_msgSend(IntPtr basePtr, IntPtr selector);
+        [GeneratedDllImport("libobjc.dylib", EntryPoint = "objc_msgSend_stret")]
+        public static partial void Rect_objc_msgSend_stret(out Rect arect, IntPtr basePtr, IntPtr selector);
+        [GeneratedDllImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
         [return:MarshalAs(UnmanagedType.U1)]
-        public static extern bool bool_objc_msgSend(IntPtr handle, IntPtr selector);
-        [DllImport("libobjc.dylib")]
-        public static extern IntPtr sel_registerName(string selectorName);
+        public static partial bool bool_objc_msgSend(IntPtr handle, IntPtr selector);
+        [GeneratedDllImport("libobjc.dylib", CharSet = CharSet.Ansi)]
+        public static partial IntPtr sel_registerName(string selectorName);
         #endregion
 
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern IntPtr CGMainDisplayID();
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern Rect CGDisplayBounds(IntPtr display);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial IntPtr CGMainDisplayID();
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial Rect CGDisplayBounds(IntPtr display);
 
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern int HIViewGetBounds(IntPtr vHnd, ref Rect r);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern int HIViewConvertRect(ref Rect r, IntPtr a, IntPtr b);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial int HIViewGetBounds(IntPtr vHnd, ref Rect r);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial int HIViewConvertRect(ref Rect r, IntPtr a, IntPtr b);
 
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern IntPtr GetControlOwner(IntPtr aView);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial IntPtr GetControlOwner(IntPtr aView);
 
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern int GetWindowBounds(IntPtr wHnd, uint reg, ref QDRect rect);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern IntPtr GetWindowPort(IntPtr hWnd);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern IntPtr GetQDGlobalsThePort();
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CreateCGContextForPort(IntPtr port, ref IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CFRelease(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void QDBeginCGContext(IntPtr port, ref IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void QDEndCGContext(IntPtr port, ref IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern int CGContextClipToRect(IntPtr context, Rect clip);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern int CGContextClipToRects(IntPtr context, Rect[] clip_rects, int count);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextTranslateCTM(IntPtr context, float tx, float ty);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextScaleCTM(IntPtr context, float x, float y);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextFlush(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextSynchronize(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern IntPtr CGPathCreateMutable();
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGPathAddRects(IntPtr path, IntPtr _void, Rect[] rects, int count);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGPathAddRect(IntPtr path, IntPtr _void, Rect rect);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextAddRects(IntPtr context, Rect[] rects, int count);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextAddRect(IntPtr context, Rect rect);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextBeginPath(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextClosePath(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextAddPath(IntPtr context, IntPtr path);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextClip(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextEOClip(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextEOFillPath(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextSaveGState(IntPtr context);
-        [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextRestoreGState(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial int GetWindowBounds(IntPtr wHnd, uint reg, ref QDRect rect);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial IntPtr GetWindowPort(IntPtr hWnd);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial IntPtr GetQDGlobalsThePort();
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CreateCGContextForPort(IntPtr port, ref IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CFRelease(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void QDBeginCGContext(IntPtr port, ref IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void QDEndCGContext(IntPtr port, ref IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial int CGContextClipToRect(IntPtr context, Rect clip);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial int CGContextClipToRects(IntPtr context, Rect[] clip_rects, int count);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextTranslateCTM(IntPtr context, float tx, float ty);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextScaleCTM(IntPtr context, float x, float y);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextFlush(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextSynchronize(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial IntPtr CGPathCreateMutable();
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGPathAddRects(IntPtr path, IntPtr _void, Rect[] rects, int count);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGPathAddRect(IntPtr path, IntPtr _void, Rect rect);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextAddRects(IntPtr context, Rect[] rects, int count);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextAddRect(IntPtr context, Rect rect);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextBeginPath(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextClosePath(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextAddPath(IntPtr context, IntPtr path);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextClip(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextEOClip(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextEOFillPath(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextSaveGState(IntPtr context);
+        [GeneratedDllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
+        internal static partial void CGContextRestoreGState(IntPtr context);
     }
 
     internal struct CGSize


### PR DESCRIPTION
Convert the last two remaining libraries to use GeneratedDllImport based on our current support.

This means that any P/Invokes that don't use HandleRef, layout classes, non-blittable structs, or non-blittable types defined in other assemblies have been converted.

For HandleRef support, we're looking at adding the support through our standard "custom type marshalling" design that we will use for non-blittable structs and layout classes, but that still requires that support to be available/used, which depends at least partially on API Review.