### PR TITLE
[build] Create clr.host subset to remove patching step for mono runtime tests

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -100,6 +100,7 @@
     <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools." />
     <SubsetName Include="Clr.PalTests" OnDemand="true" Description="The CoreCLR PAL tests." />
     <SubsetName Include="Clr.PalTestList" OnDemand="true" Description="Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead." />
+    <SubsetName Include="Clr.Hosts" Description="The CoreCLR corerun test host." />
     <SubsetName Include="Clr.Jit" Description="The JIT for the CoreCLR .NET runtime." />
     <SubsetName Include="Clr.AllJits" Description="All of the cross-targeting JIT compilers for the CoreCLR .NET runtime." />
     <SubsetName Include="Clr.CoreLib" Description="The managed System.Private.CoreLib library for CoreCLR." />
@@ -163,6 +164,10 @@
   <ItemGroup Condition="$(_subset.Contains('+clr.corelib+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot)System.Private.CoreLib\System.Private.CoreLib.csproj" Category="clr" />
   </ItemGroup>
+
+  <PropertyGroup Condition="$(_subset.Contains('+clr.hosts+'))">
+    <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrHostsSubset=true</ClrRuntimeBuildSubsets>
+  </PropertyGroup>
 
   <PropertyGroup Condition="$(_subset.Contains('+clr.runtime+'))">
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrRuntimeSubset=true</ClrRuntimeBuildSubsets>

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -324,6 +324,9 @@ if NOT DEFINED PYTHON (
 set __CMakeTarget=
 for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
     set "string=%%a"
+    if not "!string:-hosts-=!"=="!string!" (
+        set __CMakeTarget=!__CMakeTarget! hosts
+    )
     if not "!string:-jit-=!"=="!string!" (
         set __CMakeTarget=!__CMakeTarget! jit
     )
@@ -739,7 +742,7 @@ echo -all: Builds all configurations and platforms.
 echo Build architecture: one of -x64, -x86, -arm, -arm64 ^(default: -x64^).
 echo Build type: one of -Debug, -Checked, -Release ^(default: -Debug^).
 echo -component ^<name^> : specify this option one or more times to limit components built to those specified.
-echo                     Allowed ^<name^>: jit alljits runtime paltests iltools
+echo                     Allowed ^<name^>: hosts jit alljits runtime paltests iltools
 echo -enforcepgo: verify after the build that PGO was used for key DLLs, and fail the build if not
 echo -pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.
 echo -cmakeargs: user-settable additional arguments passed to CMake.

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -22,7 +22,7 @@ usage_list+=("-pgodatapath: path to profile guided optimization data.")
 usage_list+=("-pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.")
 usage_list+=("-skipcrossarchnative: Skip building cross-architecture native binaries.")
 usage_list+=("-staticanalyzer: use scan_build static analyzer.")
-usage_list+=("-component: Build individual components instead of the full project. Available options are 'jit', 'runtime', 'paltests', 'alljits', and 'iltools'. Can be specified multiple times.")
+usage_list+=("-component: Build individual components instead of the full project. Available options are 'hosts', 'jit', 'runtime', 'paltests', 'alljits', and 'iltools'. Can be specified multiple times.")
 
 setup_dirs_local()
 {

--- a/src/coreclr/components.cmake
+++ b/src/coreclr/components.cmake
@@ -1,6 +1,7 @@
 # Define all the individually buildable components of the CoreCLR build and their respective targets
 add_component(jit)
 add_component(alljits)
+add_component(hosts)
 add_component(runtime)
 add_component(paltests paltests_install)
 add_component(iltools)
@@ -15,6 +16,8 @@ add_dependencies(runtime coreclr_misc)
 
 # The runtime build requires the clrjit and iltools builds
 add_dependencies(runtime jit iltools)
+
+add_dependencies(runtime hosts)
 
 # The cross-components build is separate, so we don't need to add a dependency on coreclr_misc
 add_component(crosscomponents)

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -32,4 +32,4 @@ else(CLR_CMAKE_HOST_WIN32)
     endif()
 endif(CLR_CMAKE_HOST_WIN32)
 
-install_clr(TARGETS corerun DESTINATIONS . COMPONENT runtime)
+install_clr(TARGETS corerun DESTINATIONS . COMPONENT hosts)

--- a/src/coreclr/hosts/coreshim/CMakeLists.txt
+++ b/src/coreclr/hosts/coreshim/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(CoreShim
     ${STATIC_MT_VCRT_LIB}
 )
 
-install_clr(TARGETS CoreShim DESTINATIONS . COMPONENT runtime)
+install_clr(TARGETS CoreShim DESTINATIONS . COMPONENT hosts)

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -41,6 +41,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(ClrFullNativeBuild)' != 'true'">
+      <_CoreClrBuildArg Condition="'$(ClrHostsSubset)' == 'true'" Include="-component hosts" />
       <_CoreClrBuildArg Condition="'$(ClrRuntimeSubset)' == 'true'" Include="-component runtime" />
       <_CoreClrBuildArg Condition="'$(ClrJitSubset)' == 'true'" Include="-component jit" />
       <_CoreClrBuildArg Condition="'$(ClrPalTestsSubset)' == 'true'" Include="-component paltests" />

--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -16,6 +16,7 @@
     <GCStressDependsOnCoreDisTools Condition="'$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'x64'">true</GCStressDependsOnCoreDisTools>
     <CopyCoreDisToolsToCoreRoot>false</CopyCoreDisToolsToCoreRoot>
     <CopyCoreDisToolsToCoreRoot Condition="$(GCStressDependsOnCoreDisTools) And '$(DotNetBuildFromSource)' != 'true'">true</CopyCoreDisToolsToCoreRoot>
+    <IsDesktopArchitecture Condition="'$(TargetArchitecture)' != 'wasm' and '$(TargetArchitecture)' != 'android' and '$(TargetArchitecture)' != 'iOS' ">true</IsDesktopArchitecture>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)coredistools.targets" Condition="$(CopyCoreDisToolsToCoreRoot)" />
@@ -103,6 +104,8 @@
           Include="$(CoreCLRArtifactsPath)%(RunTimeArtifactsIncludeFolders.Identity)**/*"
           Exclude="@(RunTimeArtifactsExcludeFiles -> '$(CoreCLRArtifactsPath)%(Identity)')"
           TargetDir="%(RunTimeArtifactsIncludeFolders.Identity)" />
+
+    
     </ItemGroup>
 
     <PropertyGroup>
@@ -165,6 +168,11 @@
 
     <ItemGroup>
       <RunTimeDependencyCopyLocal Include="$(CoreDisToolsLibrary)" Condition="$(CopyCoreDisToolsToCoreRoot)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(IsDesktopArchitecture)'" >
+      <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/libcoreclr$(LibSuffix)" TargetDir=""  />
+       <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/*.dll" TargetDir="/"  />
     </ItemGroup>
 
     <Copy

--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -173,6 +173,7 @@
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(IsDesktopOS)'" >
       <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/libcoreclr$(LibSuffix)" TargetDir=""  />
+      <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/libmono-component-*" TargetDir=""  />
        <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/*.dll" TargetDir="/"  />
     </ItemGroup>
 

--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -17,7 +17,7 @@
     <CopyCoreDisToolsToCoreRoot>false</CopyCoreDisToolsToCoreRoot>
     <CopyCoreDisToolsToCoreRoot Condition="$(GCStressDependsOnCoreDisTools) And '$(DotNetBuildFromSource)' != 'true'">true</CopyCoreDisToolsToCoreRoot>
     <!-- Non-desktop OS's use a custom dotnet host, instead of corerun -->
-    <IsDesktopOS Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'android' and '$(TargetsiOS)' != true and '$(TargetsMacCatalyst)' != true">true</IsDesktopOS>
+    <IsDesktopOS Condition="'$(TargetsBrowser)' != 'true' and '$(TargetsAndroid)' != 'true' and '$(TargetstvOS)' != 'true' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true'">true</IsDesktopOS>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)coredistools.targets" Condition="$(CopyCoreDisToolsToCoreRoot)" />
@@ -171,7 +171,7 @@
       <RunTimeDependencyCopyLocal Include="$(CoreDisToolsLibrary)" Condition="$(CopyCoreDisToolsToCoreRoot)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(IsDesktopOS)'" >
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(IsDesktopOS)' == 'true' " >
       <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/libcoreclr$(LibSuffix)" TargetDir=""  />
       <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/libmono-component-*" TargetDir=""  />
        <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/*.dll" TargetDir="/"  />

--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -16,7 +16,8 @@
     <GCStressDependsOnCoreDisTools Condition="'$(TargetOS)' == 'Linux' And '$(TargetArchitecture)' == 'x64'">true</GCStressDependsOnCoreDisTools>
     <CopyCoreDisToolsToCoreRoot>false</CopyCoreDisToolsToCoreRoot>
     <CopyCoreDisToolsToCoreRoot Condition="$(GCStressDependsOnCoreDisTools) And '$(DotNetBuildFromSource)' != 'true'">true</CopyCoreDisToolsToCoreRoot>
-    <IsDesktopArchitecture Condition="'$(TargetArchitecture)' != 'wasm' and '$(TargetArchitecture)' != 'android' and '$(TargetArchitecture)' != 'iOS' ">true</IsDesktopArchitecture>
+    <!-- Non-desktop OS's use a custom dotnet host, instead of corerun -->
+    <IsDesktopOS Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'android' and '$(TargetsiOS)' != true and '$(TargetsMacCatalyst)' != true">true</IsDesktopOS>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)coredistools.targets" Condition="$(CopyCoreDisToolsToCoreRoot)" />
@@ -170,7 +171,7 @@
       <RunTimeDependencyCopyLocal Include="$(CoreDisToolsLibrary)" Condition="$(CopyCoreDisToolsToCoreRoot)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(IsDesktopArchitecture)'" >
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(IsDesktopOS)'" >
       <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/libcoreclr$(LibSuffix)" TargetDir=""  />
        <RuntimeDependencyCopyLocal Include="$(MonoArtifactsPath)/*.dll" TargetDir="/"  />
     </ItemGroup>


### PR DESCRIPTION
This pr creates a clr.hosts subset that allows corerun to be built independently from coreclr.  It also copies the mono version of libcoreclr to the core_root directory during the runtime test build, so that corerun will use it when running the tests.

This simplifies the process of running the runtime tests against mono, by removing the requirement to build coreclr first and the patch it with mono libraries. This should make it easier to reproduce the test runs locally, and also remove a potential source of erros in CI.

There will be follow up PRs to enable CI to actually use this.

I am sure I must have missed some necessary checks somewhere, but this seems to work locally. 

This partially addresses https://github.com/dotnet/runtime/issues/43952 but I will need to do the CI component before that is complete.

Contributes to https://github.com/dotnet/runtime/issues/58266