### PR TITLE
[wasm] Set iframe's referrerPolicy

### DIFF
--- a/src/mono/sample/wasm/browser-bench/appstart.js
+++ b/src/mono/sample/wasm/browser-bench/appstart.js
@@ -1,6 +1,7 @@
 var AppStart = {
   Construct: function() {
     this._frame = document.createElement('iframe');
+    this._frame.referrerPolicy="no-referrer";
     document.body.appendChild(this._frame);
   },
 


### PR DESCRIPTION
To avoid fetch errors coming from iframes:

    Failed to load config file ./mono-config.json TypeError: Failed to fetch

Fixes https://github.com/dotnet/runtime/issues/62357