### PR TITLE
Fix SuperPMI unit test 'strip' behavior

### DIFF
--- a/src/tests/JIT/superpmi/superpmicollect.cs
+++ b/src/tests/JIT/superpmi/superpmicollect.cs
@@ -369,7 +369,7 @@ namespace SuperPMICollection
 
             if (File.Exists(s_baseFailMclFile) && !String.IsNullOrEmpty(File.ReadAllText(s_baseFailMclFile)))
             {
-                RunProgram(Global.McsPath, "-strip " + s_baseMchFile + " " + s_finalMchFile);
+                RunProgram(Global.McsPath, "-strip " + s_baseFailMclFile + " " + s_baseMchFile + " " + s_finalMchFile);
             }
             else
             {


### PR DESCRIPTION
In the case where replay of a test collection contains MISSING items,
or other SuperPMI replay failures, we strip the failing method contexts
from the result. This is very rare in the test scenario, but does happen
mostly (presumably) due to SuperPMI tool bugs. However, the strip command
wasn't actually being passed the set of things to strip, so it was just
doing a straight copy. Thus, we ended up failing the "clean replay" because
the failing MCs were still in the collection.

The test has had this problem for a long time, and it looks like it has
periodically hit in testing, but we haven't had bugs opened on these failures,
so we haven't noticed.