### PR TITLE
Exclude DNNE based test project from armel builds

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -46,6 +46,11 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\DllImportGenerator.Tests\DllImportGenerator.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetArchitecture)' == 'armel'">
+    <!-- DllImportGenerator runtime tests depend on DNNE, which does not support armel as we don't officially support it. -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\DllImportGenerator.Tests\DllImportGenerator.Tests.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetArchitecture)' == 'arm'">
     <!-- Issue: https://github.com/dotnet/runtime/issues/60705 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\DllImportGenerator.UnitTests\DllImportGenerator.Unit.Tests.csproj" />


### PR DESCRIPTION
Using `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-armel-tizen-20210719212651-8b02f56` container, I have bisected the issue to this commit 78f4fa8d82635775158245d86ae889426e2ac550. Fix is to exclude DNNE dependent test project from restore and build on armel.

Fixes #62478.
cc @gbalykov, @jkoritzinsky