### PR TITLE
Fix errors in Clang 13

### DIFF
--- a/src/native/libs/System.Native/pal_threading.c
+++ b/src/native/libs/System.Native/pal_threading.c
@@ -243,9 +243,9 @@ int32_t SystemNative_CreateThread(uintptr_t stackSize, void *(*startAddress)(voi
 
     if (stackSize > 0)
     {
-        if (stackSize < PTHREAD_STACK_MIN)
+        if (stackSize < (uintptr_t)PTHREAD_STACK_MIN)
         {
-            stackSize = PTHREAD_STACK_MIN;
+            stackSize = (uintptr_t)PTHREAD_STACK_MIN;
         }
 
         error = pthread_attr_setstacksize(&attrs, stackSize);


### PR DESCRIPTION
Without that patch, I was having this errors 
```
error: implicit conversion changes signedness: 'long' to 'uintptr_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
```