### PR TITLE
Add AggressiveInlining for Char.IsLatin1

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -79,6 +79,7 @@ namespace System
         };
 
         // Return true for all characters below or equal U+00ff, which is ASCII + Latin-1 Supplement.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsLatin1(char c) => (uint)c < (uint)Latin1CharInfo.Length;
 
         // Return true for all characters below or equal U+007f, which is ASCII.


### PR DESCRIPTION
Problem: [sharplab.io](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKBuIGYACM58gdhoG8bHfWlGAJRjYAJgHkAdgBsAngGUADtkkAeYLIwwAfIwAy2DAEtJ5AMIALbFACSkgGYRGAXl2SYAd0YatAbQC6jJyMAAwIIQCiaKHhEYwAvgDcNDx8xOQCwBAQ0ow2uAbGpgAUYFZQjGAAlC66xQCuJhhVYIyqjA1NVYUm5uV2jgB0ejCSAOYYFsm01Hz83tm5+QAiRmNGGKXllVWpvNyzc3xG9h35PSXVu4dHR8RsHY2SzaWMcIwA5CEfNarOj11ih8AJwfN6fb5Vaa3Xj3Rj2bDSXAwaF8eI0dHUIA=)

`IsLatin1` is not inlined into `IsDigit`.

`IsLatin1` is pretty verbose in IL:
```
        IL_0000: ldarg.0
        IL_0001: call valuetype [System.Private.CoreLib]System.ReadOnlySpan`1<uint8> Program::get_Latin1CharInfo()
        IL_0006: stloc.0
        IL_0007: ldloca.s 0
        IL_0009: call instance int32 valuetype [System.Private.CoreLib]System.ReadOnlySpan`1<uint8>::get_Length()
        IL_000e: clt.un
        IL_0010: ret
```
none of the inliner's heuristics can catch anything here - two unknown calls 🙁 
However its final codegen is small (because `Latin1CharInfo.Length` is imported as a const):
```asm
Program.IsLatin1(Char)
    L0000: movzx eax, cx
    L0003: cmp eax, 2
    L0006: setb al
    L0009: movzx eax, al
    L000c: ret
```

cc @stephentoub 