### PR TITLE
Add instructions to skip restoring nuget packages

### DIFF
--- a/docs/workflow/building/mono/README.md
+++ b/docs/workflow/building/mono/README.md
@@ -33,6 +33,15 @@ build.cmd mono
 ```
 When the build completes, product binaries will be dropped in the `artifacts\bin\mono\<OS>.<arch>.<flavor>` folder.
 
+If you want to skip restoring nuget packages, when only making change to mono, you want to use this command:
+```bash
+./build.sh mono --build
+```
+or on Windows,
+```cmd
+build.cmd mono --build
+```
+
 ### Useful Build Arguments
 Here are a list of build arguments that may be of use:
 


### PR DESCRIPTION
Add build instructions to skip restoring nuget packages, when you only made change to mono.