### PR TITLE
Enable max warnlevel from C# compiler

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -278,6 +278,8 @@
   <PropertyGroup>
     <!-- default to allowing all language features -->
     <LangVersion>preview</LangVersion>
+    <!-- default to max warnlevel -->
+    <AnalysisLevel Condition="'$(MSBuildProjectExtension)' == '.csproj'">preview</AnalysisLevel>
     <LangVersion Condition="'$(MSBuildProjectExtension)' == '.vbproj'">latest</LangVersion>
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>


### PR DESCRIPTION
In .NET 6, the default warnlevel is 6. But the compiler is preparing to ship some warnlevel 7 warnings. Seems useful for the `runtime` repo to enable max warnlevel by default.