### PR TITLE
Fix SendPacketsAsync failures on macos

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -13,21 +13,19 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
-    public class SendPacketsAsync
+    public class SendPacketsAsync : IDisposable
     {
         private readonly ITestOutputHelper _log;
 
         private IPAddress _serverAddress = IPAddress.IPv6Loopback;
-        // Accessible directories for UWP app:
-        // C:\Users\<UserName>\AppData\Local\Packages\<ApplicationPackageName>\
-        private string TestFileName = Environment.GetEnvironmentVariable("LocalAppData") + @"\NCLTest.Socket.SendPacketsAsync.testpayload";
-        private static int s_testFileSize = 1024;
 
-        #region Additional test attributes
+        private TempFile _tempFile;
+        private static int s_testFileSize = 1024;
+        private string TestFileName => _tempFile.Path;
 
         public SendPacketsAsync(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
 
             byte[] buffer = new byte[s_testFileSize];
 
@@ -36,22 +34,15 @@ namespace System.Net.Sockets.Tests
                 buffer[i] = (byte)(i % 255);
             }
 
-            try
-            {
-                _log.WriteLine("Creating file {0} with size: {1}", TestFileName, s_testFileSize);
-                using (FileStream fs = new FileStream(TestFileName, FileMode.CreateNew))
-                {
-                    fs.Write(buffer, 0, buffer.Length);
-                }
-            }
-            catch (IOException)
-            {
-                // Test payload file already exists.
-                _log.WriteLine("Payload file exists: {0}", TestFileName);
-            }
+            _tempFile = TempFile.Create(buffer);
+            _log.WriteLine($"Created file {_tempFile.Path} with size: {s_testFileSize}");
         }
 
-        #endregion Additional test attributes
+        public void Dispose()
+        {
+            _tempFile.Dispose();
+        }
+
 
         #region Basic Arguments
 


### PR DESCRIPTION
While looking at the Windows failures reported in #62384, #60267, #60204, #60017 I noticed a bunch of new MacOS failures starting from 2021-12-08, which all report `UnauthorizedAccessException`

By default, `LocalAppData` is undefined on Unix, the following line will actually reference to a file named `\NCLTest.Socket.SendPacketsAsync.testpayload` in the working directory of the test execution process:

https://github.com/dotnet/runtime/blob/a8c2d1eae1726b1e6ec50716b7d4c34bc21ba96e/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs#L23

On CI it's a known folder so the path points to stuff like `/private/tmp/helix/working/A48D0921/w/C66409E5/e/System.Net.Sockets.Tests.app/Contents/Resources/\NCLTest.Socket.SendPacketsAsync.testpayload` on Helix Macs. I'm not sure what goes wrong with the access to the above path, but I believe it's better to use the preferred `TempFile` utility to create temporary files, and this change will likely fix the `UnauthorizedAccessException`, since other tests using `TempFile` seem to be healthy right now.

Also changing the test to use the standard xunit test output instead of the legacy `TestLogging.GetInstance()`.