### PR TITLE
Improve String.Substring performance

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -1918,6 +1919,7 @@ namespace System
             throw new ArgumentOutOfRangeException(nameof(length), SR.ArgumentOutOfRange_IndexLength);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private string InternalSubString(int startIndex, int length)
         {
             Debug.Assert(startIndex >= 0 && startIndex <= this.Length, "StartIndex is out of range!");
@@ -1925,11 +1927,42 @@ namespace System
 
             string result = FastAllocateString(length);
 
-            Buffer.Memmove(
-                elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
-                destination: ref result._firstChar,
-                source: ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex /* force zero-extension */));
-
+            ref char source = ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex); /* force zero-extension */
+            ref char destination = ref result._firstChar;
+            if (length < 16)
+            {
+                int offset = 0;
+                if (length >= 8)
+                {
+                    Unsafe.As<char, ulong>(ref destination) = Unsafe.As<char, ulong>(ref source);
+                    Unsafe.As<char, ulong>(ref Unsafe.Add(ref destination, 4)) = Unsafe.As<char, ulong>(ref Unsafe.Add(ref source, 4));
+                    length -= 8;
+                    offset += 8;
+                }
+                if (length >= 4)
+                {
+                    Unsafe.As<char, ulong>(ref Unsafe.Add(ref destination, offset)) = Unsafe.As<char, ulong>(ref Unsafe.Add(ref source, offset));
+                    length -= 4;
+                    offset += 4;
+                }
+                if (length >= 2)
+                {
+                    Unsafe.As<char, uint>(ref Unsafe.Add(ref destination, offset)) = Unsafe.As<char, uint>(ref Unsafe.Add(ref source, offset));
+                    length -= 2;
+                    offset += 2;
+                }
+                if (length > 0)
+                {
+                    Unsafe.Add(ref destination, offset) = Unsafe.Add(ref source, offset);
+                }
+            }
+            else
+            {
+                Buffer.Memmove(
+                    elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
+                    destination: ref destination,
+                    source: ref source);
+            }
             return result;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1846,7 +1846,19 @@ namespace System
 
         // Returns a substring of this string.
         //
-        public string Substring(int startIndex) => Substring(startIndex, Length - startIndex);
+        public string Substring(int startIndex)
+        {
+            if (startIndex == 0)
+            {
+                return this;
+            }
+            int length = Length;
+            if ((uint)startIndex > (uint)length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_StartIndex);
+            }
+            return InternalSubString(startIndex, length - startIndex);
+        }
 
         public string Substring(int startIndex, int length)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1929,7 +1929,7 @@ namespace System
             Buffer.Memmove(
                 elementCount: (uint)result.Length, // derefing Length now allows JIT to prove 'result' not null below
                 destination: ref result._firstChar,
-                source: ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex) /* force zero-extension */);
+                source: ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex /* force zero-extension */));
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1880,7 +1880,7 @@ namespace System
             // that information is captured correctly in the comparison against the backing _length field.
             // We don't use this same mechanism in a 32-bit process due to the overhead of 64-bit arithmetic.
             if ((ulong)(uint)startIndex + (ulong)(uint)length > (ulong)(uint)thisLength)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                ThrowSubstringArgumentOutRangeException(startIndex, length);
 #else
             if ((uint)startIndex > (uint)thisLength || (uint)length > (uint)(thisLength - startIndex))
                 ThrowSubstringArgumentOutRangeException(startIndex, length);


### PR DESCRIPTION
WIP just to get the ball rolling regarding discussion of changing exception messages or similar. cc @adamsitnik @GrabYourPitchforks @stephentoub as discussed in https://github.com/dotnet/runtime/pull/60463

Change to `Substring(int startIndex)` improvements (note highly volatile). This comes with all the caveats of potential increases code size etc.

``` ini

BenchmarkDotNet=v0.13.1.1620-nightly, OS=Windows 10.0.19044.1348 (21H2)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.100-alpha.1.21568.2
  [Host]     : .NET 6.0.0 (6.0.21.48005), X64 RyuJIT
  Job-FWUOEW : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT
  Job-HPGSVV : .NET 7.0.0 (42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable,-bl:benchmarkdotnet.binlog  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|        Method |        Job |                                                                                                    Toolchain |                    s |  i |       Mean |     Error |    StdDev |     Median |       Min |        Max | Ratio | RatioSD |  Gen 0 | Allocated |
|-------------- |----------- |------------------------------------------------------------------------------------------------------------- |--------------------- |--- |-----------:|----------:|----------:|-----------:|----------:|-----------:|------:|--------:|-------:|----------:|
| **Substring_Int** | **Job-FWUOEW** |  **m** | **dzsdzsDDZSDZSDZSddsz** |  **0** |  **1.1022 ns** | **0.0068 ns** | **0.0064 ns** |  **1.1049 ns** | **1.0853 ns** |  **1.1092 ns** |  **1.00** |    **0.00** |      **-** |         **-** |
| Substring_Int | Job-HPGSVV | pr | dzsdzsDDZSDZSDZSddsz |  0 |  0.4543 ns | 0.0069 ns | 0.0065 ns |  0.4541 ns | 0.4382 ns |  0.4658 ns |  0.41 |    0.01 |      - |         - |
|               |            |                                                                                                              |                      |    |            |           |           |            |           |            |       |         |        |           |
| **Substring_Int** | **Job-FWUOEW** |  **m** | **dzsdzsDDZSDZSDZSddsz** |  **7** |  **8.6245 ns** | **2.2287 ns** | **2.5666 ns** |  **9.5946 ns** | **5.4283 ns** | **12.5358 ns** |  **1.00** |    **0.00** | **0.0029** |      **48 B** |
| Substring_Int | Job-HPGSVV | pr | dzsdzsDDZSDZSDZSddsz |  7 |  7.1005 ns | 1.1957 ns | 1.3770 ns |  6.5014 ns | 5.6306 ns |  9.5741 ns |  0.88 |    0.22 | 0.0029 |      48 B |
|               |            |                                                                                                              |                      |    |            |           |           |            |           |            |       |         |        |           |
| **Substring_Int** | **Job-FWUOEW** |  **m** | **dzsdzsDDZSDZSDZSddsz** | **10** | **10.3062 ns** | **0.6670 ns** | **0.7681 ns** | **10.5393 ns** | **8.8757 ns** | **11.3953 ns** |  **1.00** |    **0.00** | **0.0029** |      **48 B** |
| Substring_Int | Job-HPGSVV | pr | dzsdzsDDZSDZSDZSddsz | 10 |  7.5328 ns | 0.6341 ns | 0.7302 ns |  7.4150 ns | 6.3654 ns |  9.1740 ns |  0.73 |    0.07 | 0.0028 |      48 B |
|               |            |                                                                                                              |                      |    |            |           |           |            |           |            |       |         |        |           |
| **Substring_Int** | **Job-FWUOEW** |  **m** | **dzsdzsDDZSDZSDZSddsz** | **19** | **12.9457 ns** | **1.6428 ns** | **1.8919 ns** | **13.3785 ns** | **5.5022 ns** | **14.3101 ns** |  **1.00** |    **0.00** | **0.0014** |      **24 B** |
| Substring_Int | Job-HPGSVV | pr | dzsdzsDDZSDZSDZSddsz | 19 |  6.8188 ns | 0.9429 ns | 1.0858 ns |  6.6514 ns | 5.0843 ns |  9.0324 ns |  0.55 |    0.18 | 0.0014 |      24 B |
