### PR TITLE
[release/6.0] [wasm][debugger] View object attributes - DebugType=full

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -524,10 +524,19 @@ namespace Microsoft.WebAssembly.Diagnostics
             asmStream = new MemoryStream(assembly);
             peReader = new PEReader(asmStream);
             asmMetadataReader = PEReaderExtensions.GetMetadataReader(peReader);
+            Name = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
+            AssemblyNameUnqualified = Name;
             if (pdb != null)
             {
                 pdbStream = new MemoryStream(pdb);
-                pdbMetadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
+                try
+                {
+                    pdbMetadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
+                }
+                catch (BadImageFormatException)
+                {
+                    Console.WriteLine($"Warning: Unable to read debug information of: {Name} (use DebugType=Portable/Embedded)");
+                }
             }
             else
             {
@@ -538,8 +547,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                     pdbMetadataReader = peReader.ReadEmbeddedPortablePdbDebugDirectoryData(embeddedPdbEntry).GetMetadataReader();
                 }
             }
-            Name = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
-            AssemblyNameUnqualified = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
             Populate();
         }
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -860,6 +860,34 @@ namespace DebuggerTests
             );
         }
 
+        [Fact]
+        public async Task InspectLocalsUsingClassFromLibraryUsingDebugTypeFull()
+        {
+            byte[] bytes = File.ReadAllBytes(Path.Combine(DebuggerTestAppPath, "debugger-test-with-full-debug-type.dll"));
+            string asm_base64 = Convert.ToBase64String(bytes);
+
+            string pdb_base64 = null;
+            bytes = File.ReadAllBytes(Path.Combine(DebuggerTestAppPath, "debugger-test-with-full-debug-type.pdb"));
+            pdb_base64 = Convert.ToBase64String(bytes);
+
+            var expression = $"{{ let asm_b64 = '{asm_base64}'; let pdb_b64 = '{pdb_base64}'; invoke_static_method('[debugger-test] DebugTypeFull:CallToEvaluateLocal', asm_b64, pdb_b64); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 818, 8,
+                "CallToEvaluateLocal",
+                wait_for_event_fn: async (pause_location) =>
+                {
+                    var a_props = await GetObjectOnFrame(pause_location["callFrames"][0], "a");
+                    await CheckProps(a_props, new
+                    {
+                        a = TNumber(10),
+                        b = TNumber(20),
+                        c = TNumber(30)
+                    }, "a");
+                }
+            );
+        }
         //TODO add tests covering basic stepping behavior as step in/out/over
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -807,3 +807,15 @@ public class MyIncrementer
         return count + 1;
     }
 }
+
+public class DebugTypeFull
+{
+    public static void CallToEvaluateLocal(string asm_base64, string pdb_base64)
+    {
+        var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-full-debug-type.dll");
+        var myType = asm.GetType("DebuggerTests.ClassToInspectWithDebugTypeFull");
+        var myMethod = myType.GetConstructor(new Type[] { });
+        var a = myMethod.Invoke(new object[]{});
+        System.Diagnostics.Debugger.Break();
+    }
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.csproj
@@ -22,10 +22,12 @@
     <ProjectReference Include="..\library-dependency-debugger-test2\library-dependency-debugger-test2.csproj" Private="true"/>
     <ProjectReference Include="..\debugger-test-with-source-link\debugger-test-with-source-link.csproj" Private="true"/>
     <ProjectReference Include="..\ApplyUpdateReferencedAssembly\ApplyUpdateReferencedAssembly.csproj" />
+    <ProjectReference Include="..\debugger-test-with-full-debug-type\debugger-test-with-full-debug-type.csproj" Private="true"/>
   </ItemGroup>
 
   <Target Name="PrepareForWasmBuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">
     <PropertyGroup>
+      <EnableDefaultWasmAssembliesToBundle>false</EnableDefaultWasmAssembliesToBundle>  
       <WasmAppDir>$(AppDir)</WasmAppDir>
       <WasmMainJSPath>$(MonoProjectRoot)wasm\runtime-test.js</WasmMainJSPath>
       <!-- like is used on blazor -->
@@ -37,6 +39,7 @@
     <ItemGroup>
       <WasmAssembliesToBundle Include="$(OutDir)\$(TargetFileName)" />
       <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-source-link.dll" />
+      <WasmAssembliesToBundle Include="$(OutDir)\debugger-test-with-full-debug-type.dll" />
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)native"/>
       <WasmAssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackRidDir)lib\$(NetCoreAppCurrent)"/>
 


### PR DESCRIPTION
Backport of #62278 to release/6.0

/cc @thaystg

## Customer Impact
Show object attributes even if this object is an instantiation of a class that is in a library that uses DebugType=full. On .net 5 this works, so it's a regression.

## Testing
Unit tests and manual tests on Blazor.

## Risk
Low Risk, only adding a try catch when trying to read the PDB.