### PR TITLE
Introduce automation rules for PR workflows

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1134,6 +1134,127 @@
     }
   },
   {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no recent activity"
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "labelAdded",
+                "parameters": {
+                  "label": "no recent activity"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Remove `no recent activity` label from PRs when modified",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no recent activity"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "Remove `no recent activity` label from PRs when commented on",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no recent activity"
+            }
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ],
+      "taskName": "Remove `no recent activity` label from PRs when new review is added",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        }
+      ]
+    }
+  },
+  {
     "taskType": "scheduled",
     "capabilityId": "ScheduledSearch",
     "subCapability": "ScheduledSearch",
@@ -1239,6 +1360,121 @@
           "name": "addReply",
           "parameters": {
             "comment": "This issue will now be closed since it had been marked `no recent activity` but received no further activity in the past 14 days. It is still possible to reopen or comment on the issue, but please note that the issue will be locked if it remains inactive for another 30 days."
+          }
+        },
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Close PRs with no recent activity",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            0,
+            6,
+            12,
+            18
+          ],
+          "timezoneOffset": 0
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 14
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This pull request will now be closed since it had been marked `no recent activity` but received no further activity in the past 14 days. It is still possible to reopen or comment on the pull request, but please note that it will be locked if it remains inactive for another 30 days."
           }
         },
         {
@@ -1366,6 +1602,130 @@
           "name": "addReply",
           "parameters": {
             "comment": "This issue has been automatically marked `no recent activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no recent activity`."
+          }
+        }
+      ]
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Add no recent activity label to PRs",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            4,
+            10,
+            16,
+            22
+          ],
+          "timezoneOffset": 1
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": "needs-author-action"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 14
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "no recent activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This pull request has been automatically marked `no recent activity` because it has not had any activity for 14 days. It will be closed if no further activity occurs within 14 more days. Any new comment (by anyone, not necessarily the author) will remove `no recent activity`."
           }
         }
       ]
@@ -4584,6 +4944,63 @@
           "name": "addLabel",
           "parameters": {
             "label": "community-contribution"
+          }
+        }
+      ]
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "association": "OWNER",
+                  "permissions": "admin"
+                }
+              },
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "association": "MEMBER",
+                  "permissions": "write"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Assign Team PRs to author",
+      "actions": [
+        {
+          "name": "assignToUser",
+          "parameters": {
+            "label": "community-contribution",
+            "user": {
+              "type": "prAuthor"
+            }
           }
         }
       ]


### PR DESCRIPTION
Implements part of #62496, introducing automation related to pull request workflows. Introduces the following rules:

### PR Champion automation

1. PRs authored by users with write or admin permissions in the repo get assigned to the PR automatically (aka. PRs authored by team members are championed by the authors themselves). This complements the existing rule adding the `community-contribution` label to PRs authored by community members.

### Stale PR automation

The following rules echo the automation we already have in place for `needs more info` issues.

1. Stale PRs marked `needs-author-action` get pinged automatically and are marked `no recent activity` after 14 days of inactivity.
2. Open PRs marked `no recent activity` that receive _any_ activity will remove the `no recent activity` label.
3. Open PRs marked `no recent activity` are closed automatically after 14 days of inactivity.

The above rules are complemented by existing automation deployed for the `needs-author-action` label:

1. "Changes Requested" reviews automatically apply the `needs-author-action` label.
2. PR author commenting or pushing commits to the PR branch automatically removes the `needs-author-action` label.