### PR TITLE
More cleanup for source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -659,13 +659,13 @@ namespace System.Text.RegularExpressions.Generator
             bool hasTextInfo = EmitInitializeCultureForGoIfNecessary(writer, rm);
 
             // The implementation tries to use const indexes into the span wherever possible, which we can do
-            // in all places except for variable-length loops.  For everything else, we know at any point in
-            // the regex exactly how far into it we are, and we can use that to index into the span created
-            // at the beginning of the routine to begin at exactly where we're starting in the input.  For
-            // variable-length loops, we index at this textSpanPos + i, and then after the loop we slice the input
-            // by i so that this position is still accurate for everything after it.
-            int textSpanPos = 0;
-            LoadTextSpanLocal(writer, defineLocal: true);
+            // for all fixed-length constructs.  In such cases (e.g. single chars, repeaters, strings, etc.)
+            // we know at any point in the regex exactly how far into it we are, and we can use that to index
+            // into the span created at the beginning of the routine to begin at exactly where we're starting
+            // in the input.  When we encounter a variable-length construct, we transfer the static value to
+            // pos, slicing the inputSpan appropriately, and then zero out the static position.
+            int sliceStaticPos = 0;
+            SliceInputSpan(writer, defineLocal: true);
             writer.WriteLine();
 
             // doneLabel starts out as the top-level label for the whole expression failing to match.  However,
@@ -687,9 +687,9 @@ namespace System.Text.RegularExpressions.Generator
 
             // If we fall through to this place in the code, we've successfully matched the expression.
             writer.WriteLine("// The input matched.");
-            if (textSpanPos > 0)
+            if (sliceStaticPos > 0)
             {
-                EmitAdd(writer, "pos", textSpanPos);
+                EmitAdd(writer, "pos", sliceStaticPos); // TransferSliceStaticPosToPos would also slice, which isn't needed here
             }
             writer.WriteLine("base.runtextpos = pos;");
             writer.WriteLine("base.Capture(0, original_pos, pos);");
@@ -744,8 +744,8 @@ namespace System.Text.RegularExpressions.Generator
             // Whether the node has RegexOptions.IgnoreCase set.
             static bool IsCaseInsensitive(RegexNode node) => (node.Options & RegexOptions.IgnoreCase) != 0;
 
-            // Creates a local span for inputSpan starting at pos until end.
-            void LoadTextSpanLocal(IndentedTextWriter writer, bool defineLocal = false)
+            // Slices the inputSpan starting at pos until end and stores it into slice.
+            void SliceInputSpan(IndentedTextWriter writer, bool defineLocal = false)
             {
                 if (defineLocal)
                 {
@@ -773,18 +773,18 @@ namespace System.Text.RegularExpressions.Generator
             // Returns a length check for the current span slice.  The check returns true if
             // the span isn't long enough for the specified length.
             string SpanLengthCheck(int requiredLength, string? dynamicRequiredLength = null) =>
-                dynamicRequiredLength is null && textSpanPos + requiredLength == 1 ? $"{sliceSpan}.IsEmpty" :
-                $"(uint){sliceSpan}.Length < {Sum(textSpanPos + requiredLength, dynamicRequiredLength)}";
+                dynamicRequiredLength is null && sliceStaticPos + requiredLength == 1 ? $"{sliceSpan}.IsEmpty" :
+                $"(uint){sliceSpan}.Length < {Sum(sliceStaticPos + requiredLength, dynamicRequiredLength)}";
 
-            // Adds the value of textSpanPos into the pos local, slices slice by the corresponding amount,
-            // and zeros out textSpanPos.
-            void TransferTextSpanPosToRunTextPos()
+            // Adds the value of sliceStaticPos into the pos local, slices slice by the corresponding amount,
+            // and zeros out sliceStaticPos.
+            void TransferSliceStaticPosToPos()
             {
-                if (textSpanPos > 0)
+                if (sliceStaticPos > 0)
                 {
-                    EmitAdd(writer, "pos", textSpanPos);
-                    writer.WriteLine($"{sliceSpan} = {sliceSpan}.Slice({textSpanPos});");
-                    textSpanPos = 0;
+                    EmitAdd(writer, "pos", sliceStaticPos);
+                    writer.WriteLine($"{sliceSpan} = {sliceSpan}.Slice({sliceStaticPos});");
+                    sliceStaticPos = 0;
                 }
             }
 
@@ -859,14 +859,14 @@ namespace System.Text.RegularExpressions.Generator
                     writer.WriteLine();
 
                     // Emit a switch statement on the first char of each branch.
-                    using (EmitBlock(writer, $"switch ({ToLowerIfNeeded(hasTextInfo, options, $"{sliceSpan}[{textSpanPos++}]", IsCaseInsensitive(node))})"))
+                    using (EmitBlock(writer, $"switch ({ToLowerIfNeeded(hasTextInfo, options, $"{sliceSpan}[{sliceStaticPos++}]", IsCaseInsensitive(node))})"))
                     {
-                        int startingTextSpanPos = textSpanPos;
+                        int startingSliceStaticPos = sliceStaticPos;
 
                         // Emit a case for each branch.
                         for (int i = 0; i < childCount; i++)
                         {
-                            textSpanPos = startingTextSpanPos;
+                            sliceStaticPos = startingSliceStaticPos;
 
                             RegexNode child = node.Child(i);
                             Debug.Assert(child.Type is RegexNode.One or RegexNode.Multi or RegexNode.Concatenate, DescribeNode(child));
@@ -915,10 +915,10 @@ namespace System.Text.RegularExpressions.Generator
                             doneLabel = originalDoneLabel;
 
                             // If we get here in the generated code, the branch completed successfully.
-                            // Before jumping to the end, we need to zero out textSpanPos, so that no
+                            // Before jumping to the end, we need to zero out sliceStaticPos, so that no
                             // matter what the value is after the branch, whatever follows the alternate
-                            // will see the same textSpanPos.
-                            TransferTextSpanPosToRunTextPos();
+                            // will see the same sliceStaticPos.
+                            TransferSliceStaticPosToPos();
                             writer.WriteLine($"break;");
                             writer.WriteLine();
 
@@ -936,10 +936,10 @@ namespace System.Text.RegularExpressions.Generator
                     string matchLabel = ReserveName("AlternationMatch");
 
                     // Save off pos.  We'll need to reset this each time a branch fails.
-                    string startingRunTextPos = ReserveName("alternation_starting_pos");
-                    additionalDeclarations.Add($"int {startingRunTextPos} = 0;");
-                    writer.WriteLine($"{startingRunTextPos} = pos;");
-                    int startingTextSpanPos = textSpanPos;
+                    string startingPos = ReserveName("alternation_starting_pos");
+                    additionalDeclarations.Add($"int {startingPos} = 0;");
+                    writer.WriteLine($"{startingPos} = pos;");
+                    int startingSliceStaticPos = sliceStaticPos;
 
                     // We need to be able to undo captures in two situations:
                     // - If a branch of the alternation itself contains captures, then if that branch
@@ -1011,16 +1011,16 @@ namespace System.Text.RegularExpressions.Generator
                         if (!isAtomic)
                         {
                             EmitStackPush(startingCapturePos is not null ?
-                                new[] { i.ToString(), startingRunTextPos, startingCapturePos } :
-                                new[] { i.ToString(), startingRunTextPos });
+                                new[] { i.ToString(), startingPos, startingCapturePos } :
+                                new[] { i.ToString(), startingPos });
                         }
                         labelMap[i] = doneLabel;
 
                         // If we get here in the generated code, the branch completed successfully.
-                        // Before jumping to the end, we need to zero out textSpanPos, so that no
+                        // Before jumping to the end, we need to zero out sliceStaticPos, so that no
                         // matter what the value is after the branch, whatever follows the alternate
-                        // will see the same textSpanPos.
-                        TransferTextSpanPosToRunTextPos();
+                        // will see the same sliceStaticPos.
+                        TransferSliceStaticPosToPos();
                         if (!isLastBranch || !isAtomic)
                         {
                             // If this isn't the last branch, we're about to output a reset section,
@@ -1040,9 +1040,9 @@ namespace System.Text.RegularExpressions.Generator
                         if (!isLastBranch)
                         {
                             MarkLabel(nextBranch!, emitSemicolon: false);
-                            writer.WriteLine($"pos = {startingRunTextPos};");
-                            LoadTextSpanLocal(writer);
-                            textSpanPos = startingTextSpanPos;
+                            writer.WriteLine($"pos = {startingPos};");
+                            SliceInputSpan(writer);
+                            sliceStaticPos = startingSliceStaticPos;
                             if (startingCapturePos is not null)
                             {
                                 EmitUncaptureUntil(startingCapturePos);
@@ -1067,8 +1067,8 @@ namespace System.Text.RegularExpressions.Generator
                         MarkLabel(backtrackLabel, emitSemicolon: false);
 
                         EmitStackPop(startingCapturePos is not null ?
-                            new[] { startingCapturePos, startingRunTextPos } :
-                            new[] { startingRunTextPos});
+                            new[] { startingCapturePos, startingPos } :
+                            new[] { startingPos});
                         using (EmitBlock(writer, $"switch ({StackPop()})"))
                         {
                             for (int i = 0; i < labelMap.Length; i++)
@@ -1082,7 +1082,7 @@ namespace System.Text.RegularExpressions.Generator
 
                     // Successfully completed the alternate.
                     MarkLabel(matchLabel);
-                    Debug.Assert(textSpanPos == 0);
+                    Debug.Assert(sliceStaticPos == 0);
                 }
             }
 
@@ -1093,7 +1093,7 @@ namespace System.Text.RegularExpressions.Generator
 
                 int capnum = RegexParser.MapCaptureNumber(node.M, rm.Code.Caps);
 
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
 
                 // If the specified capture hasn't yet captured anything, fail to match... except when using RegexOptions.ECMAScript,
                 // in which case per ECMA 262 section 21.2.2.9 the backreference should succeed.
@@ -1156,7 +1156,7 @@ namespace System.Text.RegularExpressions.Generator
                     writer.WriteLine();
 
                     writer.WriteLine($"pos += {matchLength};");
-                    LoadTextSpanLocal(writer);
+                    SliceInputSpan(writer);
                 }
             }
 
@@ -1165,8 +1165,8 @@ namespace System.Text.RegularExpressions.Generator
             {
                 Debug.Assert(node.Type is RegexNode.Testref, $"Unexpected type: {node.Type}");
 
-                // We're branching in a complicated fashion.  Make sure textSpanPos is 0.
-                TransferTextSpanPosToRunTextPos();
+                // We're branching in a complicated fashion.  Make sure sliceStaticPos is 0.
+                TransferSliceStaticPosToPos();
 
                 // Get the capture number to test.
                 int capnum = RegexParser.MapCaptureNumber(node.M, rm.Code.Caps);
@@ -1185,7 +1185,7 @@ namespace System.Text.RegularExpressions.Generator
                     {
                         writer.WriteLine($"// The {DescribeNonNegative(node.M)} capture group captured a value.  Match the first branch.");
                         EmitNode(yesBranch);
-                        TransferTextSpanPosToRunTextPos(); // make sure textSpanPos is 0 after each branch
+                        TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                     }
 
                     if (noBranch is not null)
@@ -1194,7 +1194,7 @@ namespace System.Text.RegularExpressions.Generator
                         {
                             writer.WriteLine($"// Otherwise, match the second branch.");
                             EmitNode(noBranch);
-                            TransferTextSpanPosToRunTextPos(); // make sure textSpanPos is 0 after each branch
+                            TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                         }
                     }
 
@@ -1224,7 +1224,7 @@ namespace System.Text.RegularExpressions.Generator
                 // The specified capture was captured.  Run the "yes" branch.
                 // If it successfully matches, jump to the end.
                 EmitNode(yesBranch);
-                TransferTextSpanPosToRunTextPos(); // make sure textSpanPos is 0 after each branch
+                TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                 string postYesDoneLabel = doneLabel;
                 if (postYesDoneLabel != originalDoneLabel)
                 {
@@ -1245,7 +1245,7 @@ namespace System.Text.RegularExpressions.Generator
                     // Output the no branch.
                     doneLabel = originalDoneLabel;
                     EmitNode(noBranch);
-                    TransferTextSpanPosToRunTextPos(); // make sure textSpanPos is 0 after each branch
+                    TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                     postNoDoneLabel = doneLabel;
                     if (postNoDoneLabel != originalDoneLabel)
                     {
@@ -1309,8 +1309,8 @@ namespace System.Text.RegularExpressions.Generator
 
                 bool isAtomic = node.IsAtomicByParent();
 
-                // We're branching in a complicated fashion.  Make sure textSpanPos is 0.
-                TransferTextSpanPosToRunTextPos();
+                // We're branching in a complicated fashion.  Make sure sliceStaticPos is 0.
+                TransferSliceStaticPosToPos();
 
                 // The first child node is the conditional expression.  If this matches, then we branch to the "yes" branch.
                 // If it doesn't match, then we branch to the optional "no" branch if it exists, or simply skip the "yes"
@@ -1357,11 +1357,11 @@ namespace System.Text.RegularExpressions.Generator
 
                 // If we get to this point of the code, the conditional successfully matched, so run the "yes" branch.
                 // Since the "yes" branch may have a different execution path than the "no" branch or the lack of
-                // any branch, we need to store the current textSpanPosition and reset it prior to emitting the code
+                // any branch, we need to store the current sliceStaticPos and reset it prior to emitting the code
                 // for what comes after the "yes" branch, so that everyone is on equal footing.
-                int startingTextSpanPos = textSpanPos;
+                int startingSliceStaticPos = sliceStaticPos;
                 EmitNode(yesBranch);
-                TransferTextSpanPosToRunTextPos(); // ensure all subsequent code sees the same textSpanPos value by setting it to 0
+                TransferSliceStaticPosToPos(); // ensure all subsequent code sees the same sliceStaticPos value by setting it to 0
                 string postYesDoneLabel = doneLabel;
                 if (!isAtomic && postYesDoneLabel != originalDoneLabel)
                 {
@@ -1387,9 +1387,9 @@ namespace System.Text.RegularExpressions.Generator
                     }
 
                     doneLabel = postConditionalDoneLabel;
-                    textSpanPos = startingTextSpanPos;
+                    sliceStaticPos = startingSliceStaticPos;
                     EmitNode(noBranch);
-                    TransferTextSpanPosToRunTextPos(); // ensure all subsequent code sees the same textSpanPos value by setting it to 0
+                    TransferSliceStaticPosToPos(); // ensure all subsequent code sees the same sliceStaticPos value by setting it to 0
                     postNoDoneLabel = doneLabel;
                     if (!isAtomic && postNoDoneLabel != originalDoneLabel)
                     {
@@ -1457,10 +1457,10 @@ namespace System.Text.RegularExpressions.Generator
                 int uncapnum = RegexParser.MapCaptureNumber(node.N, rm.Code.Caps);
                 bool isAtomic = node.IsAtomicByParent();
 
-                TransferTextSpanPosToRunTextPos();
-                string startingRunTextPos = ReserveName("capture_starting_pos");
-                additionalDeclarations.Add($"int {startingRunTextPos} = 0;");
-                writer.WriteLine($"{startingRunTextPos} = pos;");
+                TransferSliceStaticPosToPos();
+                string startingPos = ReserveName("capture_starting_pos");
+                additionalDeclarations.Add($"int {startingPos} = 0;");
+                writer.WriteLine($"{startingPos} = pos;");
                 writer.WriteLine();
 
                 RegexNode child = node.Child(0);
@@ -1479,21 +1479,21 @@ namespace System.Text.RegularExpressions.Generator
                 EmitNode(child, subsequent);
                 bool childBacktracks = doneLabel != originalDoneLabel;
 
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
                 if (uncapnum == -1)
                 {
-                    writer.WriteLine($"base.Capture({capnum}, {startingRunTextPos}, pos);");
+                    writer.WriteLine($"base.Capture({capnum}, {startingPos}, pos);");
                 }
                 else
                 {
-                    writer.WriteLine($"base.TransferCapture({capnum}, {uncapnum}, {startingRunTextPos}, pos);");
+                    writer.WriteLine($"base.TransferCapture({capnum}, {uncapnum}, {startingPos}, pos);");
                 }
 
                 if (!isAtomic && (childBacktracks || node.IsInLoop()))
                 {
                     writer.WriteLine();
 
-                    EmitStackPush(startingRunTextPos);
+                    EmitStackPush(startingPos);
 
                     // Skip past the backtracking section
                     string end = ReserveName("SkipBacktrack");
@@ -1503,11 +1503,11 @@ namespace System.Text.RegularExpressions.Generator
                     // Emit a backtracking section that restores the capture's state and then jumps to the previous done label
                     string backtrack = ReserveName($"CaptureBacktrack");
                     MarkLabel(backtrack);
-                    EmitStackPop(startingRunTextPos);
+                    EmitStackPop(startingPos);
                     if (!childBacktracks)
                     {
-                        writer.WriteLine($"pos = {startingRunTextPos};");
-                        LoadTextSpanLocal(writer);
+                        writer.WriteLine($"pos = {startingPos};");
+                        SliceInputSpan(writer);
                     }
                     writer.WriteLine($"goto {doneLabel};");
                     writer.WriteLine();
@@ -1535,19 +1535,19 @@ namespace System.Text.RegularExpressions.Generator
                 string originalDoneLabel = doneLabel;
 
                 // Save off pos.  We'll need to reset this upon successful completion of the lookahead.
-                string startingRunTextPos = ReserveName("positivelookahead_starting_pos");
-                writer.WriteLine($"int {startingRunTextPos} = pos;");
+                string startingPos = ReserveName("positivelookahead_starting_pos");
+                writer.WriteLine($"int {startingPos} = pos;");
                 writer.WriteLine();
-                int startingTextSpanPos = textSpanPos;
+                int startingSliceStaticPos = sliceStaticPos;
 
                 // Emit the child.
                 EmitNode(child);
 
                 // After the child completes successfully, reset the text positions.
                 // Do not reset captures, which persist beyond the lookahead.
-                writer.WriteLine($"pos = {startingRunTextPos};");
-                LoadTextSpanLocal(writer);
-                textSpanPos = startingTextSpanPos;
+                writer.WriteLine($"pos = {startingPos};");
+                SliceInputSpan(writer);
+                sliceStaticPos = startingSliceStaticPos;
 
                 doneLabel = originalDoneLabel;
             }
@@ -1561,9 +1561,9 @@ namespace System.Text.RegularExpressions.Generator
                 string originalDoneLabel = doneLabel;
 
                 // Save off pos.  We'll need to reset this upon successful completion of the lookahead.
-                string startingRunTextPos = ReserveName("negativelookahead_starting_pos");
-                writer.WriteLine($"int {startingRunTextPos} = pos;");
-                int startingTextSpanPos = textSpanPos;
+                string startingPos = ReserveName("negativelookahead_starting_pos");
+                writer.WriteLine($"int {startingPos} = pos;");
+                int startingSliceStaticPos = sliceStaticPos;
 
                 string negativeLookaheadDoneLabel = ReserveName("NegativeLookaheadMatch");
                 doneLabel = negativeLookaheadDoneLabel;
@@ -1580,9 +1580,9 @@ namespace System.Text.RegularExpressions.Generator
                 MarkLabel(negativeLookaheadDoneLabel, emitSemicolon: false);
 
                 // After the child completes in failure (success for negative lookahead), reset the text positions.
-                writer.WriteLine($"pos = {startingRunTextPos};");
-                LoadTextSpanLocal(writer);
-                textSpanPos = startingTextSpanPos;
+                writer.WriteLine($"pos = {startingPos};");
+                SliceInputSpan(writer);
+                sliceStaticPos = startingSliceStaticPos;
 
                 doneLabel = originalDoneLabel;
             }
@@ -1748,7 +1748,7 @@ namespace System.Text.RegularExpressions.Generator
             {
                 Debug.Assert(node.Type is RegexNode.UpdateBumpalong, $"Unexpected type: {node.Type}");
 
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
                 writer.WriteLine("base.runtextpos = pos;");
             }
 
@@ -1845,7 +1845,7 @@ namespace System.Text.RegularExpressions.Generator
                 // to generate the code for a single check, so we map those looping constructs to the
                 // appropriate single check.
 
-                string expr = $"{sliceSpan}[{Sum(textSpanPos, offset)}]";
+                string expr = $"{sliceSpan}[{Sum(sliceStaticPos, offset)}]";
 
                 if (node.IsSetFamily)
                 {
@@ -1869,7 +1869,7 @@ namespace System.Text.RegularExpressions.Generator
                     }
                 }
 
-                textSpanPos++;
+                sliceStaticPos++;
             }
 
             // Emits the code to handle a boundary check on a character.
@@ -1885,7 +1885,7 @@ namespace System.Text.RegularExpressions.Generator
                     _ => "base.IsECMABoundary",
                 };
 
-                using (EmitBlock(writer, $"if ({call}(pos{(textSpanPos > 0 ? $" + {textSpanPos}" : "")}, base.runtextbeg, end))"))
+                using (EmitBlock(writer, $"if ({call}(pos{(sliceStaticPos > 0 ? $" + {sliceStaticPos}" : "")}, base.runtextbeg, end))"))
                 {
                     writer.WriteLine($"goto {doneLabel};");
                 }
@@ -1896,12 +1896,12 @@ namespace System.Text.RegularExpressions.Generator
             {
                 Debug.Assert(node.Type is RegexNode.Beginning or RegexNode.Start or RegexNode.Bol or RegexNode.End or RegexNode.EndZ or RegexNode.Eol, $"Unexpected type: {node.Type}");
 
-                Debug.Assert(textSpanPos >= 0);
+                Debug.Assert(sliceStaticPos >= 0);
                 switch (node.Type)
                 {
                     case RegexNode.Beginning:
                     case RegexNode.Start:
-                        if (textSpanPos > 0)
+                        if (sliceStaticPos > 0)
                         {
                             // If we statically know we've already matched part of the regex, there's no way we're at the
                             // beginning or start, as we've already progressed past it.
@@ -1918,9 +1918,9 @@ namespace System.Text.RegularExpressions.Generator
                         break;
 
                     case RegexNode.Bol:
-                        if (textSpanPos > 0)
+                        if (sliceStaticPos > 0)
                         {
-                            using (EmitBlock(writer, $"if ({sliceSpan}[{textSpanPos - 1}] != '\\n')"))
+                            using (EmitBlock(writer, $"if ({sliceSpan}[{sliceStaticPos - 1}] != '\\n')"))
                             {
                                 writer.WriteLine($"goto {doneLabel};");
                             }
@@ -1937,14 +1937,14 @@ namespace System.Text.RegularExpressions.Generator
                         break;
 
                     case RegexNode.End:
-                        using (EmitBlock(writer, $"if ({sliceSpan}.Length > {textSpanPos})"))
+                        using (EmitBlock(writer, $"if ({sliceSpan}.Length > {sliceStaticPos})"))
                         {
                             writer.WriteLine($"goto {doneLabel};");
                         }
                         break;
 
                     case RegexNode.EndZ:
-                        writer.WriteLine($"if ({sliceSpan}.Length - 1 > {textSpanPos} || ({sliceSpan}.Length > {textSpanPos} && {sliceSpan}[{textSpanPos}] != '\\n'))");
+                        writer.WriteLine($"if ({sliceSpan}.Length - 1 > {sliceStaticPos} || ({sliceSpan}.Length > {sliceStaticPos} && {sliceSpan}[{sliceStaticPos}] != '\\n'))");
                         using (EmitBlock(writer, null))
                         {
                             writer.WriteLine($"goto {doneLabel};");
@@ -1952,7 +1952,7 @@ namespace System.Text.RegularExpressions.Generator
                         break;
 
                     case RegexNode.Eol:
-                        using (EmitBlock(writer, $"if ({sliceSpan}.Length > {textSpanPos} && {sliceSpan}[{textSpanPos}] != '\\n')"))
+                        using (EmitBlock(writer, $"if ({sliceSpan}.Length > {sliceStaticPos} && {sliceSpan}[{sliceStaticPos}] != '\\n')"))
                         {
                             writer.WriteLine($"goto {doneLabel};");
                         }
@@ -1991,7 +1991,7 @@ namespace System.Text.RegularExpressions.Generator
                     bool emittedFirstCheck = false;
                     if (emitLengthCheck)
                     {
-                        writer.Write($"(uint){sliceSpan}.Length < {textSpanPos + str.Length}");
+                        writer.Write($"(uint){sliceSpan}.Length < {sliceStaticPos + str.Length}");
                         emittedFirstCheck = true;
                     }
 
@@ -2010,18 +2010,18 @@ namespace System.Text.RegularExpressions.Generator
                         while (byteStr.Length >= sizeof(ulong))
                         {
                             EmitOr();
-                            string byteSpan = textSpanPos > 0 ? $"byteSpan.Slice({textSpanPos * sizeof(char)})" : "byteSpan";
+                            string byteSpan = sliceStaticPos > 0 ? $"byteSpan.Slice({sliceStaticPos * sizeof(char)})" : "byteSpan";
                             writer.Write($"global::System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian({byteSpan}) != 0x{BinaryPrimitives.ReadUInt64LittleEndian(byteStr):X}ul");
-                            textSpanPos += sizeof(ulong) / sizeof(char);
+                            sliceStaticPos += sizeof(ulong) / sizeof(char);
                             byteStr = byteStr.Slice(sizeof(ulong));
                         }
 
                         while (byteStr.Length >= sizeof(uint))
                         {
                             EmitOr();
-                            string byteSpan = textSpanPos > 0 ? $"byteSpan.Slice({textSpanPos * sizeof(char)})" : "byteSpan";
+                            string byteSpan = sliceStaticPos > 0 ? $"byteSpan.Slice({sliceStaticPos * sizeof(char)})" : "byteSpan";
                             writer.Write($"global::System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian({byteSpan}) != 0x{BinaryPrimitives.ReadUInt32LittleEndian(byteStr):X}u");
-                            textSpanPos += sizeof(uint) / sizeof(char);
+                            sliceStaticPos += sizeof(uint) / sizeof(char);
                             byteStr = byteStr.Slice(sizeof(uint));
                         }
                     }
@@ -2030,8 +2030,8 @@ namespace System.Text.RegularExpressions.Generator
                     for (int i = (str.Length * sizeof(char) - byteStr.Length) / sizeof(char); i < str.Length; i++)
                     {
                         EmitOr();
-                        writer.Write($"{ToLowerIfNeeded(hasTextInfo, options, $"{sliceSpan}[{textSpanPos}]", caseInsensitive)} != {Literal(str[i])}");
-                        textSpanPos++;
+                        writer.Write($"{ToLowerIfNeeded(hasTextInfo, options, $"{sliceSpan}[{sliceStaticPos}]", caseInsensitive)} != {Literal(str[i])}");
+                        sliceStaticPos++;
                     }
 
                     writer.WriteLine(")");
@@ -2048,25 +2048,25 @@ namespace System.Text.RegularExpressions.Generator
                     // character-by-character while respecting the culture.
                     if (!caseInsensitive)
                     {
-                        string sourceSpan = textSpanPos > 0 ? $"{sliceSpan}.Slice({textSpanPos})" : sliceSpan;
+                        string sourceSpan = sliceStaticPos > 0 ? $"{sliceSpan}.Slice({sliceStaticPos})" : sliceSpan;
                         using (EmitBlock(writer, $"if (!global::System.MemoryExtensions.StartsWith({sourceSpan}, {Literal(node.Str)}))"))
                         {
                             writer.WriteLine($"goto {doneLabel};");
                         }
-                        textSpanPos += node.Str.Length;
+                        sliceStaticPos += node.Str.Length;
                     }
                     else
                     {
                         EmitSpanLengthCheck(str.Length);
                         using (EmitBlock(writer, $"for (int i = 0; i < {Literal(node.Str)}.Length; i++)"))
                         {
-                            string textSpanIndex = textSpanPos > 0 ? $"i + {textSpanPos}" : "i";
+                            string textSpanIndex = sliceStaticPos > 0 ? $"i + {sliceStaticPos}" : "i";
                             using (EmitBlock(writer, $"if ({ToLower(hasTextInfo, options, $"{sliceSpan}[{textSpanIndex}]")} != {Literal(str)}[i])"))
                             {
                                 writer.WriteLine($"goto {doneLabel};");
                             }
                         }
-                        textSpanPos += node.Str.Length;
+                        sliceStaticPos += node.Str.Length;
                     }
                 }
             }
@@ -2094,7 +2094,7 @@ namespace System.Text.RegularExpressions.Generator
                 additionalDeclarations.Add($"int {startingPos} = 0, {endingPos} = 0;");
 
                 // We're about to enter a loop, so ensure our text position is 0.
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
 
                 // Grab the current position, then emit the loop as atomic, and then
                 // grab the current position again.  Even though we emit the loop without
@@ -2107,7 +2107,7 @@ namespace System.Text.RegularExpressions.Generator
                 EmitSingleCharAtomicLoop(node);
                 writer.WriteLine();
 
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
                 writer.WriteLine($"{endingPos} = pos;");
 
                 string? capturePos = null;
@@ -2163,7 +2163,7 @@ namespace System.Text.RegularExpressions.Generator
                     writer.WriteLine($"pos = --{endingPos};");
                 }
 
-                LoadTextSpanLocal(writer);
+                SliceInputSpan(writer);
                 writer.WriteLine();
 
                 MarkLabel(endLoop);
@@ -2197,7 +2197,7 @@ namespace System.Text.RegularExpressions.Generator
                 // to try to match, and only matching another character if the subsequent expression fails to match.
 
                 // We're about to enter a loop, so ensure our text position is 0.
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
 
                 // If the loop isn't unbounded, track the number of iterations and the max number to allow.
                 string? iterationCount = null;
@@ -2221,9 +2221,9 @@ namespace System.Text.RegularExpressions.Generator
 
                 // Track the current pos.  Each time we backtrack, we'll reset to the stored position, which
                 // is also incremented each time we match another character in the loop.
-                string startingRunTextPos = ReserveName("lazyloop_pos");
-                additionalDeclarations.Add($"int {startingRunTextPos} = 0;");
-                writer.WriteLine($"{startingRunTextPos} = pos;");
+                string startingPos = ReserveName("lazyloop_pos");
+                additionalDeclarations.Add($"int {startingPos} = 0;");
+                writer.WriteLine($"{startingPos} = pos;");
 
                 // Skip the backtracking section for the initial subsequent matching.  We've already matched the
                 // minimum number of iterations, which means we can successfully match with zero additional iterations.
@@ -2256,11 +2256,11 @@ namespace System.Text.RegularExpressions.Generator
                 // Now match the next item in the lazy loop.  We need to reset the pos to the position
                 // just after the last character in this loop was matched, and we need to store the resulting position
                 // for the next time we backtrack.
-                writer.WriteLine($"pos = {startingRunTextPos};");
-                LoadTextSpanLocal(writer);
+                writer.WriteLine($"pos = {startingPos};");
+                SliceInputSpan(writer);
                 EmitSingleChar(node);
-                TransferTextSpanPosToRunTextPos();
-                writer.WriteLine($"{startingRunTextPos} = pos;");
+                TransferSliceStaticPosToPos();
+                writer.WriteLine($"{startingPos} = pos;");
 
                 // Update the done label for everything that comes after this node.  This is done after we emit the single char
                 // matching, as that failing indicates the loop itself has failed to match.
@@ -2279,7 +2279,7 @@ namespace System.Text.RegularExpressions.Generator
                     writer.WriteLine();
 
                     // Store the capture's state
-                    var toPushPop = new List<string>(3) { startingRunTextPos };
+                    var toPushPop = new List<string>(3) { startingPos };
                     if (capturePos is not null)
                     {
                         toPushPop.Add(capturePos);
@@ -2338,20 +2338,20 @@ namespace System.Text.RegularExpressions.Generator
                     }
                 }
 
-                // We might loop any number of times.  In order to ensure this loop and subsequent code sees textSpanPos
+                // We might loop any number of times.  In order to ensure this loop and subsequent code sees sliceStaticPos
                 // the same regardless, we always need it to contain the same value, and the easiest such value is 0.
-                // So, we transfer textSpanPos to pos, and ensure that any path out of here has textSpanPos as 0.
-                TransferTextSpanPosToRunTextPos();
+                // So, we transfer sliceStaticPos to pos, and ensure that any path out of here has sliceStaticPos as 0.
+                TransferSliceStaticPosToPos();
 
-                string startingRunTextPos = ReserveName("lazyloop_starting_pos");
+                string startingPos = ReserveName("lazyloop_starting_pos");
                 string iterationCount = ReserveName("lazyloop_iteration");
                 string sawEmpty = ReserveName("lazyLoopEmptySeen");
                 string body = ReserveName("LazyLoopBody");
                 string endLoop = ReserveName("LazyLoopEnd");
 
-                additionalDeclarations.Add($"int {iterationCount} = 0, {startingRunTextPos} = 0, {sawEmpty} = 0;");
+                additionalDeclarations.Add($"int {iterationCount} = 0, {startingPos} = 0, {sawEmpty} = 0;");
                 writer.WriteLine($"{iterationCount} = 0;");
-                writer.WriteLine($"{startingRunTextPos} = pos;");
+                writer.WriteLine($"{startingPos} = pos;");
                 writer.WriteLine($"{sawEmpty} = 0;");
                 writer.WriteLine();
 
@@ -2370,8 +2370,8 @@ namespace System.Text.RegularExpressions.Generator
                 // be backtracked through later.  This needs to be the starting position from
                 // the iteration we're leaving, so it's pushed before updating it to pos.
                 EmitStackPush(expressionHasCaptures ?
-                    new[] { "base.Crawlpos()", startingRunTextPos, "pos", sawEmpty } :
-                    new[] { startingRunTextPos, "pos", sawEmpty });
+                    new[] { "base.Crawlpos()", startingPos, "pos", sawEmpty } :
+                    new[] { startingPos, "pos", sawEmpty });
 
                 writer.WriteLine();
 
