### PR TITLE
Fix named mutex PAL test issue

### DIFF
--- a/src/coreclr/pal/tests/palsuite/common/palsuite.cpp
+++ b/src/coreclr/pal/tests/palsuite/common/palsuite.cpp
@@ -20,16 +20,19 @@ CRITICAL_SECTION CriticalSection;
 
 WCHAR* convert(const char * aString) 
 {
-    int size;
-    WCHAR* wideBuffer;
+    WCHAR* wideBuffer = nullptr;
 
-    size = MultiByteToWideChar(CP_ACP,0,aString,-1,NULL,0);
-    wideBuffer = (WCHAR*) malloc(size*sizeof(WCHAR));
-    if (wideBuffer == NULL)
+    if (aString != nullptr)
     {
-        Fail("ERROR: Unable to allocate memory!\n");
+        int size = MultiByteToWideChar(CP_ACP,0,aString,-1,NULL,0);
+        wideBuffer = (WCHAR*) malloc(size*sizeof(WCHAR));
+        if (wideBuffer == NULL)
+        {
+            Fail("ERROR: Unable to allocate memory!\n");
+        }
+        MultiByteToWideChar(CP_ACP,0,aString,-1,wideBuffer,size);
     }
-    MultiByteToWideChar(CP_ACP,0,aString,-1,wideBuffer,size);
+
     return wideBuffer;
 }
 


### PR DESCRIPTION
The issue seems to be caused by a bug in the test. The problematic call
to `TestCreateMutex` is passed `nullptr` as the `name` parameter. It
then calls `convert` helper on it to convert it to wide char. However,
the `convert` helper doesn't check whether it is `nullptr` or not and
ends up returning a pointer to a memory with possibly random data,
that is returned by `malloc(0)`. The returned pointer is then passed to
the CreateMutex PAL api that probably ends up attempting to get the
length of the name or something. And depending on the random data, it
sometimes fails.

The fix is to change the `convert` function to handle `nullptr` so that
it returns `nullptr` too.

Close #62336