### PR TITLE
Add NativeAOT to build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ trim_trailing_whitespace = true
 indent_size = 2
 
 # Generated code
-[*{_AssemblyInfo.cs,.notsupported.cs}]
+[*{_AssemblyInfo.cs,.notsupported.cs,AsmOffsets.cs}]
 generated_code = true
 
 # C# files

--- a/NuGet.config
+++ b/NuGet.config
@@ -22,6 +22,8 @@
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
+    <!-- Used for NativeAOT ObjWriter. TODO: Delete once we publish the package from here. -->
+    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -49,8 +49,13 @@
     <RuntimeFlavor Condition="'$(RuntimeFlavor)' == ''">$(PrimaryRuntimeFlavor)</RuntimeFlavor>
   </PropertyGroup>
 
+  <!-- CLR NativeAot only builds in a subset of the matrix -->
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages</DefaultCoreClrSubsets>
+    <NativeAotSupported Condition="('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and ('$(TargetOS)' != 'OSX' or '$(TargetArchitecture)' != 'arm64') and ('$(__DistroRid)' != 'linux-musl-arm64')">true</NativeAotSupported>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
@@ -98,6 +103,8 @@
     <SubsetName Include="Clr.ILTools" Description="The CoreCLR IL tools." />
     <SubsetName Include="Clr.Runtime" Description="The CoreCLR .NET runtime." />
     <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools." />
+    <SubsetName Include="Clr.NativeAotLibs" Description="The CoreCLR native AOT CoreLib, runtime, and other low level class libraries." />
+    <SubsetName Include="Clr.ObjWriter" Description="Object writer for the CoreCLR Native AOT compiler." />
     <SubsetName Include="Clr.PalTests" OnDemand="true" Description="The CoreCLR PAL tests." />
     <SubsetName Include="Clr.PalTestList" OnDemand="true" Description="Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead." />
     <SubsetName Include="Clr.Hosts" Description="The CoreCLR corerun test host." />
@@ -193,6 +200,10 @@
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrILToolsSubset=true</ClrRuntimeBuildSubsets>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(_subset.Contains('+clr.nativeaotlibs+')) and '$(NativeAotSupported)' == 'true'">
+    <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrNativeAotSubset=true</ClrRuntimeBuildSubsets>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.nativeprereqs+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot)runtime-prereqs.proj" Category="clr" />
   </ItemGroup>
@@ -222,8 +233,12 @@
                              $(CoreClrProjectRoot)tools\tieringtest\tieringtest.csproj;
                              $(CoreClrProjectRoot)tools\r2rdump\R2RDump.csproj;
                              $(CoreClrProjectRoot)tools\dotnet-pgo\dotnet-pgo.csproj;
+                             $(CoreClrProjectRoot)tools\aot\ILCompiler\repro\repro.csproj;
                              $(CoreClrProjectRoot)tools\r2rtest\R2RTest.csproj" Category="clr" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.Build.Tasks\ILCompiler.Build.Tasks.csproj" Category="clr" Condition="'$(NativeAotSupported)' == 'true'" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Category="clr" Condition="'$(NativeAotSupported)' == 'true'" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" Condition="'$(NativeAotSupported)' == 'true'" />
 
     <ProjectToBuild Condition="'$(TargetArchitecture)' != 'x64' and '$(BuildArchitecture)' == 'x64'" Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2_crossarch.csproj" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.TypeSystem.ReadyToRun.Tests\ILCompiler.TypeSystem.ReadyToRun.Tests.csproj"
@@ -240,6 +255,22 @@
   <ItemGroup Condition="$(_subset.Contains('+clr.packages+')) and '$(PgoInstrument)' != 'true'">
     <ProjectToBuild Include="$(CoreClrProjectRoot).nuget\coreclr-packages.proj" Pack="true" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\dotnet-pgo\dotnet-pgo-pack.proj" Pack="true" BuildInParallel="false" Category="clr" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(RuntimeFlavor)' != 'Mono'"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+clr.nativeaotlibs+')) and '$(NativeAotSupported)' == 'true'">
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.CoreLib\src\System.Private.CoreLib.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.Reflection.Metadata\src\System.Private.Reflection.Metadata.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.TypeLoader\src\System.Private.TypeLoader.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.Interop\src\System.Private.Interop.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.Reflection.Core\src\System.Private.Reflection.Core.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.Reflection.Execution\src\System.Private.Reflection.Execution.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.DisabledReflection\src\System.Private.DisabledReflection.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\System.Private.StackTraceMetadata\src\System.Private.StackTraceMetadata.csproj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\Test.CoreLib\src\Test.CoreLib.csproj" Category="clr" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+clr.objwriter+'))">
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ObjWriter\objwriter.proj" Category="clr" />
   </ItemGroup>
 
   <!-- Mono sets -->