@@ -2379,7 +2379,7 @@ namespace System.Text.RegularExpressions.Generator
                 // pos after the iteration, in order to determine whether the iteration was empty. Empty
                 // iterations are allowed as part of min matches, but once we've met the min quote, empty matches
                 // are considered match failures.
-                writer.WriteLine($"{startingRunTextPos} = pos;");
+                writer.WriteLine($"{startingPos} = pos;");
 
                 // Proactively increase the number of iterations.  We do this prior to the match rather than once
                 // we know it's successful, because we need to decrement it as part of a failed match when
@@ -2395,9 +2395,9 @@ namespace System.Text.RegularExpressions.Generator
                 doneLabel = iterationFailedLabel;
 
                 // Finally, emit the child.
-                Debug.Assert(textSpanPos == 0);
+                Debug.Assert(sliceStaticPos == 0);
                 EmitNode(node.Child(0));
-                TransferTextSpanPosToRunTextPos(); // ensure textSpanPos remains 0
+                TransferSliceStaticPosToPos(); // ensure sliceStaticPos remains 0
                 if (doneLabel == iterationFailedLabel)
                 {
                     doneLabel = originalDoneLabel;
@@ -2415,7 +2415,7 @@ namespace System.Text.RegularExpressions.Generator
                 // If the last iteration was empty, we need to prevent further iteration from this point
                 // unless we backtrack out of this iteration.  We can do that easily just by pretending
                 // we reached the max iteration count.
-                using (EmitBlock(writer, $"if (pos == {startingRunTextPos})"))
+                using (EmitBlock(writer, $"if (pos == {startingPos})"))
                 {
                     writer.WriteLine($"{sawEmpty} = 1;");
                 }
@@ -2432,14 +2432,14 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     writer.WriteLine($"goto {originalDoneLabel};");
                 }
-                EmitStackPop(sawEmpty, "pos", startingRunTextPos);
+                EmitStackPop(sawEmpty, "pos", startingPos);
                 if (expressionHasCaptures)
                 {
                     string poppedCapturePos = ReserveName("lazyloop_capturepos");
                     writer.WriteLine($"int {poppedCapturePos} = {StackPop()};");
                     EmitUncaptureUntil(poppedCapturePos);
                 }
