### PR TITLE
[6.0] Fix named mutexes on OSX to work between arm64 and emulated x64 processes

### DIFF
--- a/src/coreclr/pal/src/include/pal/mutex.hpp
+++ b/src/coreclr/pal/src/include/pal/mutex.hpp
@@ -120,9 +120,16 @@ Miscellaneous
   existing shared memory, naming, and waiting infrastructure is not suitable for this purpose, and is not used.
 */
 
-// Temporarily disabling usage of pthread process-shared mutexes on ARM/ARM64 due to functional issues that cannot easily be
-// detected with code due to hangs. See https://github.com/dotnet/runtime/issues/6014.
-#if HAVE_FULLY_FEATURED_PTHREAD_MUTEXES && HAVE_FUNCTIONAL_PTHREAD_ROBUST_MUTEXES && !(defined(HOST_ARM) || defined(HOST_ARM64) || defined(__FreeBSD__))
+// - Temporarily disabling usage of pthread process-shared mutexes on ARM/ARM64 due to functional issues that cannot easily be
+//   detected with code due to hangs. See https://github.com/dotnet/runtime/issues/6014.
+// - On FreeBSD, pthread process-shared robust mutexes cannot be placed in shared memory mapped independently by the processes
+//   involved. See https://github.com/dotnet/runtime/issues/10519.
+// - On OSX, pthread robust mutexes were/are not available at the time of this writing. In case they are made available in the
+//   future, their use is disabled for compatibility.
+#if HAVE_FULLY_FEATURED_PTHREAD_MUTEXES && \
+    HAVE_FUNCTIONAL_PTHREAD_ROBUST_MUTEXES && \
+    !(defined(HOST_ARM) || defined(HOST_ARM64) || defined(__FreeBSD__) || defined(TARGET_OSX))
+
     #define NAMED_MUTEX_USE_PTHREAD_MUTEX 1
 #else
     #define NAMED_MUTEX_USE_PTHREAD_MUTEX 0

--- a/src/coreclr/pal/src/include/pal/sharedmemory.h
+++ b/src/coreclr/pal/src/include/pal/sharedmemory.h
@@ -173,7 +173,8 @@ private:
     };
 
 public:
-    static SIZE_T DetermineTotalByteCount(SIZE_T dataByteCount);
+    static SIZE_T GetUsedByteCount(SIZE_T dataByteCount);
+    static SIZE_T GetTotalByteCount(SIZE_T dataByteCount);
 
 public:
     SharedMemorySharedDataHeader(SharedMemoryType type, UINT8 version);

--- a/src/coreclr/pal/src/sharedmemory/sharedmemory.cpp
+++ b/src/coreclr/pal/src/sharedmemory/sharedmemory.cpp
@@ -519,9 +519,14 @@ bool SharedMemoryId::AppendSessionDirectoryName(PathCharString& path) const
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // SharedMemorySharedDataHeader
 
-SIZE_T SharedMemorySharedDataHeader::DetermineTotalByteCount(SIZE_T dataByteCount)
+SIZE_T SharedMemorySharedDataHeader::GetUsedByteCount(SIZE_T dataByteCount)
 {
-    return SharedMemoryHelpers::AlignUp(sizeof(SharedMemorySharedDataHeader) + dataByteCount, GetVirtualPageSize());
+    return sizeof(SharedMemorySharedDataHeader) + dataByteCount;
+}
+
+SIZE_T SharedMemorySharedDataHeader::GetTotalByteCount(SIZE_T dataByteCount)
+{
+    return SharedMemoryHelpers::AlignUp(GetUsedByteCount(dataByteCount), GetVirtualPageSize());
 }
 
 SharedMemorySharedDataHeader::SharedMemorySharedDataHeader(SharedMemoryType type, UINT8 version)
