### PR TITLE
Fix invalid IR in span indexer import

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4164,7 +4164,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
 
                 if (elemSize != 1)
                 {
-                    GenTree* sizeofNode = gtNewIconNode(elemSize);
+                    GenTree* sizeofNode = gtNewIconNode(static_cast<ssize_t>(elemSize), TYP_I_IMPL);
                     index               = gtNewOperNode(GT_MUL, TYP_I_IMPL, index, sizeofNode);
                 }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/ArrayTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/ArrayTests.cs
@@ -301,7 +301,6 @@ namespace DllImportGenerator.IntegrationTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60624", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsArm64Process))]
         public void ArrayWithSimpleNonBlittableTypeMarshalling(bool result)
         {
             var boolValues = new[]

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/CollectionTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/CollectionTests.cs
@@ -195,7 +195,6 @@ namespace DllImportGenerator.IntegrationTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60624", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsArm64Process))]
         public void CollectionWithSimpleNonBlittableTypeMarshalling(bool result)
         {
             var boolValues = new List<BoolStruct>

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/SpanTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/SpanTests.cs
@@ -133,7 +133,6 @@ namespace DllImportGenerator.IntegrationTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60624", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsArm64Process))]
         public void SpanWithSimpleNonBlittableTypeMarshalling(bool result)
         {
             var boolValues = new BoolStruct[]


### PR DESCRIPTION
Fixes #60624.

There are [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1509798&view=ms.vss-build-web.run-extensions-tab) with this fix, caused by CSEs originating from cases where we were accessing the same underlying address both as an array (with a `long` multiplier) and as a span (with an `int` multiplier).