-                LoadTextSpanLocal(writer);
+                SliceInputSpan(writer);
                 if (doneLabel == originalDoneLabel)
                 {
                     writer.WriteLine($"goto {originalDoneLabel};");
@@ -2459,7 +2459,7 @@ namespace System.Text.RegularExpressions.Generator
                 if (!isAtomic)
                 {
                     // Store the capture's state and skip the backtracking section
-                    EmitStackPush(startingRunTextPos, iterationCount, sawEmpty);
+                    EmitStackPush(startingPos, iterationCount, sawEmpty);
 
                     string skipBacktrack = ReserveName("SkipBacktrack");
                     writer.WriteLine($"goto {skipBacktrack};");
@@ -2469,7 +2469,7 @@ namespace System.Text.RegularExpressions.Generator
                     string backtrack = ReserveName($"LazyLoopBacktrack");
                     MarkLabel(backtrack);
 
-                    EmitStackPop(sawEmpty, iterationCount, startingRunTextPos);
+                    EmitStackPop(sawEmpty, iterationCount, startingPos);
 
                     if (maxIterations == int.MaxValue)
                     {
@@ -2509,9 +2509,9 @@ namespace System.Text.RegularExpressions.Generator
 
                 if (iterations <= MaxUnrollSize)
                 {
-                    // if ((uint)(textSpanPos + iterations - 1) >= (uint)slice.Length ||
-                    //     slice[textSpanPos] != c1 ||
-                    //     slice[textSpanPos + 1] != c2 ||
+                    // if ((uint)(sliceStaticPos + iterations - 1) >= (uint)slice.Length ||
+                    //     slice[sliceStaticPos] != c1 ||
+                    //     slice[sliceStaticPos + 1] != c2 ||
                     //     ...)
                     // {
                     //     goto doneLabel;
@@ -2537,28 +2537,28 @@ namespace System.Text.RegularExpressions.Generator
                 }
                 else
                 {
-                    // if ((uint)(textSpanPos + iterations - 1) >= (uint)slice.Length) goto doneLabel;
+                    // if ((uint)(sliceStaticPos + iterations - 1) >= (uint)slice.Length) goto doneLabel;
                     if (emitLengthCheck)
                     {
                         EmitSpanLengthCheck(iterations);
                     }
 
                     string repeaterSpan = "repeaterSlice"; // As this repeater doesn't wrap arbitrary node emits, this shouldn't conflict with anything
-                    writer.WriteLine($"global::System.ReadOnlySpan<char> {repeaterSpan} = {sliceSpan}.Slice({textSpanPos}, {iterations});");
+                    writer.WriteLine($"global::System.ReadOnlySpan<char> {repeaterSpan} = {sliceSpan}.Slice({sliceStaticPos}, {iterations});");
                     string i = ReserveName("charrepeater_iteration");
                     using (EmitBlock(writer, $"for (int {i} = 0; {i} < {repeaterSpan}.Length; {i}++)"))
                     {
                         EmitTimeoutCheck(writer, hasTimeout);
 
                         string tmpTextSpanLocal = sliceSpan; // we want EmitSingleChar to refer to this temporary
-                        int tmpTextSpanPos = textSpanPos;
+                        int tmpSliceStaticPos = sliceStaticPos;
                         sliceSpan = repeaterSpan;
-                        textSpanPos = 0;
+                        sliceStaticPos = 0;
                         EmitSingleChar(node, emitLengthCheck: false, offset: i);
                         sliceSpan = tmpTextSpanLocal;
-                        textSpanPos = tmpTextSpanPos;
+                        sliceStaticPos = tmpSliceStaticPos;
                     }
-                    textSpanPos += iterations;
+                    sliceStaticPos += iterations;
                 }
             }
 
@@ -2600,16 +2600,16 @@ namespace System.Text.RegularExpressions.Generator
                     // handle the unbounded case.
 
                     writer.Write($"int {iterationLocal} = global::System.MemoryExtensions.IndexOf({sliceSpan}");
-                    if (textSpanPos > 0)
+                    if (sliceStaticPos > 0)
                     {
-                        writer.Write($".Slice({textSpanPos})");
+                        writer.Write($".Slice({sliceStaticPos})");
                     }
                     writer.WriteLine($", {Literal(node.Ch)});");
                     
                     using (EmitBlock(writer, $"if ({iterationLocal} < 0)"))
                     {
-                        writer.WriteLine(textSpanPos > 0 ?
-                            $"{iterationLocal} = {sliceSpan}.Length - {textSpanPos};" :
+                        writer.WriteLine(sliceStaticPos > 0 ?
+                            $"{iterationLocal} = {sliceSpan}.Length - {sliceStaticPos};" :
                             $"{iterationLocal} = {sliceSpan}.Length;");
                     }
                     writer.WriteLine();
@@ -2626,9 +2626,9 @@ namespace System.Text.RegularExpressions.Generator
                     Debug.Assert(numSetChars > 1);
 
                     writer.Write($"int {iterationLocal} = global::System.MemoryExtensions.IndexOfAny({sliceSpan}");
-                    if (textSpanPos != 0)
+                    if (sliceStaticPos != 0)
                     {
-                        writer.Write($".Slice({textSpanPos})");
+                        writer.Write($".Slice({sliceStaticPos})");
                     }
                     writer.WriteLine(numSetChars switch
                     {
@@ -2638,8 +2638,8 @@ namespace System.Text.RegularExpressions.Generator
                     });
                     using (EmitBlock(writer, $"if ({iterationLocal} < 0)"))
                     {
-                        writer.WriteLine(textSpanPos > 0 ?
-                            $"{iterationLocal} = {sliceSpan}.Length - {textSpanPos};" :
+                        writer.WriteLine(sliceStaticPos > 0 ?
+                            $"{iterationLocal} = {sliceSpan}.Length - {sliceStaticPos};" :
                             $"{iterationLocal} = {sliceSpan}.Length;");
                     }
                     writer.WriteLine();
@@ -2650,7 +2650,7 @@ namespace System.Text.RegularExpressions.Generator
                     // The unbounded constraint is the same as in the Notone case above, done purely for simplicity.
 
                     // int i = end - pos;
-                    TransferTextSpanPosToRunTextPos();
+                    TransferSliceStaticPosToPos();
                     writer.WriteLine($"int {iterationLocal} = end - pos;");
                 }
                 else
@@ -2673,11 +2673,11 @@ namespace System.Text.RegularExpressions.Generator
                         // For any loops other than * loops, transfer text pos to pos in
                         // order to zero it out to be able to use the single iteration variable
                         // for both iteration count and indexer.
-                        TransferTextSpanPosToRunTextPos();
+                        TransferSliceStaticPosToPos();
                     }
 
-                    writer.WriteLine($"int {iterationLocal} = {textSpanPos};");
-                    textSpanPos = 0;
+                    writer.WriteLine($"int {iterationLocal} = {sliceStaticPos};");
+                    sliceStaticPos = 0;
 
                     string maxClause = maxIterations != int.MaxValue ? $"{CountIsLessThan(iterationLocal, maxIterations)} && " : "";
                     using (EmitBlock(writer, $"while ({maxClause}(uint){iterationLocal} < (uint){sliceSpan}.Length && {expr})"))
@@ -2711,7 +2711,7 @@ namespace System.Text.RegularExpressions.Generator
                 Debug.Assert(node.Type is RegexNode.Oneloop or RegexNode.Oneloopatomic or RegexNode.Notoneloop or RegexNode.Notoneloopatomic or RegexNode.Setloop or RegexNode.Setloopatomic, $"Unexpected type: {node.Type}");
                 Debug.Assert(node.M == 0 && node.N == 1);
 
-                string expr = $"{sliceSpan}[{textSpanPos}]";
+                string expr = $"{sliceSpan}[{sliceStaticPos}]";
                 if (node.IsSetFamily)
                 {
                     expr = MatchCharacterClass(hasTextInfo, options, expr, node.Str!, IsCaseInsensitive(node), additionalDeclarations);
@@ -2722,7 +2722,7 @@ namespace System.Text.RegularExpressions.Generator
                     expr = $"{expr} {(node.IsOneFamily ? "==" : "!=")} {Literal(node.Ch)}";
                 }
 
-                string spaceAvailable = textSpanPos != 0 ? $"(uint){sliceSpan}.Length > (uint){textSpanPos}" : $"!{sliceSpan}.IsEmpty";
+                string spaceAvailable = sliceStaticPos != 0 ? $"(uint){sliceSpan}.Length > (uint){sliceStaticPos}" : $"!{sliceSpan}.IsEmpty";
                 using (EmitBlock(writer, $"if ({spaceAvailable} && {expr})"))
                 {
                     writer.WriteLine($"{sliceSpan} = {sliceSpan}.Slice(1);");
@@ -2739,21 +2739,21 @@ namespace System.Text.RegularExpressions.Generator
                 int maxIterations = node.N;
                 bool isAtomic = node.IsAtomicByParent();
 
-                // We might loop any number of times.  In order to ensure this loop and subsequent code sees textSpanPos
+                // We might loop any number of times.  In order to ensure this loop and subsequent code sees sliceStaticPos
                 // the same regardless, we always need it to contain the same value, and the easiest such value is 0.
-                // So, we transfer textSpanPos to pos, and ensure that any path out of here has textSpanPos as 0.
-                TransferTextSpanPosToRunTextPos();
+                // So, we transfer sliceStaticPos to pos, and ensure that any path out of here has sliceStaticPos as 0.
+                TransferSliceStaticPosToPos();
 
                 string originalDoneLabel = doneLabel;
 
-                string startingRunTextPos = ReserveName("loop_starting_pos");
+                string startingPos = ReserveName("loop_starting_pos");
                 string iterationCount = ReserveName("loop_iteration");
                 string body = ReserveName("LoopBody");
                 string endLoop = ReserveName("LoopEnd");
 
-                additionalDeclarations.Add($"int {iterationCount} = 0, {startingRunTextPos} = 0;");
+                additionalDeclarations.Add($"int {iterationCount} = 0, {startingPos} = 0;");
                 writer.WriteLine($"{iterationCount} = 0;");
-                writer.WriteLine($"{startingRunTextPos} = pos;");
+                writer.WriteLine($"{startingPos} = pos;");
                 writer.WriteLine();
 
                 // Iteration body
@@ -2764,15 +2764,15 @@ namespace System.Text.RegularExpressions.Generator
                 // be backtracked through later.  This needs to be the starting position from
                 // the iteration we're leaving, so it's pushed before updating it to pos.
                 EmitStackPush(expressionHasCaptures ?
-                    new[] { "base.Crawlpos()", startingRunTextPos, "pos" } :
-                    new[] { startingRunTextPos, "pos" });
+                    new[] { "base.Crawlpos()", startingPos, "pos" } :
+                    new[] { startingPos, "pos" });
                 writer.WriteLine();
 
                 // Save off some state.  We need to store the current pos so we can compare it against
                 // pos after the iteration, in order to determine whether the iteration was empty. Empty
                 // iterations are allowed as part of min matches, but once we've met the min quote, empty matches
                 // are considered match failures.
-                writer.WriteLine($"{startingRunTextPos} = pos;");
+                writer.WriteLine($"{startingPos} = pos;");
 
                 // Proactively increase the number of iterations.  We do this prior to the match rather than once
                 // we know it's successful, because we need to decrement it as part of a failed match when
@@ -2789,19 +2789,19 @@ namespace System.Text.RegularExpressions.Generator
                 doneLabel = iterationFailedLabel;
 
                 // Finally, emit the child.
-                Debug.Assert(textSpanPos == 0);
+                Debug.Assert(sliceStaticPos == 0);
                 EmitNode(node.Child(0));
-                TransferTextSpanPosToRunTextPos(); // ensure textSpanPos remains 0
+                TransferSliceStaticPosToPos(); // ensure sliceStaticPos remains 0
                 bool childBacktracks = doneLabel != iterationFailedLabel;
 
                 // Loop condition.  Continue iterating greedily if we've not yet reached the maximum.  We also need to stop
                 // iterating if the iteration matched empty and we already hit the minimum number of iterations.
                 using (EmitBlock(writer, (minIterations > 0, maxIterations == int.MaxValue) switch
                 {
-                    (true, true) => $"if (pos != {startingRunTextPos} || {CountIsLessThan(iterationCount, minIterations)})",
-                    (true, false) => $"if ((pos != {startingRunTextPos} || {CountIsLessThan(iterationCount, minIterations)}) && {CountIsLessThan(iterationCount, maxIterations)})",
-                    (false, true) => $"if (pos != {startingRunTextPos})",
-                    (false, false) => $"if (pos != {startingRunTextPos} && {CountIsLessThan(iterationCount, maxIterations)})",
+                    (true, true) => $"if (pos != {startingPos} || {CountIsLessThan(iterationCount, minIterations)})",
+                    (true, false) => $"if ((pos != {startingPos} || {CountIsLessThan(iterationCount, minIterations)}) && {CountIsLessThan(iterationCount, maxIterations)})",
+                    (false, true) => $"if (pos != {startingPos})",
+                    (false, false) => $"if (pos != {startingPos} && {CountIsLessThan(iterationCount, maxIterations)})",
                 }))
                 {
                     writer.WriteLine($"goto {body};");
@@ -2820,14 +2820,14 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     writer.WriteLine($"goto {originalDoneLabel};");
                 }
-                EmitStackPop("pos", startingRunTextPos);
+                EmitStackPop("pos", startingPos);
                 if (expressionHasCaptures)
                 {
                     string poppedCapturePos = ReserveName("loop_capturepos");
                     writer.WriteLine($"int {poppedCapturePos} = {StackPop()};");
                     EmitUncaptureUntil(poppedCapturePos);
                 }
-                LoadTextSpanLocal(writer);
+                SliceInputSpan(writer);
 
                 if (minIterations > 0)
                 {
@@ -2871,7 +2871,7 @@ namespace System.Text.RegularExpressions.Generator
                         writer.WriteLine();
 
                         // Store the capture's state
-                        EmitStackPush(startingRunTextPos, iterationCount);
+                        EmitStackPush(startingPos, iterationCount);
 
                         // Skip past the backtracking section
                         string end = ReserveName("SkipBacktrack");
@@ -2881,7 +2881,7 @@ namespace System.Text.RegularExpressions.Generator
                         // Emit a backtracking section that restores the capture's state and then jumps to the previous done label
                         string backtrack = ReserveName("LoopBacktrack");
                         MarkLabel(backtrack);
-                        EmitStackPop(iterationCount, startingRunTextPos);
+                        EmitStackPop(iterationCount, startingPos);
 
                         writer.WriteLine($"goto {doneLabel};");
                         writer.WriteLine();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -355,8 +355,8 @@ namespace System.Text.RegularExpressions
             _readOnlySpanCharLocalsPool?.Clear();
 
             LocalBuilder inputSpan = DeclareReadOnlySpanChar();
-            LocalBuilder runtextpos = DeclareInt32();
-            LocalBuilder runtextend = DeclareInt32();
+            LocalBuilder pos = DeclareInt32();
+            LocalBuilder end = DeclareInt32();
 
             _textInfo = null;
             if ((_options & RegexOptions.CultureInvariant) == 0)
@@ -380,11 +380,11 @@ namespace System.Text.RegularExpressions
             }
 
             // Load necessary locals
-            // int runtextpos = this.runtextpos;
-            // int runtextend = this.runtextend;
-            // ReadOnlySpan<char> inputSpan = this.runtext.AsSpan();
-            Mvfldloc(s_runtextposField, runtextpos);
-            Mvfldloc(s_runtextendField, runtextend);
+            // int pos = base.runtextpos;
+            // int end = base.runtextend;
+            // ReadOnlySpan<char> inputSpan = base.runtext.AsSpan();
+            Mvfldloc(s_runtextposField, pos);
+            Mvfldloc(s_runtextendField, end);
             Ldthisfld(s_runtextField);
             Call(s_stringAsSpanMethod);
             Stloc(inputSpan);
@@ -397,13 +397,13 @@ namespace System.Text.RegularExpressions
             Label returnFalse = DefineLabel();
             Label finishedLengthCheck = DefineLabel();
 
-            // if (runtextpos > runtextend - _code.Tree.MinRequiredLength)
+            // if (pos > end - _code.Tree.MinRequiredLength)
             // {
-            //     this.runtextpos = runtextend;
+            //     base.runtextpos = end;
             //     return false;
             // }
-            Ldloc(runtextpos);
-            Ldloc(runtextend);
+            Ldloc(pos);
+            Ldloc(end);
             if (minRequiredLength > 0)
             {
                 Ldc(minRequiredLength);
@@ -413,7 +413,7 @@ namespace System.Text.RegularExpressions
 
             MarkLabel(returnFalse);
             Ldthis();
-            Ldloc(runtextend);
+            Ldloc(end);
 
             Stfld(s_runtextposField);
             Ldc(0);
@@ -465,7 +465,7 @@ namespace System.Text.RegularExpressions
                         case RegexPrefixAnalyzer.Beginning:
                             {
                                 Label l1 = DefineLabel();
-                                Ldloc(runtextpos);
+                                Ldloc(pos);
                                 Ldthisfld(s_runtextbegField);
                                 Ble(l1);
                                 Br(returnFalse);
@@ -478,7 +478,7 @@ namespace System.Text.RegularExpressions
                         case RegexPrefixAnalyzer.Start:
                             {
                                 Label l1 = DefineLabel();
-                                Ldloc(runtextpos);
+                                Ldloc(pos);
                                 Ldthisfld(s_runtextstartField);
                                 Ble(l1);
                                 Br(returnFalse);
@@ -491,13 +491,13 @@ namespace System.Text.RegularExpressions
                         case RegexPrefixAnalyzer.EndZ:
                             {
                                 Label l1 = DefineLabel();
-                                Ldloc(runtextpos);
-                                Ldloc(runtextend);
+                                Ldloc(pos);
+                                Ldloc(end);
                                 Ldc(1);
                                 Sub();
                                 Bge(l1);
                                 Ldthis();
-                                Ldloc(runtextend);
+                                Ldloc(end);
                                 Ldc(1);
                                 Sub();
                                 Stfld(s_runtextposField);
@@ -510,11 +510,11 @@ namespace System.Text.RegularExpressions
                         case RegexPrefixAnalyzer.End:
                             {
                                 Label l1 = DefineLabel();
-                                Ldloc(runtextpos);
-                                Ldloc(runtextend);
+                                Ldloc(pos);
+                                Ldloc(end);
                                 Bge(l1);
                                 Ldthis();
-                                Ldloc(runtextend);
+                                Ldloc(end);
                                 Stfld(s_runtextposField);
                                 MarkLabel(l1);
                             }
@@ -531,14 +531,14 @@ namespace System.Text.RegularExpressions
 
                                 Label atBeginningOfLine = DefineLabel();
 
-                                // if (runtextpos > runtextbeg...
-                                Ldloc(runtextpos!);
+                                // if (pos > runtextbeg...
+                                Ldloc(pos!);
                                 Ldthisfld(s_runtextbegField);
                                 Ble(atBeginningOfLine);
 
-                                // ... && inputSpan[runtextpos - 1] != '\n') { ... }
+                                // ... && inputSpan[pos - 1] != '\n') { ... }
                                 Ldloca(inputSpan);
-                                Ldloc(runtextpos);
+                                Ldloc(pos);
                                 Ldc(1);
                                 Sub();
                                 Call(s_spanGetItemMethod);
@@ -546,9 +546,9 @@ namespace System.Text.RegularExpressions
                                 Ldc('\n');
                                 Beq(atBeginningOfLine);
 
-                                // int tmp = inputSpan.Slice(runtextpos).IndexOf('\n');
+                                // int tmp = inputSpan.Slice(pos).IndexOf('\n');
                                 Ldloca(inputSpan);
-                                Ldloc(runtextpos);
+                                Ldloc(pos);
                                 Call(s_spanSliceIntMethod);
                                 Ldc('\n');
                                 Call(s_spanIndexOfChar);
@@ -556,29 +556,29 @@ namespace System.Text.RegularExpressions
                                 {
                                     Stloc(newlinePos);
 
-                                    // if (newlinePos < 0 || newlinePos + runtextpos + 1 > runtextend)
+                                    // if (newlinePos < 0 || newlinePos + pos + 1 > end)
                                     // {
-                                    //     runtextpos = runtextend;
+                                    //     base.runtextpos = end;
                                     //     return false;
                                     // }
                                     Ldloc(newlinePos);
                                     Ldc(0);
                                     Blt(returnFalse);
                                     Ldloc(newlinePos);
-                                    Ldloc(runtextpos);
+                                    Ldloc(pos);
                                     Add();
                                     Ldc(1);
                                     Add();
-                                    Ldloc(runtextend);
+                                    Ldloc(end);
                                     Bgt(returnFalse);
 
-                                    // runtextpos = newlinePos + runtextpos + 1;
+                                    // pos += newlinePos + 1;
+                                    Ldloc(pos);
                                     Ldloc(newlinePos);
-                                    Ldloc(runtextpos);
                                     Add();
                                     Ldc(1);
                                     Add();
-                                    Stloc(runtextpos);
+                                    Stloc(pos);
                                 }
 
                                 MarkLabel(atBeginningOfLine);
@@ -594,11 +594,11 @@ namespace System.Text.RegularExpressions
             {
                 using RentedLocalBuilder i = RentInt32Local();
 
-                // int i = inputSpan.Slice(runtextpos, runtextend - runtextpos).IndexOf(prefix);
+                // int i = inputSpan.Slice(pos, end - pos).IndexOf(prefix);
                 Ldloca(inputSpan);
-                Ldloc(runtextpos);
-                Ldloc(runtextend);
-                Ldloc(runtextpos);
+                Ldloc(pos);
+                Ldloc(end);
+                Ldloc(pos);
                 Sub();
                 Call(s_spanSliceIntIntMethod);
                 Ldstr(prefix);
@@ -611,10 +611,10 @@ namespace System.Text.RegularExpressions
                 Ldc(0);
                 BltFar(returnFalse);
 
-                // base.runtextpos = runtextpos + i;
+                // base.runtextpos = pos + i;
                 // return true;
                 Ldthis();
-                Ldloc(runtextpos);
+                Ldloc(pos);
                 Ldloc(i);
                 Add();
                 Stfld(s_runtextposField);
@@ -632,11 +632,11 @@ namespace System.Text.RegularExpressions
                 using RentedLocalBuilder iLocal = RentInt32Local();
                 using RentedLocalBuilder textSpanLocal = RentReadOnlySpanCharLocal();
 
-                // ReadOnlySpan<char> span = inputSpan.Slice(runtextpos, runtextend - runtextpos);
+                // ReadOnlySpan<char> span = inputSpan.Slice(pos, end - pos);
                 Ldloca(inputSpan);
-                Ldloc(runtextpos);
-                Ldloc(runtextend);
-                Ldloc(runtextpos);
+                Ldloc(pos);
+                Ldloc(end);
+                Ldloc(pos);
                 Sub();
                 Call(s_spanSliceIntIntMethod);
                 Stloc(textSpanLocal);
@@ -669,7 +669,7 @@ namespace System.Text.RegularExpressions
 
                     if (needLoop)
                     {
-                        // textSpan.Slice(iLocal + primarySet.Distance);
+                        // slice.Slice(iLocal + primarySet.Distance);
                         Ldloca(textSpanLocal);
                         Ldloc(iLocal);
                         if (primarySet.Distance != 0)
@@ -681,14 +681,14 @@ namespace System.Text.RegularExpressions
                     }
                     else if (primarySet.Distance != 0)
                     {
-                        // textSpan.Slice(primarySet.Distance)
+                        // slice.Slice(primarySet.Distance)
                         Ldloca(textSpanLocal);
                         Ldc(primarySet.Distance);
                         Call(s_spanSliceIntMethod);
                     }
                     else
                     {
-                        // textSpan
+                        // slice
                         Ldloc(textSpanLocal);
                     }
 
@@ -748,7 +748,7 @@ namespace System.Text.RegularExpressions
                         BltFar(returnFalse);
                     }
 
-                    // if (i >= textSpan.Length - (minRequiredLength - 1)) goto returnFalse;
+                    // if (i >= slice.Length - (minRequiredLength - 1)) goto returnFalse;
                     if (sets.Count > 1)
                     {
                         Debug.Assert(needLoop);
@@ -761,9 +761,9 @@ namespace System.Text.RegularExpressions
                     }
                 }
 
-                // if (!CharInClass(textSpan[i], prefix[0], "...")) continue;
-                // if (!CharInClass(textSpan[i + 1], prefix[1], "...")) continue;
-                // if (!CharInClass(textSpan[i + 2], prefix[2], "...")) continue;
+                // if (!CharInClass(slice[i], prefix[0], "...")) continue;
+                // if (!CharInClass(slice[i + 1], prefix[1], "...")) continue;
+                // if (!CharInClass(slice[i + 2], prefix[2], "...")) continue;
                 // ...
                 Debug.Assert(setIndex == 0 || setIndex == 1);
                 for ( ; setIndex < sets.Count; setIndex++)
@@ -782,10 +782,10 @@ namespace System.Text.RegularExpressions
                     BrfalseFar(charNotInClassLabel);
                 }
 
-                // this.runtextpos = runtextpos + i;
+                // base.runtextpos = pos + i;
                 // return true;
                 Ldthis();
-                Ldloc(runtextpos);
+                Ldloc(pos);
                 Ldloc(iLocal);
                 Add();
                 Stfld(s_runtextposField);
@@ -814,7 +814,7 @@ namespace System.Text.RegularExpressions
                     }
                     BltFar(loopBody);
 
-                    // runtextpos = runtextend;
+                    // base.runtextpos = end;
                     // return false;
                     BrFar(returnFalse);
                 }
@@ -887,11 +887,11 @@ namespace System.Text.RegularExpressions
             }
 
             // Initialize the main locals used throughout the implementation.
-            LocalBuilder runtextSpanLocal = DeclareReadOnlySpanChar();
-            LocalBuilder originalruntextposLocal = DeclareInt32();
-            LocalBuilder runtextposLocal = DeclareInt32();
-            LocalBuilder textSpanLocal = DeclareReadOnlySpanChar();
-            LocalBuilder runtextendLocal = DeclareInt32();
+            LocalBuilder inputSpan = DeclareReadOnlySpanChar();
+            LocalBuilder originalPos = DeclareInt32();
+            LocalBuilder pos = DeclareInt32();
+            LocalBuilder slice = DeclareReadOnlySpanChar();
+            LocalBuilder end = DeclareInt32();
             Label stopSuccessLabel = DefineLabel();
             Label doneLabel = DefineLabel();
             Label originalDoneLabel = doneLabel;
@@ -903,63 +903,63 @@ namespace System.Text.RegularExpressions
             // CultureInfo culture = CultureInfo.CurrentCulture; // only if the whole expression or any subportion is ignoring case, and we're not using invariant
             InitializeCultureForGoIfNecessary();
 
-            // ReadOnlySpan<char> inputSpan = this.runtext.AsSpan();
-            // int runtextend = this.runtextend;
+            // ReadOnlySpan<char> inputSpan = base.runtext.AsSpan();
+            // int end = base.runtextend;
             Ldthisfld(s_runtextField);
             Call(s_stringAsSpanMethod);
-            Stloc(runtextSpanLocal);
-            Mvfldloc(s_runtextendField, runtextendLocal);
+            Stloc(inputSpan);
+            Mvfldloc(s_runtextendField, end);
 
-            // int runtextpos = this.runtextpos;
-            // int originalruntextpos = this.runtextpos;
+            // int pos = base.runtextpos;
+            // int originalpos = pos;
             Ldthisfld(s_runtextposField);
-            Stloc(runtextposLocal);
-            Ldloc(runtextposLocal);
-            Stloc(originalruntextposLocal);
+            Stloc(pos);
+            Ldloc(pos);
+            Stloc(originalPos);
 
-            // int runstackpos = 0;
-            LocalBuilder runstackpos = DeclareInt32();
+            // int stackpos = 0;
+            LocalBuilder stackpos = DeclareInt32();
             Ldc(0);
-            Stloc(runstackpos);
+            Stloc(stackpos);
 
             // The implementation tries to use const indexes into the span wherever possible, which we can do
-            // in all places except for variable-length loops.  For everything else, we know at any point in
-            // the regex exactly how far into it we are, and we can use that to index into the span created
-            // at the beginning of the routine to begin at exactly where we're starting in the input.  For
-            // variable-length loops, we index at this textSpanPos + i, and then after the loop we slice the input
-            // by i so that this position is still accurate for everything after it.
-            int textSpanPos = 0;
-            LoadTextSpanLocal();
+            // for all fixed-length constructs.  In such cases (e.g. single chars, repeaters, strings, etc.)
+            // we know at any point in the regex exactly how far into it we are, and we can use that to index
+            // into the span created at the beginning of the routine to begin at exactly where we're starting
+            // in the input.  When we encounter a variable-length construct, we transfer the static value to
+            // pos, slicing the inputSpan appropriately, and then zero out the static position.
+            int sliceStaticPos = 0;
+            SliceInputSpan();
 
             // Emit the code for all nodes in the tree.
             bool expressionHasCaptures = (node.Options & RegexNode.HasCapturesFlag) != 0;
             EmitNode(node);
 
             // Success:
-            // runtextpos += textSpanPos;
-            // this.runtextpos = runtextpos;
-            // Capture(0, originalruntextpos, runtextpos);
+            // pos += sliceStaticPos;
+            // base.runtextpos = pos;
+            // Capture(0, originalpos, pos);
             MarkLabel(stopSuccessLabel);
             Ldthis();
-            Ldloc(runtextposLocal);
-            if (textSpanPos > 0)
+            Ldloc(pos);
+            if (sliceStaticPos > 0)
             {
-                Ldc(textSpanPos);
+                Ldc(sliceStaticPos);
                 Add();
-                Stloc(runtextposLocal);
-                Ldloc(runtextposLocal);
+                Stloc(pos);
+                Ldloc(pos);
             }
             Stfld(s_runtextposField);
             Ldthis();
             Ldc(0);
-            Ldloc(originalruntextposLocal);
-            Ldloc(runtextposLocal);
+            Ldloc(originalPos);
+            Ldloc(pos);
             Call(s_captureMethod);
 
             // If the graph contained captures, undo any remaining to handle failed matches.
             if (expressionHasCaptures)
             {
-                // while (Crawlpos() != 0) Uncapture();
+                // while (base.Crawlpos() != 0) base.Uncapture();
 
                 Label finalReturnLabel = DefineLabel();
                 Br(finalReturnLabel);
@@ -993,17 +993,17 @@ namespace System.Text.RegularExpressions
 
             static bool IsCaseInsensitive(RegexNode node) => (node.Options & RegexOptions.IgnoreCase) != 0;
 
-            // Creates a span for runtext starting at runtextpos until this.runtextend.
-            void LoadTextSpanLocal()
+            // Slices the inputSpan starting at pos until end and stores it into slice.
+            void SliceInputSpan()
             {
-                // textSpan = inputSpan.Slice(runtextpos, this.runtextend - runtextpos);
-                Ldloca(runtextSpanLocal);
-                Ldloc(runtextposLocal);
-                Ldloc(runtextendLocal);
-                Ldloc(runtextposLocal);
+                // slice = inputSpan.Slice(pos, end - pos);
+                Ldloca(inputSpan);
+                Ldloc(pos);
+                Ldloc(end);
+                Ldloc(pos);
                 Sub();
                 Call(s_spanSliceIntIntMethod);
-                Stloc(textSpanLocal);
+                Stloc(slice);
             }
 
             // Emits the sum of a constant and a value from a local.
@@ -1028,46 +1028,46 @@ namespace System.Text.RegularExpressions
             // Emits a check that the span is large enough at the currently known static position to handle the required additional length.
             void EmitSpanLengthCheck(int requiredLength, LocalBuilder? dynamicRequiredLength = null)
             {
-                // if ((uint)(textSpanPos + requiredLength + dynamicRequiredLength - 1) >= (uint)textSpan.Length) goto Done;
+                // if ((uint)(sliceStaticPos + requiredLength + dynamicRequiredLength - 1) >= (uint)slice.Length) goto Done;
                 Debug.Assert(requiredLength > 0);
-                EmitSum(textSpanPos + requiredLength - 1, dynamicRequiredLength);
-                Ldloca(textSpanLocal);
+                EmitSum(sliceStaticPos + requiredLength - 1, dynamicRequiredLength);
+                Ldloca(slice);
                 Call(s_spanGetLengthMethod);
                 BgeUnFar(doneLabel);
             }
 
-            // Emits code to get ref textSpan[textSpanPos]
+            // Emits code to get ref slice[sliceStaticPos]
             void EmitTextSpanOffset()
             {
-                Ldloc(textSpanLocal);
+                Ldloc(slice);
                 Call(s_memoryMarshalGetReference);
-                if (textSpanPos > 0)
+                if (sliceStaticPos > 0)
                 {
-                    Ldc(textSpanPos * sizeof(char));
+                    Ldc(sliceStaticPos * sizeof(char));
                     Add();
                 }
             }
 
-            // Adds the value of textSpanPos into the runtextpos local, slices textspan by the corresponding amount,
-            // and zeros out textSpanPos.
-            void TransferTextSpanPosToRunTextPos()
+            // Adds the value of sliceStaticPos into the pos local, slices textspan by the corresponding amount,
+            // and zeros out sliceStaticPos.
+            void TransferSliceStaticPosToPos()
             {
-                if (textSpanPos > 0)
+                if (sliceStaticPos > 0)
                 {
-                    // runtextpos += textSpanPos;
-                    Ldloc(runtextposLocal);
-                    Ldc(textSpanPos);
+                    // pos += sliceStaticPos;
+                    Ldloc(pos);
+                    Ldc(sliceStaticPos);
                     Add();
-                    Stloc(runtextposLocal);
+                    Stloc(pos);
 
-                    // textSpan = textSpan.Slice(textSpanPos);
-                    Ldloca(textSpanLocal);
-                    Ldc(textSpanPos);
+                    // slice = slice.Slice(sliceStaticPos);
+                    Ldloca(slice);
+                    Ldc(sliceStaticPos);
                     Call(s_spanSliceIntMethod);
-                    Stloc(textSpanLocal);
+                    Stloc(slice);
 
-                    // textSpanPos = 0;
-                    textSpanPos = 0;
+                    // sliceStaticPos = 0;
+                    sliceStaticPos = 0;
                 }
             }
 
@@ -1088,12 +1088,12 @@ namespace System.Text.RegularExpressions
                 // Label to jump to when any branch completes successfully.
                 Label matchLabel = DefineLabel();
 
-                // Save off runtextpos.  We'll need to reset this each time a branch fails.
-                // startingRunTextPos = runtextpos;
-                LocalBuilder startingRunTextPos = DeclareInt32();
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
-                int startingTextSpanPos = textSpanPos;
+                // Save off pos.  We'll need to reset this each time a branch fails.
+                // startingPos = pos;
+                LocalBuilder startingPos = DeclareInt32();
+                Ldloc(pos);
+                Stloc(startingPos);
+                int startingTextSpanPos = sliceStaticPos;
 
                 // We need to be able to undo captures in two situations:
                 // - If a branch of the alternation itself contains captures, then if that branch
@@ -1115,14 +1115,14 @@ namespace System.Text.RegularExpressions
                 // of the alternation, which will again dutifully unwind the remaining captures until
                 // what they were at the start of the alternation.  Of course, if there are no captures
                 // anywhere in the regex, we don't have to do any of that.
-                LocalBuilder? startingCrawlpos = null;
+                LocalBuilder? startingCapturePos = null;
                 if (expressionHasCaptures && ((node.Options & RegexNode.HasCapturesFlag) != 0 || !isAtomic))
                 {
-                    // startingCrawlpos = base.Crawlpos();
-                    startingCrawlpos = DeclareInt32();
+                    // startingCapturePos = base.Crawlpos();
+                    startingCapturePos = DeclareInt32();
                     Ldthis();
                     Call(s_crawlposMethod);
-                    Stloc(startingCrawlpos);
+                    Stloc(startingCapturePos);
                 }
 
                 // After executing the alternation, subsequent matching may fail, at which point execution
@@ -1164,48 +1164,48 @@ namespace System.Text.RegularExpressions
                     // still points to the nextBranch, which similarly is where we'll want to jump to.
                     if (!isAtomic)
                     {
-                        // if (runstackpos + 3 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
-                        // base.runstack[runstackpos++] = i;
-                        // base.runstack[runstackpos++] = startingCrawlpos;
-                        // base.runstack[runstackpos++] = startingRunTextPos;
+                        // if (stackpos + 3 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
+                        // base.runstack[stackpos++] = i;
+                        // base.runstack[stackpos++] = startingCapturePos;
+                        // base.runstack[stackpos++] = startingPos;
                         EmitRunstackResizeIfNeeded(3);
                         EmitRunstackPush(() => Ldc(i));
-                        if (startingCrawlpos is not null)
+                        if (startingCapturePos is not null)
                         {
-                            EmitRunstackPush(() => Ldloc(startingCrawlpos));
+                            EmitRunstackPush(() => Ldloc(startingCapturePos));
                         }
-                        EmitRunstackPush(() => Ldloc(startingRunTextPos));
+                        EmitRunstackPush(() => Ldloc(startingPos));
                     }
                     labelMap[i] = doneLabel;
 
                     // If we get here in the generated code, the branch completed successfully.
-                    // Before jumping to the end, we need to zero out textSpanPos, so that no
+                    // Before jumping to the end, we need to zero out sliceStaticPos, so that no
                     // matter what the value is after the branch, whatever follows the alternate
-                    // will see the same textSpanPos.
-                    // runtextpos += textSpanPos;
-                    // textSpanPos = 0;
+                    // will see the same sliceStaticPos.
+                    // pos += sliceStaticPos;
+                    // sliceStaticPos = 0;
                     // goto matchLabel;
-                    TransferTextSpanPosToRunTextPos();
+                    TransferSliceStaticPosToPos();
                     BrFar(matchLabel);
 
                     // Reset state for next branch and loop around to generate it.  This includes
-                    // setting runtextpos back to what it was at the beginning of the alternation,
-                    // updating textSpan to be the full length it was, and if there's a capture that
+                    // setting pos back to what it was at the beginning of the alternation,
+                    // updating slice to be the full length it was, and if there's a capture that
                     // needs to be reset, uncapturing it.
                     if (!isLastBranch)
                     {
                         // NextBranch:
-                        // runtextpos = startingRunTextPos;
-                        // textSpan = runtext.AsSpan(runtextpos, runtextend - runtextpos);
-                        // while (base.Crawlpos() > startingCrawlpos) base.Uncapture();
+                        // pos = startingPos;
+                        // slice = inputSpan.Slice(pos, end - pos);
+                        // while (base.Crawlpos() > startingCapturePos) base.Uncapture();
                         MarkLabel(nextBranch);
-                        Ldloc(startingRunTextPos);
-                        Stloc(runtextposLocal);
-                        LoadTextSpanLocal();
-                        textSpanPos = startingTextSpanPos;
-                        if (startingCrawlpos is not null)
+                        Ldloc(startingPos);
+                        Stloc(pos);
+                        SliceInputSpan();
+                        sliceStaticPos = startingTextSpanPos;
+                        if (startingCapturePos is not null)
                         {
-                            EmitUncaptureUntil(startingCrawlpos);
+                            EmitUncaptureUntil(startingCapturePos);
                         }
                     }
                 }
@@ -1226,15 +1226,15 @@ namespace System.Text.RegularExpressions
                     doneLabel = backtrackLabel;
                     MarkLabel(backtrackLabel);
 
-                    // startingRuntextPos = base.runstack[--runstackpos];
-                    // startingCrawlPos = base.runstack[--runstackpos];
-                    // switch (base.runstack[--runstackpos]) { ... } // branch number
+                    // startingPos = base.runstack[--stackpos];
+                    // startingCapturePos = base.runstack[--stackpos];
+                    // switch (base.runstack[--stackpos]) { ... } // branch number
                     EmitRunstackPop();
-                    Stloc(startingRunTextPos);
-                    if (startingCrawlpos is not null)
+                    Stloc(startingPos);
+                    if (startingCapturePos is not null)
                     {
                         EmitRunstackPop();
-                        Stloc(startingCrawlpos);
+                        Stloc(startingCapturePos);
                     }
                     EmitRunstackPop();
                     Switch(labelMap);
@@ -1242,7 +1242,7 @@ namespace System.Text.RegularExpressions
 
                 // Successfully completed the alternate.
                 MarkLabel(matchLabel);
-                Debug.Assert(textSpanPos == 0);
+                Debug.Assert(sliceStaticPos == 0);
             }
 
             // Emits the code to handle a backreference.