--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -376,6 +376,25 @@ function(install_symbol_file symbol_file destination_path)
   endif()
 endfunction()
 
+function(install_static_library targetName destination component)
+  if (NOT "${component}" STREQUAL "${targetName}")
+    get_property(definedComponents GLOBAL PROPERTY CLR_CMAKE_COMPONENTS)
+    list(FIND definedComponents "${component}" componentIdx)
+    if (${componentIdx} EQUAL -1)
+      message(FATAL_ERROR "The ${component} component is not defined. Add a call to `add_component(${component})` to define the component in the build.")
+    endif()
+    add_dependencies(${component} ${targetName})
+  endif()
+  install (TARGETS ${targetName} DESTINATION ${destination} COMPONENT ${component})
+  if (WIN32)
+    set_target_properties(${targetName} PROPERTIES
+        COMPILE_PDB_NAME "${targetName}"
+        COMPILE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
+    )
+    install (FILES "$<TARGET_FILE_DIR:${targetName}>/${targetName}.pdb" DESTINATION ${destination} COMPONENT ${component})
+  endif()
+endfunction()
+
 # install_clr(TARGETS targetName [targetName2 ...] [DESTINATIONS destination [destination2 ...]] [COMPONENT componentName])
 function(install_clr)
   set(multiValueArgs TARGETS DESTINATIONS)

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -134,6 +134,13 @@ include_directories(${CLR_ARTIFACTS_OBJ_DIR})
 add_subdirectory(tools/aot/jitinterface)
 
 
+if(NOT CLR_CROSS_COMPONENTS_BUILD)
+  # NativeAOT only buildable for a subset of CoreCLR-supported configurations
+  if((CLR_CMAKE_HOST_LINUX OR CLR_CMAKE_HOST_OSX OR CLR_CMAKE_HOST_WIN32) AND (CLR_CMAKE_HOST_ARCH_ARM64 OR CLR_CMAKE_HOST_ARCH_AMD64) AND NOT (CLR_CMAKE_HOST_OSX AND CLR_CMAKE_HOST_ARCH_ARM64))
+    add_subdirectory(nativeaot)
+  endif()
+endif(NOT CLR_CROSS_COMPONENTS_BUILD)
+
 # Above projects do not build with these compile options
 # All of the compiler options are specified in file compileoptions.cmake
 # Do not add any new options here. They should be added in compileoptions.cmake

--- a/src/coreclr/Directory.Build.props
+++ b/src/coreclr/Directory.Build.props
@@ -14,7 +14,9 @@
   <Import Project="..\..\Directory.Build.props" />
 
   <PropertyGroup>
-    <BaseIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'coreclr', '$(MSBuildProjectName)'))</BaseIntermediateOutputPath>
+    <IsNativeAotProject Condition="$(MSBuildProjectDirectory.Contains('nativeaot'))">true</IsNativeAotProject>
+    <BaseIntermediateOutputPath Condition="'$(IsNativeAotProject)' != 'true'">$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'coreclr', '$(MSBuildProjectName)'))</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(IsNativeAotProject)' == 'true'">$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'coreclr', 'nativeaot', '$(MSBuildProjectName)'))</BaseIntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>

--- a/src/coreclr/Directory.Build.targets
+++ b/src/coreclr/Directory.Build.targets
@@ -18,6 +18,6 @@
   </Target>
 
   <!-- Import targets here to have TargetPath and other macros defined. Limit to CoreLib. -->
