### PR TITLE
JIT: Transform "(X - Y) cmp 0" to "X cmp Y" if it's a jump condition

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2651,6 +2651,18 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 #endif
         }
     }
+    else if (op1->OperIs(GT_SUB) && !op1->gtOverflow() && op2->IsIntegralConst(0) && varTypeIsIntegralOrI(op1) &&
+             (cmp->gtFlags & GTF_RELOP_JMP_USED))
+    {
+        // Transform "(X - Y) cmp 0" to "X cmp Y" if it's a jump condition
+        cmp->AsOp()->gtOp1 = op1->gtGetOp1();
+        cmp->AsOp()->gtOp2 = op1->gtGetOp2();
+        BlockRange().Remove(op1);
+        BlockRange().Remove(op2);
+        cmp->gtGetOp1()->ClearContained();
+        cmp->gtGetOp2()->ClearContained();
+        return cmp;
+    }
 
     if (cmp->OperIs(GT_TEST_EQ, GT_TEST_NE))
     {


### PR DESCRIPTION
I noticed this pattern in [ConcurrentDictionary.TryDequeue](https://github.com/dotnet/runtime/blob/20f994c0457bcd1e2f54aa02da17290d7fc48b29/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueueSegment.cs#L167) which is a performance critical API. Also, on some CPUs `cmp` is a little bit cheaper than `sub` (e.g. Zen2)

PS: initially I did this opt in morph but the diffs are much better when it's done in Lower, mostly due to CSE: https://godbolt.org/z/8nd5a54hK (even among native compilers only clang managed to handle it)

Diffs: https://dev.azure.com/dnceng/public/_build/results?buildId=1508771&view=ms.vss-build-web.run-extensions-tab (up to `-4859 bytes` a few small regressions due to register allocation