### PR TITLE
[wasm] force versioned dotnet.d.ts to always have unix style end of line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -75,3 +75,4 @@ src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/revcomp-
 src/tests/JIT/Performance/CodeQuality/BenchmarksGame/reverse-complement/revcomp-input25000.txt text eol=lf
 src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/knucleotide-input.txt text eol=lf
 src/tests/JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/knucleotide-input-big.txt text eol=lf
+src/mono/wasm/runtime/dotnet.d.ts text eol=lf

--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -86,7 +86,7 @@ if (isDebug) {
         format: "es",
         file: "./dotnet.d.ts",
         banner: banner_generated,
-        plugins: [writeOnChangePlugin()],
+        plugins: [alwaysLF(), writeOnChangePlugin()],
     });
 }
 
@@ -100,6 +100,19 @@ function writeOnChangePlugin() {
     return {
         name: "writeOnChange",
         generateBundle: writeWhenChanged
+    };
+}
+
+// force always unix line ending
+function alwaysLF() {
+    return {
+        name: "writeOnChange",
+        generateBundle: (options, bundle) => {
+            const name = Object.keys(bundle)[0];
+            const asset = bundle[name];
+            const code = asset.code;
+            asset.code = code.replace(/\r/g, "");
+        }
     };
 }
 


### PR DESCRIPTION
This file is generated during build and at the same time versioned, so that we could observe if we affect the API.
The file should not show as changed in git because it was generated on windows, but otherwise it's the same.