-  <Import Condition="'$(MSBuildProjectName)' == 'System.Private.CoreLib'" Project="$(RepositoryEngineeringDir)illink.targets" />
+  <Import Condition="'$(MSBuildProjectName)' == 'System.Private.CoreLib' or '$(IsNativeAotProject)' == 'true'" Project="$(RepositoryEngineeringDir)illink.targets" />
 
 </Project>

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -342,6 +342,9 @@ for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
     if not "!string:-iltools-=!"=="!string!" (
         set __CMakeTarget=!__CMakeTarget! iltools
     )
+    if not "!string:-nativeaot-=!"=="!string!" (
+        set __CMakeTarget=!__CMakeTarget! nativeaot
+    )
 )
 if [!__CMakeTarget!] == [] (
     set __CMakeTarget=install

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -22,7 +22,7 @@ usage_list+=("-pgodatapath: path to profile guided optimization data.")
 usage_list+=("-pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.")
 usage_list+=("-skipcrossarchnative: Skip building cross-architecture native binaries.")
 usage_list+=("-staticanalyzer: use scan_build static analyzer.")
-usage_list+=("-component: Build individual components instead of the full project. Available options are 'hosts', 'jit', 'runtime', 'paltests', 'alljits', and 'iltools'. Can be specified multiple times.")
+usage_list+=("-component: Build individual components instead of the full project. Available options are 'hosts', 'jit', 'runtime', 'paltests', 'alljits', 'iltools', and 'nativeaot'. Can be specified multiple times.")
 
 setup_dirs_local()
 {

--- a/src/coreclr/components.cmake
+++ b/src/coreclr/components.cmake
@@ -5,6 +5,7 @@ add_component(hosts)
 add_component(runtime)
 add_component(paltests paltests_install)
 add_component(iltools)
+add_component(nativeaot)
 
 # Define coreclr_all as the fallback component and make every component depend on this component.
 # iltools and paltests should be minimal subsets, so don't add a dependency on coreclr_misc

--- a/src/coreclr/nativeaot/CMakeLists.txt
+++ b/src/coreclr/nativeaot/CMakeLists.txt
@@ -23,6 +23,11 @@ if(MSVC)
 endif (MSVC)
 
 if(CLR_CMAKE_HOST_UNIX)
+  # Up for grabs to clean these warnings up
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-Wno-error)
+  endif()
+
   add_compile_options(-fno-rtti)          # Native AOT runtime doesn't use RTTI
   add_compile_options(-fno-exceptions)    # Native AOT runtime doesn't use C++ exception handling
 

--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -277,6 +277,6 @@ convert_to_absolute_path(RUNTIME_SOURCES_ARCH_ASM ${RUNTIME_SOURCES_ARCH_ASM})
 
 if(NOT CLR_CMAKE_TARGET_ARCH_WASM)
   add_subdirectory(Full)
+else()
+  add_subdirectory(Portable)
 endif()
-
-add_subdirectory(Portable)

--- a/src/coreclr/nativeaot/Runtime/CachedInterfaceDispatch.cpp
+++ b/src/coreclr/nativeaot/Runtime/CachedInterfaceDispatch.cpp
@@ -305,7 +305,7 @@ static uintptr_t AllocateCache(uint32_t cCacheEntries, InterfaceDispatchCache * 
                                                                      (sizeof(InterfaceDispatchCacheEntry) * cCacheEntries),
                                                                      sizeof(void*) * 2);
         if (pCache == NULL)
-            return NULL;
+            return (uintptr_t)NULL;
 
         CID_COUNTER_INC(CacheAllocates);
 #ifdef FEATURE_CID_STATS

--- a/src/coreclr/nativeaot/Runtime/CommonMacros.h
+++ b/src/coreclr/nativeaot/Runtime/CommonMacros.h
@@ -43,9 +43,21 @@ char (*COUNTOF_helper(_CountofType (&_Array)[_SizeOfArray]))[_SizeOfArray];
 #define offsetof(s,m)   (uintptr_t)( (intptr_t)&reinterpret_cast<const volatile char&>((((s *)0)->m)) )
 #endif // offsetof
 
+#ifdef __GNUC__
+#ifdef HOST_64BIT
+#define __int64     long
+#else // HOST_64BIT
+#define __int64     long long
+#endif // HOST_64BIT
+#endif // __GNUC__
+
 #ifndef FORCEINLINE
 #define FORCEINLINE __forceinline
 #endif
+
+#ifdef __GNUC__
+#define __forceinline __attribute__((always_inline)) inline
+#endif // __GNUC__
 
 #ifndef NOINLINE
 #ifdef _MSC_VER
@@ -221,11 +233,11 @@ extern unsigned __int64 g_startupTimelineEvents[NUM_STARTUP_TIMELINE_EVENTS];
 #define C_ASSERT(e) static_assert(e, #e)
 #endif // C_ASSERT
 
-#ifdef __llvm__
-#define DECLSPEC_THREAD __thread
-#else // __llvm__
+#ifdef _MSC_VER
 #define DECLSPEC_THREAD __declspec(thread)
-#endif // !__llvm__
+#else // _MSC_VER
+#define DECLSPEC_THREAD __thread
+#endif // !_MSC_VER
 
 #ifndef __GCENV_BASE_INCLUDED__
 #if !defined(_INC_WINDOWS)

--- a/src/coreclr/nativeaot/Runtime/gcrhinterface.h
+++ b/src/coreclr/nativeaot/Runtime/gcrhinterface.h
@@ -158,7 +158,7 @@ private:
     // The MethodTable for the last allocation.  This value is used inside of the GC allocator
     // to emit allocation ETW events with type information.  We set this value unconditionally to avoid
     // race conditions where ETW is enabled after the value is set.
-    DECLSPEC_THREAD static MethodTable * tls_pLastAllocationEEType;
+    static DECLSPEC_THREAD MethodTable * tls_pLastAllocationEEType;
 
     // Tracks the amount of bytes that were reserved for threads in their gc_alloc_context and went unused when they died.
     // Used for GC.GetTotalAllocatedBytes

--- a/src/coreclr/nativeaot/Runtime/inc/stressLog.h
+++ b/src/coreclr/nativeaot/Runtime/inc/stressLog.h
@@ -22,12 +22,17 @@
 #ifndef StressLog_h
 #define StressLog_h  1
 
+#ifdef _MSC_VER
 #define SUPPRESS_WARNING_4127   \
     __pragma(warning(push))     \
     __pragma(warning(disable:4127)) /* conditional expression is constant*/
 
 #define POP_WARNING_STATE       \
     __pragma(warning(pop))
+#else // _MSC_VER
+#define SUPPRESS_WARNING_4127
+#define POP_WARNING_STATE
+#endif // _MSC_VER
 
 #define WHILE_0             \
     SUPPRESS_WARNING_4127   \

--- a/src/coreclr/nativeaot/Runtime/inc/varint.h
+++ b/src/coreclr/nativeaot/Runtime/inc/varint.h
@@ -95,8 +95,14 @@ private:
     static uint8_t s_shiftTab[16];
 };
 
