### PR TITLE
[arm64] JIT: X % 2 == 0 -> X & 1 == 0

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13417,7 +13417,6 @@ GenTree* Compiler::fgOptimizeEqualityComparisonWithConst(GenTreeOp* cmp)
                         // Transform to "X & (C2 - 1) ==/!= 0"
                         div->SetOper(GT_AND);
                         div->gtGetOp2()->AsIntConCommon()->SetIconValue(c2 - 1);
-                        fgUpdateConstTreeValueNumber(div->gtGetOp2());
                         cmp->gtOp1 = op1 = div;
 
                         JITDUMP("\ninto:\n");

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13371,9 +13371,58 @@ GenTree* Compiler::fgOptimizeEqualityComparisonWithConst(GenTreeOp* cmp)
                 ssize_t modValue = op1op2->AsIntCon()->IconValue();
                 if (isPow2(modValue))
                 {
+                    JITDUMP("\nTransforming:\n");
+                    DISPTREE(cmp);
+
                     op1->SetOper(GT_AND);                                 // Change % => &
                     op1op2->AsIntConCommon()->SetIconValue(modValue - 1); // Change c => c - 1
                     fgUpdateConstTreeValueNumber(op1op2);
+
+                    JITDUMP("\ninto:\n");
+                    DISPTREE(cmp);
+                }
+            }
+        }
+    }
+
+    // Now let's do the same but for a more complicated input:
+    //   (X - ((X / C1) << C2)) != 0
+    // where C1 is a power-of-two number and 1 << C2 equals C3.
+    // It is especially important for ARM64 where "X % POT_CNS ==/!= 0" is transformed to this pattern early
+    if (fgGlobalMorph && op2->IsIntegralConst(0) && op1->OperIs(GT_SUB) && !op1->gtOverflow() && varTypeIsIntegral(op1))
+    {
+        GenTree* lsh = op1->gtGetOp2();
+        if (lsh->OperIs(GT_LSH) && lsh->gtGetOp2()->IsCnsIntOrI() && lsh->gtGetOp1()->OperIs(GT_DIV))
+        {
+            GenTreeOp*    div = lsh->gtGetOp1()->AsOp();
+            const ssize_t c1  = lsh->gtGetOp2()->AsIntCon()->IconValue();
+            if (div->OperIs(GT_DIV) && div->gtGetOp2()->IsCnsIntOrI())
+            {
+                const ssize_t c2 = div->gtGetOp2()->AsIntCon()->IconValue();
+
+                // Same X is used twice, in the second case it can be a COMMA
+                if (op1->gtGetOp1()->OperIsLeaf() &&
+                    GenTree::Compare(op1->gtGetOp1(), div->gtGetOp1()->gtEffectiveVal(), false))
+                {
+                    if ((c2 > 1) && isPow2(c2) && ((1ULL << (size_t)c1) == (size_t)c2))
+                    {
+                        JITDUMP("\nTransforming:\n");
+                        DISPTREE(cmp);
+
+                        DEBUG_DESTROY_NODE(lsh->gtGetOp2());
+                        DEBUG_DESTROY_NODE(op1->gtGetOp1());
+                        DEBUG_DESTROY_NODE(lsh);
+                        DEBUG_DESTROY_NODE(op1);
+
+                        // Transform to "X & (C2 - 1) ==/!= 0"
+                        div->SetOper(GT_AND);
+                        div->gtGetOp2()->AsIntConCommon()->SetIconValue(c2 - 1);
+                        fgUpdateConstTreeValueNumber(div->gtGetOp2());
+                        cmp->gtOp1 = op1 = div;
+
+                        JITDUMP("\ninto:\n");
+                        DISPTREE(cmp);
+                    }
                 }
             }
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11462,7 +11462,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
                     GenTree* op1op2 = op1->AsOp()->gtOp2;
                     if (op1op2->IsCnsIntOrI())
                     {
-                        ssize_t modValue = op1op2->AsIntCon()->IconValue();
+                        const ssize_t modValue = op1op2->AsIntCon()->IconValue();
                         if (isPow2(modValue))
                         {
                             JITDUMP("\nTransforming:\n");
@@ -11470,6 +11470,7 @@ GenTree* Compiler::fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac)
 
                             op1->SetOper(GT_AND);                                 // Change % => &
                             op1op2->AsIntConCommon()->SetIconValue(modValue - 1); // Change c => c - 1
+                            fgUpdateConstTreeValueNumber(op1op2);
 
                             JITDUMP("\ninto:\n");
                             DISPTREE(tree);


### PR DESCRIPTION
Move `X % 2 == 0 -> X & 1 == 0` transformation to pre-order in morph - it helps ARM64 back-end to recognize it too before it  gets rid of GT_MOD (thanks @SingleAccretion for the idea).

```csharp
void Test(int x)
{
    if (x % 2 == 0)
        Console.WriteLine("x is even");
}
```

```diff
; Method Program:Test(int):this
G_M52364_IG01:
            stp     fp, lr, [sp,#-16]!
            mov     fp, sp
						;; bbWeight=1    PerfScore 1.50

G_M52364_IG02:
-            lsr     w0, w1, #31
-            add     w0, w0, w1
-            asr     w0, w0, #1
-            lsl     w0, w0, #1
-            subs    w0, w1, w0
-            bne     G_M52364_IG05
+            tbnz    w1, #0, G_M52364_IG05
						;; bbWeight=1    PerfScore 1.00

G_M52364_IG03:
            movz    x0, #0xd1ffab1e
            movk    x0, #0xd1ffab1e LSL #16
            movk    x0, #0xd1ffab1e LSL #32
            ldr     x0, [x0]
						;; bbWeight=0.50 PerfScore 2.25

G_M52364_IG04:
            ldp     fp, lr, [sp],#16
            b       System.Console:WriteLine(System.String)
						;; bbWeight=0.50 PerfScore 1.00

G_M52364_IG05:
            ldp     fp, lr, [sp],#16
            ret     lr
						;; bbWeight=0.50 PerfScore 1.00

-G_M52364_IG06:
-            bl      CORINFO_HELP_OVERFLOW
-						;; bbWeight=0    PerfScore 0.00
-
-G_M52364_IG07:
-            bl      CORINFO_HELP_THROWDIVZERO
-            brk_windows #0
-						;; bbWeight=0    PerfScore 0.00
-; Total bytes of code: 76
+; Total bytes of code: 44
```

## benchmarks.run.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 14588340 (overridden on cmd)
Total bytes of diff: 14587516 (overridden on cmd)
Total bytes of delta: -824 (-0.01 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          20 : 40.dasm (1.43% of base)

Top file improvements (bytes):
         -44 : 6600.dasm (-10.38% of base)
         -40 : 11967.dasm (-0.41% of base)
         -40 : 28.dasm (-15.38% of base)
         -40 : 2699.dasm (-0.41% of base)
         -36 : 20474.dasm (-5.26% of base)
         -32 : 6648.dasm (-4.15% of base)
         -32 : 14783.dasm (-47.06% of base)
         -32 : 21375.dasm (-47.06% of base)
         -32 : 1337.dasm (-29.63% of base)
         -32 : 10252.dasm (-21.62% of base)
         -32 : 15369.dasm (-23.53% of base)
         -32 : 4384.dasm (-8.89% of base)
         -32 : 1374.dasm (-9.30% of base)
         -28 : 18163.dasm (-0.85% of base)
         -28 : 20476.dasm (-1.52% of base)
         -28 : 18545.dasm (-14.00% of base)
         -28 : 5144.dasm (-14.00% of base)
         -28 : 24177.dasm (-6.03% of base)
         -28 : 11750.dasm (-2.02% of base)
         -28 : 10264.dasm (-12.50% of base)

31 total files with Code Size differences (30 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
          20 ( 1.43% of base) : 40.dasm - System.Diagnostics.Tracing.EventSource:Initialize(System.Guid,System.String,System.String[]):this

Top method improvements (bytes):
         -44 (-10.38% of base) : 6600.dasm - System.String:GetNonRandomizedHashCodeOrdinalIgnoreCase():int:this
         -40 (-0.41% of base) : 11967.dasm - Jil.Deserialize.Methods:ParseISO8601Date(System.IO.TextReader,System.Char[],int,int):System.DateTime
         -40 (-0.41% of base) : 2699.dasm - Jil.Deserialize.Methods:ParseISO8601DateThunkReader(byref,System.Char[],int,int):System.DateTime
         -40 (-15.38% of base) : 28.dasm - System.String:GetNonRandomizedHashCode():int:this
         -36 (-5.26% of base) : 20474.dasm - System.Xml.ValueHandle:ToByteArray():System.Byte[]:this
         -32 (-47.06% of base) : 21375.dasm - <>c:<Setup>b__6_0(int):ubyte:this
         -32 (-47.06% of base) : 14783.dasm - <>c:<Setup>b__7_0(int):int:this
         -32 (-21.62% of base) : 10252.dasm - System.Formats.Cbor.CborReader:AdvanceDataItemCounters():this
         -32 (-23.53% of base) : 15369.dasm - System.Formats.Cbor.CborWriter:AdvanceDataItemCounters():this
         -32 (-4.15% of base) : 6648.dasm - System.Net.Security.SslSessionsCache:<CacheCredential>g__ShrinkCredentialCache|5_0()
         -32 (-9.30% of base) : 1374.dasm - System.SpanHelpers:ClearWithReferences(byref,long)
         -32 (-29.63% of base) : 1337.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -32 (-8.89% of base) : 4384.dasm - System.Threading.LowLevelSpinWaiter:Wait(int,int,int)
         -28 (-14.00% of base) : 5144.dasm - Microsoft.Extensions.Logging.LogValuesFormatter:FindBraceIndex(System.String,ushort,int,int):int
         -28 (-2.02% of base) : 11750.dasm - System.Formats.Cbor.CborReader:PeekStateCore():int:this
         -28 (-12.50% of base) : 10264.dasm - System.Formats.Cbor.CborReader:ReadEndMap():this
         -28 (-6.03% of base) : 24177.dasm - System.Linq.Tests.Perf_Enumerable:AppendPrepend(System.Linq.Tests.LinqTestData):this
         -28 (-0.85% of base) : 18163.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:.ctor(int,int,int,int):this
         -28 (-14.00% of base) : 18545.dasm - System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder:.ctor(System.Reflection.Metadata.BlobBuilder):this
         -28 (-1.52% of base) : 20476.dasm - System.Text.Base64Encoding:GetBytes(System.Byte[],int,int,System.Byte[],int):int:this

Top method regressions (percentages):
          20 ( 1.43% of base) : 40.dasm - System.Diagnostics.Tracing.EventSource:Initialize(System.Guid,System.String,System.String[]):this

Top method improvements (percentages):
         -32 (-47.06% of base) : 21375.dasm - <>c:<Setup>b__6_0(int):ubyte:this
         -32 (-47.06% of base) : 14783.dasm - <>c:<Setup>b__7_0(int):int:this
         -32 (-29.63% of base) : 1337.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -32 (-23.53% of base) : 15369.dasm - System.Formats.Cbor.CborWriter:AdvanceDataItemCounters():this
         -32 (-21.62% of base) : 10252.dasm - System.Formats.Cbor.CborReader:AdvanceDataItemCounters():this
         -40 (-15.38% of base) : 28.dasm - System.String:GetNonRandomizedHashCode():int:this
         -28 (-14.00% of base) : 5144.dasm - Microsoft.Extensions.Logging.LogValuesFormatter:FindBraceIndex(System.String,ushort,int,int):int
         -28 (-14.00% of base) : 18545.dasm - System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder:.ctor(System.Reflection.Metadata.BlobBuilder):this
         -28 (-12.50% of base) : 10264.dasm - System.Formats.Cbor.CborReader:ReadEndMap():this
         -44 (-10.38% of base) : 6600.dasm - System.String:GetNonRandomizedHashCodeOrdinalIgnoreCase():int:this
         -32 (-9.30% of base) : 1374.dasm - System.SpanHelpers:ClearWithReferences(byref,long)
         -32 (-8.89% of base) : 4384.dasm - System.Threading.LowLevelSpinWaiter:Wait(int,int,int)
         -20 (-6.67% of base) : 9333.dasm - System.Globalization.GregorianCalendar:IsValidDay(int,int,int,int):bool:this
         -16 (-6.25% of base) : 11439.dasm - System.Diagnostics.Tracing.EventSource:AssertValidString(long)
         -28 (-6.03% of base) : 24177.dasm - System.Linq.Tests.Perf_Enumerable:AppendPrepend(System.Linq.Tests.LinqTestData):this
         -36 (-5.26% of base) : 20474.dasm - System.Xml.ValueHandle:ToByteArray():System.Byte[]:this
         -32 (-4.15% of base) : 6648.dasm - System.Net.Security.SslSessionsCache:<CacheCredential>g__ShrinkCredentialCache|5_0()
         -20 (-3.85% of base) : 4027.dasm - System.Globalization.GregorianCalendar:GetAbsoluteDate(int,int,int):long
         -20 (-3.57% of base) : 4236.dasm - System.Threading.SpinWait:SpinOnceCore(int):this
         -20 (-3.55% of base) : 12039.dasm - SciMark2.Random:initialize(int):this

31 total methods with Code Size differences (30 improved, 1 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 165944916 (overridden on cmd)
Total bytes of diff: 165940716 (overridden on cmd)
Total bytes of delta: -4200 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
           4 : 261219.dasm (0.93% of base)
           4 : 250169.dasm (0.55% of base)
           4 : 250181.dasm (0.70% of base)
           4 : 86166.dasm (0.75% of base)

Top file improvements (bytes):
       -1044 : 217814.dasm (-6.81% of base)
         -68 : 233256.dasm (-8.63% of base)
         -68 : 233280.dasm (-8.63% of base)
         -48 : 233227.dasm (-10.71% of base)
         -44 : 251939.dasm (-11.22% of base)
         -40 : 85309.dasm (-5.81% of base)
         -36 : 238849.dasm (-34.62% of base)
         -36 : 238873.dasm (-34.62% of base)
         -36 : 238857.dasm (-34.62% of base)
         -36 : 214803.dasm (-11.11% of base)
         -36 : 214802.dasm (-0.70% of base)
         -36 : 238843.dasm (-36.00% of base)
         -36 : 238845.dasm (-34.62% of base)
         -36 : 85312.dasm (-5.36% of base)
         -32 : 215111.dasm (-7.77% of base)
         -32 : 215130.dasm (-14.81% of base)
         -32 : 223905.dasm (-24.24% of base)
         -32 : 242997.dasm (-28.57% of base)
         -32 : 243024.dasm (-26.67% of base)
         -32 : 248667.dasm (-38.10% of base)

103 total files with Code Size differences (99 improved, 4 regressed), 1 unchanged.

Top method regressions (bytes):
           4 ( 0.55% of base) : 250169.dasm - ExternalException:runtest():this
           4 ( 0.75% of base) : 86166.dasm - ExternalException:runtest():this
           4 ( 0.93% of base) : 261219.dasm - UserException:Main(System.String[]):int
           4 ( 0.70% of base) : 250181.dasm - UserExceptionThread:runtest():this

Top method improvements (bytes):
       -1044 (-6.81% of base) : 217814.dasm - Class1:foo(int)
         -68 (-8.63% of base) : 233256.dasm - PartialCompactionTest.PartialCompactionTest:RemoveObjects(System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]])
         -68 (-8.63% of base) : 233280.dasm - PartialCompactionTest.PartialCompactionTest:RemoveObjects(System.Collections.Generic.List`1[[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]])
         -48 (-10.71% of base) : 233227.dasm - PartialCompactionTest.PartialCompactionTest:RemoveObjects(System.Collections.Generic.List`1[[PartialCompactionTest.PartialCompactionTest+ObjectWrapper, eco1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]])
         -44 (-11.22% of base) : 251939.dasm - ArrayOOM:RunTest():bool:this
         -40 (-5.81% of base) : 85309.dasm - BoxTest.Test:FibonacciImpl(System.Object):System.Object:this
         -36 (-5.36% of base) : 85312.dasm - BoxTest.Test:Fibonacci2(System.Object,System.Object):System.Object:this
         -36 (-36.00% of base) : 238843.dasm - JitTest.TestClass:Method0(JitTest.ValueClass):System.String
         -36 (-34.62% of base) : 238857.dasm - JitTest.TestClass:Method14(JitTest.ValueClass):System.String
         -36 (-34.62% of base) : 238845.dasm - JitTest.TestClass:Method2(JitTest.ValueClass):System.String
         -36 (-34.62% of base) : 238873.dasm - JitTest.TestClass:Method30(JitTest.ValueClass):System.String
         -36 (-34.62% of base) : 238849.dasm - JitTest.TestClass:Method6(JitTest.ValueClass):System.String
         -36 (-11.11% of base) : 214803.dasm - Program:Calc(byref,byref,byref)
         -36 (-0.70% of base) : 214802.dasm - Program:Main():int
         -32 (-24.24% of base) : 223905.dasm - ArrayMarshal:GetExpectedOutBoolArray(int):System.Boolean[]
         -32 (-24.24% of base) : 223931.dasm - ArrayMarshal:GetExpectedOutBoolArray(int):System.Boolean[]
         -32 (-24.24% of base) : 223895.dasm - ArrayMarshal:InitBoolArray(int):System.Boolean[]
         -32 (-13.79% of base) : 87156.dasm - BoxTest.Test:Fibonacci(System.Object,System.Object):System.Object:this
         -32 (-12.70% of base) : 85305.dasm - BoxTest.Test:Fibonacci(System.Object,System.Object):System.Object:this
         -32 (-5.97% of base) : 259786.dasm - BoxTest.Test:Fibonacci2(System.Object,System.Object):System.Object:this

Top method regressions (percentages):
           4 ( 0.93% of base) : 261219.dasm - UserException:Main(System.String[]):int
           4 ( 0.75% of base) : 86166.dasm - ExternalException:runtest():this
           4 ( 0.70% of base) : 250181.dasm - UserExceptionThread:runtest():this
           4 ( 0.55% of base) : 250169.dasm - ExternalException:runtest():this

Top method improvements (percentages):
         -32 (-47.06% of base) : 243034.dasm - FastTailCallCandidates:CallerEnregisterableAmd64WindowsStructs8Bytes(int,int):int
         -32 (-38.10% of base) : 248667.dasm - JitTest.TestClass:Method0(JitTest.TestClass):System.String
         -32 (-36.36% of base) : 248717.dasm - JitTest.TestClass:Method0():System.String:this
         -32 (-36.36% of base) : 248681.dasm - JitTest.TestClass:Method14(JitTest.TestClass):System.String
         -32 (-36.36% of base) : 248669.dasm - JitTest.TestClass:Method2(JitTest.TestClass):System.String
         -32 (-36.36% of base) : 248697.dasm - JitTest.TestClass:Method30(JitTest.TestClass):System.String
         -32 (-36.36% of base) : 248673.dasm - JitTest.TestClass:Method6(JitTest.TestClass):System.String
         -36 (-36.00% of base) : 238843.dasm - JitTest.TestClass:Method0(JitTest.ValueClass):System.String
         -32 (-34.78% of base) : 242998.dasm - FastTailCallCandidates:CallerAmd64WindowsStructs5Bytes(int,int):int
         -32 (-34.78% of base) : 261023.dasm - GitHubIssue12479:callee(int,int,int,int,int,int,int,int):int
         -32 (-34.78% of base) : 248731.dasm - JitTest.TestClass:Method14():System.String:this
         -32 (-34.78% of base) : 248719.dasm - JitTest.TestClass:Method2():System.String:this
         -32 (-34.78% of base) : 248747.dasm - JitTest.TestClass:Method30():System.String:this
         -32 (-34.78% of base) : 248723.dasm - JitTest.TestClass:Method6():System.String:this
         -36 (-34.62% of base) : 238857.dasm - JitTest.TestClass:Method14(JitTest.ValueClass):System.String
         -36 (-34.62% of base) : 238845.dasm - JitTest.TestClass:Method2(JitTest.ValueClass):System.String
         -36 (-34.62% of base) : 238873.dasm - JitTest.TestClass:Method30(JitTest.ValueClass):System.String
         -36 (-34.62% of base) : 238849.dasm - JitTest.TestClass:Method6(JitTest.ValueClass):System.String
         -32 (-32.00% of base) : 261025.dasm - GitHubIssue12479:Main():int
         -32 (-30.77% of base) : 242999.dasm - FastTailCallCandidates:CalleeAmd64WindowsStructs4Bytes(StructSizeFourNotExplicit):int

103 total methods with Code Size differences (99 improved, 4 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 52030788 (overridden on cmd)
Total bytes of diff: 52026948 (overridden on cmd)
Total bytes of delta: -3840 (-0.01 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -72 : 6680.dasm (-7.32% of base)
         -68 : 66401.dasm (-13.60% of base)
         -64 : 66402.dasm (-19.51% of base)
         -60 : 73453.dasm (-10.95% of base)
         -60 : 73769.dasm (-2.62% of base)
         -60 : 73459.dasm (-6.85% of base)
         -56 : 170788.dasm (-20.90% of base)
         -56 : 217045.dasm (-38.89% of base)
         -56 : 57588.dasm (-15.38% of base)
         -56 : 59023.dasm (-50.00% of base)
         -56 : 205308.dasm (-6.54% of base)
         -56 : 221142.dasm (-8.38% of base)
         -56 : 135689.dasm (-5.04% of base)
         -56 : 63202.dasm (-35.90% of base)
         -56 : 82444.dasm (-29.17% of base)
         -56 : 169906.dasm (-7.37% of base)
         -56 : 55155.dasm (-4.76% of base)
         -56 : 170691.dasm (-30.43% of base)
         -56 : 62840.dasm (-14.29% of base)
         -52 : 180203.dasm (-3.47% of base)

108 total files with Code Size differences (108 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -72 (-7.32% of base) : 6680.dasm - Microsoft.CodeAnalysis.CommandLineParser:SplitCommandLineIntoArguments(System.String,bool,byref):System.Collections.Generic.IEnumerable`1[System.String]
         -68 (-13.60% of base) : 66401.dasm - System.String:GetNonRandomizedHashCodeOrdinalIgnoreCase():int:this
         -64 (-19.51% of base) : 66402.dasm - System.String:GetNonRandomizedHashCode():int:this
         -60 (-2.62% of base) : 73769.dasm - System.Text.Base64Encoding:GetBytes(System.Byte[],int,int,System.Byte[],int):int:this
         -60 (-6.85% of base) : 73459.dasm - System.Xml.ValueHandle:ToByteArray():System.Byte[]:this
         -60 (-10.95% of base) : 73453.dasm - System.Xml.ValueHandle:TryReadBase64(System.Byte[],int,int,byref):bool:this
         -56 (-29.17% of base) : 82444.dasm - AppleArm64TransitionBlock:StackElemSize(int,bool,bool):int:this
         -56 (-35.90% of base) : 63202.dasm - CompatPrng:GetSampleForLargeRange():double:this
         -56 (-7.37% of base) : 169906.dasm - System.Formats.Asn1.BMPEncoding:GetChars(System.ReadOnlySpan`1[System.Byte],System.Span`1[System.Char],bool):int:this
         -56 (-20.90% of base) : 170788.dasm - System.Formats.Cbor.CborReader:AdvanceDataItemCounters():this
         -56 (-30.43% of base) : 170691.dasm - System.Formats.Cbor.CborWriter:AdvanceDataItemCounters():this
         -56 (-50.00% of base) : 59023.dasm - System.Globalization.JulianCalendar:IsLeapYear(int,int):bool:this
         -56 (-6.54% of base) : 205308.dasm - System.Net.Security.SslSessionsCache:<CacheCredential>g__ShrinkCredentialCache|5_0()
         -56 (-8.38% of base) : 221142.dasm - System.Reflection.PortableExecutable.PEBuilder:CalculateChecksum(System.Collections.Generic.IEnumerable`1[System.Reflection.Metadata.Blob]):int
         -56 (-4.76% of base) : 55155.dasm - System.Security.SecurityElement:ToString(System.Object,System.Action`2[System.Object, System.String]):this
         -56 (-14.29% of base) : 62840.dasm - System.SpanHelpers:ClearWithReferences(byref,long)
         -56 (-38.89% of base) : 217045.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -56 (-15.38% of base) : 57588.dasm - System.Threading.LowLevelSpinWaiter:Wait(int,int,int)
         -56 (-5.04% of base) : 135689.dasm - System.Xml.Xsl.Runtime.NumberFormatter:FormatSequence(System.Collections.Generic.IList`1[System.Xml.XPath.XPathItem]):System.String:this
         -52 (-22.03% of base) : 198414.dasm - Microsoft.Extensions.Logging.LogValuesFormatter:FindBraceIndex(System.String,ushort,int,int):int

Top method improvements (percentages):
         -56 (-50.00% of base) : 59023.dasm - System.Globalization.JulianCalendar:IsLeapYear(int,int):bool:this
         -56 (-38.89% of base) : 217045.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -56 (-35.90% of base) : 63202.dasm - CompatPrng:GetSampleForLargeRange():double:this
         -56 (-30.43% of base) : 170691.dasm - System.Formats.Cbor.CborWriter:AdvanceDataItemCounters():this
         -56 (-29.17% of base) : 82444.dasm - AppleArm64TransitionBlock:StackElemSize(int,bool,bool):int:this
         -52 (-25.00% of base) : 213664.dasm - System.Security.Cryptography.SymmetricAlgorithm:set_FeedbackSize(int):this
         -52 (-22.03% of base) : 198414.dasm - Microsoft.Extensions.Logging.LogValuesFormatter:FindBraceIndex(System.String,ushort,int,int):int
         -56 (-20.90% of base) : 170788.dasm - System.Formats.Cbor.CborReader:AdvanceDataItemCounters():this
         -52 (-20.00% of base) : 59033.dasm - System.Globalization.JulianCalendar:GetDaysInMonth(int,int,int):int:this
         -64 (-19.51% of base) : 66402.dasm - System.String:GetNonRandomizedHashCode():int:this
         -52 (-19.12% of base) : 219390.dasm - System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder:.ctor(System.Reflection.Metadata.BlobBuilder):this
         -36 (-16.98% of base) : 5211.dasm - Microsoft.CodeAnalysis.StrongNameKeys:IsValidPublicKeyString(System.String):bool
         -56 (-15.38% of base) : 57588.dasm - System.Threading.LowLevelSpinWaiter:Wait(int,int,int)
         -56 (-14.29% of base) : 62840.dasm - System.SpanHelpers:ClearWithReferences(byref,long)
         -68 (-13.60% of base) : 66401.dasm - System.String:GetNonRandomizedHashCodeOrdinalIgnoreCase():int:this
         -52 (-13.40% of base) : 170769.dasm - System.Formats.Cbor.CborReader:ReadEndMap():this
         -52 (-13.40% of base) : 180177.dasm - System.Security.AccessControl.RawAcl:GetBinaryForm(System.Byte[],int):this
         -52 (-12.38% of base) : 189302.dasm - System.Diagnostics.EventLogInternal:set_MaximumKilobytes(long):this
         -48 (-11.76% of base) : 55160.dasm - System.Security.SecurityElement:GetEscapeSequence(ushort):System.String
         -60 (-10.95% of base) : 73453.dasm - System.Xml.ValueHandle:TryReadBase64(System.Byte[],int,int,byref):bool:this

108 total methods with Code Size differences (108 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 50706116 (overridden on cmd)
Total bytes of diff: 50703972 (overridden on cmd)
Total bytes of delta: -2144 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          28 : 13051.dasm (4.49% of base)

Top file improvements (bytes):
         -48 : 78504.dasm (-4.43% of base)
         -40 : 231577.dasm (-2.79% of base)
         -36 : 13055.dasm (-11.54% of base)
         -36 : 116081.dasm (-7.76% of base)
         -36 : 116075.dasm (-5.26% of base)
         -32 : 207944.dasm (-5.56% of base)
         -32 : 79.dasm (-29.63% of base)
         -32 : 104066.dasm (-3.09% of base)
         -32 : 179263.dasm (-23.53% of base)
         -32 : 201750.dasm (-3.90% of base)
         -32 : 232930.dasm (-17.39% of base)
         -32 : 179185.dasm (-21.62% of base)
         -28 : 115731.dasm (-1.52% of base)
         -28 : 145862.dasm (-14.00% of base)
         -28 : 170148.dasm (-1.25% of base)
         -28 : 212804.dasm (-9.86% of base)
         -28 : 231483.dasm (-4.90% of base)
         -28 : 201123.dasm (-2.28% of base)
         -28 : 179217.dasm (-2.02% of base)
         -28 : 212806.dasm (-5.26% of base)

95 total files with Code Size differences (94 improved, 1 regressed), 1 unchanged.

Top method regressions (bytes):
          28 ( 4.49% of base) : 13051.dasm - OperatorIntrinsics:loop@5498-13(System.Decimal,System.Decimal,int):System.Decimal

Top method improvements (bytes):
         -48 (-4.43% of base) : 78504.dasm - Microsoft.CodeAnalysis.CommandLineParser:SplitCommandLineIntoArguments(System.String,bool,byref):System.Collections.Generic.IEnumerable`1[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -40 (-2.79% of base) : 231577.dasm - Internal.JitInterface.SystemVStructClassificator:AssignClassifiedEightByteTypes(byref)
         -36 (-11.54% of base) : 13055.dasm - OperatorIntrinsics:loop@5498-14(double,double,Microsoft.FSharp.Core.FSharpFunc`2[[System.Double, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.FSharp.Core.FSharpFunc`2[[System.Double, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Double, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int):double
         -36 (-5.26% of base) : 116075.dasm - System.Xml.ValueHandle:ToByteArray():System.Byte[]:this
         -36 (-7.76% of base) : 116081.dasm - System.Xml.ValueHandle:TryReadBase64(System.Byte[],int,int,byref):bool:this
         -32 (-17.39% of base) : 232930.dasm - AppleArm64TransitionBlock:StackElemSize(int,bool,bool):int:this
         -32 (-3.09% of base) : 104066.dasm - Microsoft.Diagnostics.Tracing.Ctf.CtfInteger:Read(System.Byte[],int):System.Object:this
         -32 (-21.62% of base) : 179185.dasm - System.Formats.Cbor.CborReader:AdvanceDataItemCounters():this
         -32 (-23.53% of base) : 179263.dasm - System.Formats.Cbor.CborWriter:AdvanceDataItemCounters():this
         -32 (-3.90% of base) : 201750.dasm - System.Net.Security.SslSessionsCache:<CacheCredential>g__ShrinkCredentialCache|5_0()
         -32 (-5.56% of base) : 207944.dasm - System.Reflection.PortableExecutable.PEBuilder:CalculateChecksum(System.Collections.Generic.IEnumerable`1[Blob]):int
         -32 (-29.63% of base) : 79.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -28 (-4.90% of base) : 231483.dasm - ILCompiler.DependencyAnalysis.ARM64.ARM64Emitter:EmitSUB(int,int):this
         -28 (-4.86% of base) : 231484.dasm - ILCompiler.DependencyAnalysis.ARM64.ARM64Emitter:EmitSUB(int,int,int):this
         -28 (-2.49% of base) : 231040.dasm - ILCompiler.DependencyAnalysis.ReadyToRun.DebugInfoTableNode:CreateVarBlobForMethod(Internal.JitInterface.NativeVarInfo[],Internal.TypeSystem.TargetDetails):System.Byte[]
         -28 (-0.75% of base) : 59749.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Scanner:ScanDateLiteral(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.VisualBasicSyntaxNode, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxToken:this
         -28 (-14.00% of base) : 145862.dasm - Microsoft.Extensions.Logging.LogValuesFormatter:FindBraceIndex(System.String,ushort,int,int):int
         -28 (-1.25% of base) : 170148.dasm - System.Data.OleDb.OleDbConnectionString:LoadStringFromFileStorage(System.String):System.String
         -28 (-8.14% of base) : 171985.dasm - System.Diagnostics.EventLogInternal:set_MaximumKilobytes(long):this
         -28 (-1.06% of base) : 177085.dasm - System.Drawing.Icon:Initialize(int,int):this

Top method regressions (percentages):
          28 ( 4.49% of base) : 13051.dasm - OperatorIntrinsics:loop@5498-13(System.Decimal,System.Decimal,int):System.Decimal

Top method improvements (percentages):
         -32 (-29.63% of base) : 79.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -32 (-23.53% of base) : 179263.dasm - System.Formats.Cbor.CborWriter:AdvanceDataItemCounters():this
         -32 (-21.62% of base) : 179185.dasm - System.Formats.Cbor.CborReader:AdvanceDataItemCounters():this
         -28 (-18.42% of base) : 219241.dasm - System.Security.Cryptography.SymmetricAlgorithm:set_FeedbackSize(int):this
         -32 (-17.39% of base) : 232930.dasm - AppleArm64TransitionBlock:StackElemSize(int,bool,bool):int:this
         -24 (-14.29% of base) : 79965.dasm - Microsoft.CodeAnalysis.StrongNameKeys:IsValidPublicKeyString(System.String):bool
         -28 (-14.00% of base) : 145862.dasm - Microsoft.Extensions.Logging.LogValuesFormatter:FindBraceIndex(System.String,ushort,int,int):int
         -28 (-14.00% of base) : 209782.dasm - System.Reflection.Metadata.Ecma335.MethodBodyStreamEncoder:.ctor(System.Reflection.Metadata.BlobBuilder):this
         -24 (-13.04% of base) : 86480.dasm - Microsoft.Diagnostics.Tracing.TraceEvent:EventDataAsString():System.String:this
         -28 (-12.50% of base) : 179204.dasm - System.Formats.Cbor.CborReader:ReadEndMap():this
         -20 (-11.90% of base) : 113011.dasm - System.Data.SqlTypes.SqlDateTime:IsLeapYear(int):bool
         -36 (-11.54% of base) : 13055.dasm - OperatorIntrinsics:loop@5498-14(double,double,Microsoft.FSharp.Core.FSharpFunc`2[[System.Double, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.FSharp.Core.FSharpFunc`2[[System.Double, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Double, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],int):double
         -28 (-9.86% of base) : 212804.dasm - System.Security.AccessControl.RawAcl:GetBinaryForm(System.Byte[],int):this
         -20 (-8.77% of base) : 123114.dasm - System.Xml.UTF16Decoder:GetCharCount(System.Byte[],int,int,bool):int:this
         -24 (-8.33% of base) : 13045.dasm - OperatorIntrinsics:loop@5498-10(long,int):long
         -24 (-8.33% of base) : 13140.dasm - OperatorIntrinsics:loop@5498-5(int,int):int
         -24 (-8.33% of base) : 13037.dasm - OperatorIntrinsics:loop@5498-6(int,int):int
         -24 (-8.33% of base) : 13039.dasm - OperatorIntrinsics:loop@5498-7(long,int):long
         -24 (-8.33% of base) : 13041.dasm - OperatorIntrinsics:loop@5498-8(long,int):long
         -24 (-8.33% of base) : 13043.dasm - OperatorIntrinsics:loop@5498-9(long,int):long

95 total methods with Code Size differences (94 improved, 1 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 117142792 (overridden on cmd)
Total bytes of diff: 117138756 (overridden on cmd)
Total bytes of delta: -4036 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -80 : 286266.dasm (-8.06% of base)
         -60 : 286203.dasm (-6.58% of base)
         -60 : 286307.dasm (-6.58% of base)
         -60 : 286282.dasm (-6.15% of base)
         -60 : 286331.dasm (-6.10% of base)
         -60 : 286220.dasm (-6.10% of base)
         -56 : 270029.dasm (-4.50% of base)
         -52 : 156543.dasm (-4.41% of base)
         -52 : 156531.dasm (-0.63% of base)
         -52 : 130993.dasm (-14.61% of base)
         -52 : 156542.dasm (-4.58% of base)
         -52 : 155214.dasm (-0.64% of base)
         -48 : 131005.dasm (-2.15% of base)
         -48 : 131025.dasm (-11.11% of base)
         -48 : 14447.dasm (-14.12% of base)
         -48 : 131029.dasm (-2.15% of base)
         -44 : 173040.dasm (-8.21% of base)
         -44 : 173614.dasm (-7.75% of base)
         -36 : 309056.dasm (-0.65% of base)
         -32 : 313171.dasm (-44.44% of base)

153 total files with Code Size differences (153 improved, 0 regressed), 1 unchanged.

Top method improvements (bytes):
         -80 (-8.06% of base) : 286266.dasm - System.Globalization.Tests.TaiwanCalendarGetDaysInYear:GetDaysInYear(int):this
         -60 (-6.58% of base) : 286203.dasm - System.Globalization.Tests.KoreanCalendarGetDaysInYear:GetDaysInYear(int):this
         -60 (-6.10% of base) : 286220.dasm - System.Globalization.Tests.KoreanCalendarIsLeapYear:IsLeapYear(int):this
         -60 (-6.15% of base) : 286282.dasm - System.Globalization.Tests.TaiwanCalendarIsLeapYear:IsLeapYear(int):this
         -60 (-6.58% of base) : 286307.dasm - System.Globalization.Tests.ThaiBuddhistCalendarGetDaysInYear:GetDaysInYear(int):this
         -60 (-6.10% of base) : 286331.dasm - System.Globalization.Tests.ThaiBuddhistCalendarIsLeapYear:IsLeapYear(int):this
         -56 (-4.50% of base) : 270029.dasm - System.Collections.Immutable.Tests.ImmutableSortedDictionaryTest:RandomOperationsTest():this
         -52 (-14.61% of base) : 130993.dasm - Microsoft.Diagnostics.Runtime.Utilities.Pdb.DbiModuleInfo:.ctor(Microsoft.Diagnostics.Runtime.Utilities.Pdb.BitAccess,bool):this
         -52 (-0.64% of base) : 155214.dasm - MonoTests.System.Drawing.TestBitmap:FormatTest(int):this
         -52 (-0.63% of base) : 156531.dasm - System.Drawing.Tests.BitmapTests:CustomPixelFormat_GetPixels_ReturnsExpected(int):this
         -52 (-4.41% of base) : 156543.dasm - System.Drawing.Tests.BitmapTests:MakeTransparent_CustomColorExists_SetsMatchingPixelsToTransparent():this
         -52 (-4.58% of base) : 156542.dasm - System.Drawing.Tests.BitmapTests:MakeTransparent_NoColorWithMatches_SetsMatchingPixelsToTransparent():this
         -48 (-14.12% of base) : 14447.dasm - Microsoft.CodeAnalysis.Shared.Utilities.BloomFilter:WriteBitArray(Roslyn.Utilities.ObjectWriter,System.Collections.BitArray)
         -48 (-2.15% of base) : 131005.dasm - Microsoft.Diagnostics.Runtime.Utilities.Pdb.PdbFile:LoadManagedLines(Microsoft.Diagnostics.Runtime.Utilities.Pdb.PdbFunction[],System.Collections.Generic.Dictionary`2[[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],Microsoft.Diagnostics.Runtime.Utilities.Pdb.BitAccess,Microsoft.Diagnostics.Runtime.Utilities.Pdb.MsfDirectory,System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Int32, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],Microsoft.Diagnostics.Runtime.Utilities.Pdb.PdbStreamHelper,int,System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Runtime.Utilities.Pdb.PdbSource, Microsoft.Diagnostics.Runtime, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]])
         -48 (-2.15% of base) : 131029.dasm - Microsoft.Diagnostics.Runtime.Utilities.Pdb.PdbFunction:.ctor(Microsoft.Diagnostics.Runtime.Utilities.Pdb.ManProcSym,Microsoft.Diagnostics.Runtime.Utilities.Pdb.BitAccess):this
         -48 (-11.11% of base) : 131025.dasm - Microsoft.Diagnostics.Runtime.Utilities.Pdb.PdbFunction:ReadCustomMetadata(Microsoft.Diagnostics.Runtime.Utilities.Pdb.BitAccess):this
         -44 (-8.21% of base) : 173040.dasm - System.SpanTests.ReadOnlySpanTests:SequenceCompareToNoMatch_Bool()
         -44 (-7.75% of base) : 173614.dasm - System.SpanTests.SpanTests:SequenceCompareToNoMatch_Bool()
         -36 (-0.65% of base) : 309056.dasm - <Duplex>d__13:MoveNext():this
         -32 (-1.38% of base) : 205578.dasm - <<TestData>g__RealTestData|1_0>d:MoveNext():bool:this

Top method improvements (percentages):
         -28 (-53.85% of base) : 29238.dasm - <>c:<Ctor_BoolArray_TestData>b__6_0(int):bool:this
         -28 (-53.85% of base) : 80393.dasm - <>c:<Find>b__102_2(int):bool:this
         -28 (-53.85% of base) : 171543.dasm - <>c:<PredicateManyFalseOnSecondIndex>b__10_0(int,int):bool:this
         -28 (-53.85% of base) : 171906.dasm - <>c:<SourceEmptyIndexedPredicate>b__70_0(int,int):bool:this
         -28 (-53.85% of base) : 168228.dasm - System.Linq.Tests.EnumerableTests:IsEven(int):bool
         -28 (-50.00% of base) : 61180.dasm - <>c__DisplayClass2_0:<DynamicIsActionArgument>b__0(int):this
         -28 (-46.67% of base) : 29291.dasm - <>c__DisplayClass8_0:<GetEnumerator_Data>b__0(int):bool:this
         -28 (-46.67% of base) : 292575.dasm - System.IO.Ports.Tests.Parity_Property:VerifyEvenParity(ubyte,int):bool:this
         -32 (-44.44% of base) : 313171.dasm - <>c:<ChangeItemKey_NullNewKey_Success>b__37_1(int):System.String:this
         -32 (-42.11% of base) : 165830.dasm - <>c:<Average_Long_SomeNull>b__8_0(int):System.Nullable`1[Int64]:this
         -32 (-40.00% of base) : 165817.dasm - <>c:<Average_Int_SomeNull>b__3_0(int):System.Nullable`1[Int32]:this
         -32 (-40.00% of base) : 165831.dasm - <>c:<Average_Long_SomeNull>b__8_1(int):System.Nullable`1[Int64]:this
         -32 (-38.10% of base) : 165797.dasm - <>c:<Average_Double_SomeNull>b__16_0(int):System.Nullable`1[Double]:this
         -32 (-38.10% of base) : 165835.dasm - <>c:<Average_Float_SomeNull>b__12_0(int):System.Nullable`1[Single]:this
         -32 (-38.10% of base) : 165818.dasm - <>c:<Average_Int_SomeNull>b__3_1(int):System.Nullable`1[Int32]:this
         -32 (-36.36% of base) : 165798.dasm - <>c:<Average_Double_SomeNull>b__16_1(int):System.Nullable`1[Double]:this
         -32 (-36.36% of base) : 165836.dasm - <>c:<Average_Float_SomeNull>b__12_1(int):System.Nullable`1[Single]:this
         -32 (-29.63% of base) : 79.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -32 (-29.63% of base) : 333762.dasm - System.Text.RegularExpressions.RegexCharClass:CanEasilyEnumerateSetContents(System.String):bool
         -28 (-29.17% of base) : 336546.dasm - <>c:<TestCancellationExceptionsIgnored>b__20_0(int):int:this

153 total methods with Code Size differences (153 improved, 0 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------


