### PR TITLE
Build NativeAOT flavor of clrcompression static lib

### DIFF
--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -109,11 +109,31 @@ else ()
         ${NATIVECOMPRESSION_SOURCES}
     )
 
+    if(STATIC_LIBS_ONLY)
+        add_library(System.IO.Compression.Native.Aot
+            STATIC
+            ${NATIVECOMPRESSION_SOURCES}
+        )
+        target_compile_options(System.IO.Compression.Native.Aot PRIVATE /guard:cf-)
+        target_compile_options(System.IO.Compression.Native.Aot PRIVATE /GL-)
+
+        add_library(System.IO.Compression.Native.Aot.GuardCF
+            STATIC
+            ${NATIVECOMPRESSION_SOURCES}
+        )
+        target_compile_options(System.IO.Compression.Native.Aot.GuardCF PRIVATE /GL-)
+    endif()
+
     # Allow specification of libraries that should be linked against
     if (GEN_SHARED_LIB)
         target_link_libraries(System.IO.Compression.Native ${__LinkLibraries})
     endif ()
     target_link_libraries(System.IO.Compression.Native-Static ${__LinkLibraries})
+
+    if(STATIC_LIBS_ONLY)
+        target_link_libraries(System.IO.Compression.Native.Aot ${__LinkLibraries})
+        target_link_libraries(System.IO.Compression.Native.Aot.GuardCF ${__LinkLibraries})
+    endif()
 
     if (GEN_SHARED_LIB)
         GENERATE_EXPORT_HEADER( System.IO.Compression.Native
@@ -126,6 +146,12 @@ else ()
         install (TARGETS System.IO.Compression.Native DESTINATION .)
         install (FILES $<TARGET_PDB_FILE:System.IO.Compression.Native> DESTINATION .)
     endif ()
+
+    if(STATIC_LIBS_ONLY)
+        install_static_library(System.IO.Compression.Native.Aot aotsdk nativeaot)
+        install_static_library(System.IO.Compression.Native.Aot.GuardCF aotsdk nativeaot)
+    endif()
+
 endif ()
 
 install (TARGETS System.IO.Compression.Native-Static DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)


### PR DESCRIPTION
This is similar in spirit to the static library for the single file host.

The main difference from the single file host one is that we don't want `/GL` because the static library is going to be linked on end user machine and `/GL` is super (version) fragile.

We build two flavors - with control flow guard and without control flow guard. CFG is a compile time option for end users in NativeAOT and we need static libs that support both.