### PR TITLE
Fixing a possible null reference error in WebSocket deflate.

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
@@ -148,7 +148,8 @@ namespace System.Net.WebSockets.Compression
                 // exhausted the output buffer because after deflating we're
                 // always going to issue a flush and a flush with empty output
                 // is going to throw.
-                needsMoreBuffer = errorCode == ErrorCode.BufError || _stream.AvailIn > 0
+                needsMoreBuffer = errorCode == ErrorCode.BufError
+                    || _stream.AvailIn > 0
                     || written == output.Length;
             }
         }

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
@@ -144,7 +144,12 @@ namespace System.Net.WebSockets.Compression
                 consumed = input.Length - (int)_stream.AvailIn;
                 written = output.Length - (int)_stream.AvailOut;
 
-                needsMoreBuffer = errorCode == ErrorCode.BufError || _stream.AvailIn > 0;
+                // It is important here to also check that we haven't
+                // exhausted the output buffer because after deflating we're
+                // always going to issue a flush and a flush with empty output
+                // is going to throw.
+                needsMoreBuffer = errorCode == ErrorCode.BufError || _stream.AvailIn > 0
+                    || written == output.Length;
             }
         }
 
@@ -152,6 +157,7 @@ namespace System.Net.WebSockets.Compression
         {
             Debug.Assert(_stream is not null);
             Debug.Assert(_stream.AvailIn == 0);
+            Debug.Assert(output.Length > 0);
 
             fixed (byte* fixedOutput = output)
             {


### PR DESCRIPTION
There is a possible situation (although I've been unable to reproduce) when a deflate with `FlushCode.NoFlush` flush code consumes the entire output buffer but also doesn't return a buffer error to indicate that it needs more output. In this case the WebSocket would happily call `Flush` with an empty `Span<byte>` buffer, which when used in `fixed` statement would result in null pointer.

@QuinnDamerell is there any way you could try and run your code against this build, or this error happens only in production environment?

Fixes #62422 