### PR TITLE
Relegate PatternsDataSet_ConstructRegexForAll_SourceGenerated test to 64-bit only

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.KnownPattern.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.KnownPattern.Tests.cs
@@ -1458,7 +1458,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [OuterLoop("Takes minutes to generate and compile thousands of expressions")]
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // consumes a lot of memory
         public void PatternsDataSet_ConstructRegexForAll_SourceGenerated()
         {
             Parallel.ForEach(s_patternsDataSet.Value.Chunk(50), chunk =>


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/62468
cc: @danmoseley, @joperezr 