### PR TITLE
Disable Rollup warning for use of eval

### DIFF
--- a/src/mono/wasm/runtime/rollup.config.js
+++ b/src/mono/wasm/runtime/rollup.config.js
@@ -64,6 +64,13 @@ const iffeConfig = {
             plugins,
         }
     ],
+    onwarn: (warning, handler) => {
+        if (warning.code === "EVAL" && warning.loc.file.indexOf("method-calls.ts") != -1) {
+            return;
+        }
+
+        handler(warning);
+    },
     plugins: [consts({ productVersion, configuration }), typescript()]
 };
 const typesConfig = {


### PR DESCRIPTION
As discussed in the https://github.com/dotnet/runtime/pull/61212#issuecomment-986209338 we are sticking with the use of eval for now.

As I didn't find a rollup way to disable warning in place, I have added a `onwarn` callback to the config file with filter for file name `method-calls.ts`. If you have a better way, please let me know.