@@ -1250,15 +1250,15 @@ namespace System.Text.RegularExpressions
             {
                 int capnum = RegexParser.MapCaptureNumber(node.M, _code!.Caps);
 
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
 
-                Label end = DefineLabel();
+                Label backreferenceEnd = DefineLabel();
 
-                // if (!base.IsMatched(capnum)) goto (!ecmascript ? doneLabel : end);
+                // if (!base.IsMatched(capnum)) goto (ecmascript ? end : doneLabel);
                 Ldthis();
                 Ldc(capnum);
                 Call(s_isMatchedMethod);
-                BrfalseFar((node.Options & RegexOptions.ECMAScript) == 0 ? doneLabel : end);
+                BrfalseFar((node.Options & RegexOptions.ECMAScript) == 0 ? doneLabel : backreferenceEnd);
 
                 using RentedLocalBuilder matchLength = RentInt32Local();
                 using RentedLocalBuilder matchIndex = RentInt32Local();
@@ -1270,8 +1270,8 @@ namespace System.Text.RegularExpressions
                 Call(s_matchLengthMethod);
                 Stloc(matchLength);
 
-                // if (textSpan.Length < matchLength) goto doneLabel;
-                Ldloca(textSpanLocal);
+                // if (slice.Length < matchLength) goto doneLabel;
+                Ldloca(slice);
                 Call(s_spanGetLengthMethod);
                 Ldloc(matchLength);
                 BltFar(doneLabel);
@@ -1292,8 +1292,8 @@ namespace System.Text.RegularExpressions
 
                 MarkLabel(body);
 
-                // if (inputSpan[matchIndex + i] != textSpan[i]) goto doneLabel;
-                Ldloca(runtextSpanLocal);
+                // if (inputSpan[matchIndex + i] != slice[i]) goto doneLabel;
+                Ldloca(inputSpan);
                 Ldloc(matchIndex);
                 Ldloc(i);
                 Add();
@@ -1303,7 +1303,7 @@ namespace System.Text.RegularExpressions
                 {
                     CallToLower();
                 }
-                Ldloca(textSpanLocal);
+                Ldloca(slice);
                 Ldloc(i);
                 Call(s_spanGetItemMethod);
                 LdindU2();
@@ -1325,14 +1325,14 @@ namespace System.Text.RegularExpressions
                 Ldloc(matchLength);
                 Blt(body);
 
-                // runtextpos += matchLength;
-                Ldloc(runtextposLocal);
+                // pos += matchLength;
+                Ldloc(pos);
                 Ldloc(matchLength);
                 Add();
-                Stloc(runtextposLocal);
-                LoadTextSpanLocal();
+                Stloc(pos);
+                SliceInputSpan();
 
-                MarkLabel(end);
+                MarkLabel(backreferenceEnd);
             }
 
             // Emits the code for an if(backreference)-then-else conditional.