@@ -642,7 +647,7 @@ SharedMemoryProcessDataHeader *SharedMemoryProcessDataHeader::CreateOrOpen(
     {
         _ASSERTE(
             processDataHeader->GetSharedDataTotalByteCount() ==
-            SharedMemorySharedDataHeader::DetermineTotalByteCount(sharedDataByteCount));
+            SharedMemorySharedDataHeader::GetTotalByteCount(sharedDataByteCount));
         processDataHeader->IncRefCount();
         return processDataHeader;
     }
@@ -697,14 +702,23 @@ SharedMemoryProcessDataHeader *SharedMemoryProcessDataHeader::CreateOrOpen(
     }
 
     // Set or validate the file length
-    SIZE_T sharedDataTotalByteCount = SharedMemorySharedDataHeader::DetermineTotalByteCount(sharedDataByteCount);
+    SIZE_T sharedDataUsedByteCount = SharedMemorySharedDataHeader::GetUsedByteCount(sharedDataByteCount);
+    SIZE_T sharedDataTotalByteCount = SharedMemorySharedDataHeader::GetTotalByteCount(sharedDataByteCount);
     if (createdFile)
     {
         SharedMemoryHelpers::SetFileSize(fileDescriptor, sharedDataTotalByteCount);
     }
-    else if (SharedMemoryHelpers::GetFileSize(fileDescriptor) != sharedDataTotalByteCount)
+    else
     {
-        throw SharedMemoryException(static_cast<DWORD>(SharedMemoryError::HeaderMismatch));
+        SIZE_T currentFileSize = SharedMemoryHelpers::GetFileSize(fileDescriptor);
+        if (currentFileSize < sharedDataUsedByteCount)
+        {
+            throw SharedMemoryException(static_cast<DWORD>(SharedMemoryError::HeaderMismatch));
+        }
+        if (currentFileSize < sharedDataTotalByteCount)
+        {
+            SharedMemoryHelpers::SetFileSize(fileDescriptor, sharedDataTotalByteCount);
+        }
     }
 
     // Acquire and hold a shared file lock on the shared memory file as long as it is open, to indicate that this process is
@@ -726,7 +740,7 @@ SharedMemoryProcessDataHeader *SharedMemoryProcessDataHeader::CreateOrOpen(
     {
         if (clearContents)
         {
-            memset(mappedBuffer, 0, sharedDataTotalByteCount);
+            memset(mappedBuffer, 0, sharedDataUsedByteCount);
         }
         sharedDataHeader = new(mappedBuffer) SharedMemorySharedDataHeader(requiredSharedDataHeader);
     }


### PR DESCRIPTION
- Port of https://github.com/dotnet/runtime/pull/62764 to 6.0
- The page size is different between arm64 processes and emulated x64 processes
- The shared memory file size is set to the page size and there was a strict check on the file size, leading to an exception from the second process of a different arch that tries to share the same mutex
- Made the file size check less strict, and allowed an arch to increase but not decrease the file size such that it can be mapped at page size granularity
- Fixes https://github.com/dotnet/runtime/issues/62140

## Customer Impact

Some apps involving multiple processes may have x64 and arm64 .NET process components during transition, where the processes may try to share a named mutex for synchronization. Currently this is not possible, as the second process that tries to open an existing named mutex fails with an exception.

## Regression?

No

## Testing

Verified with a test case that a named mutex can be shared for synchronization between arm64 and emulated x64 .NET processes. Also verified backward compatibility between processes of the same arch.

## Risk

Low, with a small caveat
- There is a case where this is not 100% compatible with an unfixed runtime when processes of different archs are trying to share the same mutex (in a scenario where it wouldn't have worked before the fix anyway). The fix allows an arm64 process to increase the shared memory file size to its page size such that it can be mapped. So for example, if an unfixed x64 process creates a named mutex, then a fixed arm64 process opens it (and increases the shared memory file size), then if an unfixed x64 process tries to open a new instance of the mutex it would throw an exception. It's expected that both runtimes are updated with the fix in order to interoperate successfully with named mutexes.