### PR TITLE
Fix gcc warnings in mono

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -92,7 +92,7 @@
   </ItemGroup>
 
   <!-- CI specific build options -->
-  <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and ('$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsBrowser)' == 'true')">
+  <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and ('$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsBrowser)' == 'true' or '$(Targetsillumos)' == 'true')">
     <_MonoCMakeArgs Include="-DENABLE_WERROR=1"/>
   </ItemGroup>
 
@@ -214,18 +214,18 @@
     </ItemGroup>
 
     <!-- We build LLVM bits for x64 Linux without C++11 ABI (CentOS 7 has libstdc++ < 5.1) -->
-    <ItemGroup Condition="'$(TargetOS)' == 'Linux' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' != 'true'">
+    <ItemGroup Condition="'$(TargetsLinux)' == 'true' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' != 'true'">
       <_MonoCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetOS)' == 'Linux' and '$(MonoAOTEnableLLVM)' == 'true' and '$(MonoAOTLLVMUseCxx11Abi)' != 'true'">
+    <ItemGroup Condition="'$(TargetsLinux)' == 'true' and '$(MonoAOTEnableLLVM)' == 'true' and '$(MonoAOTLLVMUseCxx11Abi)' != 'true'">
       <_MonoAOTCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=0" />
     </ItemGroup>
 
     <!-- We build LLVM bits for ARM64 Linux with C++11 ABI (Ubuntu 16.04 has libstdc++ > 5.1)-->
-    <ItemGroup Condition="'$(TargetOS)' == 'Linux' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' == 'true'">
+    <ItemGroup Condition="'$(TargetsLinux)' == 'true' and '$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMUseCxx11Abi)' == 'true'">
       <_MonoCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=1" />
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetOS)' == 'Linux' and '$(MonoAOTEnableLLVM)' == 'true' and '$(MonoAOTLLVMUseCxx11Abi)' == 'true'">
+    <ItemGroup Condition="'$(TargetsLinux)' == 'true' and '$(MonoAOTEnableLLVM)' == 'true' and '$(MonoAOTLLVMUseCxx11Abi)' == 'true'">
       <_MonoAOTCXXFLAGS Include="-D_GLIBCXX_USE_CXX11_ABI=1" />
     </ItemGroup>
 
@@ -239,7 +239,7 @@
     </ItemGroup>
 
     <!-- x64 illumos cross build options -->
-    <ItemGroup Condition="'$(TargetsIllumos)' == 'true' and '$(MonoCrossDir)' != ''">
+    <ItemGroup Condition="'$(Targetsillumos)' == 'true' and '$(MonoCrossDir)' != ''">
       <_MonoCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
       <_MonoBuildEnv Include="TARGET_BUILD_ARCH=x64" />
       <_MonoBuildEnv Include="PKG_CONFIG_PATH=$(MonoCrossDir)/lib/pkgconfig" />
@@ -574,7 +574,7 @@
     <ItemGroup Condition="'$(RealTargetOS)' == 'Linux' or $([MSBuild]::IsOSPlatform('Linux'))">
       <_LibClang Include="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(MonoToolchainPrebuiltOS)/lib64/libclang.so.*"/>
     </ItemGroup>
-    <PropertyGroup Condition="'$(TargetOS)' == 'Linux' and '$(Platform)' == 'arm64'">
+    <PropertyGroup Condition="'$(TargetsLinux)' == 'true' and '$(Platform)' == 'arm64'">
       <MonoUseCrossTool>true</MonoUseCrossTool>
       <MonoAotAbi>aarch64-linux-gnu</MonoAotAbi>
       <MonoAotOffsetsFile>$(MonoObjCrossDir)offsets-aarch-linux-gnu.h</MonoAotOffsetsFile>

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -2443,7 +2443,7 @@ notify_thread (gpointer key, gpointer value, gpointer user_data)
 	if (mono_thread_internal_is_current (thread) || tls->terminated)
 		return;
 