@@ -1340,14 +1340,14 @@ namespace System.Text.RegularExpressions
             {
                 bool isAtomic = node.IsAtomicByParent();
 
-                // We're branching in a complicated fashion.  Make sure textSpanPos is 0.
-                TransferTextSpanPosToRunTextPos();
+                // We're branching in a complicated fashion.  Make sure sliceStaticPos is 0.
+                TransferSliceStaticPosToPos();
 
                 // Get the capture number to test.
                 int capnum = RegexParser.MapCaptureNumber(node.M, _code!.Caps);
 
                 Label originalDoneLabel = doneLabel;
-                Label endRef = DefineLabel();
+                Label backreferenceConditionalEnd = DefineLabel();
                 bool hasNo = node.ChildCount() > 1 && node.Child(1).Type != RegexNode.Empty;
 
                 // As with alternations, we have potentially multiple branches, each of which may contain
@@ -1366,7 +1366,7 @@ namespace System.Text.RegularExpressions
                 // The specified capture was captured.  Run the "yes" branch.
                 // If it successfully matches, jump to the end.
                 EmitNode(node.Child(0));
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
                 Label postIfDoneLabel = doneLabel;
                 if (postIfDoneLabel != originalDoneLabel)
                 {
@@ -1377,7 +1377,7 @@ namespace System.Text.RegularExpressions
                 if (postIfDoneLabel != originalDoneLabel || hasNo)
                 {
                     // goto endRef;
-                    BrFar(endRef);
+                    BrFar(backreferenceConditionalEnd);
                 }
 
                 MarkLabel(refNotMatched);
@@ -1388,7 +1388,7 @@ namespace System.Text.RegularExpressions
                     // Output the no branch.
                     doneLabel = originalDoneLabel;
                     EmitNode(node.Child(1));
-                    TransferTextSpanPosToRunTextPos(); // make sure textSpanPos is 0 after each branch
+                    TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                     postElseDoneLabel = doneLabel;
                     if (postElseDoneLabel != originalDoneLabel)
                     {
@@ -1422,13 +1422,13 @@ namespace System.Text.RegularExpressions
                     {
                         // Skip the backtracking section
                         // goto endRef;
-                        Br(endRef);
+                        Br(backreferenceConditionalEnd);
 
                         Label backtrack = DefineLabel();
                         doneLabel = backtrack;
                         MarkLabel(backtrack);
 
-                        // resumeAt = base.runstack[--runstackpos];
+                        // resumeAt = base.runstack[--stackpos];
                         EmitRunstackPop();
                         Stloc(resumeAt);
 
@@ -1455,11 +1455,11 @@ namespace System.Text.RegularExpressions
 
                 if (postIfDoneLabel != originalDoneLabel || hasNo)
                 {
-                    MarkLabel(endRef);
+                    MarkLabel(backreferenceConditionalEnd);
                     if (!isAtomic && (postIfDoneLabel != originalDoneLabel || postElseDoneLabel != originalDoneLabel))
                     {
-                        // if (runstackpos + 1 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
-                        // base.runstack[runstackpos++] = resumeAt;
+                        // if (stackpos + 1 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
+                        // base.runstack[stackpos++] = resumeAt;
                         EmitRunstackResizeIfNeeded(1);
                         EmitRunstackPush(() => Ldloc(resumeAt));
                     }
@@ -1471,8 +1471,8 @@ namespace System.Text.RegularExpressions
             {
                 bool isAtomic = node.IsAtomicByParent();
 
-                // We're branching in a complicated fashion.  Make sure textSpanPos is 0.
-                TransferTextSpanPosToRunTextPos();
+                // We're branching in a complicated fashion.  Make sure sliceStaticPos is 0.
+                TransferSliceStaticPosToPos();
 
                 // The first child node is the conditional expression.  If this matches, then we branch to the "yes" branch.
                 // If it doesn't match, then we branch to the optional "no" branch if it exists, or simply skip the "yes"
@@ -1490,24 +1490,24 @@ namespace System.Text.RegularExpressions
                 RegexNode yesBranch = node.Child(1);
                 RegexNode? noBranch = node.ChildCount() > 2 && node.Child(2) is { Type: not RegexNode.Empty } childNo ? childNo : null;
 
-                Label end = DefineLabel();
+                Label expressionConditionalEnd = DefineLabel();
                 Label no = DefineLabel();
 
                 // If the conditional expression has captures, we'll need to uncapture them in the case of no match.
-                LocalBuilder? startingCrawlPos = null;
+                LocalBuilder? startingCapturePos = null;
                 if ((conditional.Options & RegexNode.HasCapturesFlag) != 0)
                 {
-                    // int startingCrawlPos = base.Crawlpos();
-                    startingCrawlPos = DeclareInt32();
+                    // int startingCapturePos = base.Crawlpos();
+                    startingCapturePos = DeclareInt32();
                     Ldthis();
                     Call(s_crawlposMethod);
-                    Stloc(startingCrawlPos);
+                    Stloc(startingCapturePos);
                 }
 
                 // Emit the conditional expression.  We need to reroute any match failures to either the "no" branch
                 // if it exists, or to the end of the node (skipping the "yes" branch) if it doesn't.
                 Label originalDoneLabel = doneLabel;
-                Label tmpDoneLabel = noBranch is not null ? no : end;
+                Label tmpDoneLabel = noBranch is not null ? no : expressionConditionalEnd;
                 doneLabel = tmpDoneLabel;
                 EmitPositiveLookaheadAssertion(conditional);
                 if (doneLabel == tmpDoneLabel)
@@ -1520,11 +1520,11 @@ namespace System.Text.RegularExpressions
 
                 // If we get to this point of the code, the conditional successfully matched, so run the "yes" branch.
                 // Since the "yes" branch may have a different execution path than the "no" branch or the lack of
-                // any branch, we need to store the current textSpanPosition and reset it prior to emitting the code
+                // any branch, we need to store the current sliceStaticPos and reset it prior to emitting the code
                 // for what comes after the "yes" branch, so that everyone is on equal footing.
-                int startingTextSpanPos = textSpanPos;
+                int startingTextSpanPos = sliceStaticPos;
                 EmitNode(yesBranch);
-                TransferTextSpanPosToRunTextPos(); // ensure all subsequent code sees the same textSpanPos value by setting it to 0
+                TransferSliceStaticPosToPos(); // ensure all subsequent code sees the same sliceStaticPos value by setting it to 0
                 Label postYesDoneLabel = doneLabel;
                 if (resumeAt is not null && postYesDoneLabel != originalDoneLabel)
                 {
@@ -1535,7 +1535,7 @@ namespace System.Text.RegularExpressions
                 if (postYesDoneLabel != originalDoneLabel || noBranch is not null)
                 {
                     // goto end;
-                    BrFar(end);
+                    BrFar(expressionConditionalEnd);
                 }
 
                 // If there's a no branch, we need to emit it, but skipping it from a successful "yes" branch match.
@@ -1545,21 +1545,21 @@ namespace System.Text.RegularExpressions
                     // Emit the no branch, first uncapturing any captures from the expression condition that failed
                     // to match and emit the branch.
                     MarkLabel(no);
-                    if (startingCrawlPos is not null)
+                    if (startingCapturePos is not null)
                     {
-                        // while (base.Crawlpos() > startingCrawlPos) base.Uncapture();
-                        EmitUncaptureUntil(startingCrawlPos);
+                        // while (base.Crawlpos() > startingCapturePos) base.Uncapture();
+                        EmitUncaptureUntil(startingCapturePos);
                     }
 
                     doneLabel = postConditionalDoneLabel;
-                    textSpanPos = startingTextSpanPos;
+                    sliceStaticPos = startingTextSpanPos;
                     EmitNode(noBranch);
-                    TransferTextSpanPosToRunTextPos(); // ensure all subsequent code sees the same textSpanPos value by setting it to 0
+                    TransferSliceStaticPosToPos(); // ensure all subsequent code sees the same sliceStaticPos value by setting it to 0
                     postNoDoneLabel = doneLabel;
                     if (postNoDoneLabel != originalDoneLabel)
                     {
                         // goto end;
-                        BrFar(end);
+                        BrFar(expressionConditionalEnd);
                     }
                 }
                 else
@@ -1585,7 +1585,7 @@ namespace System.Text.RegularExpressions
                     if (postYesDoneLabel != postConditionalDoneLabel || postNoDoneLabel != postConditionalDoneLabel)
                     {
                         // Skip the backtracking section.
-                        BrFar(end);
+                        BrFar(expressionConditionalEnd);
 
                         Label backtrack = DefineLabel();
                         doneLabel = backtrack;
@@ -1613,14 +1613,14 @@ namespace System.Text.RegularExpressions
 
                     if (postYesDoneLabel != originalDoneLabel || postNoDoneLabel != originalDoneLabel)
                     {
-                        // if (runstackpos + 1 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
-                        // base.runstack[runstackpos++] = resumeAt;
+                        // if (stackpos + 1 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
+                        // base.runstack[stackpos++] = resumeAt;
                         EmitRunstackResizeIfNeeded(1);
                         EmitRunstackPush(() => Ldloc(resumeAt));
                     }
                 }
 
-                MarkLabel(end);
+                MarkLabel(expressionConditionalEnd);
             }
 
             // Emits the code for a Capture node.
@@ -1631,13 +1631,13 @@ namespace System.Text.RegularExpressions
                 int uncapnum = RegexParser.MapCaptureNumber(node.N, _code.Caps);
                 bool isAtomic = node.IsAtomicByParent();
 
-                // runtextpos += textSpanPos;
-                // textSpan = textSpan.Slice(textSpanPos);
-                // startingRunTextPos = runtextpos;
-                TransferTextSpanPosToRunTextPos();
-                LocalBuilder startingRunTextPos = DeclareInt32();
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
+                // pos += sliceStaticPos;
+                // slice = slice.Slice(sliceStaticPos);
+                // startingPos = pos;
+                TransferSliceStaticPosToPos();
+                LocalBuilder startingPos = DeclareInt32();
+                Ldloc(pos);
+                Stloc(startingPos);
 
                 RegexNode child = node.Child(0);
 
@@ -1656,60 +1656,60 @@ namespace System.Text.RegularExpressions
                 EmitNode(child, subsequent);
                 bool childBacktracks = doneLabel != originalDoneLabel;
 
-                // runtextpos += textSpanPos;
-                // textSpan = textSpan.Slice(textSpanPos);
-                TransferTextSpanPosToRunTextPos();
+                // pos += sliceStaticPos;
+                // slice = slice.Slice(sliceStaticPos);
+                TransferSliceStaticPosToPos();
 
                 if (uncapnum == -1)
                 {
-                    // Capture(capnum, startingRunTextPos, runtextpos);
+                    // Capture(capnum, startingPos, pos);
                     Ldthis();
                     Ldc(capnum);
-                    Ldloc(startingRunTextPos);
-                    Ldloc(runtextposLocal);
+                    Ldloc(startingPos);
+                    Ldloc(pos);
                     Call(s_captureMethod);
                 }
                 else
                 {
-                    // TransferCapture(capnum, uncapnum, startingRunTextPos, runtextpos);
+                    // TransferCapture(capnum, uncapnum, startingPos, pos);
                     Ldthis();
                     Ldc(capnum);
                     Ldc(uncapnum);
-                    Ldloc(startingRunTextPos);
-                    Ldloc(runtextposLocal);
+                    Ldloc(startingPos);
+                    Ldloc(pos);
                     Call(s_transferCaptureMethod);
                 }
 
                 if (!isAtomic && (childBacktracks || node.IsInLoop()))
                 {
-                    // if (runstackpos + 1 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
-                    // base.runstack[runstackpos++] = startingRunTextPos;
+                    // if (stackpos + 1 >= base.runstack.Length) Array.Resize(ref base.runstack, base.runstack.Length * 2);
+                    // base.runstack[stackpos++] = startingPos;
                     EmitRunstackResizeIfNeeded(1);
-                    EmitRunstackPush(() => Ldloc(startingRunTextPos));
+                    EmitRunstackPush(() => Ldloc(startingPos));
 
                     // Skip past the backtracking section
-                    // goto end;
-                    Label end = DefineLabel();
-                    Br(end);
+                    // goto backtrackingEnd;
+                    Label backtrackingEnd = DefineLabel();
+                    Br(backtrackingEnd);
 
                     // Emit a backtracking section that restores the capture's state and then jumps to the previous done label
                     Label backtrack = DefineLabel();
                     MarkLabel(backtrack);
                     EmitRunstackPop();
-                    Stloc(startingRunTextPos);
+                    Stloc(startingPos);
                     if (!childBacktracks)
                     {
-                        // runtextpos = startingRunTextPos
-                        Ldloc(startingRunTextPos);
-                        Stloc(runtextposLocal);
-                        LoadTextSpanLocal();
+                        // pos = startingPos
+                        Ldloc(startingPos);
+                        Stloc(pos);
+                        SliceInputSpan();
                     }
 
                     // goto doneLabel;
                     BrFar(doneLabel);
 
                     doneLabel = backtrack;
-                    MarkLabel(end);
+                    MarkLabel(backtrackingEnd);
                 }
                 else
                 {
@@ -1718,11 +1718,11 @@ namespace System.Text.RegularExpressions
             }
 
             // Emits code to unwind the capture stack until the crawl position specified in the provided local.
-            void EmitUncaptureUntil(LocalBuilder startingCrawlpos)
+            void EmitUncaptureUntil(LocalBuilder startingCapturePos)
             {
-                Debug.Assert(startingCrawlpos != null);
+                Debug.Assert(startingCapturePos != null);
 
-                // while (Crawlpos() > startingCrawlpos) Uncapture();
+                // while (base.Crawlpos() > startingCapturePos) base.Uncapture();
                 Label condition = DefineLabel();
                 Label body = DefineLabel();
                 Br(condition);
@@ -1734,7 +1734,7 @@ namespace System.Text.RegularExpressions
                 MarkLabel(condition);
                 Ldthis();
                 Call(s_crawlposMethod);
-                Ldloc(startingCrawlpos);
+                Ldloc(startingCapturePos);
                 Bgt(body);
             }
 
@@ -1744,24 +1744,24 @@ namespace System.Text.RegularExpressions
                 // Lookarounds are implicitly atomic.  Store the original done label to reset at the end.
                 Label originalDoneLabel = doneLabel;
 
-                // Save off runtextpos.  We'll need to reset this upon successful completion of the lookahead.
-                // startingRunTextPos = runtextpos;
-                LocalBuilder startingRunTextPos = DeclareInt32();
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
-                int startingTextSpanPos = textSpanPos;
+                // Save off pos.  We'll need to reset this upon successful completion of the lookahead.
+                // startingPos = pos;
+                LocalBuilder startingPos = DeclareInt32();
+                Ldloc(pos);
+                Stloc(startingPos);
+                int startingTextSpanPos = sliceStaticPos;
 
                 // Emit the child.
                 EmitNode(node.Child(0));
 
                 // After the child completes successfully, reset the text positions.
                 // Do not reset captures, which persist beyond the lookahead.
-                // runtextpos = startingRunTextPos;
-                // textSpan = runtext.AsSpan(runtextpos, runtextend - runtextpos);
-                Ldloc(startingRunTextPos);
-                Stloc(runtextposLocal);
-                LoadTextSpanLocal();
-                textSpanPos = startingTextSpanPos;
+                // pos = startingPos;
+                // slice = inputSpan.Slice(pos, end - pos);
+                Ldloc(startingPos);
+                Stloc(pos);
+                SliceInputSpan();
+                sliceStaticPos = startingTextSpanPos;
 
                 doneLabel = originalDoneLabel;
             }
@@ -1772,12 +1772,12 @@ namespace System.Text.RegularExpressions
                 // Lookarounds are implicitly atomic.  Store the original done label to reset at the end.
                 Label originalDoneLabel = doneLabel;
 
-                // Save off runtextpos.  We'll need to reset this upon successful completion of the lookahead.
-                // startingRunTextPos = runtextpos;
-                LocalBuilder startingRunTextPos = DeclareInt32();
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
-                int startingTextSpanPos = textSpanPos;
+                // Save off pos.  We'll need to reset this upon successful completion of the lookahead.
+                // startingPos = pos;
+                LocalBuilder startingPos = DeclareInt32();
+                Ldloc(pos);
+                Stloc(startingPos);
+                int startingTextSpanPos = sliceStaticPos;
 
                 Label negativeLookaheadDoneLabel = DefineLabel();
                 doneLabel = negativeLookaheadDoneLabel;
@@ -1798,11 +1798,11 @@ namespace System.Text.RegularExpressions
                 }
 
                 // After the child completes in failure (success for negative lookahead), reset the text positions.
-                // runtextpos = startingRunTextPos;
-                Ldloc(startingRunTextPos);
-                Stloc(runtextposLocal);
-                LoadTextSpanLocal();
-                textSpanPos = startingTextSpanPos;
+                // pos = startingPos;
+                Ldloc(startingPos);
+                Stloc(pos);
+                SliceInputSpan();
+                sliceStaticPos = startingTextSpanPos;
 
                 doneLabel = originalDoneLabel;
             }
@@ -1935,15 +1935,15 @@ namespace System.Text.RegularExpressions
                 doneLabel = originalDoneLabel;
             }
 
-            // Emits the code to handle updating base.runtextpos to runtextpos in response to
+            // Emits the code to handle updating base.runtextpos to pos in response to
             // an UpdateBumpalong node.  This is used when we want to inform the scan loop that
             // it should bump from this location rather than from the original location.
             void EmitUpdateBumpalong()
             {
-                // base.runtextpos = runtextpos;
-                TransferTextSpanPosToRunTextPos();
+                // base.runtextpos = pos;
+                TransferSliceStaticPosToPos();
                 Ldthis();
-                Ldloc(runtextposLocal);
+                Ldloc(pos);
                 Stfld(s_runtextposField);
             }
 
@@ -1979,13 +1979,13 @@ namespace System.Text.RegularExpressions
                 // to generate the code for a single check, so we check for each "family" (one, notone, set)
                 // rather than only for the specific single character nodes.
 
-                // if ((uint)(textSpanPos + offset) >= textSpan.Length || textSpan[textSpanPos + offset] != ch) goto Done;
+                // if ((uint)(sliceStaticPos + offset) >= slice.Length || slice[sliceStaticPos + offset] != ch) goto Done;
                 if (emitLengthCheck)
                 {
                     EmitSpanLengthCheck(1, offset);
                 }
-                Ldloca(textSpanLocal);
-                EmitSum(textSpanPos, offset);
+                Ldloca(slice);
+                EmitSum(sliceStaticPos, offset);
                 Call(s_spanGetItemMethod);
                 LdindU2();
                 if (node.IsSetFamily)
@@ -2010,22 +2010,22 @@ namespace System.Text.RegularExpressions
                     }
                 }
 
