### PR TITLE
Update spmi asp.net script to collect some osr method contexts

### DIFF
--- a/src/coreclr/scripts/superpmi_aspnet.py
+++ b/src/coreclr/scripts/superpmi_aspnet.py
@@ -174,7 +174,9 @@ def build_and_run(coreclr_args):
 
         # note tricks to get one element tuples
 
-        runtime_options_list = [("Dummy=0",), ("TieredCompilation=0", ), ("TieredPGO=1", "TC_QuickJitForLoops=1"), ("TieredPGO=1", "TC_QuickJitForLoops=1", "ReadyToRun=0")]
+        runtime_options_list = [("Dummy=0",), ("TieredCompilation=0", ), ("TieredPGO=1", "TC_QuickJitForLoops=1"), ("TieredPGO=1", "TC_QuickJitForLoops=1", "ReadyToRun=0"),
+            ("TC_QuickJitForLoops=1", "ReadyToRun=0", "TC_OnStackReplacement=1", "OSR_HitLimit=0", "TC_OnStackReplacement_InitialCounter=0"),
+            ("TieredPGO=1", "TC_QuickJitForLoops=1", "ReadyToRun=0", "TC_OnStackReplacement=1", "OSR_HitLimit=0", "TC_OnStackReplacement_InitialCounter=100")]
 
         # runtime_options_list = [("TieredCompilation=0", )]
 


### PR DESCRIPTION
Collect both non-pgo and pgo cases. For non-pgo, set OSR to trigger immediately
when any patchpoint is hit to maximize number of cases collected. For PGO, set
OSR to trigger once we've got a bit of profile data gathered by the Tier0 method.