### PR TITLE
Fix duplicated FldSeq in block morphing

### DIFF
--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -1259,9 +1259,9 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                     }
                     else
                     {
-                        if (i == 0)
+                        if (i == (fieldCnt - 1))
                         {
-                            // Use the orginal m_dstAddr tree when i == 0
+                            // Reuse the orginal m_dstAddr tree for the last field.
                             dstAddrClone = m_dstAddr;
                         }
                         else
@@ -1381,9 +1381,9 @@ GenTree* MorphCopyBlockHelper::CopyFieldByField()
                     }
                     else
                     {
-                        if (i == 0)
+                        if (i == (fieldCnt - 1))
                         {
-                            // Use the orginal m_srcAddr tree when i == 0
+                            // Reuse the orginal m_srcAddr tree for the last field.
                             srcAddrClone = m_srcAddr;
                         }
                         else

--- a/src/tests/JIT/Directed/StructPromote/FldSeqsInPromotedCpBlk.cs
+++ b/src/tests/JIT/Directed/StructPromote/FldSeqsInPromotedCpBlk.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+class FldSeqsInPromotedCpBlk
+{
+    public static int Main()
+    {
+        PromotableStruct s = default;
+        return Problem(new PromotableStruct[1]) == 2 ? 100 : 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static long Problem(PromotableStruct[] a)
+    {
+        ref var firstElem = ref a[0];
+
+        firstElem.SecondLngValue = 1;
+        var b = new PromotableStruct() { SecondLngValue = 2 };
+
+        if (firstElem.SecondLngValue == 1)
+        {
+            firstElem = b;
+            return firstElem.SecondLngValue;
+        }
+
+        return -1;
+    }
+}
+
+struct PromotableStruct
+{
+    public long FirstLngValue;
+    public long SecondLngValue;
+}

--- a/src/tests/JIT/Directed/StructPromote/FldSeqsInPromotedCpBlk.cs
+++ b/src/tests/JIT/Directed/StructPromote/FldSeqsInPromotedCpBlk.cs
@@ -3,6 +3,24 @@
 
 using System.Runtime.CompilerServices;
 
+// In this test, we have a block assignment with a source that is a promoted struct and
+// an indirect destination. When morphing it, we would decompose that assignment into a series
+// of field assignments: `IND(ADDR) = FirstLngValue; IND(ADDR_CLONE + 8) = SecondLngValue`.
+// In the process, we would also attach field sequences to the destination addresses so that VN
+// knew to analyze them. That was the part which was susceptible to the bug being tested: morphing
+// reused the address node (the "firstElem" LCL_VAR) for the first field, and at the same time
+// used it to create more copies for subsequent addresses.
+//
+// Thus:
+//   1) A zero-offset field sequence for the first field was attached to ADDR
+//   2) ADDR was cloned, the clone still had the sequence attached
+//   3) ADD(ADDR_CLONE [FldSeq FirstLngValue], 8 [FldSeq SecondLngValue]) was created.
+//
+// And so we ended up with an incorrect FldSeq: [FirstLngValue, SecondLngValue], causing
+// VN to wrongly treat the "firstElem = b" store as not modifiying SecondLngValue.
+//
+// The fix was to reuse the address for the last field instead.
+
 class FldSeqsInPromotedCpBlk
 {
     public static int Main()

--- a/src/tests/JIT/Directed/StructPromote/FldSeqsInPromotedCpBlk.csproj
+++ b/src/tests/JIT/Directed/StructPromote/FldSeqsInPromotedCpBlk.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Reusing the address for the first field is problematic as the first field is likely to be at a zero offset, thus a zero-offset field sequence will be attached to it, and subsequent copies of the same tree will pick it up, which is incorrect and can result in silent bad codegen.

Fix by reusing the address for the last field instead.

```diff
 [000015] -A-X-+------              *  COMMA     void
-[000008] -A-X--------              +--*  ASG       long
-[000006] *--X---N----              |  +--*  IND       long
-[000000] -----+------              |  |  \--*  LCL_VAR   byref  V00 arg0          Zero Fseq[FirstLngValue]
-[000007] ------------              |  \--*  LCL_VAR   long   V03 tmp1
+[000009] -A-X--------              +--*  ASG       long
+[000007] *--X---N----              |  +--*  IND       long
+[000006] -----+------              |  |  \--*  LCL_VAR   byref  V00 arg0          Zero Fseq[FirstLngValue]
+[000008] ------------              |  \--*  LCL_VAR   long   V03 tmp1
 [000014] -A-X--------              \--*  ASG       long
 [000012] *--X---N----                 +--*  IND       long
 [000011] ------------                 |  \--*  ADD       byref
-[000009] -----+------                 |     +--*  LCL_VAR   byref  V00 arg0          Zero Fseq[FirstLngValue]
+[000000] -----+------                 |     +--*  LCL_VAR   byref  V00 arg0
 [000010] ------------                 |     \--*  CNS_INT   long   8 Fseq[SecondLngValue]
 [000013] ------------                 \--*  LCL_VAR   long   V04 tmp2
```

Part of #58312.

Just [one](https://dev.azure.com/dnceng/public/_build/results?buildId=1509076&view=ms.vss-build-web.run-extensions-tab) method with diffs: "better" sequences unblocked quite a few CSEs.