### PR TITLE
[wasm][debugger] Fix source-link test

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -809,7 +809,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             return (start.StartLocation.Line, start.StartLocation.Column, end.EndLocation.Line, end.EndLocation.Column);
         }
 
-        private async Task<MemoryStream> GetDataAsync(Uri uri, CancellationToken token)
+        private static async Task<MemoryStream> GetDataAsync(Uri uri, CancellationToken token)
         {
             var mem = new MemoryStream();
             try

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -816,7 +816,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             {
                 if (uri.IsFile && File.Exists(uri.LocalPath))
                 {
-                    using (FileStream file = File.Open(SourceUri.LocalPath, FileMode.Open))
+                    using (FileStream file = File.Open(uri.LocalPath, FileMode.Open))
                     {
                         await file.CopyToAsync(mem, token).ConfigureAwait(false);
                         mem.Position = 0;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -807,6 +807,25 @@ namespace DebuggerTests
         }
 
         [Fact]
+        public async Task GetSourceUsingSourceUri()
+        {
+            var bp1_res = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 10, 8);
+
+            Assert.EndsWith("debugger-test.cs", bp1_res.Value["breakpointId"].ToString());
+            Assert.Equal(1, bp1_res.Value["locations"]?.Value<JArray>()?.Count);
+
+            var loc = bp1_res.Value["locations"]?.Value<JArray>()[0];
+
+            var sourceToGet = JObject.FromObject(new
+            {
+                scriptId = loc["scriptId"]?.Value<string>()
+            });
+
+            Assert.Equal("dotnet://debugger-test.dll/debugger-test.cs", scripts[loc["scriptId"]?.Value<string>()]);
+            var source = await cli.SendCommand("Debugger.getScriptSource", sourceToGet, token);
+            Assert.True(source.IsOk);
+        }
+        [Fact]
         public async Task GetSourceUsingSourceLink()
         {
             var bp = await SetBreakpointInMethod("debugger-test-with-source-link.dll", "DebuggerTests.ClassToBreak", "TestBreakpoint", 0);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -809,6 +809,9 @@ namespace DebuggerTests
         [Fact]
         public async Task GetSourceUsingSourceUri()
         {
+            //testing without using sourcelink, expected values at GetSourceAsync
+            //SourceUri - file:///LOCAL_PATH/runtime/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+            //SourceLinkUri - empty
             var bp1_res = await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 10, 8);
 
             Assert.EndsWith("debugger-test.cs", bp1_res.Value["breakpointId"].ToString());
@@ -828,6 +831,13 @@ namespace DebuggerTests
         [Fact]
         public async Task GetSourceUsingSourceLink()
         {
+            //testing using sourcelink, expected values at GetSourceAsync
+            // On CI
+            //SourceUri - file:///fakepath/LOCAL_PATH/runtime/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
+            //SourceLinkUri - file:///LOCAL_PATH/runtime/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
+            // Locally
+            // SourceUri - file:////src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
+            // SourceLinkUri - https://raw.githubusercontent.com/FORK/runtime/COMMIT_ID/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
             var bp = await SetBreakpointInMethod("debugger-test-with-source-link.dll", "DebuggerTests.ClassToBreak", "TestBreakpoint", 0);
             var pause_location = await EvaluateAndCheck(
                 "window.setTimeout(function() { invoke_static_method ('[debugger-test-with-source-link] DebuggerTests.ClassToBreak:TestBreakpoint'); }, 1);",

--- a/src/mono/wasm/debugger/tests/debugger-test-with-source-link/debugger-test-with-source-link.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-source-link/debugger-test-with-source-link.csproj
@@ -2,14 +2,9 @@
   <PropertyGroup>
     <PackageId>LibraryTest</PackageId>
     <Version>1.0.0</Version>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <RepositoryUrl>https://github.com/dotnet/runtime.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <EnableSourceLink>true</EnableSourceLink>
-    <IncludeSymbols>true</IncludeSymbols>
-    <DebugType>embedded</DebugType>
-    <IncludeSymbols>true</IncludeSymbols>
+    <SourceLink>source-link.json</SourceLink>
     <DeterministicSourcePaths>true</DeterministicSourcePaths>
-    <DisableSourceLink>false</DisableSourceLink>
+    <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
+    <PathMap>$(AppOutputBase)=/fakepath/$(MSBuildProjectDirectory)</PathMap>
   </PropertyGroup>
 </Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-with-source-link/debugger-test-with-source-link.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-source-link/debugger-test-with-source-link.csproj
@@ -1,10 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+<PropertyGroup>
     <PackageId>LibraryTest</PackageId>
     <Version>1.0.0</Version>
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>    
+</PropertyGroup>
+<PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/dotnet/runtime.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <EnableSourceLink>true</EnableSourceLink>
+    <IncludeSymbols>true</IncludeSymbols>
+    <DebugType>embedded</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <DisableSourceLink>false</DisableSourceLink>
+</PropertyGroup>
+<PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <SourceLink>source-link.json</SourceLink>
-    <DeterministicSourcePaths>true</DeterministicSourcePaths>
     <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
     <PathMap>$(AppOutputBase)=/fakepath/$(MSBuildProjectDirectory)</PathMap>
-  </PropertyGroup>
+</PropertyGroup>
 </Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-with-source-link/debugger-test-with-source-link.csproj
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-source-link/debugger-test-with-source-link.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<PropertyGroup>
-    <PackageId>LibraryTest</PackageId>
-    <Version>1.0.0</Version>
-    <DeterministicSourcePaths>true</DeterministicSourcePaths>    
-</PropertyGroup>
-<PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <RepositoryUrl>https://github.com/dotnet/runtime.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <EnableSourceLink>true</EnableSourceLink>
-    <IncludeSymbols>true</IncludeSymbols>
-    <DebugType>embedded</DebugType>
-    <IncludeSymbols>true</IncludeSymbols>
-    <DisableSourceLink>false</DisableSourceLink>
-</PropertyGroup>
-<PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
-    <SourceLink>source-link.json</SourceLink>
-    <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
-    <PathMap>$(AppOutputBase)=/fakepath/$(MSBuildProjectDirectory)</PathMap>
-</PropertyGroup>
+    <PropertyGroup>
+        <PackageId>LibraryTest</PackageId>
+        <Version>1.0.0</Version>
+        <DeterministicSourcePaths>true</DeterministicSourcePaths>    
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <RepositoryUrl>https://github.com/dotnet/runtime.git</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <EnableSourceLink>true</EnableSourceLink>
+        <IncludeSymbols>true</IncludeSymbols>
+        <DebugType>embedded</DebugType>
+        <IncludeSymbols>true</IncludeSymbols>
+        <DisableSourceLink>false</DisableSourceLink>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+        <SourceLink>source-link.json</SourceLink>
+        <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
+        <PathMap>$(AppOutputBase)=/fakepath/$(MSBuildProjectDirectory)</PathMap>
+    </PropertyGroup>
 </Project>

--- a/src/mono/wasm/debugger/tests/debugger-test-with-source-link/source-link.json
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-source-link/source-link.json
@@ -1,0 +1,5 @@
+{
+    "documents": {
+        "/fakepath/*":               ""
+    }
+}


### PR DESCRIPTION
Like this we are still testing the source-link but we don't depend anymore of the git commit id.
Fix #62551