### PR TITLE
[wasm] only trigger global compatibility mode when usage and configuration are global

### DIFF
--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.extpost.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.extpost.js
@@ -1,4 +1,5 @@
-
-if (typeof globalThis.Module === "object") {
+// if loaded into global namespace and configured with global Module, we will self start in compatibility mode
+let ENVIRONMENT_IS_GLOBAL = typeof globalThis.Module === "object" && globalThis.__dotnet_runtime === __dotnet_runtime;
+if (ENVIRONMENT_IS_GLOBAL) {
     createDotnetRuntime(() => { return globalThis.Module; }).then((exports) => exports);
 }

--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.pre.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.pre.js
@@ -1,5 +1,4 @@
 const MONO = {}, BINDING = {}, INTERNAL = {};
-let ENVIRONMENT_IS_GLOBAL = typeof globalThis.Module === "object";
 if (ENVIRONMENT_IS_GLOBAL) {
     if (globalThis.Module.ready) {
         throw new Error("MONO_WASM: Module.ready couldn't be redefined.")

--- a/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
+++ b/src/mono/wasm/runtime/es6/dotnet.es6.lib.js
@@ -10,7 +10,7 @@ const DotnetSupportLib = {
     $DOTNET__postset: `
     let __dotnet_replacements = {scriptDirectory, readAsync, fetch: globalThis.fetch};
     let __dotnet_exportedAPI = __dotnet_runtime.__initializeImportsAndExports(
-        { isGlobal:ENVIRONMENT_IS_GLOBAL, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile }, 
+        { isGlobal:false, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile }, 
         { mono:MONO, binding:BINDING, internal:INTERNAL, module:Module },
         __dotnet_replacements);
     


### PR DESCRIPTION
Because `globalThis.Module` could be still defined after Blazor switched to modularized. 
We should not trigger self start, when loaded via `import` even if global `Module` exists.