### PR TITLE
Skip source gen DLLs in mono AOT

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -123,12 +123,13 @@
     </RemoveDuplicates>
     <ItemGroup>
       <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/*.dll" />
-      <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll" />
+      <!-- https://github.com/dotnet/runtime/issues/62372 -->
+      <CoreRootDlls Include="$(CORE_ROOT)/*.dll"
+        Exclude="$(CORE_ROOT)/xunit.performance.api.dll;
+                 $(CORE_ROOT)/Microsoft.Interop.DllImportGenerator.dll;
+                 $(CORE_ROOT)/Microsoft.Interop.SourceGeneration.dll" />
       <AllDlls Condition="'$(MonoFullAot)' == 'true'" Include="@(TestsAndAssociatedAssemblies);@(CoreRootDlls)" />
       <AllDlls Condition="'$(MonoFullAot)' != 'true'" Include="@(TestsAndAssociatedAssemblies)" />
-      <!-- https://github.com/dotnet/runtime/issues/62372 -->
-      <AllDlls Remove="*Microsoft.Interop.DllImportGenerator.dll" />
-      <AllDlls Remove="*Microsoft.Interop.SourceGeneration.dll" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(CROSSCOMPILE)' == ''">

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -126,6 +126,9 @@
       <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll" />
       <AllDlls Condition="'$(MonoFullAot)' == 'true'" Include="@(TestsAndAssociatedAssemblies);@(CoreRootDlls)" />
       <AllDlls Condition="'$(MonoFullAot)' != 'true'" Include="@(TestsAndAssociatedAssemblies)" />
+      <!-- https://github.com/dotnet/runtime/issues/62372 -->
+      <AllDlls Remove="*Microsoft.Interop.DllImportGenerator.dll" />
+      <AllDlls Remove="*Microsoft.Interop.SourceGeneration.dll" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(CROSSCOMPILE)' == ''">

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -123,7 +123,6 @@
     </RemoveDuplicates>
     <ItemGroup>
       <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/*.dll" />
-      <!-- https://github.com/dotnet/runtime/issues/62372 -->
       <CoreRootDlls Include="$(CORE_ROOT)/*.dll"
         Exclude="$(CORE_ROOT)/xunit.performance.api.dll;
                  $(CORE_ROOT)/Microsoft.Interop.DllImportGenerator.dll;

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2082,13 +2082,13 @@
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'llvmfullaot' ">
         <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/explicitlayout/NestedStructs/case03/**">
-            <Issue>tbd</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/62567</Issue>
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/explicitlayout/NestedStructs/case04/**">
-            <Issue>tbd</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/62567</Issue>
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/explicitlayout/NestedStructs/case05/**">
-            <Issue>tbd</Issue>
+            <Issue>https://github.com/dotnet/runtime/issues/62567</Issue>
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Interop/SuppressGCTransition/SuppressGCTransitionTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/57361</Issue>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2081,6 +2081,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(RuntimeVariant)' == 'llvmfullaot' ">
+        <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/explicitlayout/NestedStructs/case03/**">
+            <Issue>tbd</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/explicitlayout/NestedStructs/case04/**">
+            <Issue>tbd</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/explicitlayout/NestedStructs/case05/**">
+            <Issue>tbd</Issue>
+        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Interop/SuppressGCTransition/SuppressGCTransitionTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/57361</Issue>
         </ExcludeList>
@@ -2343,7 +2352,7 @@
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/Loader/classloader/DefaultInterfaceMethods/regressions/github60486/**">
             <Issue>https://github.com/dotnet/runtime/issues/62334</Issue>
-        </ExcludeList>        
+        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and ('$(RuntimeVariant)' == 'llvmfullaot' or '$(RuntimeVariant)' == 'llvmaot') and '$(TargetArchitecture)' == 'arm64'">


### PR DESCRIPTION
These appear to be failing because Microsoft.CodeAnalysis isn't present, but that's expected
behavior for source generators/analyzers, as they are plugins.

Fixes https://github.com/dotnet/runtime/issues/62372