### PR TITLE
[wasm] Work around the browser having a lower timer resolution than the

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -11,7 +11,6 @@ namespace System.Diagnostics.Tests
     {
         private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
 
-        // workaround for issue: https://github.com/dotnet/runtime/issues/62021
         private static readonly int s_defaultSleepTimeMs = PlatformDetection.IsBrowser ? 5 : 1;
 
         [Fact]

--- a/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Diagnostics/Stopwatch.cs
@@ -11,19 +11,14 @@ namespace System.Diagnostics.Tests
     {
         private static readonly ManualResetEvent s_sleepEvent = new ManualResetEvent(false);
 
+        // workaround for issue: https://github.com/dotnet/runtime/issues/62021
+        private static readonly int s_defaultSleepTimeMs = PlatformDetection.IsBrowser ? 5 : 1;
+
         [Fact]
         public static void GetTimestamp()
         {
             long ts1 = Stopwatch.GetTimestamp();
-            if (PlatformDetection.IsBrowser)
-            {
-                // workaround for issue: https://github.com/dotnet/runtime/issues/62021
-                Sleep(5);
-            }
-            else
-            {
-                Sleep();
-            }
+            Sleep(s_defaultSleepTimeMs);
             long ts2 = Stopwatch.GetTimestamp();
             Assert.NotEqual(ts1, ts2);
         }
@@ -38,20 +33,20 @@ namespace System.Diagnostics.Tests
             Assert.Equal(0, watch.ElapsedMilliseconds);
             watch.Start();
             Assert.True(watch.IsRunning);
-            Sleep();
+            Sleep(s_defaultSleepTimeMs);
             Assert.True(watch.Elapsed > TimeSpan.Zero);
 
             watch.Stop();
             Assert.False(watch.IsRunning);
 
             var e1 = watch.Elapsed;
-            Sleep();
+            Sleep(s_defaultSleepTimeMs);
             var e2 = watch.Elapsed;
             Assert.Equal(e1, e2);
             Assert.Equal((long)e1.TotalMilliseconds, watch.ElapsedMilliseconds);
 
             var t1 = watch.ElapsedTicks;
-            Sleep();
+            Sleep(s_defaultSleepTimeMs);
             var t2 = watch.ElapsedTicks;
             Assert.Equal(t1, t2);
         }
@@ -63,7 +58,7 @@ namespace System.Diagnostics.Tests
             Assert.True(watch.IsRunning);
             watch.Start(); // should be no-op
             Assert.True(watch.IsRunning);
-            Sleep();
+            Sleep(s_defaultSleepTimeMs);
             Assert.True(watch.Elapsed > TimeSpan.Zero);
 
             watch.Reset();
@@ -130,7 +125,7 @@ namespace System.Diagnostics.Tests
             Assert.True(false, $"All {AllowedTries} fell outside of {WindowFactor} window of {SleepTime} sleep time: {string.Join(", ", results)}");
         }
 
-        private static void Sleep(int milliseconds = 1)
+        private static void Sleep(int milliseconds)
         {
             s_sleepEvent.WaitOne(milliseconds);
         }


### PR DESCRIPTION
.. desktop. Earlier we did this for one test, but others are hitting
this issue randomly too. New one:

```
[00:32:41] fail: [FAIL] System.Diagnostics.Tests.StopwatchTests.StartNewAndReset
[00:32:41] info: Assert.True() Failure
[00:32:41] info: Expected: True
[00:32:41] info: Actual:   False
[00:32:41] info:    at System.Diagnostics.Tests.StopwatchTests.StartNewAndReset()
[00:32:41] info:    at System.Reflection.RuntimeMethodInfo.InvokeWorker(Object obj, BindingFlags invokeAttr, Span`1 parameters)
```

Issue: https://github.com/dotnet/runtime/issues/62021