### PR TITLE
Fix ReadAsync_ThrowsIfWriterCompletedWithException for PGO

### DIFF
--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -228,8 +228,6 @@ namespace System.IO.Pipelines.Tests
             invalidOperationException = await Assert.ThrowsAsync<InvalidOperationException>(async () => await _pipe.Reader.ReadAsync());
             Assert.Equal("Writer exception", invalidOperationException.Message);
             Assert.Contains(nameof(ThrowTestException), invalidOperationException.StackTrace);
-
-            Assert.Single(Regex.Matches(invalidOperationException.StackTrace, "Pipe.GetReadResult"));
         }
 
         [Fact]


### PR DESCRIPTION
The expected frame can be inlined in some cases - it explains why this test fails occasionally on PGO pipeline: https://dev.azure.com/dnceng/public/_test/analytics?definitionId=1002&contextType=build

See diff: https://www.diffchecker.com/UV1D98dZ (PGO + Aggressive Inliner is on the right)