### PR TITLE
Change assert in NewPutArg(), so it is consistent with transformation done by fgMorphArgs()

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1259,7 +1259,7 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
                 {
 #ifdef TARGET_ARM
                     assert((info->GetStackSlotsNumber() == 1) ||
-                           (arg->TypeGet() == TYP_DOUBLE) && (info->GetStackSlotsNumber() == 2));
+                           ((arg->TypeGet() == TYP_DOUBLE) && (info->GetStackSlotsNumber() == 2)));
 #else
                     assert(varTypeIsSIMD(arg) || (info->GetStackSlotsNumber() == 1));
 #endif

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1257,7 +1257,12 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
                 }
                 else if (!arg->OperIs(GT_FIELD_LIST))
                 {
+#ifdef TARGET_ARM
+                    assert((info->GetStackSlotsNumber() == 1) ||
+                           (arg->TypeGet() == TYP_DOUBLE) && (info->GetStackSlotsNumber() == 2));
+#else
                     assert(varTypeIsSIMD(arg) || (info->GetStackSlotsNumber() == 1));
+#endif
                 }
             }
 #endif // FEATURE_PUT_STRUCT_ARG_STK

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62249/Runtime_62249.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62249/Runtime_62249.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Runtime_62249
+{
+    public struct CanBeReinterpretedAsDouble
+    {
+        public double _0;
+    }
+
+    // Note that all VFP registers are occupied by d0-d7 arguments, hence the last argument is passed on the stack.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Callee(double d0, double d1, double d2, double d3, double d4, double d5, double d6, double d7, CanBeReinterpretedAsDouble onStack)
+    {
+        return onStack._0 == 62249 ? 100 : 0;
+    }
+
+    public static int Caller(ref CanBeReinterpretedAsDouble byRef)
+    {
+        // Since the last parameter
+        //   1. Is passed by value
+        //   2. Has size of power of 2
+        //   3. Has a single field
+        // morph transforms OBJ(struct<CanBeReinterpretedAsDouble, 8>, byRef) to IND(double, byRef).
+        // However, lower does not expect such transformation and asserts.
+        return Callee(0, 0, 0, 6, 2, 2, 4, 9, byRef);
+    }
+
+    public static int Main(string[] args)
+    {
+        var val = new CanBeReinterpretedAsDouble();
+        val._0 = 62249;
+
+        return Caller(ref val);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62249/Runtime_62249.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62249/Runtime_62249.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
On Arm32 lower asserts in `NewPutArg()` after morph does transformation from `OBJ(struct<CanBeReinterpretedAsDouble, 8>, byRef)` to `IND(double, byRef)` for stack arguments passed by value.

As far as I can tell, the transformation is legal, but the way lower validates the type and size of an argument is incorrect - it calls `varTypeIsSIMD()` which always returns `false` on Arm32. 

The change makes the assert look similar to the one in morph https://github.com/dotnet/runtime/blob/main/src/coreclr/jit/morph.cpp#L3676

Fixes #62249

@dotnet/jit-contrib 