-	PRINT_DEBUG_MSG (1, "[%p] Interrupting %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)(gsize)tid);
+	PRINT_DEBUG_MSG (1, "[%p] Interrupting %p...\n", (gpointer)(gsize) mono_native_thread_id_get (), (gpointer)(gsize) tid);
 
 	/* This is _not_ equivalent to mono_thread_internal_abort () */
 	InterruptData interrupt_data = { 0 };
@@ -2451,7 +2451,7 @@ notify_thread (gpointer key, gpointer value, gpointer user_data)
 
 	mono_thread_info_safe_suspend_and_run ((MonoNativeThreadId)(gsize)thread->tid, FALSE, debugger_interrupt_critical, &interrupt_data);
 	if (!interrupt_data.valid_info) {
-		PRINT_DEBUG_MSG (1, "[%p] mono_thread_info_suspend_sync () failed for %p...\n", (gpointer) (gsize) mono_native_thread_id_get (), (gpointer)tid);
+		PRINT_DEBUG_MSG (1, "[%p] mono_thread_info_suspend_sync () failed for %p...\n", (gpointer)(gsize) mono_native_thread_id_get (), (gpointer)(gsize) tid);
 		/*
 		 * Attached thread which died without detaching.
 		 */

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -10034,7 +10034,7 @@ wait_for_attach (void)
 	MONO_ENTER_GC_SAFE;
 	conn_fd = socket_transport_accept (listen_fd);
 	MONO_EXIT_GC_SAFE;
-	
+
 	PRINT_DEBUG_MSG (1, "Accepted connection on %d\n", conn_fd);
 	if (conn_fd == -1) {
 		PRINT_DEBUG_MSG (1, "[dbg] Bad client connection\n");

--- a/src/mono/mono/eglib/gunicode.c
+++ b/src/mono/mono/eglib/gunicode.c
@@ -1,5 +1,5 @@
 /*
- * gunicode.c: Some Unicode routines 
+ * gunicode.c: Some Unicode routines
  *
  * Author:
  *   Miguel de Icaza (miguel@novell.com)
@@ -49,7 +49,7 @@ const char *eg_my_charset;
  * Character set conversion
  */
 
-GUnicodeType 
+GUnicodeType
 g_unichar_type (gunichar c)
 {
 	int i;
@@ -189,7 +189,7 @@ gchar *
 g_filename_from_utf8 (const gchar *utf8string, gssize len, gsize *bytes_read, gsize *bytes_written, GError **gerror)
 {
 	char *res;
-	
+
 	if (len == -1)
 		len = strlen (utf8string);
 
@@ -234,7 +234,7 @@ g_get_charset (G_CONST_RETURN char **charset)
 #endif
 		is_utf8 = strcmp (eg_my_charset, "UTF-8") == 0;
 	}
-	
+
 	if (charset != NULL)
 		*charset = eg_my_charset;
 

--- a/src/mono/mono/eglib/gunicode.c
+++ b/src/mono/mono/eglib/gunicode.c
@@ -99,7 +99,7 @@ g_unichar_break_type (gunichar c)
 static gunichar
 g_unichar_case (gunichar c, gboolean upper)
 {
-	gint8 i, i2;
+	guint8 i, i2;
 	guint32 cp = (guint32) c, v;
 
 	for (i = 0; i < simple_case_map_ranges_count; i++) {

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -266,7 +266,7 @@ mono_thread_set_main (MonoThread *thread)
 	static gboolean registered = FALSE;
 
 	if (!registered) {
-		void *key = thread->internal_thread ? (void *) MONO_UINT_TO_NATIVE_THREAD_ID (thread->internal_thread->tid) : NULL;
+		void *key = thread->internal_thread ? (gpointer)(gsize) MONO_UINT_TO_NATIVE_THREAD_ID (thread->internal_thread->tid) : NULL;
 		MONO_GC_REGISTER_ROOT_SINGLE (main_thread, MONO_ROOT_SOURCE_THREADING, key, "Thread Main Object");
 		registered = TRUE;
 	}

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -179,21 +179,21 @@ mono_runtime_object_init_checked (MonoObject *this_obj_raw, MonoError *error)
 Note it doesn't say anything about domains - only threads.
 
 2. If the type is initialized you are done.
-2.1. If the type is not yet initialized, try to take an 
-     initialization lock.  
-2.2. If successful, record this thread as responsible for 
+2.1. If the type is not yet initialized, try to take an
+     initialization lock.
+2.2. If successful, record this thread as responsible for
      initializing the type and proceed to step 2.3.
-2.2.1. If not, see whether this thread or any thread 
+2.2.1. If not, see whether this thread or any thread
      waiting for this thread to complete already holds the lock.
-2.2.2. If so, return since blocking would create a deadlock.  This thread 
-     will now see an incompletely initialized state for the type, 
+2.2.2. If so, return since blocking would create a deadlock.  This thread
+     will now see an incompletely initialized state for the type,
      but no deadlock will arise.
 2.2.3  If not, block until the type is initialized then return.
-2.3 Initialize the parent type and then all interfaces implemented 
+2.3 Initialize the parent type and then all interfaces implemented
     by this type.
 2.4 Execute the type initialization code for this type.
-2.5 Mark the type as initialized, release the initialization lock, 
-    awaken any threads waiting for this type to be initialized, 
+2.5 Mark the type as initialized, release the initialization lock,
+    awaken any threads waiting for this type to be initialized,
     and return.
 
 */
@@ -321,8 +321,8 @@ get_type_init_exception_for_vtable (MonoVTable *vtable)
 
 	if (!vtable->init_failed)
 		g_error ("Trying to get the init exception for a non-failed vtable of class %s", mono_type_get_full_name (klass));
-	
-	/* 
+
+	/*
 	 * If the initializing thread was rudely aborted, the exception is not stored
 	 * in the hash.
 	 */
@@ -663,8 +663,8 @@ gboolean release_type_locks (gpointer key, gpointer value, gpointer user)
 	TypeInitializationLock *lock = (TypeInitializationLock*) value;
 	if (mono_native_thread_id_equals (lock->initializing_tid, MONO_UINT_TO_NATIVE_THREAD_ID (GPOINTER_TO_UINT (user))) && !lock->done) {
 		lock->done = TRUE;
-		/* 
-		 * Have to set this since it cannot be set by the normal code in 
+		/*
+		 * Have to set this since it cannot be set by the normal code in
 		 * mono_runtime_class_init (). In this case, the exception object is not stored,
 		 * and get_type_init_exception_for_class () needs to be aware of this.
 		 */
@@ -726,7 +726,7 @@ mono_set_always_build_imt_trampolines (gboolean value)
  * This JIT-compiles the method, and returns the pointer to the native code
  * produced.
  */
-gpointer 
+gpointer
 mono_compile_method (MonoMethod *method)
 {
 	gpointer result;
@@ -793,7 +793,7 @@ mono_runtime_free_method (MonoMethod *method)
 }
 
 /*
- * The vtables in the root appdomain are assumed to be reachable by other 
+ * The vtables in the root appdomain are assumed to be reachable by other
  * roots, and we don't use typed allocation in the other domains.
  */
 
@@ -932,7 +932,7 @@ mono_class_compute_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset
 }
 
 #if 0
-/* 
+/*
  * similar to the above, but sets the bits in the bitmap for any non-ref field
  * and ignores static fields
  */
@@ -1274,7 +1274,7 @@ mono_method_get_imt_slot (MonoMethod *method)
 		g_error ("mono_method_get_imt_slot: %s.%s.%s is not an interface MonoMethod",
 				m_class_get_name_space (method->klass), m_class_get_name (method->klass), method->name);
 	}
-	
+
 	/* Initialize hashes */
 	hashes [0] = mono_metadata_str_hash (m_class_get_name (method->klass));
 	hashes [1] = mono_metadata_str_hash (m_class_get_name_space (method->klass));
@@ -1298,7 +1298,7 @@ mono_method_get_imt_slot (MonoMethod *method)
 	}
 
 	/* Handle the last 3 hashes (all the case statements fall through) */
-	switch (hashes_count) { 
+	switch (hashes_count) {
 	case 3 : c += hashes [2];
 	case 2 : b += hashes [1];
 	case 1 : a += hashes [0];
@@ -1306,7 +1306,7 @@ mono_method_get_imt_slot (MonoMethod *method)
 	case 0: /* nothing left to add */
 		break;
 	}
-	
+
 	g_free (hashes_start);
 	/* Report the result */
 	return c % MONO_IMT_SIZE;
@@ -1376,7 +1376,7 @@ static int
 compare_imt_builder_entries (const void *p1, const void *p2) {
 	MonoImtBuilderEntry *e1 = *(MonoImtBuilderEntry**) p1;
 	MonoImtBuilderEntry *e2 = *(MonoImtBuilderEntry**) p2;
-	
+
 	return (e1->key < e2->key) ? -1 : ((e1->key > e2->key) ? 1 : 0);
 }
 
@@ -1423,7 +1423,7 @@ imt_sort_slot_entries (MonoImtBuilderEntry *entries) {
 	GPtrArray *result = g_ptr_array_new ();
 	MonoImtBuilderEntry *current_entry;
 	int i;
-	
+
 	for (current_entry = entries, i = 0; current_entry != NULL; current_entry = current_entry->next, i++) {
 		sorted_array [i] = current_entry;
 	}
@@ -1514,12 +1514,12 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 				/*
 				 * The imt slot of the method is the same as for its declaring method,
 				 * see the comment in mono_method_get_imt_slot (), so we can
-				 * avoid inflating methods which will be discarded by 
+				 * avoid inflating methods which will be discarded by
 				 * add_imt_builder_entry anyway.
 				 */
 				method = mono_class_get_method_by_index (mono_class_get_generic_class (iface)->container_class, method_slot_in_interface);
 				if (m_method_is_static (method))
-					continue;				
+					continue;
 				if (mono_method_get_imt_slot (method) != slot_num) {
 					vt_slot ++;
 					continue;
@@ -1559,7 +1559,7 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 		}
 	}
 	for (i = 0; i < MONO_IMT_SIZE; ++i) {
-		/* overwrite the imt slot only if we're building all the entries or if 
+		/* overwrite the imt slot only if we're building all the entries or if
 		 * we're building this specific one
 		 */
 		if (slot_num < 0 || i == slot_num) {
@@ -1590,8 +1590,8 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 				 */
 				imt_collisions_bitmap |= (1 << i);
 
-				/* 
-				 * The IMT trampoline might be called with an instance of one of the 
+				/*
+				 * The IMT trampoline might be called with an instance of one of the
 				 * generic virtual methods, so has to fallback to the IMT trampoline.
 				 */
 				imt [i] = initialize_imt_slot (vt, imt_builder [i], callbacks.get_imt_trampoline (vt, i));
@@ -1612,12 +1612,12 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 			method_count += methods_in_slot;
 		}
 	}
-	
+
 	UnlockedAdd (&mono_stats.imt_number_of_methods, method_count);
 	if (record_method_count_for_max_collisions) {
 		UnlockedWrite (&mono_stats.imt_method_count_when_max_collisions, method_count);
 	}
-	
+
 	for (i = 0; i < MONO_IMT_SIZE; i++) {
 		MonoImtBuilderEntry* entry = imt_builder [i];
 		while (entry != NULL) {
@@ -1676,7 +1676,7 @@ typedef struct _GenericVirtualCase {
  *   Return IMT entries for the generic virtual method instances and
  *   variant interface methods for vtable slot
  * VTABLE_SLOT.
- */ 
+ */
 static MonoImtBuilderEntry*
 get_generic_virtual_entries (MonoMemoryManager *mem_manager, gpointer *vtable_slot)
 {
@@ -1688,16 +1688,16 @@ get_generic_virtual_entries (MonoMemoryManager *mem_manager, gpointer *vtable_sl
 	mono_mem_manager_lock (mem_manager);
  	if (!mem_manager->generic_virtual_cases)
  		mem_manager->generic_virtual_cases = g_hash_table_new (mono_aligned_addr_hash, NULL);
- 
+
 	list = (GenericVirtualCase *)g_hash_table_lookup (mem_manager->generic_virtual_cases, vtable_slot);
- 
+
  	entries = NULL;
  	for (; list; list = list->next) {
  		MonoImtBuilderEntry *entry;
- 
+
  		if (list->count < THUNK_THRESHOLD)
  			continue;
- 
+
  		entry = g_new0 (MonoImtBuilderEntry, 1);
  		entry->key = list->method;
  		entry->value.target_code = mono_get_addr_from_ftnptr (list->code);
@@ -1707,9 +1707,9 @@ get_generic_virtual_entries (MonoMemoryManager *mem_manager, gpointer *vtable_sl
  		entry->next = entries;
  		entries = entry;
  	}
- 
+
 	mono_mem_manager_unlock (mem_manager);
- 
+
  	/* FIXME: Leaking memory ? */
  	return entries;
 }
@@ -1823,7 +1823,7 @@ static MonoVTable *mono_class_create_runtime_vtable (MonoClass *klass, MonoError
  * mono_class_vtable:
  * \param domain the application domain
  * \param class the class to initialize
- * VTables are domain specific because we create domain specific code, and 
+ * VTables are domain specific because we create domain specific code, and
  * they contain the domain specific static class data.
  * On failure, NULL is returned, and \c class->exception_type is set.
  */
@@ -1843,7 +1843,7 @@ mono_class_vtable (MonoDomain *domain, MonoClass *klass)
  * mono_class_vtable_checked:
  * \param class the class to initialize
  * \param error set on failure.
- * VTables are domain specific because we create domain specific code, and 
+ * VTables are domain specific because we create domain specific code, and
  * they contain the domain specific static class data.
  */
 MonoVTable *
@@ -1958,7 +1958,7 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 		/*mono_class_init_internal can leave the vtable layout to be lazily done and we can't afford this here*/
 		if (!mono_class_has_failure (element_class) && !m_class_get_vtable_size (element_class))
 			mono_class_setup_vtable (element_class);
-		
+
 		if (mono_class_has_failure (element_class)) {
 			/*Can happen if element_class only got bad after mono_class_setup_vtable*/
 			if (!mono_class_has_failure (klass))
@@ -1969,8 +1969,8 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 		}
 	}
 
-	/* 
-	 * For some classes, mono_class_init_internal () already computed klass->vtable_size, and 
+	/*
+	 * For some classes, mono_class_init_internal () already computed klass->vtable_size, and
 	 * that is all that is needed because of the vtable trampolines.
 	 */
 	if (!m_class_get_vtable_size (klass))
@@ -2022,7 +2022,7 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 	vt->domain = domain;
 	if ((vt->rank > 0) || klass == mono_get_string_class ())
 		vt->flags |= MONO_VT_FLAG_ARRAY_OR_STRING;
-	
+
 	if (m_class_has_references (klass))
 		vt->flags |= MONO_VT_FLAG_HAS_REFERENCES;
 
@@ -2102,7 +2102,7 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 				mono_mem_manager_unlock (mem_manager);
 				if (bitmap != default_bitmap)
 					g_free (bitmap);
-				/* 
+				/*
 				 * This marks the field as special static to speed up the
 				 * checks in mono_field_static_get/set_value ().
 				 */
@@ -2127,12 +2127,12 @@ mono_class_create_runtime_vtable (MonoClass *klass, MonoError *error)
 				*t = *(char *)data;
 			}
 			continue;
-		}		
+		}
 	}
 
 	vt->max_interface_id = m_class_get_max_interface_id (klass);
 	vt->interface_bitmap = m_class_get_interface_bitmap (klass);
-	
+
 	//printf ("Initializing VT for class %s (interface_offsets_count = %d)\n",
 	//		class->name, klass->interface_offsets_count);
 
@@ -2350,7 +2350,7 @@ mono_class_get_virtual_method (MonoClass *klass, MonoMethod *method, MonoError *
 		/* method->slot might not be set for instances of generic methods */
 		if (method->is_inflated) {
 			g_assert (((MonoMethodInflated*)method)->declaring->slot != -1);
-			method->slot = ((MonoMethodInflated*)method)->declaring->slot; 
+			method->slot = ((MonoMethodInflated*)method)->declaring->slot;
 		} else {
 			g_assert_not_reached ();
 		}
@@ -2389,7 +2389,7 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
 	g_assert (callbacks.runtime_invoke);
 
 	error_init (error);
-	
+
 	MONO_PROFILER_RAISE (method_begin_invoke, (method));
 
 	result = callbacks.runtime_invoke (method, obj, params, exc, error);
@@ -2416,7 +2416,7 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
  * The params array contains the arguments to the method with the
  * same convention: \c MonoObject* pointers for object instances and
  * pointers to the value type otherwise.
- * 
+ *
  * From unmanaged code you'll usually use the
  * \c mono_runtime_invoke variant.
  *
@@ -2425,12 +2425,12 @@ do_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **ex
  * expose a function to lookup the derived class implementation
  * of a virtual method (there are examples of this in the code,
  * though).
- * 
+ *
  * You can pass NULL as the \p exc argument if you don't want to
  * catch exceptions, otherwise, \c *exc will be set to the exception
  * thrown, if any.  if an exception is thrown, you can't use the
  * \c MonoObject* result from the function.
- * 
+ *
  * If the method returns a value type, it is boxed in an object
  * reference.
  */
@@ -2479,12 +2479,12 @@ mono_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObject **
  * expose a function to lookup the derived class implementation
  * of a virtual method (there are examples of this in the code,
  * though).
- * 
+ *
  * For this function, you must not pass NULL as the \p exc argument if
  * you don't want to catch exceptions, use
  * mono_runtime_invoke_checked().  If an exception is thrown, you
  * can't use the \c MonoObject* result from the function.
- * 
+ *
  * If this method cannot be invoked, \p error will be set and \p exc and
  * the return value must not be used.
  *
@@ -2531,8 +2531,8 @@ mono_runtime_try_invoke_handle (MonoMethod *method, MonoObjectHandle obj, void *
  *
  * The \p params array contains the arguments to the method with the
  * same convention: \c MonoObject* pointers for object instances and
- * pointers to the value type otherwise. 
- * 
+ * pointers to the value type otherwise.
+ *
  * From unmanaged code you'll usually use the
  * mono_runtime_invoke() variant.
  *
@@ -2541,10 +2541,10 @@ mono_runtime_try_invoke_handle (MonoMethod *method, MonoObjectHandle obj, void *
  * expose a function to lookup the derived class implementation
  * of a virtual method (there are examples of this in the code,
  * though).
- * 
+ *
  * If an exception is thrown, you can't use the \c MonoObject* result
  * from the function.
- * 
+ *
  * If this method cannot be invoked, \p error will be set.  If the
  * method throws an exception (and we're in coop mode) the exception
  * will be set in \p error.
@@ -2767,7 +2767,7 @@ mono_field_set_value_internal (MonoObject *obj, MonoClassField *field, void *val
  * to the value passed in \p value.   This method should only be used for instance
  * fields.   For static fields, use \c mono_field_static_set_value.
  *
- * The value must be in the native format of the field type. 
+ * The value must be in the native format of the field type.
  */
 void
 mono_field_set_value (MonoObject *obj, MonoClassField *field, void *value)
@@ -2809,7 +2809,7 @@ mono_special_static_field_get_offset (MonoClassField *field, MonoError *error)
  * \param value The value to be set
  * Sets the value of the static field described by \p field
  * to the value passed in \p value.
- * The value must be in the native format of the field type. 
+ * The value must be in the native format of the field type.
  */
 void
 mono_field_static_set_value (MonoVTable *vt, MonoClassField *field, void *value)
@@ -3031,7 +3031,7 @@ mono_field_get_value_object_checked (MonoClassField *field, MonoObject *obj, Mon
 	} else {
 		g_assert (obj);
 	}
-	
+
 	if (is_ref) {
 		if (is_literal) {
 			get_default_field_value (field, &o, string_handle, error);
@@ -3188,7 +3188,7 @@ get_default_field_value (MonoClassField *field, void *value, MonoStringHandleOut
 	const char* data;
 
 	error_init (error);
-	
+
 	data = mono_class_get_field_default_value (field, &def_type);
 	(void)mono_get_constant_value_from_blob (def_type, data, value, string_handle, error);
 }
@@ -3203,7 +3203,7 @@ mono_field_static_get_value_for_thread (MonoInternalThread *thread, MonoVTable *
 	error_init (error);
 
 	g_return_if_fail (field->type->attrs & FIELD_ATTRIBUTE_STATIC);
-	
+
 	if (field->type->attrs & FIELD_ATTRIBUTE_LITERAL) {
 		get_default_field_value (field, value, string_handle, error);
 		return;
@@ -3331,7 +3331,7 @@ mono_property_set_value_handle (MonoProperty *prop, MonoObjectHandle obj, void *
  * \param exc optional exception
  * Invokes the property's \c get method with the given arguments on the
  * object instance \p obj (or NULL for static properties).
- * 
+ *
  * You can pass NULL as the \p exc argument if you don't want to
  * catch exceptions, otherwise, \c *exc will be set to the exception
  * thrown, if any.  if an exception is thrown, you can't use the
@@ -3364,7 +3364,7 @@ mono_property_get_value (MonoProperty *prop, void *obj, void **params, MonoObjec
  * \param error set on error
  * Invokes the property's \c get method with the given arguments on the
  * object instance obj (or NULL for static properties).
- * 
+ *
  * If an exception is thrown, you can't use the
  * \c MonoObject* result from the function.  The exception will be propagated via \p error.
  *
@@ -3500,7 +3500,7 @@ mono_nullable_init_from_handle (guint8 *buf, MonoObjectHandle value, MonoClass *
  * Since Nullables have variable structure, we can not define a C
  * structure for them.
  *
- * This function expects all objects to be pinned or for 
+ * This function expects all objects to be pinned or for
  * MONO_ENTER_NO_SAFEPOINTS to be used in a caller.
  */
 void
@@ -3917,7 +3917,7 @@ mono_runtime_set_main_args (int argc, char* argv[])
  * Prepare an array of arguments in order to execute a standard Main()
  * method (argc/argv contains the executable name). This method also
  * sets the command line argument value needed by System.Environment.
- * 
+ *
  */
 static MonoArray*
 prepare_run_main (MonoMethod *method, int argc, char *argv[])
@@ -3931,7 +3931,7 @@ prepare_run_main (MonoMethod *method, int argc, char *argv[])
 	MonoMethodSignature *sig;
 
 	g_assert (method != NULL);
-	
+
 	mono_thread_set_main (mono_thread_current ());
 
 	main_args = g_new0 (char*, argc);
@@ -4008,7 +4008,7 @@ prepare_run_main (MonoMethod *method, int argc, char *argv[])
 		args = (MonoArray*)mono_array_new_checked (mono_defaults.string_class, 0, error);
 		mono_error_assert_ok (error);
 	}
-	
+
 	mono_assembly_set_main (m_class_get_image (method->klass)->assembly);
 
 	return args;
@@ -4274,7 +4274,7 @@ mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error)
 	MonoDomain *current_domain = mono_domain_get ();
 	MonoClass *klass = mono_handle_class (exc);
 	/*
-	 * AppDomainUnloadedException don't behave like unhandled exceptions unless thrown from 
+	 * AppDomainUnloadedException don't behave like unhandled exceptions unless thrown from
 	 * a thread started in unmanaged world.
 	 * https://msdn.microsoft.com/en-us/library/system.appdomainunloadedexception(v=vs.110).aspx#Anchor_6
 	 */
@@ -4645,7 +4645,7 @@ invoke_span_extract_argument (MonoSpanOfObjects *params_span, int i, MonoType *t
  * variant takes a C# \c object[] as the params argument (\c MonoArray*):
  * in this case the value types are boxed inside the
  * respective reference representation.
- * 
+ *
  * From unmanaged code you'll usually use the
  * mono_runtime_invoke_checked() variant.
  *
@@ -4654,12 +4654,12 @@ invoke_span_extract_argument (MonoSpanOfObjects *params_span, int i, MonoType *t
  * expose a function to lookup the derived class implementation
  * of a virtual method (there are examples of this in the code,
  * though).
- * 
+ *
  * You can pass NULL as the \p exc argument if you don't want to
  * catch exceptions, otherwise, \c *exc will be set to the exception
  * thrown, if any.  if an exception is thrown, you can't use the
  * \c MonoObject* result from the function.
- * 
+ *
  * If the method returns a value type, it is boxed in an object
  * reference.
  */
@@ -4779,8 +4779,8 @@ mono_runtime_try_invoke_span (MonoMethod *method, void *obj, MonoSpanOfObjects *
 			void *box_args [2];
 			MonoObject *box_exc;
 
-			/* 
-			 * The runtime-invoke wrapper returns a boxed IntPtr, need to 
+			/*
+			 * The runtime-invoke wrapper returns a boxed IntPtr, need to
 			 * convert it to a Pointer object.
 			 */
 			pointer_class = mono_class_get_pointer_class ();
@@ -4973,10 +4973,10 @@ object_new_handle_common_tail (MonoObjectHandle o, MonoClass *klass, MonoError *
  * mono_object_new:
  * \param klass the class of the object that we want to create
  * \returns a newly created object whose definition is
- * looked up using \p klass.   This will not invoke any constructors, 
+ * looked up using \p klass.   This will not invoke any constructors,
  * so the consumer of this routine has to invoke any constructors on
  * its own to initialize the object.
- * 
+ *
  * It returns NULL on failure.
  */
 MonoObject *
@@ -5134,7 +5134,7 @@ mono_object_new_specific_checked (MonoVTable *vtable, MonoError *error)
 			}
 			create_proxy_for_type_method = im;
 		}
-	
+
 		pa [0] = mono_type_get_object_checked (m_class_get_byval_arg (vtable->klass), error);
 		if (!is_ok (error))
 			return NULL;
@@ -5210,14 +5210,14 @@ ves_icall_object_new_specific (MonoVTable *vtable)
  * mono_object_new_alloc_specific:
  * \param vtable virtual table for the object.
  * This function allocates a new \c MonoObject with the type derived
- * from the \p vtable information.   If the class of this object has a 
+ * from the \p vtable information.   If the class of this object has a
  * finalizer, then the object will be tracked for finalization.
  *
  * This method might raise an exception on errors.  Use the
  * \c mono_object_new_fast_checked method if you want to manually raise
  * the exception.
  *
- * \returns the allocated object.   
+ * \returns the allocated object.
  */
 MonoObject *
 mono_object_new_alloc_specific (MonoVTable *vtable)
@@ -5235,7 +5235,7 @@ mono_object_new_alloc_specific (MonoVTable *vtable)
  * \param error holds the error return value.
  *
  * This function allocates a new \c MonoObject with the type derived
- * from the \p vtable information. If the class of this object has a 
+ * from the \p vtable information. If the class of this object has a
  * finalizer, then the object will be tracked for finalization.
  *
  * If there is not enough memory, the \p error parameter will be set
@@ -5280,7 +5280,7 @@ mono_object_new_alloc_by_vtable (MonoVTable *vtable, MonoError *error)
  * \c mono_object_new_fast_checked method if you want to manually raise
  * the exception.
  *
- * \returns the allocated object.   
+ * \returns the allocated object.
  */
 MonoObject*
 mono_object_new_fast (MonoVTable *vtable)
@@ -5351,7 +5351,7 @@ mono_object_new_from_token  (MonoDomain *domain, MonoImage *image, guint32 token
 
 	klass = mono_class_get_checked (image, token, error);
 	mono_error_assert_ok (error);
-	
+
 	MonoObjectHandle result = mono_object_new_handle (klass, error);
 
 	mono_error_cleanup (error);
@@ -5468,7 +5468,7 @@ mono_array_clone_in_domain (MonoArrayHandle array_handle, MonoError *error)
 
 	/* Pin source array here - if bounds is non-NULL, it's a pointer into the object data */
 	MonoGCHandle src_handle = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, array_handle), TRUE);
-	
+
 	MonoArrayBounds *array_bounds = MONO_HANDLE_GETVAL (array_handle, bounds);
 	MonoArrayHandle o;
 	if (array_bounds == NULL) {
@@ -5657,7 +5657,7 @@ mono_array_new_full_checked (MonoClass *array_class, uintptr_t *lengths, intptr_
 		}
 		byte_len += bounds_size;
 	}
-	/* 
+	/*
 	 * Following three lines almost taken from mono_object_new ():
 	 * they need to be kept in sync.
 	 */
@@ -5956,9 +5956,9 @@ mono_string_new_utf16_checked (const gunichar2 *text, gint32 len, MonoError *err
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoString *s;
-	
+
 	error_init (error);
-	
+
 	s = mono_string_new_size_checked (len, error);
 	if (s != NULL)
 		memcpy (mono_string_chars_internal (s), text, len * 2);
@@ -5994,12 +5994,12 @@ mono_string_new_utf32_checked (const mono_unichar4 *text, gint32 len, MonoError 
 
 	MonoString *s;
 	mono_unichar2 *utf16_output = NULL;
-	
+
 	error_init (error);
 	utf16_output = g_ucs4_to_utf16 (text, len, NULL, NULL, NULL);
-	
+
 	gint32 utf16_len = g_utf16_len (utf16_output);
-	
+
 	s = mono_string_new_size_checked (utf16_len, error);
 	goto_if_nok (error, exit);
 
@@ -6007,7 +6007,7 @@ mono_string_new_utf32_checked (const mono_unichar4 *text, gint32 len, MonoError 
 
 exit:
 	g_free (utf16_output);
-	
+
 	return s;
 }
 
@@ -6200,18 +6200,18 @@ mono_string_new_checked (const char *text, MonoError *error)
 	int len;
 
 	error_init (error);
-	
+
 	len = strlen (text);
-	
+
 	ut = g_utf8_to_utf16 (text, len, NULL, &items_written, &eg_error);
-	
+
 	if (!eg_error)
 		o = mono_string_new_utf16_checked (ut, items_written, error);
 	else {
 		mono_error_set_execution_engine (error, "String conversion error: %s", eg_error->message);
 		g_error_free (eg_error);
 	}
-	
+
 	g_free (ut);
 
 /*FIXME g_utf8_get_char, g_utf8_next_char and g_utf8_validate are not part of eglib.*/
@@ -6444,7 +6444,7 @@ mono_value_copy_array_handle (MonoArrayHandle dest, int dest_idx, gconstpointer 
  * \param dest_idx index in the \p dest array
  * \param src source pointer
  * \param count number of items
- * Copy \p count valuetype items from \p src to the array \p dest at index \p dest_idx. 
+ * Copy \p count valuetype items from \p src to the array \p dest at index \p dest_idx.
  * This function must be used when \p klass contains references fields.
  * Overlap is handled.
  */
@@ -6573,7 +6573,7 @@ mono_object_isinst (MonoObject *obj_raw, MonoClass *klass)
 /**
  * mono_object_isinst_checked:
  * \param obj an object
- * \param klass a pointer to a class 
+ * \param klass a pointer to a class
  * \param error set on error
  * \returns \p obj if \p obj is derived from \p klass or NULL if it isn't.
  * On failure returns NULL and sets \p error.
@@ -6593,7 +6593,7 @@ mono_object_isinst_checked (MonoObject *obj_raw, MonoClass *klass, MonoError *er
 /**
  * mono_object_handle_isinst:
  * \param obj an object
- * \param klass a pointer to a class 
+ * \param klass a pointer to a class
  * \param error set on error
  * \returns \p obj if \p obj is derived from \p klass or NULL if it isn't.
  * On failure returns NULL and sets \p error.
@@ -6602,7 +6602,7 @@ MonoObjectHandle
 mono_object_handle_isinst (MonoObjectHandle obj, MonoClass *klass, MonoError *error)
 {
 	error_init (error);
-	
+
 	if (!m_class_is_inited (klass))
 		mono_class_init_internal (klass);
 
@@ -6663,7 +6663,7 @@ mono_object_handle_isinst_mbyref_raw (MonoObjectHandle obj, MonoClass *klass, Mo
 
 	MonoVTable *vt;
 	vt = MONO_HANDLE_GETVAL (obj, vtable);
-	
+
 	if (mono_class_is_interface (klass)) {
 		if (MONO_VTABLE_IMPLEMENTS_INTERFACE (vt, m_class_get_interface_id (klass))) {
 			result = TRUE;
@@ -7000,7 +7000,7 @@ mono_string_to_utf8 (MonoString *s)
 	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
 	result = mono_string_to_utf8_checked_internal (s, error);
-	
+
 	if (!is_ok (error)) {
 		mono_error_cleanup (error);
 		result = NULL;
@@ -7191,11 +7191,11 @@ mono_unichar4*
 mono_string_to_utf32_internal_impl (MonoStringHandle s, MonoError *error)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
-	
+
 	// FIXME This optimization ok to miss before wrapper? Or null is rare?
 	if (MONO_HANDLE_RAW (s) == NULL)
 		return NULL;
-		
+
 	return g_utf16_to_ucs4 (MONO_HANDLE_RAW (s)->chars, mono_string_handle_length (s), NULL, NULL, NULL);
 }
 
@@ -7387,7 +7387,7 @@ mono_raise_exception (MonoException *ex)
  * DEPRECATED. DO NOT ADD NEW CALLERS FOR THIS FUNCTION.
  */
 void
-mono_raise_exception_deprecated (MonoException *ex) 
+mono_raise_exception_deprecated (MonoException *ex)
 {
 	MONO_REQ_GC_UNSAFE_MODE;
 
@@ -7565,7 +7565,7 @@ mono_print_unhandled_exception_internal (MonoObject *exc)
 		message = g_strdup ("StackOverflowException"); //if we OVF, we can't expect to have stack space to JIT Exception::ToString.
 		free_message = TRUE;
 	} else {
-		
+
 		if (((MonoException*)exc)->native_trace_ips) {
 			message = get_native_backtrace ((MonoException*)exc);
 			free_message = TRUE;
@@ -7579,7 +7579,7 @@ mono_print_unhandled_exception_internal (MonoObject *exc)
 			if (other_exc) {
 				char *original_backtrace = mono_exception_get_managed_backtrace ((MonoException*)exc);
 				char *nested_backtrace = mono_exception_get_managed_backtrace ((MonoException*)other_exc);
-				
+
 				message = g_strdup_printf ("Nested exception detected.\nOriginal Exception: %s\nNested exception:%s\n",
 					original_backtrace, nested_backtrace);
 
@@ -7599,11 +7599,11 @@ mono_print_unhandled_exception_internal (MonoObject *exc)
 	}
 
 	/*
-	 * g_printerr ("\nUnhandled Exception: %s.%s: %s\n", exc->vtable->klass->name_space, 
+	 * g_printerr ("\nUnhandled Exception: %s.%s: %s\n", exc->vtable->klass->name_space,
 	 *	   exc->vtable->klass->name, message);
 	 */
 	g_printerr ("\nUnhandled Exception:\n%s\n", message);
-	
+
 	if (free_message)
 		g_free (message);
 }
@@ -7665,7 +7665,7 @@ gpointer
 mono_get_addr_from_ftnptr (gpointer descr)
 {
 	return callbacks.get_addr_from_ftnptr (descr);
-}	
+}
 
 /**
  * mono_string_chars:

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2163,9 +2163,9 @@ sgen_client_thread_attach (SgenThreadInfo* info)
 	if (mono_gc_get_gc_callbacks ()->thread_attach_func)
 		info->client_info.runtime_data = mono_gc_get_gc_callbacks ()->thread_attach_func ();
 
-	sgen_binary_protocol_thread_register ((gpointer)mono_thread_info_get_tid (info));
+	sgen_binary_protocol_thread_register ((gpointer)(gsize) mono_thread_info_get_tid (info));
 
-	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)mono_thread_info_get_tid (info), info->client_info.info.stack_end);
+	SGEN_LOG (3, "registered thread %p (%p) stack end %p", info, (gpointer)(gsize) mono_thread_info_get_tid (info), info->client_info.info.stack_end);
 
 	info->client_info.info.handle_stack = mono_handle_stack_alloc ();
 }
@@ -2199,8 +2199,8 @@ sgen_client_thread_detach_with_lock (SgenThreadInfo *p)
 		p->client_info.runtime_data = NULL;
 	}
 
-	sgen_binary_protocol_thread_unregister ((gpointer)tid);
-	SGEN_LOG (3, "unregister thread %p (%p)", p, (gpointer)tid);
+	sgen_binary_protocol_thread_unregister ((gpointer)(gsize) tid);
+	SGEN_LOG (3, "unregister thread %p (%p)", p, (gpointer)(gsize) tid);
 
 	HandleStack *handles = p->client_info.info.handle_stack;
 	p->client_info.info.handle_stack = NULL;
@@ -2335,7 +2335,7 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 			skip_reason = 4;
 		}
 
-		sgen_binary_protocol_scan_stack ((gpointer)mono_thread_info_get_tid (info), info->client_info.stack_start, info->client_info.info.stack_end, skip_reason);
+		sgen_binary_protocol_scan_stack ((gpointer)(gsize) mono_thread_info_get_tid (info), info->client_info.stack_start, info->client_info.info.stack_end, skip_reason);
 
 		if (skip_reason) {
 			if (precise) {

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -118,7 +118,7 @@ mono_gc_wbarrier_value_copy_internal (gpointer dest, gconstpointer src, int coun
 	if (sgen_ptr_in_nursery (dest) || ptr_on_stack (dest) || !sgen_gc_descr_has_references ((mword)m_class_get_gc_descr (klass))) {
 		size_t element_size = mono_class_value_size (klass, NULL);
 		size_t size = count * element_size;
-		mono_gc_memmove_atomic (dest, src, size);		
+		mono_gc_memmove_atomic (dest, src, size);
 		return;
 	}
 
@@ -154,7 +154,7 @@ mono_gc_wbarrier_object_copy_internal (MonoObject* obj, MonoObject *src)
 		size = m_class_get_instance_size (mono_object_class (obj));
 		mono_gc_memmove_aligned ((char*)obj + MONO_ABI_SIZEOF (MonoObject), (char*)src + MONO_ABI_SIZEOF (MonoObject),
 				size - MONO_ABI_SIZEOF (MonoObject));
-		return;	
+		return;
 	}
 
 #ifdef SGEN_HEAVY_BINARY_PROTOCOL

--- a/src/mono/mono/metadata/sgen-stw.c
+++ b/src/mono/mono/metadata/sgen-stw.c
@@ -171,7 +171,7 @@ static
 void
 sgen_client_stop_world_thread_restarted_callback (THREAD_INFO_TYPE *info)
 {
-	sgen_binary_protocol_thread_restart ((gpointer) mono_thread_info_get_tid (info));
+	sgen_binary_protocol_thread_restart ((gpointer)(gsize) mono_thread_info_get_tid (info));
 }
 
 /* LOCKING: assumes the GC lock is held */

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -1096,7 +1096,7 @@ fire_attach_profiler_events (MonoNativeThreadId tid)
 		(const mono_byte*)(info->stack_start_limit),
 		(char *) info->stack_end - (char *) info->stack_start_limit,
 		MONO_ROOT_SOURCE_STACK,
-		(void *) tid,
+		(gpointer)(gsize) tid,
 		"Thread Stack"));
 
 	// The handle stack is a pseudo-root similar to the finalizer queues.
@@ -1104,7 +1104,7 @@ fire_attach_profiler_events (MonoNativeThreadId tid)
 		(const mono_byte*)info->handle_stack,
 		1,
 		MONO_ROOT_SOURCE_HANDLE,
-		(void *) tid,
+		(gpointer)(gsize) tid,
 		"Handle Stack"));
 }
 
@@ -3391,7 +3391,7 @@ alloc_thread_static_data_helper (gpointer key, gpointer value, gpointer user)
 	MonoInternalThread *thread = (MonoInternalThread *)value;
 	guint32 offset = GPOINTER_TO_UINT (user);
 
-	mono_alloc_static_data (&(thread->static_data), offset, (void *) MONO_UINT_TO_NATIVE_THREAD_ID (thread->tid));
+	mono_alloc_static_data (&(thread->static_data), offset, (gpointer)(gsize) MONO_UINT_TO_NATIVE_THREAD_ID (thread->tid));
 }
 
 static StaticDataFreeList*
@@ -4441,7 +4441,7 @@ threads_add_pending_joinable_runtime_thread (MonoThreadInfo *mono_thread_info)
 	g_assert (mono_thread_info);
 
 	if (mono_thread_info->runtime_thread) {
-		threads_add_pending_joinable_thread ((gpointer)(MONO_UINT_TO_NATIVE_THREAD_ID (mono_thread_info_get_tid (mono_thread_info))));
+		threads_add_pending_joinable_thread ((gpointer)(gsize) (MONO_UINT_TO_NATIVE_THREAD_ID (mono_thread_info_get_tid (mono_thread_info))));
 	}
 }
 
@@ -4502,7 +4502,7 @@ mono_threads_add_joinable_runtime_thread (MonoThreadInfo *thread_info)
 	MonoThreadInfo *mono_thread_info = thread_info;
 
 	if (mono_thread_info->runtime_thread) {
-		gpointer tid = (gpointer)(MONO_UINT_TO_NATIVE_THREAD_ID (mono_thread_info_get_tid (mono_thread_info)));
+		gpointer tid = (gpointer)(gsize) (MONO_UINT_TO_NATIVE_THREAD_ID (mono_thread_info_get_tid (mono_thread_info)));
 
 		joinable_threads_lock ();
 

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -121,7 +121,7 @@ typedef union {
 	gint64 ival;
 	gdouble fval;
 } LongDoubleUnion;
- 
+
 typedef struct _StaticDataFreeList StaticDataFreeList;
 struct _StaticDataFreeList {
 	StaticDataFreeList *next;
@@ -662,7 +662,7 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 		g_error ("%s: SetThreadPriority failed, error %d", __func__, last_error);
 #elif defined(HOST_FUCHSIA)
 	int z_priority;
-	
+
 	if (priority == MONO_THREAD_PRIORITY_LOWEST)
 		z_priority = ZX_PRIORITY_LOWEST;
 	else if (priority == MONO_THREAD_PRIORITY_BELOW_NORMAL)
@@ -675,7 +675,7 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 		z_priority = ZX_PRIORITY_HIGHEST;
 	else
 		return;
-	
+
 	//
 	// When this API becomes available on an arbitrary thread, we can use it,
 	// not available on current Zircon
@@ -773,7 +773,7 @@ mono_thread_internal_set_priority (MonoInternalThread *internal, MonoThreadPrior
 #endif /* HOST_WIN32 */
 }
 
-static void 
+static void
 mono_alloc_static_data (gpointer **static_data_ptr, guint32 offset, void *alloc_key);
 
 static gboolean
@@ -1115,7 +1115,7 @@ start_wrapper_internal (StartInfo *start_info, gsize *stack_ptr)
 	MonoThreadStart start_func;
 	void *start_func_arg;
 	gsize tid;
-	/* 
+	/*
 	 * We don't create a local to hold start_info->thread, so hopefully it won't get pinned during a
 	 * GC stack walk.
 	 */
@@ -1173,7 +1173,7 @@ start_wrapper_internal (StartInfo *start_info, gsize *stack_ptr)
 	/* start_info is not valid anymore */
 	start_info = NULL;
 
-	/* 
+	/*
 	 * Call this after calling start_notify, since the profiler callback might want
 	 * to lock the thread, and the lock is held by thread_start () which waits for
 	 * start_notify.
@@ -1547,7 +1547,7 @@ mono_thread_internal_attach (MonoDomain *domain)
 	}
 
 	if (G_UNLIKELY ((info = mono_thread_info_current_unchecked ()))) {
-		/* 
+		/*
 		 * We are not attached currently, but we were earlier.  Ensure the thread is in GC Unsafe mode.
 		 * Have to do this before creating the managed thread object.
 		 *
@@ -1871,7 +1871,7 @@ mono_thread_set_name (MonoInternalThread *this_obj,
 		this_obj->flags &= ~MONO_THREAD_FLAG_NAME_SET;
 	} else if (this_obj->flags & MONO_THREAD_FLAG_NAME_SET) {
 		UNLOCK_THREAD (this_obj);
-		
+
 		if (error)
 			mono_error_set_invalid_operation (error, "%s", "Thread.Name can only be set once.");
 
@@ -1905,7 +1905,7 @@ mono_thread_set_name (MonoInternalThread *this_obj,
 	mono_free (0); // FIXME keep mono-publib.c in use and its functions exported
 }
 
-void 
+void
 ves_icall_System_Threading_Thread_SetName_icall (MonoInternalThreadHandle thread_handle, const gunichar2* name16, gint32 name16_length, MonoError* error)
 {
 	long name8_length = 0;
@@ -1923,7 +1923,7 @@ ves_icall_System_Threading_Thread_SetName_icall (MonoInternalThreadHandle thread
 		name8, (gint32)name8_length, name16, flags, error);
 }
 
-/* 
+/*
  * ves_icall_System_Threading_Thread_SetPriority_internal:
  * @param this_obj: The MonoInternalThread on which to operate.
  * @param priority: The priority to set.
@@ -2017,10 +2017,10 @@ ves_icall_System_Threading_Thread_Join_internal (MonoThreadObjectHandle thread_h
 	gboolean ret = FALSE;
 
 	LOCK_THREAD (thread);
-	
+
 	if ((thread->state & ThreadState_Unstarted) != 0) {
 		UNLOCK_THREAD (thread);
-		
+
 		mono_error_set_exception_thread_state (error, "Thread has not been started.");
 		return FALSE;
 	}
@@ -2048,7 +2048,7 @@ ves_icall_System_Threading_Thread_Join_internal (MonoThreadObjectHandle thread_h
 
 		return TRUE;
 	}
-	
+
 	THREAD_DEBUG (g_message ("%s: join failed", __func__));
 
 	return FALSE;
@@ -2149,7 +2149,7 @@ gfloat ves_icall_System_Threading_Interlocked_Exchange_Single (gfloat *location,
 	return ret.fval;
 }
 
-gint64 
+gint64
 ves_icall_System_Threading_Interlocked_Exchange_Long (gint64 *location, gint64 value)
 {
 #if SIZEOF_VOID_P == 4
@@ -2165,7 +2165,7 @@ ves_icall_System_Threading_Interlocked_Exchange_Long (gint64 *location, gint64 v
 	return mono_atomic_xchg_i64 (location, value);
 }
 
-gdouble 
+gdouble
 ves_icall_System_Threading_Interlocked_Exchange_Double (gdouble *location, gdouble value)
 {
 	LongDoubleUnion val, ret;
@@ -2238,7 +2238,7 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Double (gdouble *location
 #endif
 }
 
-gint64 
+gint64
 ves_icall_System_Threading_Interlocked_CompareExchange_Long (gint64 *location, gint64 value, gint64 comparand)
 {
 #if SIZEOF_VOID_P == 4
@@ -2255,13 +2255,13 @@ ves_icall_System_Threading_Interlocked_CompareExchange_Long (gint64 *location, g
 	return mono_atomic_cas_i64 (location, value, comparand);
 }
 
-gint32 
+gint32
 ves_icall_System_Threading_Interlocked_Add_Int (gint32 *location, gint32 value)
 {
 	return mono_atomic_add_i32 (location, value);
 }
 
-gint64 
+gint64
 ves_icall_System_Threading_Interlocked_Add_Long (gint64 *location, gint64 value)
 {
 #if SIZEOF_VOID_P == 4
@@ -2277,7 +2277,7 @@ ves_icall_System_Threading_Interlocked_Add_Long (gint64 *location, gint64 value)
 	return mono_atomic_add_i64 (location, value);
 }
 
-gint64 
+gint64
 ves_icall_System_Threading_Interlocked_Read_Long (gint64 *location)
 {
 #if SIZEOF_VOID_P == 4
@@ -2327,11 +2327,11 @@ ves_icall_System_Threading_Thread_GetState (MonoInternalThreadHandle thread_hand
 	guint32 state;
 
 	LOCK_THREAD (this_obj);
-	
+
 	state = this_obj->state;
 
 	UNLOCK_THREAD (this_obj);
-	
+
 	return state;
 }
 
@@ -2452,7 +2452,7 @@ mono_thread_suspend (MonoInternalThread *thread)
 		UNLOCK_THREAD (thread);
 		return TRUE;
 	}
-	
+
 	thread->state |= ThreadState_SuspendRequested;
 	MONO_ENTER_GC_SAFE;
 	mono_os_event_reset (thread->suspended);
@@ -2483,8 +2483,8 @@ mono_thread_resume (MonoInternalThread *thread)
 	}
 
 	if ((thread->state & ThreadState_Suspended) == 0 ||
-		(thread->state & ThreadState_Unstarted) != 0 || 
-		(thread->state & ThreadState_Aborted) != 0 || 
+		(thread->state & ThreadState_Unstarted) != 0 ||
+		(thread->state & ThreadState_Aborted) != 0 ||
 		(thread->state & ThreadState_Stopped) != 0)
 	{
 		// g_async_safe_printf ("RESUME (2) thread %p\n", thread_get_tid (thread));
@@ -2535,7 +2535,7 @@ find_wrapper (MonoMethod *m, gint no, gint ilo, gboolean managed, gpointer data)
 	return FALSE;
 }
 
-static gboolean 
+static gboolean
 is_running_protected_wrapper (void)
 {
 	gboolean found = FALSE;
@@ -2580,7 +2580,7 @@ void mono_thread_init (MonoThreadStartCB start_cb,
 	mono_coop_mutex_init (&exiting_threads_mutex);
 
 	mono_os_event_init (&background_change_event, FALSE);
-	
+
 	mono_coop_cond_init (&pending_native_thread_join_calls_event);
 	mono_coop_cond_init (&zero_pending_joinable_thread_event);
 
@@ -2718,7 +2718,7 @@ static void print_tids (gpointer key, gpointer value, gpointer user)
 	g_message ("Waiting for: %p", key);
 }
 
-struct wait_data 
+struct wait_data
 {
 	MonoThreadHandle *handles[MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
 	MonoInternalThread *threads[MONO_W32HANDLE_MAXIMUM_WAIT_OBJECTS];
@@ -2730,7 +2730,7 @@ wait_for_tids (struct wait_data *wait, guint32 timeout, gboolean check_state_cha
 {
 	guint32 i;
 	MonoThreadInfoWaitRet ret;
-	
+
 	THREAD_DEBUG (g_message("%s: %d threads to wait for in this batch", __func__, wait->num));
 
 	/* Add the thread state change event, so it wakes
@@ -2748,7 +2748,7 @@ wait_for_tids (struct wait_data *wait, guint32 timeout, gboolean check_state_cha
 		THREAD_DEBUG (g_message ("%s: Wait failed", __func__));
 		return;
 	}
-	
+
 	for( i = 0; i < wait->num; i++)
 		mono_threads_close_thread_handle (wait->handles [i]);
 
@@ -2777,7 +2777,7 @@ static void build_wait_tids (gpointer key, gpointer value, gpointer user)
 			THREAD_DEBUG (g_message ("%s: ignoring background thread %" G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
 			return; /* just leave, ignore */
 		}
-		
+
 		if (mono_gc_is_finalizer_internal_thread (thread)) {
 			THREAD_DEBUG (g_message ("%s: ignoring finalizer thread %" G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
 			return;
@@ -2808,8 +2808,8 @@ static void build_wait_tids (gpointer key, gpointer value, gpointer user)
 		} else {
 			THREAD_DEBUG (g_message ("%s: ignoring (because of callback) thread %" G_GSIZE_FORMAT, __func__, (gsize)thread->tid));
 		}
-		
-		
+
+
 	} else {
 		/* Just ignore the rest, we can't do anything with
 		 * them yet
@@ -2817,7 +2817,7 @@ static void build_wait_tids (gpointer key, gpointer value, gpointer user)
 	}
 }
 
-/** 
+/**
  * mono_threads_set_shutting_down:
  *
  * Is called by a thread that wants to shut down Mono. If the runtime is already
@@ -2879,7 +2879,7 @@ mono_thread_manage_internal (void)
 	memset (wait, 0, sizeof (struct wait_data));
 	/* join each thread that's still running */
 	THREAD_DEBUG (g_message ("%s: Joining each running thread...", __func__));
-	
+
 	mono_threads_lock ();
 	if(threads==NULL) {
 		THREAD_DEBUG (g_message("%s: No threads", __func__));
@@ -2888,12 +2888,12 @@ mono_thread_manage_internal (void)
 	}
 
 	mono_threads_unlock ();
-	
+
 	do {
 		mono_threads_lock ();
 		THREAD_DEBUG (g_message ("%s: There are %d threads to join", __func__, mono_g_hash_table_size (threads));
 			mono_g_hash_table_foreach (threads, print_tids, NULL));
-	
+
 		MONO_ENTER_GC_SAFE;
 		mono_os_event_reset (&background_change_event);
 		MONO_EXIT_GC_SAFE;
@@ -2915,7 +2915,7 @@ mono_thread_manage_internal (void)
 		mono_thread_execute_interruption_void ();
 	}
 
-	/* 
+	/*
 	 * give the subthreads a chance to really quit (this is mainly needed
 	 * to get correct user and system times from getrusage/wait/time(1)).
 	 * This could be removed if we avoid pthread_detach() and use pthread_join().
@@ -3226,9 +3226,9 @@ mono_thread_get_undeniable_exception (void)
 		return NULL;
 
 	/*
-	 * FIXME: Clear the abort exception and return an AppDomainUnloaded 
+	 * FIXME: Clear the abort exception and return an AppDomainUnloaded
 	 * exception if the thread no longer references a dying appdomain.
-	 */ 
+	 */
 	thread->abort_exc->trace_ips = NULL;
 	thread->abort_exc->stack_trace = NULL;
 	return thread->abort_exc;
@@ -3279,7 +3279,7 @@ mark_tls_slots (void *addr, MonoGCMarkFunc mark_func, void *gc_data)
  *
  *   Allocate memory blocks for storing threads static data
  */
-static void 
+static void
 mono_alloc_static_data (gpointer **static_data_ptr, guint32 offset, void *alloc_key)
 {
 	guint idx = ACCESS_SPECIAL_STATIC_OFFSET (offset, index);
@@ -3316,7 +3316,7 @@ mono_alloc_static_data (gpointer **static_data_ptr, guint32 offset, void *alloc_
 	}
 }
 
-static void 
+static void
 mono_free_static_data (gpointer* static_data)
 {
 	int i;
@@ -3363,9 +3363,9 @@ static guint32
 mono_alloc_static_data_slot (StaticDataInfo *static_data, guint32 size, guint32 align)
 {
 	if (!static_data->idx && !static_data->offset) {
-		/* 
+		/*
 		 * we use the first chunk of the first allocation also as
-		 * an array for the rest of the data 
+		 * an array for the rest of the data
 		 */
 		static_data->offset = sizeof (gpointer) * NUM_STATIC_DATA_IDX;
 	}
@@ -3385,7 +3385,7 @@ mono_alloc_static_data_slot (StaticDataInfo *static_data, guint32 size, guint32 
 /*
  * LOCKING: requires that threads_mutex is held
  */
-static void 
+static void
 alloc_thread_static_data_helper (gpointer key, gpointer value, gpointer user)
 {
 	MonoInternalThread *thread = (MonoInternalThread *)value;
@@ -3504,7 +3504,7 @@ typedef struct {
 /*
  * LOCKING: requires that threads_mutex is held
  */
-static void 
+static void
 free_thread_static_data_helper (gpointer key, gpointer value, gpointer user)
 {
 	MonoInternalThread *thread = (MonoInternalThread *)value;
@@ -3592,7 +3592,7 @@ flush_thread_interrupt_queue (void)
 
 /*
  * mono_thread_execute_interruption
- * 
+ *
  * Performs the operation that the requested thread state requires (abort,
  * suspend or stop)
  */
@@ -3704,7 +3704,7 @@ mono_thread_request_interruption_internal (gboolean running_managed, MonoExcepti
 		   request count. When exiting the unmanaged method the count will be
 		   checked and the thread will be interrupted. */
 
-		/* this will awake the thread if it is in WaitForSingleObject 
+		/* this will awake the thread if it is in WaitForSingleObject
 		   or similar */
 #ifdef HOST_WIN32
 		mono_win32_interrupt_wait (thread->thread_info, thread->native_handle, (DWORD)thread->tid);
@@ -3763,7 +3763,7 @@ mono_thread_interruption_requested (void)
 	if (mono_thread_interruption_request_flag) {
 		MonoInternalThread *thread = mono_thread_internal_current ();
 		/* The thread may already be stopping */
-		if (thread != NULL) 
+		if (thread != NULL)
 			return mono_thread_get_interruption_requested (thread);
 	}
 	return FALSE;
@@ -3892,7 +3892,7 @@ mono_set_pending_exception_handle (MonoExceptionHandle exc)
 	mono_thread_request_interruption_native ();
 }
 
-void 
+void
 mono_thread_init_apartment_state (void)
 {
 #ifdef HOST_WIN32
@@ -3904,8 +3904,8 @@ mono_thread_init_apartment_state (void)
 	 * threading model. A negative value indicates failure,
 	 * probably due to trying to change the threading model.
 	 */
-	if (CoInitializeEx(NULL, (thread->apartment_state == ThreadApartmentState_STA) 
-			? COINIT_APARTMENTTHREADED 
+	if (CoInitializeEx(NULL, (thread->apartment_state == ThreadApartmentState_STA)
+			? COINIT_APARTMENTTHREADED
 			: COINIT_MULTITHREADED) < 0) {
 		thread->apartment_state = ThreadApartmentState_Unknown;
 	}
@@ -4014,7 +4014,7 @@ gboolean
 mono_thread_test_and_set_state (MonoInternalThread *thread, MonoThreadState test, MonoThreadState set)
 {
 	LOCK_THREAD (thread);
-	
+
 	MonoThreadState const old_state = (MonoThreadState)thread->state;
 
 	if ((old_state & test) != 0) {
@@ -4044,9 +4044,9 @@ mono_thread_test_state (MonoInternalThread *thread, MonoThreadState test)
 	LOCK_THREAD (thread);
 
 	gboolean const ret = ((thread->state & test) != 0);
-	
+
 	UNLOCK_THREAD (thread);
-	
+
 	return ret;
 }
 
@@ -4155,7 +4155,7 @@ async_abort_critical (MonoThreadInfo *info, gpointer ud)
 			mono_thread_info_setup_async_call (info, self_interrupt_thread, NULL);
 		return MonoResumeThread;
 	} else {
-		/* 
+		/*
 		 * This will cause waits to be broken.
 		 * It will also prevent the thread from entering a wait, so if the thread returns
 		 * from the wait before it receives the abort signal, it will just spin in the wait

--- a/src/mono/mono/metadata/w32process-unix-default.c
+++ b/src/mono/mono/metadata/w32process-unix-default.c
@@ -48,7 +48,6 @@ mono_w32process_get_name (pid_t pid)
 {
 	FILE *fp;
 	gchar *filename;
-	gchar buf[256];
 	gchar *ret = NULL;
 
 #if defined(HOST_SOLARIS) || (defined(_AIX) && !defined(__PASE__))
@@ -75,6 +74,7 @@ mono_w32process_get_name (pid_t pid)
 		ret = g_strdup (proc.pi_comm);
 	}
 #else
+	gchar buf[256];
 	memset (buf, '\0', sizeof(buf));
 	filename = g_strdup_printf ("/proc/%d/exe", pid);
 #if defined(HAVE_READLINK)

--- a/src/mono/mono/mini/mini-amd64.h
+++ b/src/mono/mono/mini/mini-amd64.h
@@ -306,12 +306,12 @@ typedef enum {
 
 typedef struct {
 	gint16 offset;
-	gint8  reg;
+	guint8  reg;
 	ArgStorage storage : 8;
 
 	/* Only if storage == ArgValuetypeInReg */
 	ArgStorage pair_storage [2];
-	gint8 pair_regs [2];
+	guint8 pair_regs [2];
 	/* The size of each pair (bytes) */
 	int pair_size [2];
 	int nregs;

--- a/src/mono/mono/mini/mini-x86.h
+++ b/src/mono/mono/mini/mini-x86.h
@@ -290,14 +290,14 @@ typedef enum {
 
 typedef struct {
 	gint16 offset;
-	gint8  reg;
+	guint8  reg;
 	ArgStorage storage;
 	int nslots;
 	gboolean is_pair;
 
 	/* Only if storage == ArgValuetypeInReg */
 	ArgStorage pair_storage [2];
-	gint8 pair_regs [2];
+	guint8 pair_regs [2];
 	guint8 pass_empty_struct : 1; // Set in scenarios when empty structs needs to be represented as argument.
 } ArgInfo;
 

--- a/src/mono/mono/mini/mini-x86.h
+++ b/src/mono/mono/mini/mini-x86.h
@@ -47,7 +47,7 @@ LONG CALLBACK seh_handler(EXCEPTION_POINTERS* ep);
 #ifndef HOST_WIN32
 
 #ifdef HAVE_WORKING_SIGALTSTACK
-/* 
+/*
  * solaris doesn't have pthread_getattr_np () needed by the sigaltstack setup
  * code.
  */
@@ -96,8 +96,8 @@ LONG CALLBACK seh_handler(EXCEPTION_POINTERS* ep);
 #define MONO_ARCH_INST_FIXED_MASK(desc) ((desc == 'y') ? (X86_BYTE_REGS) : 0)
 
 /* RDX is clobbered by the opcode implementation before accessing sreg2 */
-/* 
- * Originally this contained X86_EDX for div/rem opcodes, but that led to unsolvable 
+/*
+ * Originally this contained X86_EDX for div/rem opcodes, but that led to unsolvable
  * situations since there are only 3 usable registers for local register allocation.
  * Instead, we handle the sreg2==edx case in the opcodes.
  */
@@ -112,7 +112,7 @@ LONG CALLBACK seh_handler(EXCEPTION_POINTERS* ep);
 /* must be at a power of 2 and >= 8 */
 #define MONO_ARCH_FRAME_ALIGNMENT 16
 
-/* fixme: align to 16byte instead of 32byte (we align to 32byte to get 
+/* fixme: align to 16byte instead of 32byte (we align to 32byte to get
  * reproduceable results for benchmarks */
 #define MONO_ARCH_CODE_ALIGNMENT 32
 
@@ -125,7 +125,7 @@ the monitor.enter call and must be already protected.*/
 #define MONO_ARCH_MONITOR_ENTER_ADJUSTMENT 4
 
 struct MonoLMF {
-	/* 
+	/*
 	 * If the lowest bit is set to 1, then this is a trampoline LMF frame.
 	 * If the second lowest bit is set to 1, then this is a MonoLMFExt structure, and
 	 * the other fields are not valid.
@@ -350,5 +350,5 @@ mono_x86_start_gsharedvt_call (GSharedVtCallInfo *info, gpointer *caller, gpoint
 CallInfo*
 mono_arch_get_call_info (MonoMemPool *mp, MonoMethodSignature *sig);
 
-#endif /* __MONO_MINI_X86_H__ */  
+#endif /* __MONO_MINI_X86_H__ */
 

--- a/src/mono/mono/mini/trace.c
+++ b/src/mono/mono/mini/trace.c
@@ -82,7 +82,7 @@ static void indent (int diff) {
 		indent_level += diff;
 	if (start_time == 0)
 		start_time = mono_100ns_ticks ();
-	printf ("[%p: %.5f %d] ", (void*)mono_native_thread_id_get (), seconds_since_start (), indent_level);
+	printf ("[%p: %.5f %d] ", (gpointer)(gsize) mono_native_thread_id_get (), seconds_since_start (), indent_level);
 	if (diff > 0)
 		indent_level += diff;
 }

--- a/src/mono/mono/mini/trace.c
+++ b/src/mono/mono/mini/trace.c
@@ -248,7 +248,7 @@ mono_trace_enter_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 
 				printf ("[STRING:%p:%s]", s, as);
 				g_free (as);
-			} else 
+			} else
 				printf ("[STRING:null]");
 			break;
 		}
@@ -406,7 +406,7 @@ mono_trace_leave_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 			}
 		} else
 			printf ("[OBJECT:%p]", o);
-	       
+
 		break;
 	}
 	case MONO_TYPE_I8: {

--- a/src/mono/mono/sgen/sgen-debug.c
+++ b/src/mono/mono/sgen/sgen-debug.c
@@ -511,7 +511,7 @@ find_pinning_ref_from_thread (char *obj, size_t size)
 			continue;
 		while (start < (char**)info->client_info.info.stack_end) {
 			if (*start >= obj && *start < endobj)
-				SGEN_LOG (0, "Object %p referenced in thread %p (id %p) at %p, stack: %p-%p", obj, info, (gpointer)mono_thread_info_get_tid (info), start, info->client_info.stack_start, info->client_info.info.stack_end);
+				SGEN_LOG (0, "Object %p referenced in thread %p (id %p) at %p, stack: %p-%p", obj, info, (gpointer)(gsize) mono_thread_info_get_tid (info), start, info->client_info.stack_start, info->client_info.info.stack_end);
 			start++;
 		}
 
@@ -519,7 +519,7 @@ find_pinning_ref_from_thread (char *obj, size_t size)
 			mword w = *ctxcurrent;
 
 			if (w >= (mword)obj && w < (mword)obj + size)
-				SGEN_LOG (0, "Object %p referenced in saved reg %d of thread %p (id %p)", obj, (int) (ctxcurrent - ctxstart), info, (gpointer)(gsize)mono_thread_info_get_tid (info));
+				SGEN_LOG (0, "Object %p referenced in saved reg %d of thread %p (id %p)", obj, (int) (ctxcurrent - ctxstart), info, (gpointer)(gsize) mono_thread_info_get_tid (info));
 		}
 	} FOREACH_THREAD_END
 #endif

--- a/src/mono/mono/sgen/sgen-debug.c
+++ b/src/mono/mono/sgen/sgen-debug.c
@@ -322,7 +322,7 @@ static GCObject **valid_nursery_objects;
 static int valid_nursery_object_count;
 static gboolean broken_heap;
 
-static void 
+static void
 setup_mono_sgen_scan_area_with_callback (GCObject *object, size_t size, void *data)
 {
 	valid_nursery_objects [valid_nursery_object_count++] = object;
@@ -396,7 +396,7 @@ is_valid_object_pointer (char *object)
 {
 	if (sgen_ptr_in_nursery (object))
 		return find_object_in_nursery_dump (object);
-	
+
 	if (sgen_los_is_valid_object (object))
 		return TRUE;
 
@@ -479,7 +479,7 @@ ptr_in_heap (char *object)
 {
 	if (sgen_ptr_in_nursery (object))
 		return TRUE;
-	
+
 	if (sgen_los_is_valid_object (object))
 		return TRUE;
 

--- a/src/mono/mono/utils/mono-threads.c
+++ b/src/mono/mono/utils/mono-threads.c
@@ -298,9 +298,9 @@ dump_threads (void)
 		char thread_name [256] = { 0 };
 		pthread_getname_np (mono_thread_info_get_tid (info), thread_name, 255);
 
-		g_async_safe_printf ("--thread %p id %p [%p] (%s) state %x  %s\n", info, (void *) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, thread_name, info->thread_state, info == cur ? "GC INITIATOR" : "" );
+		g_async_safe_printf ("--thread %p id %p [%p] (%s) state %x  %s\n", info, (gpointer)(gsize) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, thread_name, info->thread_state, info == cur ? "GC INITIATOR" : "" );
 #else
-		g_async_safe_printf ("--thread %p id %p [%p] state %x  %s\n", info, (void *) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, info->thread_state, info == cur ? "GC INITIATOR" : "" );
+		g_async_safe_printf ("--thread %p id %p [%p] state %x  %s\n", info, (gpointer)(gsize) mono_thread_info_get_tid (info), (void*)(size_t)info->native_handle, info->thread_state, info == cur ? "GC INITIATOR" : "" );
 #endif
 	} FOREACH_THREAD_SAFE_END
 }

--- a/src/mono/mono/utils/mono-threads.c
+++ b/src/mono/mono/utils/mono-threads.c
@@ -265,7 +265,7 @@ mono_threads_begin_global_suspend (void)
 }
 
 void
-mono_threads_end_global_suspend (void) 
+mono_threads_end_global_suspend (void)
 {
 	size_t ps = pending_suspends;
 	if (G_UNLIKELY (ps != 0))
@@ -363,7 +363,7 @@ mono_thread_info_lookup (MonoNativeThreadId id)
 	if (!mono_lls_find (&thread_list, hp, (uintptr_t)id)) {
 		mono_hazard_pointer_clear_all (hp, -1);
 		return NULL;
-	} 
+	}
 
 	mono_hazard_pointer_clear_all (hp, 1);
 	return (MonoThreadInfo *) mono_hazard_pointer_get_val (hp, 1);
@@ -377,7 +377,7 @@ mono_thread_info_insert (MonoThreadInfo *info)
 	if (!mono_lls_insert (&thread_list, hp, (MonoLinkedListSetNode*)info)) {
 		mono_hazard_pointer_clear_all (hp, -1);
 		return FALSE;
-	} 
+	}
 
 	mono_hazard_pointer_clear_all (hp, -1);
 	return TRUE;
@@ -892,7 +892,7 @@ mono_thread_info_wait_inited (void)
 			break;
 		} else if (old_read == GINT_TO_POINTER (MONO_END_INIT_CB)) {
 			// Is inited
-			return; 
+			return;
 		} else {
 			// We raced with another writer
 			wait_request.next = (GSList *) old_read;
@@ -1324,7 +1324,7 @@ suspend_sync (MonoNativeThreadId tid, gboolean interrupt_kernel)
 
 		if (suspend_result != BeginSuspendOkNoWait)
 			mono_threads_wait_pending_operations ();
-		
+
 		if (!check_async_suspend (info, suspend_result)) {
 			mono_thread_info_core_resume (info);
 			mono_threads_wait_pending_operations ();
@@ -1453,7 +1453,7 @@ mono_thread_info_setup_async_call (MonoThreadInfo *info, void (*target_func)(voi
 /*
 The suspend lock is held during any suspend in progress.
 A GC that has safepoints must take this lock as part of its
-STW to make sure no unsafe pending suspend is in progress.   
+STW to make sure no unsafe pending suspend is in progress.
 */
 
 static void
@@ -1605,7 +1605,7 @@ mono_thread_info_is_async_context (void)
 /*
  * mono_thread_info_get_stack_bounds:
  *
- *   Return the address and size of the current threads stack. Return NULL as the 
+ *   Return the address and size of the current threads stack. Return NULL as the
  * stack address if the stack address cannot be determined.
  */
 void


### PR DESCRIPTION
Fixes all 38 warnings reported by gcc 8.4 cross-compiler for illumos: http://sprunge.us/m2Krom
command-line:
```sh
$ docker run -e ROOTFS_DIR=/crossrootfs/x64 -v $(pwd):/runtime \
    mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-illumos-20211208134944-f13d79e \
    /runtime/build.sh mono -arch x64 -os illumos -cross -gcc
```
These code paths are probably not exercised by linux-x64 gcc build (otherwise we would have tackled them earlier in https://github.com/dotnet/runtime/commit/577a70afa472a2b7aa8e05947e185d920f42b23d and https://github.com/dotnet/runtime/commit/ab9ee763e500649ac42ca5058cc576b6d7f96357).

cc @lambdageek, @akoeplinger (second commit is just a trailing whitespace cleanup of modified files in the first one)