### PR TITLE
Do not perform vector save/restore around call that will never return

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -6274,6 +6274,15 @@ void LinearScan::insertUpperVectorSave(GenTree*     tree,
         return;
     }
 
+#ifdef DEBUG
+    GenTreeCall* call = tree->AsCall();
+    if ((call != nullptr) && (call->gtOper == GT_CALL))
+    {
+        // Make sure that we do not insert vector save before calls that does not return.
+        assert((call->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) == 0);
+    }
+#endif
+
     LclVarDsc* varDsc = compiler->lvaGetDesc(lclVarInterval->varNum);
     assert(Compiler::varTypeNeedsPartialCalleeSave(varDsc->GetRegisterType()));
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -6275,11 +6275,10 @@ void LinearScan::insertUpperVectorSave(GenTree*     tree,
     }
 
 #ifdef DEBUG
-    GenTreeCall* call = tree->AsCall();
-    if ((call != nullptr) && (call->gtOper == GT_CALL))
+    if ((tree != nullptr) && tree->IsCall())
     {
         // Make sure that we do not insert vector save before calls that does not return.
-        assert((call->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) == 0);
+        assert((tree->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) == 0);
     }
 #endif
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -6275,10 +6275,10 @@ void LinearScan::insertUpperVectorSave(GenTree*     tree,
     }
 
 #ifdef DEBUG
-    if ((tree != nullptr) && tree->IsCall())
+    if (tree->IsCall())
     {
         // Make sure that we do not insert vector save before calls that does not return.
-        assert((tree->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) == 0);
+        assert(!tree->AsCall()->IsNoReturn());
     }
 #endif
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1481,10 +1481,9 @@ Interval* LinearScan::getUpperVectorInterval(unsigned varIndex)
 //
 void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet)
 {
-    GenTreeCall* call = tree->AsCall();
-    if ((call != nullptr) && (call->gtOper == GT_CALL))
+    if ((tree != nullptr) && tree->IsCall())
     {
-        if ((call->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) != 0)
+        if ((tree->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) != 0)
         {
             // No point in having vector save/restore if the call will not return.
             return;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1483,7 +1483,7 @@ void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation cu
 {
     if ((tree != nullptr) && tree->IsCall())
     {
-        if ((tree->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) != 0)
+        if (tree->AsCall()->IsNoReturn())
         {
             // No point in having vector save/restore if the call will not return.
             return;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1481,6 +1481,16 @@ Interval* LinearScan::getUpperVectorInterval(unsigned varIndex)
 //
 void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet)
 {
+    GenTreeCall* call = tree->AsCall();
+    if ((call != nullptr) && (call->gtOper == GT_CALL))
+    {
+        if ((call->AsCall()->gtCallMoreFlags & GTF_CALL_M_DOES_NOT_RETURN) != 0)
+        {
+            // No point in having vector save/restore if the call will not return.
+            return;
+        }
+    }
+
     if (enregisterLocalVars && !VarSetOps::IsEmpty(compiler, largeVectorVars))
     {
         // We assume that the kill set includes at least some callee-trash registers, but


### PR DESCRIPTION
We were inserting vector save/restore moves around `ThrowException` that never returns. As such, we hit an assert because the code doesn't expect the restore generated in the end of blocks other than `BBJ_COND`, `BBJ_NONE`, `BBJ_SWITCH` or `BBJ_ALWAYS`. In this case, it was `BBJ_THROW`.

The fix is to not generate save/restore around such calls. We were hitting this issue while jitting a method that was added in #61439.

Fixes: #62005 