### PR TITLE
Use "pipeline-caching" for coreclr and libraries builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# .NET Runtime 
+# .NET Runtime
 [![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/runtime/runtime?branchName=main)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=686&branchName=main)
 [![Help Wanted](https://img.shields.io/github/issues/dotnet/runtime/up-for-grabs?style=flat-square&color=%232EA043&label=help%20wanted)](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3A%22up-for-grabs%22)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/runtime)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# .NET Runtime
+# .NET Runtime 
 [![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/dotnet/runtime/runtime?branchName=main)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=686&branchName=main)
 [![Help Wanted](https://img.shields.io/github/issues/dotnet/runtime/up-for-grabs?style=flat-square&color=%232EA043&label=help%20wanted)](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3A%22up-for-grabs%22)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dotnet/runtime)

--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -3,6 +3,7 @@ steps:
     inputs:
       nuGetServiceConnections: 'dotnet-core-internal-tooling'
       forceReinstallCredentialProvider: true
+    condition: ne(variables.BUILD_CACHE_RESTORED, 'true')
 
   - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
             -ci
@@ -12,4 +13,4 @@ steps:
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/RestoreInternal.binlog
             /v:normal
     displayName: Restore internal tools
-    condition: and(succeeded(), ne(variables['_skipRestoreInternalTools'], 'true'))
+    condition: and(succeeded(), ne(variables['_skipRestoreInternalTools'], 'true'), ne(variables.BUILD_CACHE_RESTORED, 'true'))

--- a/eng/pipelines/common/upload-artifact-step.yml
+++ b/eng/pipelines/common/upload-artifact-step.yml
@@ -8,7 +8,7 @@ parameters:
   displayName: ''
 
 steps:
-  # Zip Artifact
+  # Zip Artifact only if not cached
   - task: ArchiveFiles@2
     displayName: 'Zip ${{ parameters.displayName }}'
     inputs:
@@ -17,6 +17,7 @@ steps:
       archiveType:       ${{ parameters.archiveType }}
       tarCompression:    ${{ parameters.tarCompression }}
       includeRootFolder: ${{ parameters.includeRootFolder }}
+    condition: ne(variables.BUILD_CACHE_RESTORED, 'true')
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish ${{ parameters.displayName }}'

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -29,26 +29,26 @@ jobs:
     - windows_x64
     - windows_x86
     - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    # - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: outerloop
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/jit-exploratory-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    helixQueueGroup: ci
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    jobParameters:
-      testGroup: outerloop
-      liveLibrariesBuildConfig: Release
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/jit-exploratory-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     helixQueueGroup: ci
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     jobParameters:
+#       testGroup: outerloop
+#       liveLibrariesBuildConfig: Release
       toolName: ${{ variables.toolName }}

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -152,9 +152,88 @@ jobs:
       - name: clrRuntimePortableBuildArg
         value: '-portablebuild=false'
 
+    - name: CommitsOutputFile
+      value: '$(Build.SourcesDirectory)/coreclr.commit_hash'
+
+    - name: GetCommitScript
+      value: '$(Build.SourcesDirectory)/src/coreclr/scripts/get_commit_hash.py'
+
+    # Currently only support pipeline caching for PRs and manual triggered runs
+    - ${{ if or(in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+      - name: UsePipelineCache
+        value: true
+
+    # Otherwise set all the cache-specific variables to 'false' which will ensure to build product.
+    - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables['Build.Reason'], 'Manual')) }}:
+      - name: UsePipelineCache
+        value: false
+      - name: BUILD_CACHE_RESTORED
+        value: false
+      - name: DAC_BUILD_CACHE_RESTORED
+        value: false
+      - name: BUILD_LOGS_RESTORED
+        value: false
+
+    - ${{ if eq(parameters.osGroup, 'windows') }}:
+      - name: PythonScript
+        value: 'py -3'
+      - name: PipScript
+        value: 'py -3 -m pip'
+
+    - ${{ if ne(parameters.osGroup, 'windows') }}:
+      - name: PythonScript
+        value: 'python3'
+      - name: PipScript
+        value: 'pip3'
+
     - ${{ parameters.variables }}
 
     steps:
+
+    # Get the commit hashes of interesting folder for caching
+    - script: |
+        $(PythonScript) $(GetCommitScript) -run_type coreclr -output $(CommitsOutputFile)
+      displayName: Record commit hashes of coreclr
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        REPO_URI: $(Build.Repository.Uri)
+      condition: eq(variables.UsePipelineCache, 'true')
+
+    # Cache tasks
+    - task: Cache@2
+      displayName: Cache coreclr build
+      inputs:
+        key: '" coreclr-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+        path: $(Build.StagingDirectory)
+        cacheHitVar: BUILD_CACHE_RESTORED
+      condition: eq(variables.UsePipelineCache, 'true')
+
+    - ${{ if and(in(parameters.osGroup, 'windows', 'Linux'), ne(parameters.archType, 'x86'), ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
+      - task: Cache@2
+        displayName: Cache cross DAC build
+        inputs:
+          key: '" crossDAC-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+          path: $(crossDacArtifactPath)
+          cacheHitVar: DAC_BUILD_CACHE_RESTORED
+        condition: eq(variables.UsePipelineCache, 'true')
+
+    - task: Cache@2
+      displayName: Cache coreclr build logs
+      inputs:
+        key: '"coreclr-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+        path: $(Build.SourcesDirectory)/artifacts/log/
+        cacheHitVar: BUILD_LOGS_RESTORED
+        condition: eq(variables.UsePipelineCache, 'true')
+
+    - script: |
+        echo Cache restored
+      displayName: Cache Hit
+      condition: eq(variables.BUILD_CACHE_RESTORED, 'true')
+
+    - script: |
+        echo Cache not restored
+      displayName: Cache miss
+      condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
     # Install native dependencies
     # Linux builds use docker images with dependencies preinstalled,
@@ -163,10 +242,12 @@ jobs:
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
       - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup) ${{ parameters.archType }} azDO
         displayName: Install native dependencies
+        condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       # Necessary to install python
       - script: $(Build.SourcesDirectory)\eng\common\init-tools-native.cmd -InstallDirectory $(Build.SourcesDirectory)\native-tools -Force
         displayName: Install native dependencies
+        condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
     # Install internal tools on official builds
     # Since our internal tools are behind an authenticated feed,
@@ -195,14 +276,18 @@ jobs:
     # Build/Generate native prerequisites
     - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.nativeprereqs $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(officialBuildIdArg) -ci /bl:$(Build.SourcesDirectory)artifacts/log/$(buildConfig)/CoreCLRNativePrereqs.binlog
       displayName: Build and generate native prerequisites
+      condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
     # Build CoreCLR Runtime
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) $(osArg) -ci $(compilerArg) $(clrRuntimeComponentsBuildArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(clrRuntimePortableBuildArg) $(CoreClrPgoDataArg)
         displayName: Build CoreCLR Runtime
+        condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
+
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci $(enforcePgoArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg)
         displayName: Build CoreCLR Runtime
+        condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
       - script: |
@@ -214,9 +299,12 @@ jobs:
     - ${{ if or(ne(parameters.osGroup, 'Linux'), ne(parameters.archType, 'x86')) }}:
       - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib+clr.nativecorelib+clr.tools+clr.packages+clr.paltestlist $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
         displayName: Build managed product components and packages
+        condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
+
     - ${{ if and(eq(parameters.osGroup, 'Linux'), eq(parameters.archType, 'x86')) }}:
       - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
         displayName: Build managed product components and packages
+        condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
     # Run CoreCLR Tools unit tests
     - ${{ if eq(parameters.testGroup, 'clrTools') }}:
@@ -227,6 +315,7 @@ jobs:
     - ${{ if and(ne(parameters.isOfficialBuild, true), ne(parameters.disableClrTest, true)) }}:
       - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) skipmanaged skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(osArg) $(priorityArg) $(compilerArg)
         displayName: Build native test components
+        condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
     # Build libs.native, host.native and mono with gcc
     - ${{ if eq(parameters.compilerName, 'gcc') }}:

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -152,6 +152,9 @@ jobs:
       - name: clrRuntimePortableBuildArg
         value: '-portablebuild=false'
 
+    - name: ConfigurationName
+      value: ${{ format('CoreCLR {0} {1}{2} {3} {4} {5} {6}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.pgoType, parameters.compilerName) }}
+
     - name: CommitsOutputFile
       value: '$(Build.SourcesDirectory)/coreclr.commit_hash'
 
@@ -192,7 +195,7 @@ jobs:
 
     # Get the commit hashes of interesting folder for caching
     - script: |
-        $(PythonScript) $(GetCommitScript) -run_type coreclr -output $(CommitsOutputFile)
+        $(PythonScript) $(GetCommitScript) -configuration $(ConfigurationName) -run_type coreclr -output $(CommitsOutputFile)
       displayName: Record commit hashes of coreclr
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -201,38 +204,38 @@ jobs:
 
     # Cache tasks
     - task: Cache@2
-      displayName: Cache coreclr build
+      displayName: Cache Build $(ConfigurationName)
       inputs:
-        key: '" coreclr-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.pgoType }}" | $(CommitsOutputFile)'
+        key: '"Build" | $(CommitsOutputFile)'
         path: $(Build.StagingDirectory)
         cacheHitVar: BUILD_CACHE_RESTORED
       condition: eq(variables.UsePipelineCache, 'true')
 
     - ${{ if and(in(parameters.osGroup, 'windows', 'Linux'), ne(parameters.archType, 'x86'), ne(parameters.compilerName, 'gcc'), ne(parameters.testGroup, 'clrTools'), eq(parameters.pgoType, '')) }}:
       - task: Cache@2
-        displayName: Cache cross DAC build
+        displayName: Cache Cross DAC Build $(ConfigurationName)
         inputs:
-          key: '" crossDAC-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.pgoType }}" | $(CommitsOutputFile)'
+          key: '"CrossDAC-Build" | $(CommitsOutputFile)'
           path: $(crossDacArtifactPath)
           cacheHitVar: DAC_BUILD_CACHE_RESTORED
         condition: eq(variables.UsePipelineCache, 'true')
 
     - task: Cache@2
-      displayName: Cache coreclr build logs
+      displayName: Cache BuildLogs $(ConfigurationName)
       inputs:
-        key: '"coreclr-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.pgoType }}" | $(CommitsOutputFile)'
+        key: '"Logs" | $(CommitsOutputFile)'
         path: $(Build.SourcesDirectory)/artifacts/log/
         cacheHitVar: BUILD_LOGS_RESTORED
         condition: eq(variables.UsePipelineCache, 'true')
 
     - script: |
-        echo Cache restored
-      displayName: Cache Hit
+        echo Cache restored for $(ConfigurationName)
+      displayName: Cache Hit - $(ConfigurationName)
       condition: eq(variables.BUILD_CACHE_RESTORED, 'true')
 
     - script: |
-        echo Cache not restored
-      displayName: Cache miss
+        echo Cache not restored for $(ConfigurationName)
+      displayName: Cache Miss - $(ConfigurationName)
       condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
     # Install native dependencies

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -203,7 +203,7 @@ jobs:
     - task: Cache@2
       displayName: Cache coreclr build
       inputs:
-        key: '" coreclr-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+        key: '" coreclr-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.pgoType }}" | $(CommitsOutputFile)'
         path: $(Build.StagingDirectory)
         cacheHitVar: BUILD_CACHE_RESTORED
       condition: eq(variables.UsePipelineCache, 'true')
@@ -212,7 +212,7 @@ jobs:
       - task: Cache@2
         displayName: Cache cross DAC build
         inputs:
-          key: '" crossDAC-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+          key: '" crossDAC-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.pgoType }}" | $(CommitsOutputFile)'
           path: $(crossDacArtifactPath)
           cacheHitVar: DAC_BUILD_CACHE_RESTORED
         condition: eq(variables.UsePipelineCache, 'true')
@@ -220,7 +220,7 @@ jobs:
     - task: Cache@2
       displayName: Cache coreclr build logs
       inputs:
-        key: '"coreclr-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+        key: '"coreclr-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.pgoType }}" | $(CommitsOutputFile)'
         path: $(Build.SourcesDirectory)/artifacts/log/
         cacheHitVar: BUILD_LOGS_RESTORED
         condition: eq(variables.UsePipelineCache, 'true')

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -195,7 +195,7 @@ jobs:
 
     # Get the commit hashes of interesting folder for caching
     - script: |
-        $(PythonScript) $(GetCommitScript) -configuration $(ConfigurationName) -run_type coreclr -output $(CommitsOutputFile)
+        $(PythonScript) $(GetCommitScript) -configuration "$(ConfigurationName)" -run_type coreclr -output $(CommitsOutputFile)
       displayName: Record commit hashes of coreclr
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/pipelines/coreclr/templates/crossdac-build.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-build.yml
@@ -8,9 +8,11 @@ steps:
   - ${{ if and(eq(parameters.osGroup, 'windows'), notin(parameters.archType, 'x86')) }}:
     - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -linuxdac -ninja $(officialBuildIdArg)
       displayName: Build Cross OS Linux DAC for Windows
+      condition: ne(variables.DAC_BUILD_CACHE_RESTORED, 'true')
 
     - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -alpinedac -ninja $(officialBuildIdArg)
       displayName: Build Cross OS Linux-musl DAC for Windows
+      condition: ne(variables.DAC_BUILD_CACHE_RESTORED, 'true')
 
     - task: CopyFiles@2
       displayName: Gather CrossDac Artifacts (Linux)
@@ -20,6 +22,7 @@ steps:
           **/*
           !**/sharedFramework/**/*
         TargetFolder: $(buildLinuxDacStagingPath)
+      condition: ne(variables.DAC_BUILD_CACHE_RESTORED, 'true')
 
     - task: CopyFiles@2
       displayName: Gather CrossDac Artifacts (Linux_musl)
@@ -29,6 +32,7 @@ steps:
           **/*
           !**/sharedFramework/**/*
         TargetFolder: '$(buildMuslDacStagingPath)'
+      condition: ne(variables.DAC_BUILD_CACHE_RESTORED, 'true')
 
   - ${{ if eq(parameters.osGroup, 'Linux') }}:
     - task: CopyFiles@2
@@ -37,6 +41,7 @@ steps:
         SourceFolder: $(coreClrProductRootFolderPath)
         Contents: libcoreclr.so
         TargetFolder: '$(crossDacArtifactPath)/${{ parameters.osGroup }}${{ parameters.osSubgroup }}.$(archType).$(buildConfigUpper)/$(crossDacHostArch)'
+      condition: ne(variables.DAC_BUILD_CACHE_RESTORED, 'true')
 
   # Make the assets available in a single container for the packaging job.
   - task: PublishBuildArtifacts@1

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -129,7 +129,7 @@ jobs:
         - task: Cache@2
           displayName: Cache libraries build
           inputs:
-            key: '"libraries-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+            key: '"libraries-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.framework }}" | $(CommitsOutputFile)'
             path: $(Build.StagingDirectory)
             cacheHitVar: BUILD_CACHE_RESTORED
           condition: eq(variables.UsePipelineCache, 'true')
@@ -137,7 +137,7 @@ jobs:
         - task: Cache@2
           displayName: Cache libraries build logs
           inputs:
-            key: '"libraries-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+            key: '"libraries-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.framework }}" | $(CommitsOutputFile)'
             path: $(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)
             cacheHitVar: BUILD_LOGS_RESTORED
             condition: eq(variables.UsePipelineCache, 'true')

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -81,9 +81,77 @@ jobs:
         - ${{ if eq(parameters.useHelix, true) }}:
           - _additionalBuildArguments: /p:ArchiveTests=true
 
+        # Currently only support pipeline caching for PRs and manual triggered runs
+        - ${{ if or(in(variables['Build.Reason'], 'PullRequest'), in(variables['Build.Reason'], 'Manual')) }}:
+          - name: UsePipelineCache
+            value: true
+
+        - name: CommitsOutputFile
+          value: '$(Build.SourcesDirectory)/libraries.commit_hash'
+        - name: GetCommitScript
+          value: '$(Build.SourcesDirectory)/src/coreclr/scripts/get_commit_hash.py'
+
+        # Otherwise set all the cache-specific variables to 'false' which will ensure to build product.
+        - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), notin(variables['Build.Reason'], 'Manual')) }}:
+          - name: UsePipelineCache
+            value: false
+          - name: BUILD_CACHE_RESTORED
+            value: false
+          - name: BUILD_LOGS_RESTORED
+            value: false
+
+        - ${{ if eq(parameters.osGroup, 'windows') }}:
+          - name: PythonScript
+            value: 'py -3'
+          - name: PipScript
+            value: 'py -3 -m pip'
+
+        - ${{ if ne(parameters.osGroup, 'windows') }}:
+          - name: PythonScript
+            value: 'python3'
+          - name: PipScript
+            value: 'pip3'
+
         - ${{ parameters.variables }}
 
       steps:
+
+        # Get the commit hashes of interesting folder for caching
+        - script: |
+            $(PythonScript) $(GetCommitScript) -run_type libraries -output $(CommitsOutputFile)
+          displayName: Record commit hashes of libraries
+          env:
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            REPO_URI: $(Build.Repository.Uri)
+          condition: eq(variables.UsePipelineCache, 'true')
+
+        #  Cache tasks
+        - task: Cache@2
+          displayName: Cache libraries build
+          inputs:
+            key: '"libraries-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+            path: $(Build.StagingDirectory)
+            cacheHitVar: BUILD_CACHE_RESTORED
+          condition: eq(variables.UsePipelineCache, 'true')
+
+        - task: Cache@2
+          displayName: Cache libraries build logs
+          inputs:
+            key: '"libraries-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | $(CommitsOutputFile)'
+            path: $(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)
+            cacheHitVar: BUILD_LOGS_RESTORED
+            condition: eq(variables.UsePipelineCache, 'true')
+
+        - script: |
+            echo Cache restored
+          displayName: Cache Hit
+          condition: eq(variables.BUILD_CACHE_RESTORED, 'true')
+
+        - script: |
+            echo Cache not restored
+          displayName: Cache Miss
+          condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
+
         - ${{ if eq(parameters.isOfficialBuild, true) }}:
           - template: /eng/pipelines/common/restore-internal-tools.yml
 
@@ -102,6 +170,7 @@ jobs:
                 $(_buildArguments)
                 $(_additionalBuildArguments)
           displayName: Restore and Build Product
+          condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
         - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
           - script: |

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -122,7 +122,7 @@ jobs:
 
         # Get the commit hashes of interesting folder for caching
         - script: |
-            $(PythonScript) $(GetCommitScript) -configuration $(ConfigurationName) -run_type libraries -output $(CommitsOutputFile)
+            $(PythonScript) $(GetCommitScript) -configuration "$(ConfigurationName)" -run_type libraries -output $(CommitsOutputFile)
           displayName: Record commit hashes of libraries
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -158,11 +158,13 @@ jobs:
         - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
           - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }} ${{ parameters.archType }} azDO
             displayName: Install Build Dependencies
+            condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
           - script: |
               du -sh $(Build.SourcesDirectory)/*
               df -h
             displayName: Disk Usage before Build
+            condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
         - script: $(_buildScript)
                 -subset $(_subset)

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -86,8 +86,12 @@ jobs:
           - name: UsePipelineCache
             value: true
 
+        - name: ConfigurationName
+          value: ${{ format('Libraries {0} {1}{2} {3} {4} {5}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.framework) }}
+
         - name: CommitsOutputFile
           value: '$(Build.SourcesDirectory)/libraries.commit_hash'
+
         - name: GetCommitScript
           value: '$(Build.SourcesDirectory)/src/coreclr/scripts/get_commit_hash.py'
 
@@ -118,7 +122,7 @@ jobs:
 
         # Get the commit hashes of interesting folder for caching
         - script: |
-            $(PythonScript) $(GetCommitScript) -run_type libraries -output $(CommitsOutputFile)
+            $(PythonScript) $(GetCommitScript) -configuration $(ConfigurationName) -run_type libraries -output $(CommitsOutputFile)
           displayName: Record commit hashes of libraries
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -127,29 +131,29 @@ jobs:
 
         #  Cache tasks
         - task: Cache@2
-          displayName: Cache libraries build
+          displayName: Cache Build $(ConfigurationName)
           inputs:
-            key: '"libraries-build" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.framework }}" | $(CommitsOutputFile)'
+            key: '"Build" | $(CommitsOutputFile)'
             path: $(Build.StagingDirectory)
             cacheHitVar: BUILD_CACHE_RESTORED
           condition: eq(variables.UsePipelineCache, 'true')
 
         - task: Cache@2
-          displayName: Cache libraries build logs
+          displayName: Cache BuildLogs $(ConfigurationName)
           inputs:
-            key: '"libraries-logs" | "${{ parameters.runtimeVariant }}" | "${{ parameters.osGroup }}" | "${{ parameters.osSubgroup }}" | "${{ parameters.archType }}" | "${{ parameters.buildConfig }}" | "${{ parameters.framework }}" | $(CommitsOutputFile)'
+            key: '"Logs" | $(CommitsOutputFile)'
             path: $(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)
             cacheHitVar: BUILD_LOGS_RESTORED
             condition: eq(variables.UsePipelineCache, 'true')
 
         - script: |
-            echo Cache restored
-          displayName: Cache Hit
+            echo Cache restored for $(ConfigurationName)
+          displayName: Cache Hit - $(ConfigurationName)
           condition: eq(variables.BUILD_CACHE_RESTORED, 'true')
 
         - script: |
-            echo Cache not restored
-          displayName: Cache Miss
+            echo Cache not restored for $(ConfigurationName)
+          displayName: Cache Miss - $(ConfigurationName)
           condition: eq(variables.BUILD_CACHE_RESTORED, 'false')
 
         - ${{ if eq(parameters.isOfficialBuild, true) }}:

--- a/eng/pipelines/libraries/prepare-for-bin-publish.yml
+++ b/eng/pipelines/libraries/prepare-for-bin-publish.yml
@@ -4,6 +4,9 @@ parameters:
   isOfficialBuild: ''
 
 steps:
+
+
+
   - ${{ if ne(parameters.isOfficialBuild, true) }}:
     - task: CopyFiles@2
       displayName: Prepare bin folders to publish (unofficial build)
@@ -14,6 +17,7 @@ steps:
           ref/**
           runtime/**
           testhost/**
+      condition: ne(variables.BUILD_CACHE_RESTORED, 'true')
 
   - task: CopyFiles@2
     displayName: Prepare bin folders to publish
@@ -24,10 +28,11 @@ steps:
         docs/**
         microsoft.netcore.app.*/**
         native/**
+    condition: ne(variables.BUILD_CACHE_RESTORED, 'true')
   
   - task: CopyFiles@2
     displayName: Prepare artifacts packages folder to publish
     inputs:
       sourceFolder: $(Build.SourcesDirectory)/artifacts/packages
       targetFolder: $(Build.ArtifactStagingDirectory)/artifacts/packages
-    condition: and(succeeded(), eq(variables['_librariesBuildProducedPackages'], true))
+    condition: and(and(succeeded(), eq(variables['_librariesBuildProducedPackages'], true)), ne(variables.BUILD_CACHE_RESTORED, 'true'))

--- a/src/coreclr/scripts/get_commit_hash.py
+++ b/src/coreclr/scripts/get_commit_hash.py
@@ -104,6 +104,8 @@ def main(main_args):
     print("Source directory: {}".format(source_directory))
 
     run_command(["git", "--version"], source_directory, _exit_on_fail=True)
+
+    print(" -- Printing commit history")
     run_command(["git", "--no-pager", "log", "-100", "--oneline"], source_directory, _exit_on_fail=True)
 
     # We fetch upto 20 commits only when the repository is cloned. All the commits past 20 commits are grafted. If
@@ -112,16 +114,20 @@ def main(main_args):
     #
     # If the PR branch has 100+ commits, we might still see similar issue, but changes are rare to have
     # a PR having 100+ commits. In such case, the commit hash will be "grafted" everytime.
-    print("Fetching history of 80 more commits from HEAD, so we can find the correct hash.")
+    print(" -- Fetching history of 80 more commits from HEAD, so we can find the correct hash.")
     _, _, return_code = run_command(["git", "fetch", "--depth=80", repo_url, "HEAD"], source_directory)
 
-    print("Printing logs of Directory* files")
+    print(" -- Printing commit history")
+    run_command(["git", "--no-pager", "log", "-100", "--oneline"], source_directory, _exit_on_fail=True)
+
+    print(" -- Printing logs of Directory* files")
     run_command(["git", "--no-pager", "log", "-10", "--oneline", "--", os.path.join(source_directory, "Directory.Build.targets")], source_directory, _exit_on_fail=True)
     run_command(["git", "--no-pager", "log", "-10", "--oneline", "--", os.path.join(source_directory, "Directory.Solution.props")], source_directory, _exit_on_fail=True)
 
     if return_code != 0:
         print("git fetch failed. Use grafted commit hashes.")
 
+    print(" -- Creating commits file")
     create_commits_file(['common', run_type], source_directory, output_file)
 
 if __name__ == "__main__":

--- a/src/coreclr/scripts/get_commit_hash.py
+++ b/src/coreclr/scripts/get_commit_hash.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+#
+## Licensed to the .NET Foundation under one or more agreements.
+## The .NET Foundation licenses this file to you under the MIT license.
+#
+##
+# Title: get_commit_hash.py
+#
+# Notes:
+#
+# Script to store git commit hash of certain paths and store them in a file.
+#
+################################################################################
+################################################################################
+
+import argparse
+import os
+from coreclr_arguments import *
+from jitutil import run_command
+
+
+parser = argparse.ArgumentParser(description="description")
+
+parser.add_argument("-run_type", help="Type of run. Options: 'coreclr', 'libraries'")
+parser.add_argument("-output", help="Path to output file")
+
+paths = {
+    'common': [
+        'global.json',
+        'Directory.Build.targets',
+        'Directory.Build.props',
+        'Directory.Solution.props',
+        'eng'
+    ],
+    'coreclr' : [
+        'src/coreclr',
+        'src/native',
+    ],
+    'libraries' : [
+        'src/libraries',
+        'src/coreclr/System.Private.CoreLib',
+    ]
+}
+
+def setup_args(args):
+    """ Setup the args
+
+    Args:
+        args (ArgParse): args parsed by arg parser
+
+    Returns:
+        args (CoreclrArguments)
+
+    """
+    coreclr_args = CoreclrArguments(args, require_built_core_root=False, require_built_product_dir=False,
+                                    require_built_test_dir=False, default_build_type="Checked")
+
+    coreclr_args.verify(args,
+                        "run_type",
+                        lambda unused: True,
+                        "Unable to set run_type")
+
+    coreclr_args.verify(args,
+                        "output",
+                        lambda unused: True,
+                        "Unable to set paths")
+
+    return coreclr_args
+
+def create_commits_file(run_types, source_directory, output_file):
+    """Creates a commit file containing hashes for all the paths specific
+    to the run_types specified
+
+    Args:
+        run_types ([string]): Array of run_types
+    """
+
+    with open(output_file, 'w') as of:
+        for run_type in run_types:
+            for git_path in paths[run_type]:
+                git_path = os.path.join(source_directory, git_path)
+                if not os.path.exists(git_path):
+                    continue
+                git_output, _, _ = run_command(["git", "--no-pager", "log", "-n", "1", "--oneline", "--", git_path])
+                of.write(git_output.decode("utf-8"))
+
+def main(main_args):
+    """Main entrypoint
+
+    Args:
+        main_args ([type]): Arguments to the script
+    """
+
+    coreclr_args = setup_args(main_args)
+    run_type = coreclr_args.run_type
+    output_file = coreclr_args.output
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    source_directory = os.path.join(current_directory, "..", "..", "..")
+
+    access_token = os.environ['SYSTEM_ACCESSTOKEN']
+    repo_url = os.environ['REPO_URI'].replace("https://dnceng", "https://{}".format(access_token))
+
+    print("Repo url: {}".format(repo_url))
+    print("Source directory: {}".format(source_directory))
+
+    run_command(["git", "--version"], source_directory, _exit_on_fail=True)
+    run_command(["git", "--no-pager", "log", "-100", "--oneline"], source_directory, _exit_on_fail=True)
+
+    # We fetch upto 20 commits only when the repository is cloned. All the commits past 20 commits are grafted. If
+    # the changes in PR are 20+ commits, we will get "grafted" commit hash of folders that are not touched.
+    # Hence, fetch 80 more commits to hope to get accurate commit hash.
+    #
+    # If the PR branch has 100+ commits, we might still see similar issue, but changes are rare to have
+    # a PR having 100+ commits. In such case, the commit hash will be "grafted" everytime.
+    print("Fetching history of 80 more commits from HEAD, so we can find the correct hash.")
+    _, _, return_code = run_command(["git", "fetch", "--depth=80", repo_url, "HEAD"], source_directory)
+
+    print("Printing logs of Directory* files")
+    run_command(["git", "--no-pager", "log", "-10", "--oneline", "--", os.path.join(source_directory, "Directory.Build.targets")], source_directory, _exit_on_fail=True)
+    run_command(["git", "--no-pager", "log", "-10", "--oneline", "--", os.path.join(source_directory, "Directory.Solution.props")], source_directory, _exit_on_fail=True)
+
+    if return_code != 0:
+        print("git fetch failed. Use grafted commit hashes.")
+
+    create_commits_file(['common', run_type], source_directory, output_file)
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    sys.exit(main(args))

--- a/src/coreclr/scripts/get_commit_hash.py
+++ b/src/coreclr/scripts/get_commit_hash.py
@@ -29,7 +29,7 @@ paths = {
         'Directory.Build.targets',
         'Directory.Build.props',
         'Directory.Solution.props',
-        'eng'
+#        'eng'
     ],
     'coreclr': [
         'src/coreclr',
@@ -93,6 +93,10 @@ def create_commits_file(run_types, source_directory, output_file):
                     git_output = "grafted{}".format(os.linesep)
 
                 of.write("'{}': {}".format(git_path, git_output))
+
+    print(" -- {} contents: ".format(output_file))
+    with open(output_file, 'r') as of:
+        print(of.read())
 
 def main(main_args):
     """Main entrypoint


### PR DESCRIPTION
The goal of this PR is to enable [pipeline-caching](https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops) for build scenarios of coreclr and libraries. In future, we would like to extend it for scenarios like building test, Mono and to some extent test execution. 

## Overview

The idea behind pipeline caching is simple. After the artifacts of a particular job is produced, store it in an Azure cache against a particular "cache key". If there is a subsequent run that happens in the pipeline (related or unrelated to the original run), and if the "cache key" matches, the job will simply download the cached contents and skip producing the artifacts entirely, saving us some machine time. In this PR, the artifacts creation that I am optimizing is the creation of coreclr and libraries binaries. During the coreclr/libraries build step, it will see if we have already built the binaries and if yes, it will simply download it from Azure storage and upload it as pipeline artifacts. All the steps related to installing pre-requisite tools, product build, zipping, etc. will be skipped. This is possible using `Cache@2` task of AzDo.

## Scenarios

In this PR, the support of pipeline-caching is added to all the pipelines (internal and public) that consumes `coreclr/templates/build-job.yml` and `libraries/build-job.yml` files and if triggered `Manually` or through a `PullRequest`. To take an example, if a developer submits a PullRequest that just touches `libraries` folder. During the first execution of `runtime` pipeline on the PR branch, the `build-job.yml` would build required coreclr/libraries builds. If the developer further pushes more changes and if between the initial and subsequent changes, if there were no additional changes done in `coreclr` folder on `main` branch (see more details below), the caching will restore the previously cached CoreCLR binaries without needing to build them again. It will also upload the required artifacts, just as it happens today. Since there are at least 10~30 different configuration of `coreclr` builds we do, if the cache is "hit", we could save approximately 30 * 15 mins = 450 minutes of machine execution time on the subsequent run once this feature is enabled. As of today, the cache key is only matched per PR-branch. In other words, if there is a PR# AAA that touched `libraries` folder and we built and cached the artifacts that were produced out of it. Next there is another PR# BBB that is sent out and it too just touched `libraries` folder, and between `AAA` and `BBB` there were no `coreclr` commits in `main`, PR #BBB will still not be able to use cached contents. I have opened an https://github.com/microsoft/azure-pipelines-tasks/issues/15589 to check why. The documentation clearly says that such scenarios are allowed, and cache can be used across branches within the same pipeline. However, if there were further updates to PR `AAA`, the cached contents can be used.

To summarize, in the best case, for a single additional push to a PR branch, pipeline caching can save up to 450 minutes of machine time. The worst case, when there are too many frequent changes in `coreclr` and `libraries`, the cache-key will never match and we will end up building the product, the way we do today except that we will continue to cache them in the hope that some run will use it. The step that caches the contents takes approximately 20 seconds and hence should not regress the current workflow.

## Cache Key

`Cache@2` needs a cache-key that should be unique for that particular run. Azdo creates a fingerprint of the cache-key and uses it to search for the cached contents. One portion of the cache-key should contain the build specific information like OS name, Architecture, BuildType (Debug, Checked or Release), framework name, etc. However, we also need a unique identifier to confirm if there were any changes in folders/files that would help us decide if a build is needed or not. The way I approached it is by checking the git-hashes of the paths we are interested in. [get_commit_hash](https://github.com/dotnet/runtime/pull/62464/files#diff-e60af28e3f16bb69b02b4c0017f9bd4b7abfdd0a50416e1848858d4a59c886faR41) is the python script that I would trigger to fetch the git-hashes of the paths that are interested for that particular build. For examples, if building `coreclr`, I would check the git commit hashes of `src/coreclr` and `src/native` folder. All the git commit hashes along with the build configuration (OS, architecture, etc.) is saved in a commit.txt file. I then use the contents of this file as the cache key that AzDo will use to check if it is a "cache hit" or a "cache miss".

Before we run the pipeline, we always merge the latest `main` in the PR branch. In such cases, if files inside `coreclr` is touched, we will always find a unique *merge* hash commit for `coreclr` folder and hence mismatch the previous cache key. This will guarantee that we build `coreclr` if there are any changes in that folder. On the contrary, we just fetch 40 commit's history during checkout. I added code to fetch little more history so we can correctly see the last commit that changed a folder/file. But sometimes, that might not be enough, and the files/folders might have changed prior to the history we have on AzDo machine. In such case, I will make an entry of `grafted` next to the file path. [Here](https://dev.azure.com/dnceng/public/_build/results?buildId=1503794&view=logs&j=54cabf5c-1ba4-54c9-31cb-a3ef0d378039&t=43aed140-0b0f-5596-36b8-b27458d6e610) are sample logs from [get_commit_hash file](https://github.com/dotnet/runtime/pull/62464/files#diff-e60af28e3f16bb69b02b4c0017f9bd4b7abfdd0a50416e1848858d4a59c886fa).

## Design

As mentioned previously, the `UsePipeline` variable is set to true only if the run is triggered from a PullRequest or Manually. It will be used to determine if `Cache@2` needs to be executed. There are other variables like `BUILD_CACHE_RESTORED`, BUILD_LOGS_RESTORED`, etc. that are set if the cache is restored. The values of these variables are then used to determine whether we should perform a particular step or should skip it.

There are few templates where the checks for `BUILD_CACHE_RESTORED` was needed and there is not a reliable way to add this in condition. Hence, I had to add their check explicitly in those yml files.

## Lookouts

Reviewers, please make sure if the paths I have listed in [get_commit_hash](https://github.com/dotnet/runtime/pull/62464/files#diff-e60af28e3f16bb69b02b4c0017f9bd4b7abfdd0a50416e1848858d4a59c886faR41) are correct and if more paths need to be added in the given categories.

## Next

I have a kustos query to understand if we are hitting "Cache Hit" or not. So in future, if we think that we almost never hit cache, we can look back and see how to improve things. Overall, if this is successful, it will also prove beneficial to cache building coreclr/libraries test because they are changed less frequently and hence will certainly be restored from the cache.

## Risk

It could happen that due to a bug, we might restore the cache that contains wrong or incorrect build artifacts. To work around, a developer can always make changes to one of the paths listed under `common` category and in such cases, the cache will always guarantee to see a cache miss. I have also opened https://github.com/microsoft/azure-pipelines-tasks/issues/15583 to track some other issues in this feature.


Contributes to https://github.com/dotnet/runtime/issues/59598