### PR TITLE
Revise the Regex description output in source

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2273,6 +2273,7 @@ namespace System.Text.RegularExpressions
             return false;
         }
 
+#if DEBUG
         private string TypeName =>
             Type switch
             {
@@ -2390,7 +2391,6 @@ namespace System.Text.RegularExpressions
             return sb.ToString();
         }
 
-#if DEBUG
         [ExcludeFromCodeCoverage]
         public void Dump() => Debug.WriteLine(ToString());
 


### PR DESCRIPTION
Provides a nice-to-read description of what the regex is doing operation by operation.  Also cleans up how the RegexOptions is formatted in the text.

cc: @joperezr 