### PR TITLE
Adds BitArray.CopyTo(Span<byte>)

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -857,7 +857,7 @@ namespace System.Collections
             }
         }
 
-        private void InternalCopyTo(Span<byte> span)
+        private void InternalCopyTo(Span<byte> span, int arrayLength)
         {
             // equivalent to m_length % BitsPerByte, since BitsPerByte is a power of 2
             uint extraBits = (uint)m_length & (BitsPerByte - 1);
@@ -906,7 +906,7 @@ namespace System.Collections
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             }
 
-            InternalCopyTo(span);
+            InternalCopyTo(span, arrayLength);
         }
 
         public unsafe void CopyTo(Array array, int index)
@@ -949,7 +949,7 @@ namespace System.Collections
 
                 Span<byte> span = byteArray.AsSpan(index);
 
-                InternalCopyTo(span);
+                InternalCopyTo(span, arrayLength);
             }
             else if (array is bool[] boolArray)
             {

--- a/src/libraries/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/libraries/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -351,6 +351,28 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        public static void CopyToByteSpan()
+        {
+            for (int size = 4; size < 100; size++)
+            {
+                var bitArray = new BitArray(size);
+                bitArray[1] = true;
+                bitArray[3] = true;
+
+                for (int i = 0; i < 100; i++)
+                {
+                    byte[] expectedOutput = new byte[100 + (size / 8 + 1)];
+                    byte[] actualOutput = new byte[expectedOutput.Length];
+
+                    expectedOutput[i] = 10;
+                    bitArray.CopyTo(actualOutput.AsSpan(i));
+
+                    Assert.Equal(expectedOutput, actualOutput);
+                }
+            }
+        }
+
+        [Fact]
         public static void CopyToBoolArray()
         {
             for (int size = 4; size < 100; size++)


### PR DESCRIPTION
### Summary
Adds `CopyTo(Span<byte> span);` to BitArray to avoid an unnecessary allocation.

If this PR looks good, let me know and I'll be happy to add/update tests where necessary.

### Considerations / Discussion Points
* Should we support `CopyTo(Span<int>)` since `int[]` is already supported?
* I used an `InternalCopyTo` to deduplicate the code. Should we leave it copy/pasted instead?