### PR TITLE
Symlink for dotnet host should be created at build time

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -54,9 +54,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>59775387deb609d7c62f9e713d133c34ba28ffcd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.21602.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="7.0.0-beta.21606.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>59775387deb609d7c62f9e713d133c34ba28ffcd</Sha>
+      <Sha>d312d907be65bc3cc8dedac12e01b27e4384d0e2</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="7.0.0-beta.21602.3">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <MicrosoftDotNetXUnitExtensionsVersion>7.0.0-beta.21602.3</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.21602.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>7.0.0-beta.21602.3</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.21602.3</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>7.0.0-beta.21606.3</MicrosoftDotNetBuildTasksInstallersVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>7.0.0-beta.21602.3</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetBuildTasksTemplatingVersion>7.0.0-beta.21602.3</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>7.0.0-beta.21602.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>

--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -4,6 +4,7 @@
     <GenerateInstallers>true</GenerateInstallers>
     <InstallerName>dotnet-host</InstallerName>
     <InstallerName Condition="'$(TargetOS)' == 'OSX'">dotnet-host-internal</InstallerName>
+    <LinuxInstallRoot Condition="'$(BuildRpmPackage)' == 'true'">/</LinuxInstallRoot>
     <PackageBrandNameSuffix>Host</PackageBrandNameSuffix>
     <VSInsertionShortComponentName>NetCore.SharedHost</VSInsertionShortComponentName>
     <UseCustomDirectoryHarvesting>true</UseCustomDirectoryHarvesting>
@@ -19,9 +20,6 @@
     <IncludeVersionInMacOSComponentName>false</IncludeVersionInMacOSComponentName>
     <MacOSScriptsTemplateDirectory>osx_scripts/host</MacOSScriptsTemplateDirectory>
     <MacOSPackageDescription>The .NET Shared Host.</MacOSPackageDescription>
-    <RpmScriptsDirectory>$(MSBuildThisFileDirectory)rpm_scripts/host</RpmScriptsDirectory>
-    <RpmAfterInstallScript>$(RpmScriptsDirectory)/after_install.sh</RpmAfterInstallScript>
-    <RpmAfterRemoveScript>$(RpmScriptsDirectory)/after_remove.sh</RpmAfterRemoveScript>
     <!-- Enables stable upgrade code - do not change -->
     <MsiUpgradeCodeSeed>dotnet-host $(MajorVersion).$(MinorVersion) $(Platform)</MsiUpgradeCodeSeed>
   </PropertyGroup>
@@ -41,21 +39,37 @@
   <Target Name="PublishToDisk">
     <Error Condition="'$(OutputPath)' == ''" Text="Publishing to disk requires the OutputPath to be set to the root of the path to write to." />
 
+    <PropertyGroup>
+      <_DestinationPath>$(OutputPath)</_DestinationPath>
+      <_DestinationPath Condition="'$(BuildRpmPackage)' == 'true'">$(OutputPath)usr/share/dotnet/</_DestinationPath>
+      <_UsrBinPath>$(OutputPath)usr/bin/</_UsrBinPath>
+    </PropertyGroup>
+
+    <MakeDir Condition="'$(BuildRpmPackage)' == 'true'" Directories="$(_DestinationPath)" />
+    <MakeDir Condition="'$(BuildRpmPackage)' == 'true'" Directories="$(_UsrBinPath)" />
+
     <ItemGroup>
       <FilesToPublish Include="$(DotNetHostBinDir)\dotnet$(ExeSuffix)"
-            Destination="$(OutputPath)dotnet$(ExeSuffix)" />
+            Destination="$(_DestinationPath)dotnet$(ExeSuffix)" />
       <FilesToPublish Include="$(InstallerProjectRoot)pkg\THIRD-PARTY-NOTICES.TXT"
-            Destination="$(OutputPath)ThirdPartyNotices.txt" />
+            Destination="$(_DestinationPath)ThirdPartyNotices.txt" />
       <FilesToPublish Include="$(RepoRoot)LICENSE.TXT"
-            Destination="$(OutputPath)LICENSE.txt"
+            Destination="$(_DestinationPath)LICENSE.txt"
             Condition="'$(TargetsUnix)' == 'true'"/>
       <FilesToPublish Include="$(InstallerProjectRoot)pkg\LICENSE-MSFT.TXT"
-            Destination="$(OutputPath)LICENSE.txt"
+            Destination="$(_DestinationPath)LICENSE.txt"
             Condition="'$(TargetsUnix)' != 'true'"/>
     </ItemGroup>
 
     <Copy SourceFiles="@(FilesToPublish)"
           DestinationFiles="%(FilesToPublish.Destination)" />
+
+    <!--
+      Create symlink so the dotnet host is in PATH. It points to where dotnet will be installed, so
+      it may seem to point to the wrong place in the build machine's layout.
+    -->
+    <Exec Condition="'$(BuildRpmPackage)' == 'true'" Command="ln -sf &quot;/usr/share/dotnet/dotnet&quot; &quot;$(_UsrBinPath)dotnet&quot;" />
+
   </Target>
 
   <Target Name="PublishSymbolsToDisk">
@@ -77,8 +91,6 @@
     <ItemGroup>
       <DebJsonProperty Include="symlinks" Object="{ &quot;dotnet&quot;: &quot;/usr/bin/dotnet&quot; }" />
       <RpmJsonProperty Include="directories" Object="[ &quot;/usr/share/dotnet&quot;, &quot;/usr/share/doc/dotnet-host&quot; ]" />
-      <RpmJsonProperty Include="after_install_source" Object="&quot;$(RpmAfterInstallScript)&quot;" />
-      <RpmJsonProperty Include="after_remove_source" Object="&quot;$(RpmAfterRemoveScript)&quot;" />
       <PackageConflictsProperty Include="package_conflicts" Object="[ &quot;dotnet&quot;, &quot;dotnet-nightly&quot; ]" />
       <DebJsonProperty Include="@(PackageConflictsProperty)" />
       <RpmJsonProperty Include="@(PackageConflictsProperty)" />

--- a/src/installer/pkg/sfx/installers/rpm_scripts/host/after_install.sh
+++ b/src/installer/pkg/sfx/installers/rpm_scripts/host/after_install.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if [[ -L /usr/local/bin/dotnet ]]; then
-  rm /usr/local/bin/dotnet
-fi
-ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
-

--- a/src/installer/pkg/sfx/installers/rpm_scripts/host/after_remove.sh
+++ b/src/installer/pkg/sfx/installers/rpm_scripts/host/after_remove.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-if [[ -L /usr/local/bin/dotnet ]]; then
-  rm /usr/local/bin/dotnet
-fi
-


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/61849

Symlink, installed using scripts, is not owned by the package, which causes issues with upgrades from 3.1 or 5.0, where symlink will get removed from disk. (RPM installation is done in "install-new then uninstall-old" fashion.)

This PR restores the infra that was in place for 3.1 and 5.0 releases.

This work will be ported to 6.0 servicing, in the near future, along with dependent Arcade change: https://github.com/dotnet/arcade/pull/8238.