### PR TITLE
[wasm][debugger] Avoiding assert on mono runtime

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -580,7 +580,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             Populate();
         }
 
-        public async Task<int> DebugId(MonoSDBHelper sdbAgent, CancellationToken token)
+        public async Task<int> GetDebugId(MonoSDBHelper sdbAgent, CancellationToken token)
         {
             if (debugId != -1)
                 return debugId;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -530,7 +530,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal MetadataReader asmMetadataReader { get; }
         internal MetadataReader pdbMetadataReader { get; set; }
         internal List<MetadataReader> enCMetadataReader  = new List<MetadataReader>();
-        public int DebugId { get; set; }
+        private int debugId;
         internal int PdbAge { get; }
         internal System.Guid PdbGuid { get; }
         internal string PdbName { get; }
@@ -539,6 +539,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public unsafe AssemblyInfo(MonoProxy monoProxy, SessionId sessionId, string url, byte[] assembly, byte[] pdb, CancellationToken token)
         {
+            debugId = -1;
             this.id = Interlocked.Increment(ref next_id);
             using var asmStream = new MemoryStream(assembly);
             peReader = new PEReader(asmStream);
@@ -577,6 +578,19 @@ namespace Microsoft.WebAssembly.Diagnostics
                 }
             }
             Populate();
+        }
+
+        public async Task<int> DebugId(MonoSDBHelper sdbAgent, CancellationToken token)
+        {
+            if (debugId != -1)
+                return debugId;
+            debugId = await sdbAgent.GetAssemblyId(Name, token);
+            return debugId;
+        }
+
+        public void SetDebugId(int id)
+        {
+            debugId = id;
         }
 
         public bool EnC(byte[] meta, byte[] pdb)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -582,7 +582,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public async Task<int> GetDebugId(MonoSDBHelper sdbAgent, CancellationToken token)
         {
-            if (debugId != -1)
+            if (debugId > 0)
                 return debugId;
             debugId = await sdbAgent.GetAssemblyId(Name, token);
             return debugId;
@@ -590,7 +590,8 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public void SetDebugId(int id)
         {
-            debugId = id;
+            if (debugId <= 0 && debugId != id)
+                debugId = id;
         }
 
         public bool EnC(byte[] meta, byte[] pdb)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -163,7 +163,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     if (type == null)
                         continue;
 
-                    int id = await context.SdbAgent.GetTypeIdFromToken(asm.DebugId, type.Token, token);
+                    int id = await context.SdbAgent.GetTypeIdFromToken(await asm.DebugId(context.SdbAgent, token), type.Token, token);
                     if (id != -1)
                         return id;
                 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -163,7 +163,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     if (type == null)
                         continue;
 
-                    int id = await context.SdbAgent.GetTypeIdFromToken(await asm.DebugId(context.SdbAgent, token), type.Token, token);
+                    int id = await context.SdbAgent.GetTypeIdFromToken(await asm.GetDebugId(context.SdbAgent, token), type.Token, token);
                     if (id != -1)
                         return id;
                 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -749,7 +749,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     return null;
                 }
             }
-            asm.DebugId = assemblyId;
+            asm.SetDebugId(assemblyId);
             assemblies[assemblyId] = asm;
             return asm;
         }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -865,6 +865,16 @@ namespace DebuggerTests
                    ("ClassToBreak.valueToCheck", TNumber(10)));
            });
 
+        [Fact]
+        public async Task EvaluateLocalObjectFromAssemblyNotRelatedButLoaded()
+         => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateTestsClass", "EvaluateLocalsFromAnotherAssembly", 5, "EvaluateLocalsFromAnotherAssembly",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateTestsClass:EvaluateLocalsFromAnotherAssembly'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               await RuntimeEvaluateAndCheck(
+                   ("a.valueToCheck", TNumber(20)));
+           });
     }
 
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -855,6 +855,16 @@ namespace DebuggerTests
                    ("\"15\"", TString("15")));
            });
 
+        [Fact]
+        public async Task EvaluateStaticAttributeInAssemblyNotRelatedButLoaded() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateTestsClass", "EvaluateLocals", 9, "EvaluateLocals",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateTestsClass:EvaluateLocals'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               await RuntimeEvaluateAndCheck(
+                   ("ClassToBreak.valueToCheck", TNumber(10)));
+           });
+
     }
 
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -905,14 +905,7 @@ namespace DebuggerTests
         [Fact]
         public async Task InspectLocalsUsingClassFromLibraryUsingDebugTypeFull()
         {
-            byte[] bytes = File.ReadAllBytes(Path.Combine(DebuggerTestAppPath, "debugger-test-with-full-debug-type.dll"));
-            string asm_base64 = Convert.ToBase64String(bytes);
-
-            string pdb_base64 = null;
-            bytes = File.ReadAllBytes(Path.Combine(DebuggerTestAppPath, "debugger-test-with-full-debug-type.pdb"));
-            pdb_base64 = Convert.ToBase64String(bytes);
-
-            var expression = $"{{ let asm_b64 = '{asm_base64}'; let pdb_b64 = '{pdb_base64}'; invoke_static_method('[debugger-test] DebugTypeFull:CallToEvaluateLocal', asm_b64, pdb_b64); }}";
+            var expression = $"{{ invoke_static_method('[debugger-test] DebugTypeFull:CallToEvaluateLocal'); }}";
 
             await EvaluateAndCheck(
                 "window.setTimeout(function() {" + expression + "; }, 1);",

--- a/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
@@ -10,4 +10,12 @@ namespace DebuggerTests
         }
         public static int valueToCheck = 10;
     }
+    public class ClassToCheckFieldValue
+    {
+        public int valueToCheck;
+        public ClassToCheckFieldValue()
+        {
+            valueToCheck = 20;
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
@@ -8,5 +8,6 @@ namespace DebuggerTests
         {
             return 50;
         }
+        public static int valueToCheck = 10;
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -43,6 +43,14 @@ namespace DebuggerTests
             f_g_s.EvaluateTestsGenericStructInstanceMethod(100, 200, "test");
         }
 
+        public static void EvaluateLocalsFromAnotherAssembly()
+        {
+            var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-source-link.dll");
+            var myType = asm.GetType("DebuggerTests.ClassToCheckFieldValue");
+            var myMethod = myType.GetConstructor(new Type[] { });
+            var a = myMethod.Invoke(new object[]{});
+        }
+
     }
 
     public struct EvaluateTestsGenericStruct<T>

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -852,7 +852,7 @@ public class DebuggerAttribute
 
 public class DebugTypeFull
 {
-    public static void CallToEvaluateLocal(string asm_base64, string pdb_base64)
+    public static void CallToEvaluateLocal()
     {
         var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-full-debug-type.dll");
         var myType = asm.GetType("DebuggerTests.ClassToInspectWithDebugTypeFull");


### PR DESCRIPTION
It was passing id = 0 and asserting on mono runtime when trying to evaluate something in a Class that has the assembly loaded, but doesn't have any breakpoint added.

Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1427671?src=WorkItemMention&src-action=artifact_link