### PR TITLE
Put generated `InvalidClientHelloDataTruncatedBytes` data into one test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
@@ -23,11 +23,14 @@ namespace System.Net.Security.Tests
             InvalidClientHello(clientHello, id, shouldPass: false);
         }
 
-        [Theory]
-        [MemberData(nameof(InvalidClientHelloDataTruncatedBytes))]
-        public void SniHelper_TruncatedData_Fails(int id, byte[] clientHello)
+        [Fact]
+        public void SniHelper_TruncatedData_Fails()
         {
-            InvalidClientHello(clientHello, id, shouldPass: false);
+            // moving inside one test because there are more than 3000 cases and they overflow subresults
+            foreach ((int id, byte[] clientHello) in InvalidClientHelloDataTruncatedBytes())
+            {
+                InvalidClientHello(clientHello, id, shouldPass: false);
+            }
         }
 
         private void InvalidClientHello(byte[] clientHello, int id, bool shouldPass)
@@ -94,7 +97,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        public static IEnumerable<object[]> InvalidClientHelloDataTruncatedBytes()
+        public static IEnumerable<Tuple<int, byte[]>> InvalidClientHelloDataTruncatedBytes()
         {
             // converting to base64 first to remove duplicated test cases
             var uniqueInvalidHellos = new HashSet<string>();
@@ -115,7 +118,7 @@ namespace System.Net.Security.Tests
             foreach (string invalidClientHello in uniqueInvalidHellos)
             {
                 id++;
-                yield return new object[] { id, Convert.FromBase64String(invalidClientHello) };
+                yield return new Tuple<int, byte[]>(id, Convert.FromBase64String(invalidClientHello));
             }
         }
 


### PR DESCRIPTION
There are 3980 generated test cases in `SniHelper_TruncatedData_Fails` scenario, it breaks XUnit limits for subresults and therefore doesn't report them properly.
The same change was made in YARP's test https://github.com/microsoft/reverse-proxy/pull/1432