### PR TITLE
Fix createdump failure on MacOS Monterey version 12.0.1

### DIFF
--- a/src/coreclr/debug/dbgutil/machoreader.cpp
+++ b/src/coreclr/debug/dbgutil/machoreader.cpp
@@ -126,19 +126,36 @@ MachOModule::TryLookupSymbol(const char* symbolName, uint64_t* symbolValue)
         _ASSERTE(m_nlists != nullptr);
         _ASSERTE(m_strtabAddress != 0);
 
-        for (int i = 0; i < m_dysymtabCommand->nextdefsym; i++)
+        // First, search just the "external" export symbols 
+        if (TryLookupSymbol(m_dysymtabCommand->iextdefsym, m_dysymtabCommand->nextdefsym, symbolName, symbolValue))
         {
-            std::string name = GetSymbolName(i);
-            // Skip the leading underscores to match Linux externs
-            if (name[0] == '_')
-            {
-                name.erase(0, 1);
-            }
-            if (strcmp(name.c_str(), symbolName) == 0)
-            {
-                *symbolValue = m_loadBias + m_nlists[i].n_value;
-                return true;
-            }
+            return true;
+        }
+        // If not found in external symbols, search all of them
+        if (TryLookupSymbol(0, m_symtabCommand->nsyms, symbolName, symbolValue))
+        {
+            return true;
+        }
+    }
+    *symbolValue = 0;
+    return false;
+}
+
+bool
+MachOModule::TryLookupSymbol(int start, int nsyms, const char* symbolName, uint64_t* symbolValue)
+{
+    for (int i = 0; i < nsyms; i++)
+    {
+        std::string name = GetSymbolName(start + i);
+        // Skip the leading underscores to match Linux externs
+        if (name[0] == '_')
+        {
+            name.erase(0, 1);
+        }
+        if (strcmp(name.c_str(), symbolName) == 0)
+        {
+            *symbolValue = m_loadBias + m_nlists[start + i].n_value;
+            return true;
         }
     }
     *symbolValue = 0;
@@ -263,17 +280,21 @@ MachOModule::ReadSymbolTable()
         _ASSERTE(m_symtabCommand != nullptr);
         _ASSERTE(m_strtabAddress == 0);
 
-        m_reader.TraceVerbose("SYM: symoff %08x nsyms %d stroff %08x strsize %d iext %d next %d\n",
+        m_reader.TraceVerbose("SYM: symoff %08x nsyms %d stroff %08x strsize %d iext %d next %d iundef %d nundef %d extref %d nextref %d\n",
             m_symtabCommand->symoff,
             m_symtabCommand->nsyms,
             m_symtabCommand->stroff,
             m_symtabCommand->strsize,
             m_dysymtabCommand->iextdefsym,
-            m_dysymtabCommand->nextdefsym);
+            m_dysymtabCommand->nextdefsym,
+            m_dysymtabCommand->iundefsym,
+            m_dysymtabCommand->nundefsym,
+            m_dysymtabCommand->extrefsymoff,
+            m_dysymtabCommand->nextrefsyms);
 
-        // Read the external symbol part of symbol table. An array of "nlist" structs.
-        void* extSymbolTableAddress = (void*)(GetAddressFromFileOffset(m_symtabCommand->symoff) + (m_dysymtabCommand->iextdefsym * sizeof(nlist_64)));
-        size_t symtabSize = sizeof(nlist_64) * m_dysymtabCommand->nextdefsym;
+        // Read the entire symbol part of symbol table. An array of "nlist" structs.
+        void* extSymbolTableAddress = (void*)GetAddressFromFileOffset(m_symtabCommand->symoff);
+        size_t symtabSize = sizeof(nlist_64) * m_symtabCommand->nsyms;
         m_nlists = (nlist_64*)malloc(symtabSize);
         if (m_nlists == nullptr)
         {

--- a/src/coreclr/debug/dbgutil/machoreader.h
+++ b/src/coreclr/debug/dbgutil/machoreader.h
@@ -37,6 +37,7 @@ public:
 
     bool ReadHeader();
     bool TryLookupSymbol(const char* symbolName, uint64_t* symbolValue);
+    bool TryLookupSymbol(int start, int nsyms, const char* symbolName, uint64_t* symbolValue);
     bool EnumerateSegments();
 
 private:


### PR DESCRIPTION
Fails looking for the symbol _dyld_all_image_infos in dylinker. The fix is to fallback to searching all the symbols after searching the "external" symbols.

https://github.com/dotnet/runtime/issues/62181