### PR TITLE
System.IO.Stream: Decorate validation helpers with [NotNull] to fix CA1062 false positives

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -738,7 +738,7 @@ namespace System.IO
         /// <paramref name="offset"/> and <paramref name="count"/> exceed the length of <paramref name="buffer"/>.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static void ValidateBufferArguments(byte[] buffer, int offset, int count)
+        protected static void ValidateBufferArguments([NotNull] byte[]? buffer, int offset, int count)
         {
             if (buffer is null)
             {
@@ -763,7 +763,7 @@ namespace System.IO
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bufferSize"/> was not a positive value.</exception>
         /// <exception cref="NotSupportedException"><paramref name="destination"/> does not support writing.</exception>
         /// <exception cref="ObjectDisposedException"><paramref name="destination"/> does not support writing or reading.</exception>
-        protected static void ValidateCopyToArguments(Stream destination, int bufferSize)
+        protected static void ValidateCopyToArguments([NotNull] Stream? destination, int bufferSize)
         {
             if (destination is null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -738,7 +738,7 @@ namespace System.IO
         /// <paramref name="offset"/> and <paramref name="count"/> exceed the length of <paramref name="buffer"/>.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static void ValidateBufferArguments([NotNull] byte[]? buffer, int offset, int count)
+        protected static void ValidateBufferArguments([NotNull] byte[] buffer, int offset, int count)
         {
             if (buffer is null)
             {
@@ -763,7 +763,7 @@ namespace System.IO
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bufferSize"/> was not a positive value.</exception>
         /// <exception cref="NotSupportedException"><paramref name="destination"/> does not support writing.</exception>
         /// <exception cref="ObjectDisposedException"><paramref name="destination"/> does not support writing or reading.</exception>
-        protected static void ValidateCopyToArguments([NotNull] Stream? destination, int bufferSize)
+        protected static void ValidateCopyToArguments([NotNull] Stream destination, int bufferSize)
         {
             if (destination is null)
             {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10791,8 +10791,8 @@ namespace System.IO
         public abstract long Seek(long offset, System.IO.SeekOrigin origin);
         public abstract void SetLength(long value);
         public static System.IO.Stream Synchronized(System.IO.Stream stream) { throw null; }
-        protected static void ValidateBufferArguments(byte[] buffer, int offset, int count) { }
-        protected static void ValidateCopyToArguments(System.IO.Stream destination, int bufferSize) { }
+        protected static void ValidateBufferArguments([System.Diagnostics.CodeAnalysis.NotNull] byte[]? buffer, int offset, int count) { throw null; }
+        protected static void ValidateCopyToArguments([System.Diagnostics.CodeAnalysis.NotNull] System.IO.Stream? destination, int bufferSize) { throw null; }
         public abstract void Write(byte[] buffer, int offset, int count);
         public virtual void Write(System.ReadOnlySpan<byte> buffer) { }
         public System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10791,8 +10791,8 @@ namespace System.IO
         public abstract long Seek(long offset, System.IO.SeekOrigin origin);
         public abstract void SetLength(long value);
         public static System.IO.Stream Synchronized(System.IO.Stream stream) { throw null; }
-        protected static void ValidateBufferArguments([System.Diagnostics.CodeAnalysis.NotNullAttribute] byte[]? buffer, int offset, int count) { }
-        protected static void ValidateCopyToArguments([System.Diagnostics.CodeAnalysis.NotNullAttribute] System.IO.Stream? destination, int bufferSize) { }
+        protected static void ValidateBufferArguments([System.Diagnostics.CodeAnalysis.NotNullAttribute] byte[] buffer, int offset, int count) { }
+        protected static void ValidateCopyToArguments([System.Diagnostics.CodeAnalysis.NotNullAttribute] System.IO.Stream destination, int bufferSize) { }
         public abstract void Write(byte[] buffer, int offset, int count);
         public virtual void Write(System.ReadOnlySpan<byte> buffer) { }
         public System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10791,8 +10791,8 @@ namespace System.IO
         public abstract long Seek(long offset, System.IO.SeekOrigin origin);
         public abstract void SetLength(long value);
         public static System.IO.Stream Synchronized(System.IO.Stream stream) { throw null; }
-        protected static void ValidateBufferArguments([System.Diagnostics.CodeAnalysis.NotNull] byte[]? buffer, int offset, int count) { throw null; }
-        protected static void ValidateCopyToArguments([System.Diagnostics.CodeAnalysis.NotNull] System.IO.Stream? destination, int bufferSize) { throw null; }
+        protected static void ValidateBufferArguments([System.Diagnostics.CodeAnalysis.NotNullAttribute] byte[]? buffer, int offset, int count) { }
+        protected static void ValidateCopyToArguments([System.Diagnostics.CodeAnalysis.NotNullAttribute] System.IO.Stream? destination, int bufferSize) { }
         public abstract void Write(byte[] buffer, int offset, int count);
         public virtual void Write(System.ReadOnlySpan<byte> buffer) { }
         public System.Threading.Tasks.Task WriteAsync(byte[] buffer, int offset, int count) { throw null; }


### PR DESCRIPTION
I have a custom stream implementation doing something like...

```csharp
public sealed class MyStream : Stream
{
   public void WriteHeader(Stream destination)
   {
      ValidateCopyToArguments(destination, bufferSize: 128);

      // Triggers CA1062
      destination.Write(s_Header);
   }
```

I think the CA1062 can be avoided with some hints on the validation call.

Question: I couldn't find the /refs/ for the Stream definition does that exist somewhere and if so does it also need updating?