### PR TITLE
Fix setting timestamp on Windows on readonly files

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FileOperations.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FileOperations.cs
@@ -23,7 +23,8 @@ internal static partial class Interop
             internal const int FILE_FLAG_OVERLAPPED = 0x40000000;
 
             internal const int FILE_LIST_DIRECTORY = 0x0001;
-        }
 
+            internal const int FILE_WRITE_ATTRIBUTES = 0x100;
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -21,7 +21,9 @@ namespace System.IO.Tests
         protected static bool LowTemporalResolution => PlatformDetection.IsBrowser || isHFS;
         protected static bool HighTemporalResolution => !LowTemporalResolution;
 
-        protected abstract T GetExistingItem();
+        protected abstract bool CanBeReadOnly { get; }
+
+        protected abstract T GetExistingItem(bool readOnly = false);
         protected abstract T GetMissingItem();
 
         protected abstract T CreateSymlink(string path, string pathToTarget);
@@ -81,6 +83,16 @@ namespace System.IO.Tests
         public void SettingUpdatesProperties()
         {
             T item = GetExistingItem();
+            SettingUpdatesPropertiesCore(item);
+        }
+
+        [Fact]
+        public void SettingUpdatesPropertiesWhenReadOnly()
+        {
+            if (!CanBeReadOnly)
+                return; // directories can't be read only, so automatic pass
+
+            T item = GetExistingItem(readOnly: true);
             SettingUpdatesPropertiesCore(item);
         }
 
@@ -164,7 +176,7 @@ namespace System.IO.Tests
                 TimeFunction function1 = functions.x;
                 TimeFunction function2 = functions.y;
                 bool reverse = functions.reverse;
-                
+
                 // Checking that milliseconds are not dropped after setter.
                 DateTime dt1 = new DateTime(2002, 12, 1, 12, 3, 3, LowTemporalResolution ? 0 : 321, DateTimeKind.Utc);
                 DateTime dt2 = new DateTime(2001, 12, 1, 12, 3, 3, LowTemporalResolution ? 0 : 321, DateTimeKind.Utc);

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -90,7 +90,9 @@ namespace System.IO.Tests
         public void SettingUpdatesPropertiesWhenReadOnly()
         {
             if (!CanBeReadOnly)
+            {
                 return; // directories can't be read only, so automatic pass
+            }
 
             T item = GetExistingItem(readOnly: true);
             SettingUpdatesPropertiesCore(item);

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -7,7 +7,9 @@ namespace System.IO.Tests
 {
     public class Directory_GetSetTimes : StaticGetSetTimes
     {
-        protected override string GetExistingItem() => Directory.CreateDirectory(GetTestFilePath()).FullName;
+        protected override bool CanBeReadOnly => false;
+
+        protected override string GetExistingItem(bool _) => Directory.CreateDirectory(GetTestFilePath()).FullName;
 
         protected override string CreateSymlink(string path, string pathToTarget) => Directory.CreateSymbolicLink(path, pathToTarget).FullName;
 

--- a/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -7,7 +7,9 @@ namespace System.IO.Tests
 {
     public class DirectoryInfo_GetSetTimes : InfoGetSetTimes<DirectoryInfo>
     {
-        protected override DirectoryInfo GetExistingItem() => Directory.CreateDirectory(GetTestFilePath());
+        protected override bool CanBeReadOnly => false;
+
+        protected override DirectoryInfo GetExistingItem(bool _) => Directory.CreateDirectory(GetTestFilePath());
 
         protected override DirectoryInfo GetMissingItem() => new DirectoryInfo(GetTestFilePath());
 

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -23,7 +23,9 @@ namespace System.IO.Tests
             File.Create(path).Dispose();
 
             if (readOnly)
+            {
                 File.SetAttributes(path, FileAttributes.ReadOnly);
+            }
 
             return path;
         }

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -11,14 +11,20 @@ namespace System.IO.Tests
 {
     public class File_GetSetTimes : StaticGetSetTimes
     {
+        protected override bool CanBeReadOnly => true;
+
         // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
         // 32bit Unix has time_t up to ~ 2038.
         private static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (!PlatformDetection.Is32BitProcess && !PlatformDetection.IsOSXLike);
 
-        protected override string GetExistingItem()
+        protected override string GetExistingItem(bool readOnly = false)
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
+
+            if (readOnly)
+                File.SetAttributes(path, FileAttributes.ReadOnly);
+
             return path;
         }
 
@@ -120,7 +126,7 @@ namespace System.IO.Tests
                 });
             }
         }
-
+        
         [Fact]
         public void SetLastWriteTimeTicks()
         {

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -126,7 +126,7 @@ namespace System.IO.Tests
                 });
             }
         }
-        
+
         [Fact]
         public void SetLastWriteTimeTicks()
         {

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -10,10 +10,16 @@ namespace System.IO.Tests
 {
     public class FileInfo_GetSetTimes : InfoGetSetTimes<FileInfo>
     {
-        protected override FileInfo GetExistingItem()
+        protected override bool CanBeReadOnly => true;
+
+        protected override FileInfo GetExistingItem(bool readOnly = false)
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
+
+            if (readOnly)
+                File.SetAttributes(path, FileAttributes.ReadOnly);
+
             return new FileInfo(path);
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -18,7 +18,9 @@ namespace System.IO.Tests
             File.Create(path).Dispose();
 
             if (readOnly)
+            {
                 File.SetAttributes(path, FileAttributes.ReadOnly);
+            }
 
             return new FileInfo(path);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -182,7 +182,7 @@ namespace System.IO
             }
         }
 
-        private static SafeFileHandle OpenHandle(string fullPath, bool asDirectory)
+        private static SafeFileHandle OpenHandleToWriteAttributes(string fullPath, bool asDirectory)
         {
             string root = fullPath.Substring(0, PathInternal.GetRootLength(fullPath.AsSpan()));
             if (root == fullPath && root[1] == Path.VolumeSeparatorChar)
@@ -199,7 +199,7 @@ namespace System.IO
 
             SafeFileHandle handle = Interop.Kernel32.CreateFile(
                 fullPath,
-                Interop.Kernel32.GenericOperations.GENERIC_WRITE,
+                Interop.Kernel32.FileOperations.FILE_WRITE_ATTRIBUTES,
                 FileShare.ReadWrite | FileShare.Delete,
                 FileMode.Open,
                 dwFlagsAndAttributes);
@@ -425,7 +425,7 @@ namespace System.IO
             long changeTime = -1,
             uint fileAttributes = 0)
         {
-            using (SafeFileHandle handle = OpenHandle(fullPath, asDirectory))
+            using (SafeFileHandle handle = OpenHandleToWriteAttributes(fullPath, asDirectory))
             {
                 var basicInfo = new Interop.Kernel32.FILE_BASIC_INFO()
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -184,8 +184,7 @@ namespace System.IO
 
         private static SafeFileHandle OpenHandleToWriteAttributes(string fullPath, bool asDirectory)
         {
-            string root = fullPath.Substring(0, PathInternal.GetRootLength(fullPath.AsSpan()));
-            if (root == fullPath && root[1] == Path.VolumeSeparatorChar)
+            if (fullPath.Length == PathInternal.GetRootLength(fullPath) && fullPath[1] == Path.VolumeSeparatorChar)
             {
                 // intentionally not fullpath, most upstack public APIs expose this as path.
                 throw new ArgumentException(SR.Arg_PathIsVolume, "path");


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/62602

All other attribute/timestamp operations go through GetFileAttributesEx/SetFileAttributes and work fine.

Curiously this is a bug back to .NET Framework.