### PR TITLE
Do not create non-null assertions from location nodes

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_13762/Runtime_13762.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_13762/Runtime_13762.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Runtime_13762
+{
+    public static int Main()
+    {
+        try
+        {
+            Problem(null);
+        }
+        catch (NullReferenceException)
+        {
+            return 100;
+        }
+
+        return 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Problem(ClassWithField a)
+    {
+        a.Field = a.Call(ref a.Field);
+    }
+}
+
+public class ClassWithField
+{
+    public int Field;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public int Call(ref int a)
+    {
+        throw new Exception("This should have been an NRE!");
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_13762/Runtime_13762.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_13762/Runtime_13762.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Some indirection nodes in the compiler represent locations, not values. These are either the LHSs of `ASG`s or the operands of `ADDR` nodes (they can be also be chained via `COMMA`s). We cannot create non-null assertions from such nodes because they do not end up dereferencing their operands.

The problem is that we also cannot detect them reliably. The optimization phases use the `GTF_IND_ASG_LHS` flag, but that is not strong enough as it does not account for `ADDR` operands (indeed, we "evaluate" these nodes in VN, wasting memory and potentially confusing people who are new to the compiler). Adding a new flag that will capture the general idea of such a location indirection seems very risky and cumbersome to me, as the flag would need to be maintained throughout all the front-end phases (and the maintenance of such flags is known to be a source of bugs).

Thus, the solution I propose is a conservative one, but correct: rely on `GTF_NO_CSE`. All locations will be marked with it, and it has already been "plumbed through" the compiler.

Contributes to #13762.

 Mixed [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1520911&view=ms.vss-build-web.run-extensions-tab): the change unblocks some CSEs (because their defs now have the exception sets of their uses).