### PR TITLE
Try to improve HttpConnectionPool lock contention

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -572,8 +572,11 @@ namespace System.Net.Http
                 _pendingHttp2Connection = false;
 
                 // Signal to any queued HTTP2 requests that they must downgrade.
-                while (_http2RequestQueue.TryDequeueNextRequest(null))
-                    ;
+                while (_http2RequestQueue.TryDequeueRequest(out RequestQueue<Http2Connection?>.QueueItem item))
+                {
+                    // We don't care if this fails; that means the request was previously canceled.
+                    item.Waiter.TrySetResult(null);
+                }
 
                 if (_associatedHttp11ConnectionCount < _maxHttp11Connections)
                 {
@@ -2122,7 +2125,7 @@ namespace System.Net.Http
 
         private struct RequestQueue<T>
         {
-            private struct QueueItem
+            public struct QueueItem
             {
                 public HttpRequestMessage Request;
                 public TaskCompletionSourceWithCancellation<T> Waiter;
@@ -2141,6 +2144,12 @@ namespace System.Net.Http
                 _queue.Enqueue(new QueueItem { Request = request, Waiter = waiter });
                 return waiter;
             }
+
+            // TODO: TryDequeueNextRequest below was changed to not handle request cancellation.
+            // TryFailNextRequest should probably be changed similarly -- or rather, callers should just use the new
+            // TryDequeueRequest call below and then handle canceled requests themselves.
+            // However, we should fix the issue re cancellation failure first because that will affect this code too.
+            // TODO: Link cancellation failure issue here.
 
             public bool TryFailNextRequest(Exception e)
             {
@@ -2165,6 +2174,8 @@ namespace System.Net.Http
                 return false;
             }
 
+            // TODO: Remove this in favor of TryDequeueNextRequest below
+
             public bool TryDequeueNextRequest(T connection)
             {
                 if (_queue is not null)
@@ -2182,6 +2193,17 @@ namespace System.Net.Http
                     }
                 }
 
+                return false;
+            }
+
+            public bool TryDequeueRequest(out QueueItem item)
+            {
+                if (_queue is not null)
+                {
+                    return _queue.TryDequeue(out item);
+                }
+
+                item = default;
                 return false;
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1687,44 +1687,69 @@ namespace System.Net.Http
                 return;
             }
 
-            lock (SyncObj)
+            // Loop in case we get a cancelled request.
+            while (true)
             {
-                Debug.Assert(!_availableHttp11Connections.Contains(connection));
-
-                if (isNewConnection)
+                TaskCompletionSourceWithCancellation<HttpConnection>? waiter = null;
+                bool added = false;
+                lock (SyncObj)
                 {
-                    Debug.Assert(_pendingHttp11ConnectionCount > 0);
-                    _pendingHttp11ConnectionCount--;
+                    Debug.Assert(!_availableHttp11Connections.Contains(connection), $"Connection already in available list");
+                    Debug.Assert(_associatedHttp11ConnectionCount > 0, $"Expected {_associatedHttp11ConnectionCount} > 0");
+                    Debug.Assert(_associatedHttp11ConnectionCount <= _maxHttp11Connections, $"Expected {_associatedHttp11ConnectionCount} <= {_maxHttp11Connections}");
+
+                    if (isNewConnection)
+                    {
+                        Debug.Assert(_pendingHttp11ConnectionCount > 0);
+                        _pendingHttp11ConnectionCount--;
+                        isNewConnection = false;
+                    }
+
+                    if (_http11RequestQueue.TryDequeueRequest(out RequestQueue<HttpConnection>.QueueItem item))
+                    {
+                        Debug.Assert(_availableHttp11Connections.Count == 0, $"With {_availableHttp11Connections.Count} available HTTP/1.1 connections, we shouldn't have a waiter.");
+                        waiter = item.Waiter;
+                    }
+                    else if (!_disposed)
+                    {
+                        // Add connection to the pool.
+                        added = true;
+                        _availableHttp11Connections.Add(connection);
+                        Debug.Assert(_availableHttp11Connections.Count <= _associatedHttp11ConnectionCount, $"Expected {_availableHttp11Connections.Count} <= {_associatedHttp11ConnectionCount}");
+                    }
+
+                    // If the pool has been disposed of, we will dispose the connection below outside the lock.
+                    // We do this after processing the queue above so that any queued requests will be handled properly.
                 }
 
-                if (_http11RequestQueue.TryDequeueNextRequest(connection))
+                if (waiter is not null)
                 {
-                    Debug.Assert(_availableHttp11Connections.Count == 0, $"With {_availableHttp11Connections.Count} available HTTP/1.1 connections, we shouldn't have a waiter.");
-
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Dequeued waiting HTTP/1.1 request.");
-                    return;
+                    Debug.Assert(!added);
+                    if (waiter.TrySetResult(connection))
+                    {
+                        if (NetEventSource.Log.IsEnabled()) connection.Trace("Dequeued waiting HTTP/1.1 request.");
+                        return;
+                    }
+                    else
+                    {
+                        Debug.Assert(waiter.Task.IsCanceled);
+                        if (NetEventSource.Log.IsEnabled()) connection.Trace("Discarding canceled request from queue.");
+                        // Loop and process the queue again
+                    }
                 }
-
-                if (_disposed)
+                else if (added)
                 {
-                    // If the pool has been disposed of, dispose the connection being returned,
-                    // as the pool is being deactivated. We do this after the above in order to
-                    // use pooled connections to satisfy any requests that pended before the
-                    // the pool was disposed of.
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing connection returned to pool. Pool was disposed.");
-                }
-                else
-                {
-                    // Add connection to the pool.
-                    _availableHttp11Connections.Add(connection);
-                    Debug.Assert(_availableHttp11Connections.Count <= _maxHttp11Connections, $"Expected {_availableHttp11Connections.Count} <= {_maxHttp11Connections}");
                     if (NetEventSource.Log.IsEnabled()) connection.Trace("Put connection in pool.");
                     return;
                 }
+                else
+                {
+                    Debug.Assert(_disposed);
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing connection returned to pool. Pool was disposed.");
+                    connection.Dispose();
+                    return;
+                }
             }
-
-            // We determined that the connection is no longer usable.
-            connection.Dispose();
         }
 
         public void ReturnHttp2Connection(Http2Connection connection, bool isNewConnection)


### PR DESCRIPTION
Two related changes:

(1) Avoid doing any logging logic under the lock
(2) Avoid calling TrySetResult on the waiter under the lock -- instead, do this outside the lock and retry as necessary for canceled requests

This PR is in progress and only addresses HTTP/1.1 at the moment.