### PR TITLE
Fix SC tests

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateService.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateService.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true)]
-        public static extern IntPtr CreateService(SafeServiceHandle databaseHandle, string serviceName, string displayName, int access, int serviceType,
+        public static partial IntPtr CreateService(SafeServiceHandle databaseHandle, string serviceName, string displayName, int access, int serviceType,
             int startType, int errorControl, string binaryPath, string loadOrderGroup, IntPtr pTagId, string dependencies,
             string servicesStartName, string password);
 


### PR DESCRIPTION
Fix #62616

Broken by #61741 which is easy to do because these tests only run on Windows + Elevated + OuterLoop, which does not normally run on either local machine or PR validation.