-                textSpanPos++;
+                sliceStaticPos++;
             }
 
             // Emits the code to handle a boundary check on a character.
             void EmitBoundary(RegexNode node)
             {
-                // if (!IsBoundary(runtextpos + textSpanPos, this.runtextbeg, this.runtextend)) goto doneLabel;
+                // if (!IsBoundary(pos + sliceStaticPos, base.runtextbeg, end)) goto doneLabel;
                 Ldthis();
-                Ldloc(runtextposLocal);
-                if (textSpanPos > 0)
+                Ldloc(pos);
+                if (sliceStaticPos > 0)
                 {
-                    Ldc(textSpanPos);
+                    Ldc(sliceStaticPos);
                     Add();
                 }
                 Ldthisfld(s_runtextbegField);
-                Ldloc(runtextendLocal);
+                Ldloc(end);
                 switch (node.Type)
                 {
                     case RegexNode.Boundary:
@@ -2054,12 +2054,12 @@ namespace System.Text.RegularExpressions
             // Emits the code to handle various anchors.
             void EmitAnchors(RegexNode node)
             {
-                Debug.Assert(textSpanPos >= 0);
+                Debug.Assert(sliceStaticPos >= 0);
                 switch (node.Type)
                 {
                     case RegexNode.Beginning:
                     case RegexNode.Start:
-                        if (textSpanPos > 0)
+                        if (sliceStaticPos > 0)
                         {
                             // If we statically know we've already matched part of the regex, there's no way we're at the
                             // beginning or start, as we've already progressed past it.
@@ -2067,19 +2067,19 @@ namespace System.Text.RegularExpressions
                         }
                         else
                         {
-                            // if (runtextpos > this.runtextbeg/start) goto doneLabel;
-                            Ldloc(runtextposLocal);
+                            // if (pos > base.runtextbeg/start) goto doneLabel;
+                            Ldloc(pos);
                             Ldthisfld(node.Type == RegexNode.Beginning ? s_runtextbegField : s_runtextstartField);
                             BneFar(doneLabel);
                         }
                         break;
 
                     case RegexNode.Bol:
-                        if (textSpanPos > 0)
+                        if (sliceStaticPos > 0)
                         {
-                            // if (textSpan[textSpanPos - 1] != '\n') goto doneLabel;
-                            Ldloca(textSpanLocal);
-                            Ldc(textSpanPos - 1);
+                            // if (slice[sliceStaticPos - 1] != '\n') goto doneLabel;
+                            Ldloca(slice);
+                            Ldc(sliceStaticPos - 1);
                             Call(s_spanGetItemMethod);
                             LdindU2();
                             Ldc('\n');
@@ -2087,14 +2087,14 @@ namespace System.Text.RegularExpressions
                         }
                         else
                         {
-                            // We can't use our textSpan in this case, because we'd need to access textSpan[-1], so we access the runtext field directly:
-                            // if (runtextpos > this.runtextbeg && this.runtext[runtextpos - 1] != '\n') goto doneLabel;
+                            // We can't use our slice in this case, because we'd need to access slice[-1], so we access the runtext field directly:
+                            // if (pos > base.runtextbeg && base.runtext[pos - 1] != '\n') goto doneLabel;
                             Label success = DefineLabel();
-                            Ldloc(runtextposLocal);
+                            Ldloc(pos);
                             Ldthisfld(s_runtextbegField);
                             Ble(success);
-                            Ldloca(runtextSpanLocal);
-                            Ldloc(runtextposLocal);
+                            Ldloca(inputSpan);
+                            Ldloc(pos);
                             Ldc(1);
                             Sub();
                             Call(s_spanGetItemMethod);
@@ -2106,17 +2106,17 @@ namespace System.Text.RegularExpressions
                         break;
 
                     case RegexNode.End:
-                        // if (textSpanPos < textSpan.Length) goto doneLabel;
-                        Ldc(textSpanPos);
-                        Ldloca(textSpanLocal);
+                        // if (sliceStaticPos < slice.Length) goto doneLabel;
+                        Ldc(sliceStaticPos);
+                        Ldloca(slice);
                         Call(s_spanGetLengthMethod);
                         BltUnFar(doneLabel);
                         break;
 
                     case RegexNode.EndZ:
-                        // if (textSpanPos < textSpan.Length - 1) goto doneLabel;
-                        Ldc(textSpanPos);
-                        Ldloca(textSpanLocal);
+                        // if (sliceStaticPos < slice.Length - 1) goto doneLabel;
+                        Ldc(sliceStaticPos);
+                        Ldloca(slice);
                         Call(s_spanGetLengthMethod);
                         Ldc(1);
                         Sub();
@@ -2124,15 +2124,15 @@ namespace System.Text.RegularExpressions
                         goto case RegexNode.Eol;
 
                     case RegexNode.Eol:
-                        // if (textSpanPos < textSpan.Length && textSpan[textSpanPos] != '\n') goto doneLabel;
+                        // if (sliceStaticPos < slice.Length && slice[sliceStaticPos] != '\n') goto doneLabel;
                         {
                             Label success = DefineLabel();
-                            Ldc(textSpanPos);
-                            Ldloca(textSpanLocal);
+                            Ldc(sliceStaticPos);
+                            Ldloca(slice);
                             Call(s_spanGetLengthMethod);
                             BgeUn(success);
-                            Ldloca(textSpanLocal);
-                            Ldc(textSpanPos);
+                            Ldloca(slice);
+                            Ldc(sliceStaticPos);
                             Call(s_spanGetItemMethod);
                             LdindU2();
                             Ldc('\n');
@@ -2161,20 +2161,20 @@ namespace System.Text.RegularExpressions
                 if (!caseInsensitive && // StartsWith(..., XxIgnoreCase) won't necessarily be the same as char-by-char comparison
                     node.Str!.Length > MaxUnrollLength)
                 {
-                    // if (!textSpan.Slice(textSpanPos).StartsWith("...") goto doneLabel;
-                    Ldloca(textSpanLocal);
-                    Ldc(textSpanPos);
+                    // if (!slice.Slice(sliceStaticPos).StartsWith("...") goto doneLabel;
+                    Ldloca(slice);
+                    Ldc(sliceStaticPos);
                     Call(s_spanSliceIntMethod);
                     Ldstr(node.Str);
                     Call(s_stringAsSpanMethod);
                     Call(s_spanStartsWith);
                     BrfalseFar(doneLabel);
-                    textSpanPos += node.Str.Length;
+                    sliceStaticPos += node.Str.Length;
                     return;
                 }
 
                 // Emit the length check for the whole string.  If the generated code gets past this point,
-                // we know the span is at least textSpanPos + s.Length long.
+                // we know the span is at least sliceStaticPos + s.Length long.
                 ReadOnlySpan<char> s = node.Str;
                 if (emitLengthCheck)
                 {
@@ -2196,13 +2196,13 @@ namespace System.Text.RegularExpressions
                         const int CharsPerInt64 = 4;
                         while (s.Length >= CharsPerInt64)
                         {
-                            // if (Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetReference(textSpan), textSpanPos)) != value) goto doneLabel;
+                            // if (Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref MemoryMarshal.GetReference(slice), sliceStaticPos)) != value) goto doneLabel;
                             EmitTextSpanOffset();
                             Unaligned(1);
                             LdindI8();
                             LdcI8(MemoryMarshal.Read<long>(MemoryMarshal.AsBytes(s)));
                             BneFar(doneLabel);
-                            textSpanPos += CharsPerInt64;
+                            sliceStaticPos += CharsPerInt64;
                             s = s.Slice(CharsPerInt64);
                         }
                     }
@@ -2211,13 +2211,13 @@ namespace System.Text.RegularExpressions
                     const int CharsPerInt32 = 2;
                     while (s.Length >= CharsPerInt32)
                     {
-                        // if (Unsafe.ReadUnaligned<int>(ref Unsafe.Add(ref MemoryMarshal.GetReference(textSpan), textSpanPos)) != value) goto doneLabel;
+                        // if (Unsafe.ReadUnaligned<int>(ref Unsafe.Add(ref MemoryMarshal.GetReference(slice), sliceStaticPos)) != value) goto doneLabel;
                         EmitTextSpanOffset();
                         Unaligned(1);
                         LdindI4();
                         Ldc(MemoryMarshal.Read<int>(MemoryMarshal.AsBytes(s)));
                         BneFar(doneLabel);
-                        textSpanPos += CharsPerInt32;
+                        sliceStaticPos += CharsPerInt32;
                         s = s.Slice(CharsPerInt32);
                     }
                 }
@@ -2225,9 +2225,9 @@ namespace System.Text.RegularExpressions
                 // Finally, process all of the remaining characters one by one.
                 for (int i = 0; i < s.Length; i++)
                 {
-                    // if (s[i] != textSpan[textSpanPos++]) goto doneLabel;
+                    // if (s[i] != slice[sliceStaticPos++]) goto doneLabel;
                     EmitTextSpanOffset();
-                    textSpanPos++;
+                    sliceStaticPos++;
                     LdindU2();
                     if (caseInsensitive)
                     {
@@ -2257,10 +2257,10 @@ namespace System.Text.RegularExpressions
                 Label endLoop = DefineLabel();
                 LocalBuilder startingPos = DeclareInt32();
                 LocalBuilder endingPos = DeclareInt32();
-                LocalBuilder? crawlPos = expressionHasCaptures ? DeclareInt32() : null;
+                LocalBuilder? capturepos = expressionHasCaptures ? DeclareInt32() : null;
 
                 // We're about to enter a loop, so ensure our text position is 0.
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
 
                 // Grab the current position, then emit the loop as atomic, and then
                 // grab the current position again.  Even though we emit the loop without
@@ -2268,24 +2268,24 @@ namespace System.Text.RegularExpressions
                 // through the individual characters (a benefit of the loop matching exactly
                 // one character per iteration, no possible captures within the loop, etc.)
 
-                // int startingPos = runtextpos;
-                Ldloc(runtextposLocal);
+                // int startingPos = pos;
+                Ldloc(pos);
                 Stloc(startingPos);
 
                 EmitSingleCharAtomicLoop(node);
 
-                // runtextpos += textSpanPos;
-                // int endingPos = runtextpos;
-                TransferTextSpanPosToRunTextPos();
-                Ldloc(runtextposLocal);
+                // pos += sliceStaticPos;
+                // int endingPos = pos;
+                TransferSliceStaticPosToPos();
+                Ldloc(pos);
                 Stloc(endingPos);
 
-                // int crawlPos = base.Crawlpos();
-                if (crawlPos is not null)
+                // int capturepos = base.Crawlpos();
+                if (capturepos is not null)
                 {
                     Ldthis();
                     Call(s_crawlposMethod);
-                    Stloc(crawlPos!);
+                    Stloc(capturepos);
                 }
 
                 // startingPos += node.M;
@@ -2305,17 +2305,17 @@ namespace System.Text.RegularExpressions
                 // required, and try again by flowing to everything that comes after this.
 
                 MarkLabel(backtrackingLabel);
-                if (crawlPos is not null)
+                if (capturepos is not null)
                 {
-                    // crawlPos = base.runstack[--runstackpos];
-                    // while (base.Crawlpos() > crawlpos) base.Uncapture();
+                    // capturepos = base.runstack[--stackpos];
+                    // while (base.Crawlpos() > capturepos) base.Uncapture();
                     EmitRunstackPop();
-                    Stloc(crawlPos);
-                    EmitUncaptureUntil(crawlPos);
+                    Stloc(capturepos);
+                    EmitUncaptureUntil(capturepos);
                 }
 
-                // endingPos = base.runstack[--runstackpos];
-                // startingPos = base.runstack[--runstackpos];
+                // endingPos = base.runstack[--stackpos];
+                // startingPos = base.runstack[--stackpos];
                 EmitRunstackPop();
                 Stloc(endingPos);
                 EmitRunstackPop();
@@ -2335,7 +2335,7 @@ namespace System.Text.RegularExpressions
                     // {
                     //     goto originalDoneLabel;
                     // }
-                    Ldloca(runtextSpanLocal);
+                    Ldloca(inputSpan);
                     Ldloc(startingPos);
                     Ldloc(endingPos);
                     Ldloc(startingPos);
@@ -2363,20 +2363,20 @@ namespace System.Text.RegularExpressions
                     Stloc(endingPos);
                 }
 
-                // runtextpos = endingPos;
+                // pos = endingPos;
                 Ldloc(endingPos);
-                Stloc(runtextposLocal);
+                Stloc(pos);
 
-                // textspan = runtext.AsSpan(runtextpos, runtextend - runtextpos);
-                LoadTextSpanLocal();
+                // slice = inputSpan.Slice(pos, end - pos);
+                SliceInputSpan();
 
                 MarkLabel(endLoop);
                 EmitRunstackResizeIfNeeded(expressionHasCaptures ? 3 : 2);
                 EmitRunstackPush(() => Ldloc(startingPos));
                 EmitRunstackPush(() => Ldloc(endingPos));
-                if (crawlPos is not null)
+                if (capturepos is not null)
                 {
-                    EmitRunstackPush(() => Ldloc(crawlPos!));
+                    EmitRunstackPush(() => Ldloc(capturepos!));
                 }
             }
 
@@ -2403,7 +2403,7 @@ namespace System.Text.RegularExpressions
                 // to try to match, and only matching another character if the subsequent expression fails to match.
 
                 // We're about to enter a loop, so ensure our text position is 0.
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
 
                 // If the loop isn't unbounded, track the number of iterations and the max number to allow.
                 LocalBuilder? iterationCount = null;
@@ -2419,14 +2419,14 @@ namespace System.Text.RegularExpressions
                 }
 
                 // Track the current crawl position.  Upon backtracking, we'll unwind any captures beyond this point.
-                LocalBuilder? crawlPos = expressionHasCaptures ? DeclareInt32() : null;
+                LocalBuilder? capturepos = expressionHasCaptures ? DeclareInt32() : null;
 
-                // Track the current runtextpos.  Each time we backtrack, we'll reset to the stored position, which
+                // Track the current pos.  Each time we backtrack, we'll reset to the stored position, which
                 // is also incremented each time we match another character in the loop.
-                // int startingRunTextPos = runtextpos;
-                LocalBuilder startingRunTextPos = DeclareInt32();
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
+                // int startingPos = pos;
+                LocalBuilder startingPos = DeclareInt32();
+                Ldloc(pos);
+                Stloc(startingPos);
 
                 // Skip the backtracking section for the initial subsequent matching.  We've already matched the
                 // minimum number of iterations, which means we can successfully match with zero additional iterations.
@@ -2440,10 +2440,10 @@ namespace System.Text.RegularExpressions
 
                 // Uncapture any captures if the expression has any.  It's possible the captures it has
                 // are before this node, in which case this is wasted effort, but still functionally correct.
-                if (crawlPos is not null)
+                if (capturepos is not null)
                 {
-                    // while (base.Crawlpos() > crawlPos) base.Uncapture();
-                    EmitUncaptureUntil(crawlPos);
+                    // while (base.Crawlpos() > capturepos) base.Uncapture();
+                    EmitUncaptureUntil(capturepos);
                 }
 
                 // If there's a max number of iterations, see if we've exceeded the maximum number of characters
@@ -2462,22 +2462,22 @@ namespace System.Text.RegularExpressions
                     Stloc(iterationCount!);
                 }
 
-                // Now match the next item in the lazy loop.  We need to reset the runtextpos to the position
+                // Now match the next item in the lazy loop.  We need to reset the pos to the position
                 // just after the last character in this loop was matched, and we need to store the resulting position
                 // for the next time we backtrack.
 
-                // runtextpos = startingRunTextPos;
-                Ldloc(startingRunTextPos);
-                Stloc(runtextposLocal);
-                LoadTextSpanLocal();
+                // pos = startingPos;
+                Ldloc(startingPos);
+                Stloc(pos);
+                SliceInputSpan();
 
                 // Match single character
                 EmitSingleChar(node);
-                TransferTextSpanPosToRunTextPos();
+                TransferSliceStaticPosToPos();
 
-                // startingRunTextPos = runtextpos;
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
+                // startingPos = pos;
+                Ldloc(pos);
+                Stloc(startingPos);
 
                 // Update the done label for everything that comes after this node.  This is done after we emit the single char
                 // matching, as that failing indicates the loop itself has failed to match.
@@ -2485,25 +2485,25 @@ namespace System.Text.RegularExpressions
                 doneLabel = backtrackingLabel; // leave set to the backtracking label for all subsequent nodes
 
                 MarkLabel(endLoopLabel);
-                if (crawlPos is not null)
+                if (capturepos is not null)
                 {
-                    // crawlPos = base.CrawlPos();
+                    // capturepos = base.CrawlPos();
                     Ldthis();
                     Call(s_crawlposMethod);
-                    Stloc(crawlPos);
+                    Stloc(capturepos);
                 }
 
                 if (node.IsInLoop())
                 {
                     // Store the capture's state
-                    // base.runstack[runstackpos++] = startingRunTextPos;
-                    // base.runstack[runstackpos++] = crawlPos;
-                    // base.runstack[runstackpos++] = iterationCount;
+                    // base.runstack[stackpos++] = startingPos;
+                    // base.runstack[stackpos++] = capturepos;
+                    // base.runstack[stackpos++] = iterationCount;
                     EmitRunstackResizeIfNeeded(3);
-                    EmitRunstackPush(() => Ldloc(startingRunTextPos));
-                    if (crawlPos is not null)
+                    EmitRunstackPush(() => Ldloc(startingPos));
+                    if (capturepos is not null)
                     {
-                        EmitRunstackPush(() => Ldloc(crawlPos));
+                        EmitRunstackPush(() => Ldloc(capturepos));
                     }
                     if (iterationCount is not null)
                     {
@@ -2511,34 +2511,34 @@ namespace System.Text.RegularExpressions
                     }
 
                     // Skip past the backtracking section
-                    Label end = DefineLabel();
-                    BrFar(end);
+                    Label backtrackingEnd = DefineLabel();
+                    BrFar(backtrackingEnd);
 
                     // Emit a backtracking section that restores the capture's state and then jumps to the previous done label
                     Label backtrack = DefineLabel();
                     MarkLabel(backtrack);
 
-                    // iterationCount = base.runstack[--runstackpos];
-                    // crawlPos = base.runstack[--runstackpos];
-                    // startingRunTextPos = base.runstack[--runstackpos];
+                    // iterationCount = base.runstack[--stackpos];
+                    // capturepos = base.runstack[--stackpos];
+                    // startingPos = base.runstack[--stackpos];
                     if (iterationCount is not null)
                     {
                         EmitRunstackPop();
                         Stloc(iterationCount);
                     }
-                    if (crawlPos is not null)
+                    if (capturepos is not null)
                     {
                         EmitRunstackPop();
-                        Stloc(crawlPos);
+                        Stloc(capturepos);
                     }
                     EmitRunstackPop();
-                    Stloc(startingRunTextPos);
+                    Stloc(startingPos);
 
                     // goto doneLabel;
                     BrFar(doneLabel);
 
                     doneLabel = backtrack;
-                    MarkLabel(end);
+                    MarkLabel(backtrackingEnd);
                 }
             }
 
@@ -2569,24 +2569,24 @@ namespace System.Text.RegularExpressions
                     }
                 }
 
