### PR TITLE
Do not contain zeroes for `STOREIND(CLS_VAR_ADDR)`

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -4318,8 +4318,7 @@ void Lowering::ContainCheckStoreIndir(GenTreeStoreInd* node)
     // an int-size or larger store of zero to memory, because we can generate smaller code
     // by zeroing a register and then storing it.
     GenTree* src = node->Data();
-    if (IsContainableImmed(node, src) &&
-        (!src->IsIntegralConst(0) || varTypeIsSmall(node) || node->Addr()->OperIs(GT_CLS_VAR_ADDR)))
+    if (IsContainableImmed(node, src) && (!src->IsIntegralConst(0) || varTypeIsSmall(node)))
     {
         MakeSrcContained(node, src);
     }


### PR DESCRIPTION
There is no good reason for this special case, it seems, and removing it is a CQ improvement across the board.

Additionally, it is likely that `CLS_VAR` will soon be deleted, and this change helps avoid diffs for that change.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1509049&view=ms.vss-build-web.run-extensions-tab)

Just two few regressions - uncontaining the zero makes reuse-reg-val less effective.