### PR TITLE
Fix lazy-initialization of Trace.s_correlationManager to be thread-safe

### DIFF
--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
@@ -4,6 +4,7 @@
 #define TRACE
 using System;
 using System.Collections;
+using System.Threading;
 
 namespace System.Diagnostics
 {
@@ -19,18 +20,11 @@ namespace System.Diagnostics
         }
 
         private static CorrelationManager? s_correlationManager;
-        public static CorrelationManager CorrelationManager
-        {
-            get
-            {
-                if (s_correlationManager == null)
-                {
-                    s_correlationManager = new CorrelationManager();
-                }
 
-                return s_correlationManager;
-            }
-        }
+        public static CorrelationManager CorrelationManager =>
+            Volatile.Read(ref s_correlationManager) ??
+            Interlocked.CompareExchange(ref s_correlationManager, new CorrelationManager(), null) ??
+            s_correlationManager;
 
         /// <devdoc>
         ///    <para>Gets the collection of listeners that is monitoring the trace output.</para>


### PR DESCRIPTION
If two threads race to initialize it, one may end up overwriting the other's, which means state pushed onto the losing thread's stack might end up disappearing.

Fixes https://github.com/dotnet/runtime/issues/50480