### PR TITLE
App does not Run as a service in a Windows Container

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             {
                 return false;
             }
-            return parent.SessionId == 0 && string.Equals("services", parent.ProcessName, StringComparison.OrdinalIgnoreCase);
+            return string.Equals("services", parent.ProcessName, StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Removing SessionId check in IsWindowsService(). This check is not correct when the process is being run in a Windows container. The container will get a different SessionId.

Fix #52416