### PR TITLE
Unblock tests in LINQ interpreter only mode

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/tests/NewLateBindingTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/NewLateBindingTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             static object[] CreateData(string memberName, object[] arguments, Type[] typeArguments, string expectedValue) => new object[] { memberName, arguments, typeArguments, expectedValue };
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51834", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         [MemberData(nameof(LateCall_OptionalValues_Data))]
         public void LateCall_OptionalValues(string memberName, object[] arguments, Type[] typeArguments, string expectedValue)

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.genclass.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.genclass.cs
@@ -774,7 +774,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.genclas
     public class Test
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55118", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55118", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void TryCatchFinally()
         {
             dynamic dy = new MemberClass<int>();

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.basic.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.basic.cs
@@ -239,7 +239,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
     // <RelatedBugs></RelatedBugs>
     // <Expects Status=success></Expects>
     // <Code>
-    using System;
 
     public class Test
     {

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.basic.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.compound.basic.cs
@@ -244,7 +244,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.compoun
     public class Test
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.formalParameter.Methods.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.formalParameter.Methods.cs
@@ -98,8 +98,6 @@ public class MyClass
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.extensionmethod006.extensionmethod006
 {
-    using System;
-
     static // <Title>Extension method that extends dynamic</Title>
            // <Description>
            // </Description>
@@ -192,8 +190,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method001.method001
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -266,8 +262,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method003.method003
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -303,8 +297,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method004.method004
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -342,8 +334,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method005.method005
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -382,8 +372,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method007.method007
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -421,8 +409,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method008.method008
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -459,8 +445,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method009.method009
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -497,8 +481,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method010.method010
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -536,8 +518,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method011.method011
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -573,8 +553,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method012.method012
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;
@@ -612,8 +590,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalParameter.Methods.method013.method013
 {
-    using System;
-
     public class Test
     {
         private static bool s_ok = false;

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.formalParameter.Methods.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.formalParameter.Methods.cs
@@ -117,7 +117,7 @@ public class MyClass
     public class Test
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -208,7 +208,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -281,7 +281,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -317,7 +317,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -359,7 +359,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -397,7 +397,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -436,7 +436,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -474,7 +474,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -514,7 +514,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -552,7 +552,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -587,7 +587,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));
@@ -626,7 +626,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.formalPara
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.localVariable.blockVariable.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.localVariable.blockVariable.cs
@@ -1194,7 +1194,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.localVaria
     public class Test
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.localVariable.blockVariable.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Declarations/Conformance.dynamic.declarations.localVariable.blockVariable.cs
@@ -1189,8 +1189,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.localVaria
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.declarations.localVariable.blockVariable.trycatch002.trycatch002
 {
-    using System;
-    
     public class Test
     {
         [Fact]

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.DynamicType/Conformance.dynamic.dynamicType.conversions.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.DynamicType/Conformance.dynamic.dynamicType.conversions.cs
@@ -4377,7 +4377,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.dynamicType.conversions
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.DynamicType/Conformance.dynamic.dynamicType.conversions.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.DynamicType/Conformance.dynamic.dynamicType.conversions.cs
@@ -4356,8 +4356,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.dynamicType.conversions
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.dynamicType.conversions.dlgate003.dlgate003
 {
-    using System;
-    
     // <Title>Delegate conversions</Title>
     // <Description>
     // Tests to figure out if the right conversion from method groups to delegates are applied

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Indexers.1class2indexers.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Indexers.1class2indexers.cs
@@ -722,7 +722,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Inde
     public class Test
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Indexers.1class2indexers.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Indexers.1class2indexers.cs
@@ -665,8 +665,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Inde
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Indexers.Oneclass2indexers.onedynamicparam004.onedynamicparam004
 {
-    using System;
-    
     // <Title> Tests overload resolution for 1 class and 2 methods</Title>
     // <Description>
     // </Description>

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Methods.1class2methods.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Methods.1class2methods.cs
@@ -501,8 +501,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Meth
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Methods.Oneclass2methods.onedynamicparam004.onedynamicparam004
 {
-    using System;
-    
     // <Title> Tests overload resolution for 1 class and 2 methods</Title>
     // <Description>
     // </Description>

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Methods.1class2methods.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.OverloadResolution/Conformance.dynamic.overloadResolution.Methods.1class2methods.cs
@@ -532,7 +532,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.overloadResolution.Meth
     public class Test
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55117", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod(null));

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Variance/Conformance.dynamic.Variance.assign.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Variance/Conformance.dynamic.Variance.assign.cs
@@ -476,8 +476,6 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.Variance.assign.assignm
 
 namespace ManagedTests.DynamicCSharp.Conformance.dynamic.Variance.assign.assignment07.assignment07
 {
-    using System;
-    
     // <Area>variance</Area>
     // <Title> assignment Contravariant delegates</Title>
     // <Description> contravariance on delegates assigned to arrays</Description>

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Variance/Conformance.dynamic.Variance.assign.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.Variance/Conformance.dynamic.Variance.assign.cs
@@ -501,7 +501,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.Variance.assign.assignm
         private static dynamic s_array3;
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55119", typeof(PlatformDetection), nameof(PlatformDetection.IsLinqExpressionsBuiltWithIsInterpretingOnly))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55119", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());


### PR DESCRIPTION
These tests were blocked for the expression interpreter only mode in #54970, but the failures don't repro when run with the interpreter only mode on CoreCLR. The failures are specific to iDevice testing or Mono.