### PR TITLE
Improve ARM64 JIT disassembly

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12063,22 +12063,25 @@ void emitter::emitDispExtendReg(regNumber reg, insOpts opt, ssize_t imm)
     assert(insOptsNone(opt) || insOptsAnyExtend(opt) || (opt == INS_OPTS_LSL));
 
     // size is based on the extend option, not the instr size.
-    emitAttr size = insOpts64BitExtend(opt) ? EA_8BYTE : EA_4BYTE;
+    // Assume INS_OPTS_NONE and INS_OPTS_LSL are 64bit as they usually are.
+    emitAttr size = (insOptsNone(opt) || insOptsLSL(opt) || insOpts64BitExtend(opt)) ? EA_8BYTE : EA_4BYTE;
 
     if (strictArmAsm)
     {
-        if (insOptsNone(opt))
+        if (insOptsNone(opt) || (insOptsLSL(opt) && imm == 0))
         {
             emitDispReg(reg, size, false);
         }
         else
         {
             emitDispReg(reg, size, true);
-            if (opt == INS_OPTS_LSL)
+
+            if (insOptsLSL(opt))
                 printf("LSL");
             else
                 emitDispExtendOpts(opt);
-            if ((imm > 0) || (opt == INS_OPTS_LSL))
+
+            if (imm > 0)
             {
                 printf(" ");
                 emitDispImm(imm, false);

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12063,7 +12063,7 @@ void emitter::emitDispExtendReg(regNumber reg, insOpts opt, ssize_t imm)
     assert(insOptsNone(opt) || insOptsAnyExtend(opt) || (opt == INS_OPTS_LSL));
 
     // size is based on the extend option, not the instr size.
-    emitAttr size = insOpts32BitExtend(opt) ? EA_4BYTE : EA_8BYTE;
+    emitAttr size = insOpts64BitExtend(opt) ? EA_8BYTE : EA_4BYTE;
 
     if (strictArmAsm)
     {

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -667,11 +667,6 @@ inline static bool insOptsLSExtend(insOpts opt)
             (opt == INS_OPTS_UXTX) || (opt == INS_OPTS_SXTX));
 }
 
-inline static bool insOpts32BitExtend(insOpts opt)
-{
-    return ((opt == INS_OPTS_UXTW) || (opt == INS_OPTS_SXTW));
-}
-
 inline static bool insOpts64BitExtend(insOpts opt)
 {
     return ((opt == INS_OPTS_UXTX) || (opt == INS_OPTS_SXTX));


### PR DESCRIPTION
This improves the ARM64 JIT disassembly by displaying the ext register by its correct size in 'cmp', 'add', and 'sub'.
This should handle more cases from: https://github.com/dotnet/runtime/issues/36846

Left is without the change. Right is with the change.
These are the only diffs.
![before_after1](https://user-images.githubusercontent.com/1278959/145906545-a3d433c7-a08d-4dea-b7b2-326566c73fbc.png)
![before_after2](https://user-images.githubusercontent.com/1278959/145906558-7a1aee75-1173-48ef-824a-644dfcdf2afd.png)

@dotnet/jit-contrib 