### PR TITLE
Make `gtHasRef` pay attention to LCL_FLD nodes

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1642,11 +1642,11 @@ AGAIN:
 //    lclNum  - the local's number, *or* the handle for the field
 //
 // Return Value:
-//    Whether "tree" has any LCL_VAR nodes that refer to the local,
-//    LHS or RHS, or FIELD nodes with the specified handle.
+//    Whether "tree" has any LCL_VAR/LCL_FLD nodes that refer to the
+//    local, LHS or RHS, or FIELD nodes with the specified handle.
 //
 // Notes:
-//    Does not pay attention to local address nodes or LCL_FLD nodes.
+//    Does not pay attention to local address nodes.
 //
 /* static */ bool Compiler::gtHasRef(GenTree* tree, ssize_t lclNum)
 {
@@ -1657,7 +1657,7 @@ AGAIN:
 
     if (tree->OperIsLeaf())
     {
-        if (tree->OperIs(GT_LCL_VAR) && (tree->AsLclVarCommon()->GetLclNum() == (unsigned)lclNum))
+        if (tree->OperIs(GT_LCL_VAR, GT_LCL_FLD) && (tree->AsLclVarCommon()->GetLclNum() == (unsigned)lclNum))
         {
             return true;
         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62524/Runtime_62524.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62524/Runtime_62524.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_62524
+{
+    public static int Main()
+    {
+        return Problem(new() { Value = 1 }) == 1 ? 100 : 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Problem(StructWithIndex a)
+    {
+        bool k = a.Value == 1;
+        a = default;
+        if (k)
+        {
+            return 1;
+        }
+
+        return a.Index;
+    }
+}
+
+public struct StructWithIndex
+{
+    public int Index;
+    public int Value;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62524/Runtime_62524.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62524/Runtime_62524.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <CLRTestBatchPreCommands><![CDATA[
+      $(CLRTestBatchPreCommands)
+      set DOTNET_JitNoStructPromotion=1
+      set DOTNET_JitNoCSE=1
+      ]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+      $(BashCLRTestPreCommands)
+      export DOTNET_JitNoStructPromotion=1
+      export DOTNET_JitNoCSE=1
+      ]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes the interference checks in the forward substitution of relops optimization.

Fixes #62524.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1504523&view=ms.vss-build-web.run-extensions-tab).