### PR TITLE
Unify the namespaces of HashProviderDispenser

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.Browser.cs
@@ -6,8 +6,9 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
+using Internal.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal static partial class HashProviderDispenser
     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashProviderDispenser.OpenSsl.cs
@@ -6,8 +6,9 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
+using Internal.Cryptography;
 
-namespace Internal.Cryptography
+namespace System.Security.Cryptography
 {
     internal static partial class HashProviderDispenser
     {


### PR DESCRIPTION
I was spiking out an idea and noticed that some of the hash provider dispensers were still in `Internal.Cryptography`. This moves them to all be in `System.Security.Cryptography`.

Browser and OpenSsl were the outliers. Windows and Apple were already moved.

Being in separate namespaces made it impossible to create a managed partial that all platforms could use.