-                // We might loop any number of times.  In order to ensure this loop and subsequent code sees textSpanPos
+                // We might loop any number of times.  In order to ensure this loop and subsequent code sees sliceStaticPos
                 // the same regardless, we always need it to contain the same value, and the easiest such value is 0.
-                // So, we transfer textSpanPos to runtextpos, and ensure that any path out of here has textSpanPos as 0.
-                TransferTextSpanPosToRunTextPos();
+                // So, we transfer sliceStaticPos to pos, and ensure that any path out of here has sliceStaticPos as 0.
+                TransferSliceStaticPosToPos();
 
-                LocalBuilder startingRunTextPos = DeclareInt32();
+                LocalBuilder startingPos = DeclareInt32();
                 LocalBuilder iterationCount = DeclareInt32();
                 LocalBuilder sawEmpty = DeclareInt32();
                 Label body = DefineLabel();
                 Label endLoop = DefineLabel();
 
                 // iterationCount = 0;
-                // startingRunTextPos = runtextpos;
+                // startingPos = pos;
                 // sawEmpty = 0; // false
                 Ldc(0);
                 Stloc(iterationCount);
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
+                Ldloc(pos);
+                Stloc(startingPos);
                 Ldc(0);
                 Stloc(sawEmpty);
 
@@ -2602,13 +2602,13 @@ namespace System.Text.RegularExpressions
                 MarkLabel(body);
                 EmitTimeoutCheck();
 
-                // We need to store the starting runtextpos and crawl position so that it may
+                // We need to store the starting pos and crawl position so that it may
                 // be backtracked through later.  This needs to be the starting position from
-                // the iteration we're leaving, so it's pushed before updating it to runtextpos.
-                // base.runstack[runstackpos++] = base.Crawlpos();
-                // base.runstack[runstackpos++] = startingRunTextPos;
-                // base.runstack[runstackpos++] = runtextpos;
-                // base.runstack[runstackpos++] = sawEmpty;
+                // the iteration we're leaving, so it's pushed before updating it to pos.
+                // base.runstack[stackpos++] = base.Crawlpos();
+                // base.runstack[stackpos++] = startingPos;
+                // base.runstack[stackpos++] = pos;
+                // base.runstack[stackpos++] = sawEmpty;
                 EmitRunstackResizeIfNeeded(3);
                 if (expressionHasCaptures)
                 {
@@ -2618,17 +2618,17 @@ namespace System.Text.RegularExpressions
                         Call(s_crawlposMethod);
                     });
                 }
-                EmitRunstackPush(() => Ldloc(startingRunTextPos));
-                EmitRunstackPush(() => Ldloc(runtextposLocal));
+                EmitRunstackPush(() => Ldloc(startingPos));
+                EmitRunstackPush(() => Ldloc(pos));
                 EmitRunstackPush(() => Ldloc(sawEmpty));
 
-                // Save off some state.  We need to store the current runtextpos so we can compare it against
-                // runtextpos after the iteration, in order to determine whether the iteration was empty. Empty
+                // Save off some state.  We need to store the current pos so we can compare it against
+                // pos after the iteration, in order to determine whether the iteration was empty. Empty
                 // iterations are allowed as part of min matches, but once we've met the min quote, empty matches
                 // are considered match failures.
-                // startingRunTextPos = runtextpos;
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
+                // startingPos = pos;
+                Ldloc(pos);
+                Stloc(startingPos);
 
                 // Proactively increase the number of iterations.  We do this prior to the match rather than once
                 // we know it's successful, because we need to decrement it as part of a failed match when
@@ -2648,9 +2648,9 @@ namespace System.Text.RegularExpressions
                 doneLabel = iterationFailedLabel;
 
                 // Finally, emit the child.
-                Debug.Assert(textSpanPos == 0);
+                Debug.Assert(sliceStaticPos == 0);
                 EmitNode(node.Child(0));
-                TransferTextSpanPosToRunTextPos(); // ensure textSpanPos remains 0
+                TransferSliceStaticPosToPos(); // ensure sliceStaticPos remains 0
                 if (doneLabel == iterationFailedLabel)
                 {
                     doneLabel = originalDoneLabel;
@@ -2668,10 +2668,10 @@ namespace System.Text.RegularExpressions
                 // If the last iteration was empty, we need to prevent further iteration from this point
                 // unless we backtrack out of this iteration.  We can do that easily just by pretending
                 // we reached the max iteration count.
-                // if (runtextpos == startingRunTextPos) sawEmpty = 1; // true
+                // if (pos == startingPos) sawEmpty = 1; // true
                 Label skipSawEmptySet = DefineLabel();
-                Ldloc(runtextposLocal);
-                Ldloc(startingRunTextPos);
+                Ldloc(pos);
+                Ldloc(startingPos);
                 Bne(skipSawEmptySet);
                 Ldc(1);
                 Stloc(sawEmpty);
@@ -2682,7 +2682,7 @@ namespace System.Text.RegularExpressions
                 BrFar(endLoop);
 
                 // Now handle what happens when an iteration fails.  We need to reset state to what it was before just that iteration
-                // started.  That includes resetting runtextpos and clearing out any captures from that iteration.
+                // started.  That includes resetting pos and clearing out any captures from that iteration.
                 MarkLabel(iterationFailedLabel);
 
                 // iterationCount--;
@@ -2696,17 +2696,17 @@ namespace System.Text.RegularExpressions
                 Ldc(0);
                 BltFar(originalDoneLabel);
 
-                // sawEmpty = base.runstack[--runstackpos];
-                // runtextpos = base.runstack[--runstackpos];
-                // startingRunTextPos = base.runstack[--runstackpos];
-                // crawlpos = base.runstack[--runstackpos];
-                // while (base.Crawlpos() > crawlpos) base.Uncapture();
+                // sawEmpty = base.runstack[--stackpos];
+                // pos = base.runstack[--stackpos];
+                // startingPos = base.runstack[--stackpos];
+                // capturepos = base.runstack[--stackpos];
+                // while (base.Crawlpos() > capturepos) base.Uncapture();
                 EmitRunstackPop();
                 Stloc(sawEmpty);
                 EmitRunstackPop();
-                Stloc(runtextposLocal);
+                Stloc(pos);
                 EmitRunstackPop();
-                Stloc(startingRunTextPos);
+                Stloc(startingPos);
                 if (expressionHasCaptures)
                 {
                     using RentedLocalBuilder poppedCrawlPos = RentInt32Local();
@@ -2714,7 +2714,7 @@ namespace System.Text.RegularExpressions
                     Stloc(poppedCrawlPos);
                     EmitUncaptureUntil(poppedCrawlPos);
                 }
-                LoadTextSpanLocal();
+                SliceInputSpan();
 
                 if (doneLabel == originalDoneLabel)
                 {
@@ -2737,7 +2737,7 @@ namespace System.Text.RegularExpressions
                 {
                     // Store the capture's state and skip the backtracking section
                     EmitRunstackResizeIfNeeded(3);
-                    EmitRunstackPush(() => Ldloc(startingRunTextPos));
+                    EmitRunstackPush(() => Ldloc(startingPos));
                     EmitRunstackPush(() => Ldloc(iterationCount));
                     EmitRunstackPush(() => Ldloc(sawEmpty));
                     Label skipBacktrack = DefineLabel();
@@ -2747,15 +2747,15 @@ namespace System.Text.RegularExpressions
                     Label backtrack = DefineLabel();
                     MarkLabel(backtrack);
 
-                    // sawEmpty = base.runstack[--runstackpos];
-                    // iterationCount = base.runstack[--runstackpos];
-                    // startingRunTextPos = base.runstack[--runstackpos];
+                    // sawEmpty = base.runstack[--stackpos];
+                    // iterationCount = base.runstack[--stackpos];
+                    // startingPos = base.runstack[--stackpos];
                     EmitRunstackPop();
                     Stloc(sawEmpty);
                     EmitRunstackPop();
                     Stloc(iterationCount);
                     EmitRunstackPop();
-                    Stloc(startingRunTextPos);
+                    Stloc(startingPos);
 
                     if (maxIterations == int.MaxValue)
                     {
@@ -2795,7 +2795,7 @@ namespace System.Text.RegularExpressions
                     return;
                 }
 
-                // if ((uint)(textSpanPos + iterations - 1) >= (uint)textSpan.Length) goto doneLabel;
+                // if ((uint)(sliceStaticPos + iterations - 1) >= (uint)slice.Length) goto doneLabel;
                 if (emitLengthChecksIfRequired)
                 {
                     EmitSpanLengthCheck(iterations);
@@ -2807,8 +2807,8 @@ namespace System.Text.RegularExpressions
 
                 if (iterations <= MaxUnrollSize)
                 {
-                    // if (textSpan[textSpanPos] != c1 ||
-                    //     textSpan[textSpanPos + 1] != c2 ||
+                    // if (slice[sliceStaticPos] != c1 ||
+                    //     slice[sliceStaticPos + 1] != c2 ||
                     //     ...)
                     //       goto doneLabel;
                     for (int i = 0; i < iterations; i++)
@@ -2818,20 +2818,20 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
-                    // ReadOnlySpan<char> tmp = textSpan.Slice(textSpanPos, iterations);
+                    // ReadOnlySpan<char> tmp = slice.Slice(sliceStaticPos, iterations);
                     // for (int i = 0; i < tmp.Length; i++)
                     // {
                     //     TimeoutCheck();
                     //     if (tmp[i] != ch) goto Done;
                     // }
-                    // textSpanPos += iterations;
+                    // sliceStaticPos += iterations;
 
                     Label conditionLabel = DefineLabel();
                     Label bodyLabel = DefineLabel();
 
                     using RentedLocalBuilder spanLocal = RentReadOnlySpanCharLocal();
-                    Ldloca(textSpanLocal);
-                    Ldc(textSpanPos);
+                    Ldloca(slice);
+                    Ldc(sliceStaticPos);
                     Ldc(iterations);
                     Call(s_spanSliceIntIntMethod);
                     Stloc(spanLocal);
@@ -2844,13 +2844,13 @@ namespace System.Text.RegularExpressions
                     MarkLabel(bodyLabel);
                     EmitTimeoutCheck();
 
-                    LocalBuilder tmpTextSpanLocal = textSpanLocal; // we want EmitSingleChar to refer to this temporary
-                    int tmpTextSpanPos = textSpanPos;
-                    textSpanLocal = spanLocal;
-                    textSpanPos = 0;
+                    LocalBuilder tmpTextSpanLocal = slice; // we want EmitSingleChar to refer to this temporary
+                    int tmpTextSpanPos = sliceStaticPos;
+                    slice = spanLocal;
+                    sliceStaticPos = 0;
                     EmitSingleChar(node, emitLengthCheck: false, offset: iterationLocal);
-                    textSpanLocal = tmpTextSpanLocal;
-                    textSpanPos = tmpTextSpanPos;
+                    slice = tmpTextSpanLocal;
+                    sliceStaticPos = tmpTextSpanPos;
 
                     Ldloc(iterationLocal);
                     Ldc(1);
@@ -2863,7 +2863,7 @@ namespace System.Text.RegularExpressions
                     Call(s_spanGetLengthMethod);
                     BltFar(bodyLabel);
 
-                    textSpanPos += iterations;
+                    sliceStaticPos += iterations;
                 }
             }
 
@@ -2905,16 +2905,16 @@ namespace System.Text.RegularExpressions
                     // restriction is purely for simplicity; it could be removed in the future with additional code to
                     // handle the unbounded case.
 
-                    // int i = textSpan.Slice(textSpanPos).IndexOf(char);
-                    if (textSpanPos > 0)
+                    // int i = slice.Slice(sliceStaticPos).IndexOf(char);
+                    if (sliceStaticPos > 0)
                     {
-                        Ldloca(textSpanLocal);
-                        Ldc(textSpanPos);
+                        Ldloca(slice);
+                        Ldc(sliceStaticPos);
                         Call(s_spanSliceIntMethod);
                     }
                     else
                     {
-                        Ldloc(textSpanLocal);
+                        Ldloc(slice);
                     }
                     Ldc(node.Ch);
                     Call(s_spanIndexOfChar);
@@ -2925,12 +2925,12 @@ namespace System.Text.RegularExpressions
                     Ldc(0);
                     BgeFar(atomicLoopDoneLabel);
 
-                    // i = textSpan.Length - textSpanPos;
-                    Ldloca(textSpanLocal);
+                    // i = slice.Length - sliceStaticPos;
+                    Ldloca(slice);
                     Call(s_spanGetLengthMethod);
-                    if (textSpanPos > 0)
+                    if (sliceStaticPos > 0)
                     {
-                        Ldc(textSpanPos);
+                        Ldc(sliceStaticPos);
                         Sub();
                     }
                     Stloc(iterationLocal);
@@ -2946,16 +2946,16 @@ namespace System.Text.RegularExpressions
                     // As with the notoneloopatomic above, the unbounded constraint is purely for simplicity.
                     Debug.Assert(numSetChars > 1);
 
-                    // int i = textSpan.Slice(textSpanPos).IndexOfAny(ch1, ch2, ...);
-                    if (textSpanPos > 0)
+                    // int i = slice.Slice(sliceStaticPos).IndexOfAny(ch1, ch2, ...);
+                    if (sliceStaticPos > 0)
                     {
-                        Ldloca(textSpanLocal);
-                        Ldc(textSpanPos);
+                        Ldloca(slice);
+                        Ldc(sliceStaticPos);
                         Call(s_spanSliceIntMethod);
                     }
                     else
                     {
-                        Ldloc(textSpanLocal);
+                        Ldloc(slice);
                     }
                     switch (numSetChars)
                     {
@@ -2985,12 +2985,12 @@ namespace System.Text.RegularExpressions
                     Ldc(0);
                     BgeFar(atomicLoopDoneLabel);
 
-                    // i = textSpan.Length - textSpanPos;
-                    Ldloca(textSpanLocal);
+                    // i = slice.Length - sliceStaticPos;
+                    Ldloca(slice);
                     Call(s_spanGetLengthMethod);
-                    if (textSpanPos > 0)
+                    if (sliceStaticPos > 0)
                     {
-                        Ldc(textSpanPos);
+                        Ldc(sliceStaticPos);
                         Sub();
                     }
                     Stloc(iterationLocal);
@@ -3000,10 +3000,10 @@ namespace System.Text.RegularExpressions
                     // .* was used with RegexOptions.Singleline, which means it'll consume everything.  Just jump to the end.
                     // The unbounded constraint is the same as in the Notone case above, done purely for simplicity.
 
-                    // int i = runtextend - runtextpos;
-                    TransferTextSpanPosToRunTextPos();
-                    Ldloc(runtextendLocal);
-                    Ldloc(runtextposLocal);
+                    // int i = end - pos;
+                    TransferSliceStaticPosToPos();
+                    Ldloc(end);
+                    Ldloc(pos);
                     Sub();
                     Stloc(iterationLocal);
                 }
@@ -3011,8 +3011,8 @@ namespace System.Text.RegularExpressions
                 {
                     // For everything else, do a normal loop.
 
-                    // Transfer text pos to runtextpos to help with bounds check elimination on the loop.
-                    TransferTextSpanPosToRunTextPos();
+                    // Transfer sliceStaticPos to pos to help with bounds check elimination on the loop.
+                    TransferSliceStaticPosToPos();
 
                     Label conditionLabel = DefineLabel();
                     Label bodyLabel = DefineLabel();
@@ -3027,14 +3027,14 @@ namespace System.Text.RegularExpressions
                     MarkLabel(bodyLabel);
                     EmitTimeoutCheck();
 
-                    // if ((uint)i >= (uint)textSpan.Length) goto atomicLoopDoneLabel;
+                    // if ((uint)i >= (uint)slice.Length) goto atomicLoopDoneLabel;
                     Ldloc(iterationLocal);
-                    Ldloca(textSpanLocal);
+                    Ldloca(slice);
                     Call(s_spanGetLengthMethod);
                     BgeUnFar(atomicLoopDoneLabel);
 
-                    // if (textSpan[i] != ch) goto atomicLoopDoneLabel;
-                    Ldloca(textSpanLocal);
+                    // if (slice[i] != ch) goto atomicLoopDoneLabel;
+                    Ldloca(slice);
                     Ldloc(iterationLocal);
                     Call(s_spanGetItemMethod);
                     LdindU2();
@@ -3092,19 +3092,19 @@ namespace System.Text.RegularExpressions
                 }
 
                 // Now that we've completed our optional iterations, advance the text span
-                // and runtextpos by the number of iterations completed.
+                // and pos by the number of iterations completed.
 
-                // textSpan = textSpan.Slice(i);
-                Ldloca(textSpanLocal);
+                // slice = slice.Slice(i);
+                Ldloca(slice);
                 Ldloc(iterationLocal);
                 Call(s_spanSliceIntMethod);
-                Stloc(textSpanLocal);
+                Stloc(slice);
 
-                // runtextpos += i;
-                Ldloc(runtextposLocal);
+                // pos += i;
+                Ldloc(pos);
                 Ldloc(iterationLocal);
                 Add();
-                Stloc(runtextposLocal);
+                Stloc(pos);
             }
 
             // Emits the code to handle a non-backtracking optional zero-or-one loop.
@@ -3114,15 +3114,15 @@ namespace System.Text.RegularExpressions
 
                 Label skipUpdatesLabel = DefineLabel();
 
-                // if ((uint)textSpanPos >= (uint)textSpan.Length) goto skipUpdatesLabel;
-                Ldc(textSpanPos);
-                Ldloca(textSpanLocal);
+                // if ((uint)sliceStaticPos >= (uint)slice.Length) goto skipUpdatesLabel;
+                Ldc(sliceStaticPos);
+                Ldloca(slice);
                 Call(s_spanGetLengthMethod);
                 BgeUnFar(skipUpdatesLabel);
 
-                // if (textSpan[textSpanPos] != ch) goto skipUpdatesLabel;
-                Ldloca(textSpanLocal);
-                Ldc(textSpanPos);
+                // if (slice[sliceStaticPos] != ch) goto skipUpdatesLabel;
+                Ldloca(slice);
+                Ldc(sliceStaticPos);
                 Call(s_spanGetItemMethod);
                 LdindU2();
                 if (node.IsSetFamily)
@@ -3147,17 +3147,17 @@ namespace System.Text.RegularExpressions
                     }
                 }
 