+#ifndef __GNUC__
 __declspec(selectany)
-int8_t VarInt::s_negLengthTab[16] =
+#endif
+int8_t
+#ifdef __GNUC__
+__attribute__((weak))
+#endif
+VarInt::s_negLengthTab[16] =
 {
     -1,    // 0
     -2,    // 1
@@ -119,8 +125,14 @@ int8_t VarInt::s_negLengthTab[16] =
     -5,    // 15
 };
 
+#ifndef __GNUC__
 __declspec(selectany)
-uint8_t VarInt::s_shiftTab[16] =
+#endif
+uint8_t
+#ifdef __GNUC__
+__attribute__((weak))
+#endif
+VarInt::s_shiftTab[16] =
 {
     32-7*1,    // 0
     32-7*2,    // 1

--- a/src/coreclr/nativeaot/Runtime/portable.cpp
+++ b/src/coreclr/nativeaot/Runtime/portable.cpp
@@ -539,7 +539,7 @@ COOP_PINVOKE_HELPER(void*, RhpGetThunkStubsBlockAddress, (void* pThunkDataAddres
 COOP_PINVOKE_HELPER(int, RhpGetThunkBlockSize, ())
 {
     ASSERT_UNCONDITIONALLY("NYI");
-    return NULL;
+    return 0;
 }
 
 COOP_PINVOKE_HELPER(void, RhCallDescrWorker, (void * callDescr))

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkInline.h
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkInline.h
@@ -27,12 +27,20 @@ FORCEINLINE uint32_t PalInterlockedAnd(_Inout_ uint32_t volatile *pDst, uint32_t
 
 FORCEINLINE int32_t PalInterlockedExchange(_Inout_ int32_t volatile *pDst, int32_t iValue)
 {
+#ifdef __clang__
     return __sync_swap(pDst, iValue);
+#else
+    return __atomic_exchange_n(pDst, iValue, __ATOMIC_ACQ_REL);
+#endif
 }
 
 FORCEINLINE int64_t PalInterlockedExchange64(_Inout_ int64_t volatile *pDst, int64_t iValue)
 {
+#ifdef __clang__
     return __sync_swap(pDst, iValue);
+#else
+    return __atomic_exchange_n(pDst, iValue, __ATOMIC_ACQ_REL);
+#endif
 }
 
 FORCEINLINE int32_t PalInterlockedCompareExchange(_Inout_ int32_t volatile *pDst, int32_t iValue, int32_t iComparand)

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -829,7 +829,7 @@ REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI PalVirtualProtect(_In_ void* pAddre
 REDHAWK_PALEXPORT _Ret_maybenull_ void* REDHAWK_PALAPI PalSetWerDataBuffer(_In_ void* pNewBuffer)
 {
     static void* pBuffer;
-    return _InterlockedExchangePointer(&pBuffer, pNewBuffer);
+    return PalInterlockedExchangePointer(&pBuffer, pNewBuffer);
 }
 
 extern "C" HANDLE GetCurrentProcess()

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -196,7 +196,7 @@ uintptr_t UnixNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Method
         INT32 slot = decoder.GetReversePInvokeFrameStackSlot();
         assert(slot != NO_REVERSE_PINVOKE_FRAME);
 
-        TADDR basePointer = NULL;
+        TADDR basePointer = (TADDR)NULL;
         UINT32 stackBasedRegister = decoder.GetStackBaseRegister();
         if (stackBasedRegister == NO_STACK_BASE_REGISTER)
         {
@@ -257,7 +257,7 @@ bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
         INT32 slot = decoder.GetReversePInvokeFrameStackSlot();
         assert(slot != NO_REVERSE_PINVOKE_FRAME);
 
-        TADDR basePointer = NULL;
+        TADDR basePointer = (TADDR)NULL;
         UINT32 stackBasedRegister = decoder.GetStackBaseRegister();
         if (stackBasedRegister == NO_STACK_BASE_REGISTER)
         {

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -47,6 +47,7 @@
       <_CoreClrBuildArg Condition="'$(ClrPalTestsSubset)' == 'true'" Include="-component paltests" />
       <_CoreClrBuildArg Condition="'$(ClrAllJitsSubset)' == 'true'" Include="-component alljits" />
       <_CoreClrBuildArg Condition="'$(ClrILToolsSubset)' == 'true'" Include="-component iltools" />
+      <_CoreClrBuildArg Condition="'$(ClrNativeAotSubset)' == 'true'" Include="-component nativeaot" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -62,10 +62,12 @@ namespace System
                     }
                     _infinitelyRecursingCount++;
 
+#if SYSTEM_PRIVATE_CORELIB
                     // Note: our infrastructure for reporting this exception will again cause resource lookup.
                     // This is the most direct way of dealing with that problem.
                     string message = $"Infinite recursion during resource lookup within {System.CoreLib.Name}.  This may be a bug in {System.CoreLib.Name}, or potentially in certain extensibility points such as assembly resolve events or CultureInfo names.  Resource name: {key}";
                     Environment.FailFast(message);
+#endif
                 }
 
                 _currentlyLoading ??= new List<string>();


### PR DESCRIPTION
NativeAOT becomes part of the clr subset.

The NativeAOT runtime and libraries are a clr.nativeaotlibs subset.
The NativeAOT object writer (not built by default) is clr.objwriter subset.
The AOT compiler is part of the existing clr.tools subset.