### PR TITLE
Remove dummy project property IlasmRoundTrip

### DIFF
--- a/src/tests/JIT/BBT/Scenario4/Not-Int32.ilproj
+++ b/src/tests/JIT/BBT/Scenario4/Not-Int32.ilproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Add1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Add1_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array1_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array2_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array3_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array3_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/Array4_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/Array4_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayExc_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayExc_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayJagged_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD1_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayMD2_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_d.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_do.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_r.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/CodeGenBringUpTests/ArrayObj_ro.csproj
+++ b/src/tests/JIT/CodeGenBringUpTests/ArrayObj_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Directed/array-il/_Arrayscomplex3.ilproj
+++ b/src/tests/JIT/Directed/array-il/_Arrayscomplex3.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Generics/Exceptions/general_class_instance01.csproj
+++ b/src/tests/JIT/Generics/Exceptions/general_class_instance01.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/directed/heap_ovf.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/directed/heap_ovf.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/fp/apps/bouncingball_cs_d.csproj
+++ b/src/tests/JIT/Methodical/fp/apps/bouncingball_cs_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/structs/ExplicitLayout.csproj
+++ b/src/tests/JIT/Methodical/structs/ExplicitLayout.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/structs/valuetuple.csproj
+++ b/src/tests/JIT/Methodical/structs/valuetuple.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b00719/b00719.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b00719/b00719.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/SIMD/BitwiseOperations_r.csproj
+++ b/src/tests/JIT/SIMD/BitwiseOperations_r.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/SIMD/BitwiseOperations_ro.csproj
+++ b/src/tests/JIT/SIMD/BitwiseOperations_ro.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Stress/ABI/pinvokes_d.csproj
+++ b/src/tests/JIT/Stress/ABI/pinvokes_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/JIT/Stress/ABI/pinvokes_do.csproj
+++ b/src/tests/JIT/Stress/ABI/pinvokes_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/JIT/Stress/ABI/stubs_do.csproj
+++ b/src/tests/JIT/Stress/ABI/stubs_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/JIT/Stress/ABI/tailcalls_d.csproj
+++ b/src/tests/JIT/Stress/ABI/tailcalls_d.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/JIT/Stress/ABI/tailcalls_do.csproj
+++ b/src/tests/JIT/Stress/ABI/tailcalls_do.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/JIT/jit64/eh/basics/loopEH.csproj
+++ b/src/tests/JIT/jit64/eh/basics/loopEH.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/opt/FastTailCall/FastTailCallCandidates.csproj
+++ b/src/tests/JIT/opt/FastTailCall/FastTailCallCandidates.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/FastTailCall/FastTailCallInlining.csproj
+++ b/src/tests/JIT/opt/FastTailCall/FastTailCallInlining.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/FastTailCall/GitHubIssue12479.csproj
+++ b/src/tests/JIT/opt/FastTailCall/GitHubIssue12479.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/FastTailCall/StackFixup.csproj
+++ b/src/tests/JIT/opt/FastTailCall/StackFixup.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/FastTailCall/StructPassingSimple.csproj
+++ b/src/tests/JIT/opt/FastTailCall/StructPassingSimple.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->

--- a/src/tests/JIT/opt/perf/doublealign/Locals.csproj
+++ b/src/tests/JIT/opt/perf/doublealign/Locals.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
I have identified 63 tests in the tree that set IlasmRoundTrip
to true in their MSBuild project scripts. I haven't found any place
in the scripts that would be looking at the value so I'm guessing
it may have been a predecessor to today property
IlasmRoundTripIncompatible and I'm proposing to delete the unused
property. Please let me know if you're aware of any test script logic
that queries it.

Thanks

Tomas

/cc @dotnet/jit-contrib