### PR TITLE
Notepad window title is uppercase on Windows 11

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -1318,7 +1318,7 @@ namespace System.Diagnostics.Tests
             string expected = Path.GetFileNameWithoutExtension(filename);
 
             process.WaitForInputIdle(); // Give the file a chance to load
-            Assert.Equal("notepad", process.ProcessName);
+            Assert.Equal("notepad", process.ProcessName.ToLower());
 
             // Notepad calls CreateWindowEx with pWindowName of empty string, then calls SetWindowTextW
             // with "Untitled - Notepad" then finally if you're opening a file, calls SetWindowTextW

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -267,11 +267,16 @@ namespace System.Diagnostics.Tests
                 {
                     if (px != null) // sometimes process is null
                     {
-                        Assert.Equal("notepad", px.ProcessName);
-
-                        px.Kill();
-                        Assert.True(px.WaitForExit(WaitInMS));
-                        px.WaitForExit(); // wait for event handlers to complete
+                        try
+                        {
+                            Assert.Equal("notepad", px.ProcessName.ToLower());
+                        }
+                        finally
+                        {
+                            px.Kill();
+                            Assert.True(px.WaitForExit(WaitInMS));
+                            px.WaitForExit(); // wait for event handlers to complete
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix failure seen in https://github.com/dotnet/runtime/pull/62396/