### PR TITLE
Remove small casts on the RHS of `ASG(CLS_VAR)`

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12024,7 +12024,7 @@ DONE_MORPHING_CHILDREN:
             effectiveOp1 = op1->gtEffectiveVal();
 
             // If we are storing a small type, we might be able to omit a cast.
-            if (effectiveOp1->OperIs(GT_IND) && varTypeIsSmall(effectiveOp1))
+            if (effectiveOp1->OperIs(GT_IND, GT_CLS_VAR) && varTypeIsSmall(effectiveOp1))
             {
                 if (!gtIsActiveCSE_Candidate(op2) && op2->OperIs(GT_CAST) &&
                     varTypeIsIntegral(op2->AsCast()->CastOp()) && !op2->gtOverflow())


### PR DESCRIPTION
`CLS_VAR` stores have the same truncating semantics as `IND` stores (they are, in fact, the same in the backend), we can take advantage of that and remove some casts.

This is another change that will help make the deletion of `CLS_VAR` zero-diff.

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1509314&view=ms.vss-build-web.run-extensions-tab).