### PR TITLE
JIT: three fixes for OSR

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1494,14 +1494,18 @@ void Compiler::fgPostImportationCleanup()
 
                 // We'll need a state variable to control the branching.
                 //
-                // It will be zero when the OSR method is entered and set to one
+                // It will be initialized to zero when the OSR method is entered and set to one
                 // once flow reaches the osrEntry.
                 //
-                unsigned const entryStateVar       = lvaGrabTemp(false DEBUGARG("OSR entry state var"));
-                lvaTable[entryStateVar].lvType     = TYP_INT;
-                lvaTable[entryStateVar].lvMustInit = true;
+                unsigned const entryStateVar   = lvaGrabTemp(false DEBUGARG("OSR entry state var"));
+                lvaTable[entryStateVar].lvType = TYP_INT;
 
-                // Set the state variable when we reach the entry.
+                // Zero the entry state at method entry.
+                //
+                GenTree* const initEntryState = gtNewTempAssign(entryStateVar, gtNewZeroConNode(TYP_INT));
+                fgNewStmtAtBeg(fgFirstBB, initEntryState);
+
+                // Set the state variable once control flow reaches the OSR entry.
                 //
                 GenTree* const setEntryState = gtNewTempAssign(entryStateVar, gtNewOneConNode(TYP_INT));
                 fgNewStmtAtBeg(osrEntry, setEntryState);
@@ -3409,6 +3413,11 @@ bool Compiler::fgOptimizeUncondBranchToSimpleCond(BasicBlock* block, BasicBlock*
     JITDUMP("Considering uncond to cond " FMT_BB " -> " FMT_BB "\n", block->bbNum, target->bbNum);
 
     if (!BasicBlock::sameEHRegion(block, target))
+    {
+        return false;
+    }
+
+    if (fgBBisScratch(block))
     {
         return false;
     }

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -726,8 +726,6 @@ public:
             delete [] ((BYTE*) m_pPatchpointInfoFromJit);
 
         m_pPatchpointInfoFromJit = NULL;
-        m_pPatchpointInfoFromRuntime = NULL;
-        m_ilOffset = 0;
 #endif
 
 #ifdef FEATURE_EH_FUNCLETS


### PR DESCRIPTION
Found when trying to enable OSR by default and prospecting for arm64 support.

* Explicitly initalize the OSR step variable.
* Prevent `fgOptimizeUncondBranchToSimpleCond` from changing the scratch entry
  BB to have conditional flow.
* Retain runtime supplied patchpoint info when cleaning up after an altjit failure.