### PR TITLE
Bump SdkBandVersion prop to 6.0.200

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>1</PatchVersion>
-    <SdkBandVersion>6.0.100</SdkBandVersion>
+    <SdkBandVersion>6.0.200</SdkBandVersion>
     <PreReleaseVersionLabel>mauipre</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <!-- Set assembly version to align with major and minor version,

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <!-- File version numbers -->
     <MajorVersion>6</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <SdkBandVersion>6.0.200</SdkBandVersion>
     <PreReleaseVersionLabel>mauipre</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>


### PR DESCRIPTION
In order to isolate the mauipre workload from 6.0 rtm, we need to make sure the manifest name contains the 200 band.  This change modifies the msbuild property that controls the sdk band part of the name.