### PR TITLE
Deduplicate JIT/Methodical/Boxing/xlang tests

### DIFF
--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs.cs
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace SinCalc
+namespace SinCalc_against_sinlib_cs
 {
     using System;
     using SinCalcLib;

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_d.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_d.csproj
@@ -9,7 +9,7 @@
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_cs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_cs.csproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_do.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_do.csproj
@@ -9,7 +9,7 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_cs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_cs.csproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_r.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_r.csproj
@@ -8,7 +8,7 @@
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_cs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_cs.csproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_cs_ro.csproj
@@ -9,7 +9,7 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_cs.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_cs.csproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_d.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_d.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_il.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_il.ilproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_do.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_do.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_il.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_il.ilproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_r.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_r.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_il.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_il.ilproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_ro.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_cs_il_ro.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sin.cs" />
+    <Compile Include="sin_il.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="sinlib_il.ilproj" />

--- a/src/tests/JIT/Methodical/Boxing/xlang/sin_il.cs
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sin_il.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace SinCalc_against_sinlib_il
+{
+    using System;
+    using SinCalcLib;
+
+    class SinCalc
+    {
+        static int Main()
+        {
+            object i;
+            object Angle;
+            object Result1, Result2;
+            object[] testresults = new object[10];
+            testresults[0] = 0.000000000d;
+            testresults[1] = 0.309016994d;
+            testresults[2] = 0.587785252d;
+            testresults[3] = 0.809016994d;
+            testresults[4] = 0.951056516d;
+            testresults[5] = 1.000000000d;
+            testresults[6] = 0.951056516d;
+            testresults[7] = 0.809016994d;
+            testresults[8] = 0.587785252d;
+            testresults[9] = 0.309016994d;
+
+            object mistake = 1e-9d;
+            for (i = 0; (int)i < 10; i = (int)i + 1)
+            {
+                Angle = ((PiVal)SinCalcLib.PI).Value * ((int)i / 10.0);
+                Console.Write("Classlib Sin(");
+                Console.Write(Angle);
+                Console.Write(")=");
+                Console.WriteLine(Result1 = Math.Sin((double)Angle));
+                Console.Write("This Version(");
+                Console.Write(Angle);
+                Console.Write(")=");
+                Console.WriteLine(Result2 = (double)SinCalcLib.mySin(Angle));
+                Console.Write("Error is:");
+                Console.WriteLine((double)Result1 - (double)Result2);
+                Console.WriteLine();
+                if (Math.Abs((double)Result1 - (double)Result2) > (double)mistake) // reasonable considering double
+                {
+                    Console.WriteLine("ERROR, Versions too far apart!");
+                    return 1;
+                }
+                if (Math.Abs((double)testresults[(int)i] - (double)Result1) > (double)mistake) // reasonable considering double
+                {
+                    Console.WriteLine("ERROR, Classlib version isnt right!");
+                    return 1;
+                }
+                if (Math.Abs((double)testresults[(int)i] - (double)Result2) > (double)mistake) // reasonable considering double
+                {
+                    Console.WriteLine("ERROR, our version isnt right!");
+                    return 1;
+                }
+
+            }
+            Console.WriteLine("Yippie, all correct");
+            return 100;
+        }
+    }
+}


### PR DESCRIPTION
This group comprises a C# & IL main module and a C# & IL library
and tries all four pairings between them. The C# version of the
main module used to be shared but that's problematic with test
merging as distinguishing the two tests with an identical
namespace, class name and entry point would be hard. As this is
the only occurrence of this pattern in the runtime test source
tree, I'm proposing to duplicate the C# main module source and
adjust it for the two scenarios (targeting C# vs. IL version
of the dependent library).

Thanks

Tomas

/cc @dotnet/jit-contrib