### PR TITLE
Added missed penultimate bytes in `SniHelper_TruncatedData_Fails` scenario

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TlsFrameHelperTests.cs
@@ -100,13 +100,13 @@ namespace System.Net.Security.Tests
             var uniqueInvalidHellos = new HashSet<string>();
             foreach (byte[] invalidClientHello in InvalidClientHello())
             {
-                for (int i = 0; i < invalidClientHello.Length - 1; i++)
+                for (int i = 0; i < invalidClientHello.Length; i++)
                 {
                     uniqueInvalidHellos.Add(Convert.ToBase64String(invalidClientHello.Take(i).ToArray()));
                 }
             }
 
-            for (int i = 0; i < s_validClientHello.Length - 1; i++)
+            for (int i = 0; i < s_validClientHello.Length; i++)
             {
                 uniqueInvalidHellos.Add(Convert.ToBase64String(s_validClientHello.Take(i).ToArray()));
             }


### PR DESCRIPTION
I noticed that we penultimate bytes are missed in `SniHelper_TruncatedData_Fails` scenario generator, adding them. 