### PR TITLE
Fix re-initialization of hash objects on CNG.

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
@@ -127,10 +127,15 @@ namespace Internal.Cryptography
         {
             if (_reusable && !_running)
                 return;
+
             DestroyHash();
 
+            BCryptCreateHashFlags flags = _reusable ?
+                BCryptCreateHashFlags.BCRYPT_HASH_REUSABLE_FLAG :
+                BCryptCreateHashFlags.None;
+
             SafeBCryptHashHandle hHash;
-            NTSTATUS ntStatus = Interop.BCrypt.BCryptCreateHash(_hAlgorithm, out hHash, IntPtr.Zero, 0, _key, _key == null ? 0 : _key.Length, BCryptCreateHashFlags.None);
+            NTSTATUS ntStatus = Interop.BCrypt.BCryptCreateHash(_hAlgorithm, out hHash, IntPtr.Zero, 0, _key, _key == null ? 0 : _key.Length, flags);
             if (ntStatus != NTSTATUS.STATUS_SUCCESS)
                 throw Interop.BCrypt.CreateCryptographicException(ntStatus);
 

--- a/src/libraries/System.Security.Cryptography/tests/HashAlgorithmTestDriver.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HashAlgorithmTestDriver.cs
@@ -506,7 +506,7 @@ namespace System.Security.Cryptography.Tests
                 hash.Initialize();
                 hash.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
                 hash.Initialize();
-                hash.TransformFinalBlock (hashInput, 0, hashInput.Length);
+                hash.TransformFinalBlock(hashInput, 0, hashInput.Length);
 
                 Assert.Equal(expectedDigest, hash.Hash);
             }

--- a/src/libraries/System.Security.Cryptography/tests/HashAlgorithmTestDriver.cs
+++ b/src/libraries/System.Security.Cryptography/tests/HashAlgorithmTestDriver.cs
@@ -488,6 +488,30 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
+        [Fact]
+        public void Initialize_DoubleInitialize_Works()
+        {
+            byte[] hashInput = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] expectedDigest;
+
+            using (HashAlgorithm hash = Create())
+            {
+                expectedDigest = hash.ComputeHash(hashInput);
+            }
+
+            using (HashAlgorithm hash = Create())
+            {
+                byte[] buffer = new byte[1024];
+                hash.TransformBlock(buffer, 0, buffer.Length, buffer, 0);
+                hash.Initialize();
+                hash.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                hash.Initialize();
+                hash.TransformFinalBlock (hashInput, 0, hashInput.Length);
+
+                Assert.Equal(expectedDigest, hash.Hash);
+            }
+        }
+
         protected class DataRepeatingStream : Stream
         {
             private int _remaining;


### PR DESCRIPTION
In .NET 6, we added real support for Initialize on hash objects, prior to that it was a no-op. However, the Reset call would create a new hash object without the CNG "resuable" flag. This led to the HashProvider's "_reusable" field and the actual reusability of the hash instance to disagree.

Contributes to #61417 