### PR TITLE
Remove errors during first run of runpaltests.h

### DIFF
--- a/src/coreclr/pal/tests/palsuite/runpaltests.sh
+++ b/src/coreclr/pal/tests/palsuite/runpaltests.sh
@@ -32,13 +32,6 @@ pushd $BUILD_ROOT_DIR
 
 export LD_LIBRARY_PATH=$BUILD_ROOT_DIR:$LD_LIBRARY_PATH
 
-# Create absolute path to the file that contains a list of PAL tests to execute.
-# This file is located next to this script in the source tree
-RELATIVE_PATH_TO_PAL_TESTS=$0
-# Remove the name of this script from the path
-RELATIVE_PATH_TO_PAL_TESTS=${RELATIVE_PATH_TO_PAL_TESTS%/*.*}
-# Change current directory to the location of this script
-cd $RELATIVE_PATH_TO_PAL_TESTS
 # Environment variable PWD contains absolute path to the current folder
 # so use it to create absolute path to the file with a list of tests.
 PAL_TEST_LIST=$BUILD_ROOT_DIR/paltestlist.txt
@@ -78,8 +71,6 @@ then
     PAL_TEST_OUTPUT_DIR=$(mktemp -d /tmp/PalTestOutput/tmp.XXXXXXXX)
   fi
 fi
-
-cd $PAL_TEST_OUTPUT_DIR
 
 echo PAL tests will store their temporary files and output in $PAL_TEST_OUTPUT_DIR.
 if [ "$COPY_TO_TEST_OUTPUT_DIR" != "$PAL_TEST_OUTPUT_DIR" ]; then

--- a/src/coreclr/pal/tests/palsuite/runpaltests.sh
+++ b/src/coreclr/pal/tests/palsuite/runpaltests.sh
@@ -127,7 +127,7 @@ do
     rm -f -r $TEST_WORKING_DIR
   fi
   mkdir $TEST_WORKING_DIR
-  pushd $TEST_WORKING_DIR
+  cd $TEST_WORKING_DIR
 
   # Create path to a test executable to run
   TEST_COMMAND="$PAL_TEST_BUILD/$TEST_NAME"
@@ -145,7 +145,7 @@ do
   ENDTIME=$(date +%s)
 
   # Change back to the output directory, and remove the test's working directory if it's empty
-  popd
+  cd $PAL_TEST_OUTPUT_DIR
   rmdir $TEST_WORKING_DIR 2>/dev/null
 
   TEST_XUNIT_NAME=$(dirname $TEST_NAME)

--- a/src/coreclr/pal/tests/palsuite/runpaltests.sh
+++ b/src/coreclr/pal/tests/palsuite/runpaltests.sh
@@ -23,7 +23,7 @@ if [ ! -e "$1" ]; then
   echo "Core_Root not found at $1"
   exit 1
 fi
-BUILD_ROOT_DIR="$(pushd "$1"; pwd -P)"
+BUILD_ROOT_DIR="$(cd "$1"; pwd -P)"
 
 # Create path to the compiled PAL tets in the build directory
 PAL_TEST_BUILD=$BUILD_ROOT_DIR


### PR DESCRIPTION
If you run `runpaltests.h` for first time, you will see 2 errors about file or folder not found.

First error comes from using `RELATIVE_PATH_TO_PAL_TESTS` which does not used anywhere, except maybe some platform where you can `cd` to non-existing folder. In that case 3rd parameter to script would be interpreted incorrectly. I doubt that, but who know what's somewhere deep in infra.

Second error is entirely preventable, since `cd $PAL_TEST_OUTPUT_DIR` does not affect anything until subsequent `cd $PAL_TEST_OUTPUT_DIR` on line 118.
 
Discovered here https://github.com/dotnet/runtime/pull/62625#issuecomment-991172978