### PR TITLE
Do not promote struct locals with holes

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2045,21 +2045,13 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
         // multiple registers?
         if (compiler->lvaIsMultiregStruct(varDsc, compiler->info.compIsVarArgs))
         {
-            if (structPromotionInfo.fieldCnt == 2)
+            if (structPromotionInfo.containsHoles && structPromotionInfo.customLayout)
             {
-                unsigned structSize = varDsc->GetLayout()->GetSize();
-                if ((structPromotionInfo.fields[0].fldSize + structPromotionInfo.fields[1].fldSize) != structSize)
-                {
-                    // Ensure that the combined fldSize matches the structSize otherwise partial information might
-                    // be passed.
-                    JITDUMP("Not promoting multireg struct local V%02u, because lvIsParam is true, #fields == 2, "
-                            "field#0 size == %u, field#1 size == %u, total structSize= %u.\n",
-                            lclNum, structPromotionInfo.fields[0].fldSize, structPromotionInfo.fields[1].fldSize,
-                            structSize);
-                    shouldPromote = false;
-                }
+                JITDUMP("Not promoting multi-reg struct local V%02u with holes.\n", lclNum);
+                shouldPromote = false;
             }
-            else if (!((structPromotionInfo.fieldCnt == 1) && varTypeIsSIMD(structPromotionInfo.fields[0].fldType)))
+            else if ((structPromotionInfo.fieldCnt != 2) &&
+                     !((structPromotionInfo.fieldCnt == 1) && varTypeIsSIMD(structPromotionInfo.fields[0].fldType)))
             {
                 JITDUMP("Not promoting multireg struct local V%02u, because lvIsParam is true, #fields != 2 and it's "
                         "not a single SIMD.\n",

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2048,7 +2048,7 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
             if (structPromotionInfo.fieldCnt == 2)
             {
                 unsigned structSize = varDsc->GetLayout()->GetSize();
-                if (structPromotionInfo.fields[0].fldSize * 2 != structSize)
+                if ((structPromotionInfo.fields[0].fldSize + structPromotionInfo.fields[1].fldSize) != structSize)
                 {
                     // Ensure that the combined fldSize matches the structSize otherwise partial information might
                     // be passed.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.cs
@@ -44,27 +44,26 @@ public static class Program
     public static int Main()
     {
         var value = new SmallString("foobar");
-        Execute(value);
 
-        var method = new DynamicMethod("test", typeof(void), new[] { typeof(SmallString) }, typeof(Program), true);
-        var il = method.GetILGenerator();
-        il.Emit(OpCodes.Ldarg_0);
-        il.EmitCall(OpCodes.Call, typeof(Program).GetMethod("Execute")!, null);
-        il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ret);
-
-        var action = (Action<SmallString>)method.CreateDelegate(typeof(Action<SmallString>));
-        action.Invoke(value);
+        TheTest(value);
 
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void TheTest(SmallString foo)
+    {
+        Execute(foo);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static object Execute(SmallString foo)
     {
         byte value = foo.Dump();
+        // 111 corresponds to the ASCII code of 2nd characted of string "foobar" i.e. ASCII value of 'o'.
         if (value == 111)
         {
-            result += 50;
+            result = 100;
         }
         return new StringBuilder();
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// Note: In below test case, we were not honoring the fact that the explicit struct size
+//       of struct is 32 bytes while the only 2 fields it has is just 2 bytes. In such case,
+//       we would pass partial struct value.
+using System;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+[StructLayout(LayoutKind.Explicit, Size = 32)]
+public readonly unsafe struct SmallString
+{
+    [FieldOffset(0)] private readonly byte _length;
+    [FieldOffset(1)] private readonly byte _firstByte;
+
+    public SmallString(string value)
+    {
+        fixed (char* srcPtr = value)
+        fixed (byte* destPtr = &_firstByte)
+        {
+            Encoding.ASCII.GetBytes(srcPtr, value.Length, destPtr, value.Length);
+        }
+
+        _length = (byte)value.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public byte Dump()
+    {
+        fixed (byte* ptr = &_firstByte)
+        {
+            byte* next = ptr + 1;
+            return *next;
+        }
+    }
+}
+
+public static class Program
+{
+    static int result = 0;
+    public static int Main()
+    {
+        var value = new SmallString("foobar");
+        Execute(value);
+
+        var method = new DynamicMethod("test", typeof(void), new[] { typeof(SmallString) }, typeof(Program), true);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.EmitCall(OpCodes.Call, typeof(Program).GetMethod("Execute")!, null);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        var action = (Action<SmallString>)method.CreateDelegate(typeof(Action<SmallString>));
+        action.Invoke(value);
+
+        return result;
+    }
+
+    public static object Execute(SmallString foo)
+    {
+        byte value = foo.Dump();
+        if (value == 111)
+        {
+            result += 50;
+        }
+        return new StringBuilder();
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62597/Runtime_62597.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>


### PR DESCRIPTION
In #43870 , when we added more support for multireg args, we added a check for struct's field count. We didn't check if the total size of struct matched the combined size of both the fields. That led us to generate code that partially copy the struct fields on stack when passing as arguments. Add an explicit check to verify the combined size matches.

Fixes: #62597 