### PR TITLE
[build] Don't download CoreCLR product for Mono runtime tests

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -248,16 +248,6 @@ jobs:
         artifactName: '$(buildProductArtifactName)'
         displayName: 'product build'
 
-
-    - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
-      # We need to explictly download CoreCLR for Mono
-      - template: /eng/pipelines/common/download-artifact-step.yml
-        parameters:
-          unpackFolder: $(coreClrProductRootFolderPath)
-          artifactFileName: '$(coreClrProductArtifactName)$(archiveExtension)'
-          artifactName: '$(coreClrProductArtifactName)'
-          displayName: 'CoreCLR product download for Mono'
-
     # Download and unzip the Microsoft.NET.Sdk.IL package needed for traversing
     # ilproj test projects during copynativeonly.
     - template: /eng/pipelines/common/download-artifact-step.yml


### PR DESCRIPTION
Shouldn't be needed after https://github.com/dotnet/runtime/pull/62652

Contributes to https://github.com/dotnet/runtime/issues/51584, I think