-                // textSpan = textSpan.Slice(1);
-                Ldloca(textSpanLocal);
+                // slice = slice.Slice(1);
+                Ldloca(slice);
                 Ldc(1);
                 Call(s_spanSliceIntMethod);
-                Stloc(textSpanLocal);
+                Stloc(slice);
 
-                // runtextpos++;
-                Ldloc(runtextposLocal);
+                // pos++;
+                Ldloc(pos);
                 Ldc(1);
                 Add();
-                Stloc(runtextposLocal);
+                Stloc(pos);
 
                 MarkLabel(skipUpdatesLabel);
             }
@@ -3171,48 +3171,48 @@ namespace System.Text.RegularExpressions
                 int maxIterations = node.N;
                 bool isAtomic = node.IsAtomicByParent();
 
-                // We might loop any number of times.  In order to ensure this loop and subsequent code sees textSpanPos
+                // We might loop any number of times.  In order to ensure this loop and subsequent code sees sliceStaticPos
                 // the same regardless, we always need it to contain the same value, and the easiest such value is 0.
-                // So, we transfer textSpanPos to runtextpos, and ensure that any path out of here has textSpanPos as 0.
-                TransferTextSpanPosToRunTextPos();
+                // So, we transfer sliceStaticPos to pos, and ensure that any path out of here has sliceStaticPos as 0.
+                TransferSliceStaticPosToPos();
 
                 Label originalDoneLabel = doneLabel;
 
-                LocalBuilder startingRunTextPos = DeclareInt32();
+                LocalBuilder startingPos = DeclareInt32();
                 LocalBuilder iterationCount = DeclareInt32();
                 Label body = DefineLabel();
                 Label endLoop = DefineLabel();
 
                 // iterationCount = 0;
-                // startingRunTextPos = 0;
+                // startingPos = 0;
                 Ldc(0);
                 Stloc(iterationCount);
                 Ldc(0);
-                Stloc(startingRunTextPos);
+                Stloc(startingPos);
 
                 // Iteration body
                 MarkLabel(body);
                 EmitTimeoutCheck();
 
-                // We need to store the starting runtextpos and crawl position so that it may
+                // We need to store the starting pos and crawl position so that it may
                 // be backtracked through later.  This needs to be the starting position from
-                // the iteration we're leaving, so it's pushed before updating it to runtextpos.
+                // the iteration we're leaving, so it's pushed before updating it to pos.
                 EmitRunstackResizeIfNeeded(3);
                 if (expressionHasCaptures)
                 {
-                    // base.runstack[runstackpos++] = base.Crawlpos();
+                    // base.runstack[stackpos++] = base.Crawlpos();
                     EmitRunstackPush(() => { Ldthis(); Call(s_crawlposMethod); });
                 }
-                EmitRunstackPush(() => Ldloc(startingRunTextPos));
-                EmitRunstackPush(() => Ldloc(runtextposLocal));
+                EmitRunstackPush(() => Ldloc(startingPos));
+                EmitRunstackPush(() => Ldloc(pos));
 
-                // Save off some state.  We need to store the current runtextpos so we can compare it against
-                // runtextpos after the iteration, in order to determine whether the iteration was empty. Empty
+                // Save off some state.  We need to store the current pos so we can compare it against
+                // pos after the iteration, in order to determine whether the iteration was empty. Empty
                 // iterations are allowed as part of min matches, but once we've met the min quote, empty matches
                 // are considered match failures.
-                // startingRunTextPos = runtextpos;
-                Ldloc(runtextposLocal);
-                Stloc(startingRunTextPos);
+                // startingPos = pos;
+                Ldloc(pos);
+                Stloc(startingPos);
 
                 // Proactively increase the number of iterations.  We do this prior to the match rather than once
                 // we know it's successful, because we need to decrement it as part of a failed match when
@@ -3232,9 +3232,9 @@ namespace System.Text.RegularExpressions
                 doneLabel = iterationFailedLabel;
 
                 // Finally, emit the child.
-                Debug.Assert(textSpanPos == 0);
+                Debug.Assert(sliceStaticPos == 0);
                 EmitNode(node.Child(0));
-                TransferTextSpanPosToRunTextPos(); // ensure textSpanPos remains 0
+                TransferSliceStaticPosToPos(); // ensure sliceStaticPos remains 0
                 bool childBacktracks = doneLabel != iterationFailedLabel;
 
                 // Loop condition.  Continue iterating greedily if we've not yet reached the maximum.  We also need to stop
@@ -3243,10 +3243,10 @@ namespace System.Text.RegularExpressions
                 switch ((minIterations > 0, maxIterations == int.MaxValue))
                 {
                     case (true, true):
-                        // if (runtextpos != startingRunTextPos || iterationCount < minIterations) goto body;
+                        // if (pos != startingPos || iterationCount < minIterations) goto body;
                         // goto endLoop;
-                        Ldloc(runtextposLocal);
-                        Ldloc(startingRunTextPos);
+                        Ldloc(pos);
+                        Ldloc(startingPos);
                         BneFar(body);
                         Ldloc(iterationCount);
                         Ldc(minIterations);
@@ -3255,13 +3255,13 @@ namespace System.Text.RegularExpressions
                         break;
 
                     case (true, false):
-                        // if ((runtextpos != startingRunTextPos || iterationCount < minIterations) && iterationCount < maxIterations) goto body;
+                        // if ((pos != startingPos || iterationCount < minIterations) && iterationCount < maxIterations) goto body;
                         // goto endLoop;
                         Ldloc(iterationCount);
                         Ldc(maxIterations);
                         BgeFar(endLoop);
-                        Ldloc(runtextposLocal);
-                        Ldloc(startingRunTextPos);
+                        Ldloc(pos);
+                        Ldloc(startingPos);
                         BneFar(body);
                         Ldloc(iterationCount);
                         Ldc(minIterations);
@@ -3270,19 +3270,19 @@ namespace System.Text.RegularExpressions
                         break;
 
                     case (false, true):
-                        // if (runtextpos != startingRunTextPos) goto body;
+                        // if (pos != startingPos) goto body;
                         // goto endLoop;
-                        Ldloc(runtextposLocal);
-                        Ldloc(startingRunTextPos);
+                        Ldloc(pos);
+                        Ldloc(startingPos);
                         BneFar(body);
                         BrFar(endLoop);
                         break;
 
                     case (false, false):
-                        // if (runtextpos == startingRunTextPos || iterationCount >= maxIterations) goto endLoop;
+                        // if (pos == startingPos || iterationCount >= maxIterations) goto endLoop;
                         // goto body;
-                        Ldloc(runtextposLocal);
-                        Ldloc(startingRunTextPos);
+                        Ldloc(pos);
+                        Ldloc(startingPos);
                         BeqFar(endLoop);
                         Ldloc(iterationCount);
                         Ldc(maxIterations);
@@ -3293,7 +3293,7 @@ namespace System.Text.RegularExpressions
 
                 // Now handle what happens when an iteration fails, which could be an initial failure or it
                 // could be while backtracking.  We need to reset state to what it was before just that iteration
-                // started.  That includes resetting runtextpos and clearing out any captures from that iteration.
+                // started.  That includes resetting pos and clearing out any captures from that iteration.
                 MarkLabel(iterationFailedLabel);
 
                 // iterationCount--;
@@ -3307,22 +3307,22 @@ namespace System.Text.RegularExpressions
                 Ldc(0);
                 BltFar(originalDoneLabel);
 
-                // runtextpos = base.runstack[--runstackpos];
-                // startingRunTextPos = base.runstack[--runstackpos];
+                // pos = base.runstack[--stackpos];
+                // startingPos = base.runstack[--stackpos];
                 EmitRunstackPop();
-                Stloc(runtextposLocal);
+                Stloc(pos);
                 EmitRunstackPop();
-                Stloc(startingRunTextPos);
+                Stloc(startingPos);
                 if (expressionHasCaptures)
                 {
-                    // int poppedCrawlPos = base.runstack[--runstackpos];
+                    // int poppedCrawlPos = base.runstack[--stackpos];
                     // while (base.Crawlpos() > poppedCrawlPos) base.Uncapture();
                     using RentedLocalBuilder poppedCrawlPos = RentInt32Local();
                     EmitRunstackPop();
                     Stloc(poppedCrawlPos);
                     EmitUncaptureUntil(poppedCrawlPos);
                 }
-                LoadTextSpanLocal();
+                SliceInputSpan();
 
                 if (minIterations > 0)
                 {
@@ -3370,30 +3370,30 @@ namespace System.Text.RegularExpressions
                     {
                         // Store the capture's state
                         EmitRunstackResizeIfNeeded(3);
-                        EmitRunstackPush(() => Ldloc(startingRunTextPos));
+                        EmitRunstackPush(() => Ldloc(startingPos));
                         EmitRunstackPush(() => Ldloc(iterationCount));
 
                         // Skip past the backtracking section
-                        // goto end;
-                        Label end = DefineLabel();
-                        BrFar(end);
+                        // goto backtrackingEnd;
+                        Label backtrackingEnd = DefineLabel();
+                        BrFar(backtrackingEnd);
 
                         // Emit a backtracking section that restores the capture's state and then jumps to the previous done label
                         Label backtrack = DefineLabel();
                         MarkLabel(backtrack);
 
                         // iterationCount = base.runstack[--runstack];
-                        // startingRunTextPos = base.runstack[--runstack];
+                        // startingPos = base.runstack[--runstack];
                         EmitRunstackPop();
                         Stloc(iterationCount);
                         EmitRunstackPop();
-                        Stloc(startingRunTextPos);
+                        Stloc(startingPos);
 
                         // goto doneLabel;
                         BrFar(doneLabel);
 
                         doneLabel = backtrack;
-                        MarkLabel(end);
+                        MarkLabel(backtrackingEnd);
                     }
                 }
             }
@@ -3402,14 +3402,14 @@ namespace System.Text.RegularExpressions
             {
                 Debug.Assert(count >= 1);
 
-                // if (runstackpos >= base.runstack!.Length - (count - 1))
+                // if (stackpos >= base.runstack!.Length - (count - 1))
                 // {
                 //     Array.Resize(ref base.runstack, base.runstack.Length * 2);
                 // }
 
                 Label skipResize = DefineLabel();
 
-                Ldloc(runstackpos);
+                Ldloc(stackpos);
                 Ldthisfld(s_runstackField);
                 Ldlen();
                 if (count > 1)
@@ -3432,28 +3432,28 @@ namespace System.Text.RegularExpressions
 
             void EmitRunstackPush(Action load)
             {
-                // base.runstack[runstackpos] = load();
+                // base.runstack[stackpos] = load();
                 Ldthisfld(s_runstackField);
-                Ldloc(runstackpos);
+                Ldloc(stackpos);
                 load();
                 StelemI4();
 
-                // runstackpos++;
-                Ldloc(runstackpos);
+                // stackpos++;
+                Ldloc(stackpos);
                 Ldc(1);
                 Add();
-                Stloc(runstackpos);
+                Stloc(stackpos);
             }
 
             void EmitRunstackPop()
             {
-                // ... = base.runstack[--runstackpos];
+                // ... = base.runstack[--stackpos];
                 Ldthisfld(s_runstackField);
-                Ldloc(runstackpos);
+                Ldloc(stackpos);
                 Ldc(1);
                 Sub();
-                Stloc(runstackpos);
-                Ldloc(runstackpos);
+                Stloc(stackpos);
+                Ldloc(stackpos);
                 LdelemI4();
             }
         }


### PR DESCRIPTION
- Add more comments, both to the implementation and to the generated code
- Avoid an unnecessary goto in the last branch of an alternation
- Invert the backreference logic so that we don't have an extra else branch / level of nesting in the common case
- Add node type asserts to all EmitXx functions
- Move the open-coded uncapture loop into its own shared function
- Remove scoping when outputting a Nothing
- Swap the sides of some if clauses to make them more idiomatic
- Change some "if (i < 1)" to "if (i == 0)"
- Change some "if (0 < span.Length)" to be "if (!span.IsEmpty)"

cc: @joperezr 