### PR TITLE
Two small fixes for the recently merged in merged wrapper logic

### DIFF
--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -11,7 +11,7 @@
 
   <!-- Default priority building values. -->
   <PropertyGroup>
-    <CLRTestTargetUnsupported Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and $(BuildAsStandalone)">true</CLRTestTargetUnsupported>
+    <DisableProjectBuild Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and $(BuildAsStandalone)">true</DisableProjectBuild>
     <OutputType Condition="'$(IsMergedTestRunnerAssembly)' == 'true' and !$(BuildAsStandalone)">Exe</OutputType>
     <CLRTestKind Condition="'$(CLRTestKind)' == '' and '$(OutputType)' == 'Exe'">BuildAndRun</CLRTestKind>
     <CLRTestKind Condition="'$(CLRTestKind)' == ''">BuildOnly</CLRTestKind>

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -1191,6 +1191,8 @@ def parse_test_results_xml_file(args, item, item_name, tests, assemblies):
     print("Analyzing {}".format(xml_result_file))
     xml_assemblies = xml.etree.ElementTree.parse(xml_result_file).getroot()
     for assembly in xml_assemblies:
+        if "name" not in assembly.attrib:
+            continue
         assembly_name = assembly.attrib["name"]
         assembly_info = assemblies[assembly_name]
         display_name = assembly_name


### PR DESCRIPTION
1. When running the entire Pri1 test file I noticed that xUnit
sometimes generates an empty <assembly /> entry that was crashing
the new logic in run.py. I have added a check to harden the script
against this eventuality.

2. My logic to disable merged test wrapper build in BuildAsStandalone
mode wasn't completely correct - I used the CLRTestTargetUnsupported
property but that's ignored when CLRTestBuildAllTargets is set to
'allTargets'. I have changed it to DisableProjectBuild.

Thanks

Tomas