### PR TITLE
Fix some outerloop tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -235,6 +235,8 @@ namespace System
             }
         }
 
+        public static bool CanRunImpersonatedTests => PlatformDetection.IsNotWindowsNanoServer && PlatformDetection.IsWindowsAndElevated;
+
         private static int s_isWindowsElevated = -1;
         public static bool IsWindowsAndElevated
         {

--- a/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
+using Xunit;
 
 namespace System
 {
@@ -37,6 +38,8 @@ namespace System
 
         public WindowsTestAccount(string userName)
         {
+            Assert.True(PlatformDetection.IsWindowsAndElevated);
+
             _userName = userName;
             CreateUser();
         }

--- a/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
@@ -77,6 +77,10 @@ namespace System
                         throw new Win32Exception((int)result);
                     }
                 }
+                else if (result != 0)
+                {
+                    throw new Win32Exception((int)result);
+                }
 
                 const int LOGON32_PROVIDER_DEFAULT = 0;
                 const int LOGON32_LOGON_INTERACTIVE = 2;

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/DeleteOnClose.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/DeleteOnClose.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -63,6 +64,7 @@ namespace System.IO.Tests
                 }
             };
 
+            var sw = Stopwatch.StartNew();
             var tasks = new Task[50];
             for (int i = 0; i < tasks.Length; i++)
             {
@@ -70,12 +72,13 @@ namespace System.IO.Tests
             }
 
             // Wait for 1000 locks.
-            cts.CancelAfter(TimeSpan.FromSeconds(120)); // Test timeout (reason for outerloop)
+            cts.CancelAfter(TimeSpan.FromSeconds(240)); // Test timeout (reason for outerloop)
             Volatile.Write(ref locksRemaining, 500);
             await Task.WhenAll(tasks);
+            sw.Stop();
 
             Assert.True(exclusive, "Exclusive");
-            Assert.False(cts.IsCancellationRequested, "Test cancelled");
+            Assert.False(cts.IsCancellationRequested, $"Test cancelled with {locksRemaining}/500 locks remaining after {sw.Elapsed.TotalSeconds} seconds");
             Assert.False(File.Exists(path), "File exists");
         }
     }

--- a/src/libraries/System.IO.Ports/tests/SerialPort/DosDevices.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/DosDevices.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 namespace System.IO.Ports.Tests
@@ -127,14 +128,20 @@ namespace System.IO.Ports.Tests
                     buffer = new char[buffer.Length * 2];
                     dataSize = QueryDosDevice(null, buffer, buffer.Length);
                 }
+                else if (lastError == ERROR_ACCESS_DENIED) // Access denied eg for "MSSECFLTSYS" - just skip
+                {
+                    dataSize = 0;
+                    break;
+                }
                 else
                 {
-                    throw new Exception("Unknown Win32 Error: " + lastError);
+                    throw new Exception($"Error {lastError} calling QueryDosDevice for '{name}' with buffer size {buffer.Length}. {new Win32Exception((int)lastError).Message}");
                 }
             }
             return buffer;
         }
 
+        public const int ERROR_ACCESS_DENIED = 5;
         public const int ERROR_INSUFFICIENT_BUFFER = 122;
         public const int ERROR_MORE_DATA = 234;
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ImpersonatedAuthTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ImpersonatedAuthTests.cs
@@ -14,7 +14,6 @@ namespace System.Net.Http.Functional.Tests
 {
     public class ImpersonatedAuthTests: IClassFixture<WindowsIdentityFixture>
     {
-        public static bool CanRunImpersonatedTests = PlatformDetection.IsWindows && PlatformDetection.IsNotWindowsNanoServer;
         private readonly WindowsIdentityFixture _fixture;
         private readonly ITestOutputHelper _output;
 
@@ -28,11 +27,11 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop]
-        [ConditionalTheory(nameof(CanRunImpersonatedTests))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.CanRunImpersonatedTests))]
         [InlineData(true)]
         [InlineData(false)]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public async Task DefaultHandler_ImpersonificatedUser_Success(bool useNtlm)
+        public async Task DefaultHandler_ImpersonatedUser_Success(bool useNtlm)
         {
             await LoopbackServer.CreateClientAndServerAsync(
                 async uri =>

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -854,7 +854,7 @@ namespace System.Net.NetworkInformation.Tests
             options.Ttl = 1;
             // This should always fail unless host is one IP hop away.
             pingReply = await ping.SendPingAsync(host, TestSettings.PingTimeout, TestSettings.PayloadAsBytesShort, options);
-            Assert.Equal(IPStatus.TimeExceeded, pingReply.Status);
+            Assert.True(pingReply.Status == IPStatus.TimeExceeded || pingReply.Status == IPStatus.TtlExpired);
             Assert.NotEqual(IPAddress.Any, pingReply.Address);
         }
 

--- a/src/libraries/System.Security.Principal.Windows/tests/WindowsIdentityImpersonatedTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Principal.Windows/tests/WindowsIdentityImpersonatedTests.netcoreapp.cs
@@ -26,7 +26,7 @@ public class WindowsIdentityImpersonatedTests : IClassFixture<WindowsIdentityFix
         Assert.False(string.IsNullOrEmpty(_fixture.TestAccount.AccountName));
     }
 
-    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanRunImpersonatedTests))]
     [OuterLoop]
     public async Task RunImpersonatedAsync_TaskAndTaskOfT()
     {
@@ -60,7 +60,7 @@ public class WindowsIdentityImpersonatedTests : IClassFixture<WindowsIdentityFix
         }
     }
 
-    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanRunImpersonatedTests))]
     [OuterLoop]
     public void RunImpersonated_NameResolution()
     {
@@ -78,7 +78,7 @@ public class WindowsIdentityImpersonatedTests : IClassFixture<WindowsIdentityFix
         });
     }
 
-    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.CanRunImpersonatedTests))]
     [OuterLoop]
     public async Task RunImpersonatedAsync_NameResolution()
     {


### PR DESCRIPTION
My ongoing mission to get outerloop to pass clean on my home machine.

1. QueryDosDevice was failing with access denied on a security-related entry. Skip it.
2. Protect tests that create a user behind a check for elevation.
3. Increase timeout for OpenOrCreate_DeleteOnClose_UsableAsMutex which somehow timed out.
4. Change ping test to expect TtlExpired.

@wfurt I'm not sure about (4). Shouldn't this test always produce TtlExpired, rather than TimeExceeded?