### PR TITLE
Fix bugs with generation for ctor param default values

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/Common/JsonConstants.cs
@@ -7,5 +7,9 @@ namespace System.Text.Json
     {
         // The maximum number of parameters a constructor can have where it can be supported by the serializer.
         public const int MaxParameterCount = 64;
+
+        // Standard format for double and single on non-inbox frameworks.
+        public const string DoubleFormatString = "G17";
+        public const string SingleFormatString = "G9";
     }
 }

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Reflection;
@@ -1326,9 +1327,32 @@ private static readonly {JsonEncodedTextTypeRef} {name_varName_pair.Value} = {Js
             {
                 case null:
                     return $"default({objectTypeAsStr})";
-                case bool boolVal:
-                    return ToCSharpKeyword(boolVal);
+                case bool @bool:
+                    return ToCSharpKeyword(@bool);
+                case string @string:
+                    return @$"""{@string}""";
+                case char @char:
+                    return @$"'{@char}'";
+                case double.NegativeInfinity:
+                    return "double.NegativeInfinity";
+                case double.PositiveInfinity:
+                    return "double.PositiveInfinity";
+                case double.NaN:
+                    return "double.NaN";
+                case float.NegativeInfinity:
+                    return "float.NegativeInfinity";
+                case float.PositiveInfinity:
+                    return "float.PositiveInfinity";
+                case float.NaN:
+                    return "float.NaN";
+                case double @double:
+                    return @double.ToString(JsonConstants.DoubleFormatString, CultureInfo.InvariantCulture);
+                case float @float:
+                    return @float.ToString(JsonConstants.SingleFormatString, CultureInfo.InvariantCulture);
+                case decimal @decimal:
+                    return @decimal.ToString(CultureInfo.InvariantCulture);
                 default:
+                    // Assume this is a number.
                     return value!.ToString();
             }
         }

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -377,6 +377,9 @@ namespace System.Text.Json.SourceGeneration
                     GuidType = _guidType,
                     StringType = _stringType,
                     NumberTypes = _numberTypes,
+#if DEBUG
+                    MetadataLoadContext = _metadataLoadContext,
+#endif
                 };
             }
 

--- a/src/libraries/System.Text.Json/gen/SourceGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/SourceGenerationSpec.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json.Reflection;
+using Microsoft.CodeAnalysis;
 
 namespace System.Text.Json.SourceGeneration
 {
@@ -11,6 +13,9 @@ namespace System.Text.Json.SourceGeneration
     {
         public List<ContextGenerationSpec> ContextGenerationSpecList { get; init; }
 
+#if DEBUG
+        public MetadataLoadContextInternal MetadataLoadContext { get; init; }
+#endif
         public Type BooleanType { get; init; }
         public Type ByteArrayType { get; init; }
         public Type CharType { get; init; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
@@ -109,9 +109,7 @@ namespace System.Text.Json
 #if BUILDING_INBOX_LIBRARY
             return Utf8Formatter.TryFormat(value, destination, out bytesWritten);
 #else
-            const string FormatString = "G17";
-
-            string utf16Text = value.ToString(FormatString, CultureInfo.InvariantCulture);
+            string utf16Text = value.ToString(JsonConstants.DoubleFormatString, CultureInfo.InvariantCulture);
 
             // Copy the value to the destination, if it's large enough.
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
@@ -109,9 +109,7 @@ namespace System.Text.Json
 #if BUILDING_INBOX_LIBRARY
             return Utf8Formatter.TryFormat(value, destination, out bytesWritten);
 #else
-            const string FormatString = "G9";
-
-            string utf16Text = value.ToString(FormatString, CultureInfo.InvariantCulture);
+            string utf16Text = value.ToString(JsonConstants.SingleFormatString, CultureInfo.InvariantCulture);
 
             // Copy the value to the destination, if it's large enough.
 

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1385,5 +1385,57 @@ namespace System.Text.Json.Serialization.Tests
             public long A;
             public StructWithExplicitParameterlessCtor() => A = 42;
         }
+        
+        public async Task TestClassWithEmptyStringDefaultCtorParam()
+        {
+            ClassWithDefaultCtorParams obj = new ClassWithDefaultCtorParams("value", "val", 'v', 1, 2, 3, 4, 5, 6);
+            string json = await JsonSerializerWrapperForString.SerializeWrapper(obj);
+
+            obj = await JsonSerializerWrapperForString.DeserializeWrapper<ClassWithDefaultCtorParams>(json);
+            Assert.Equal("value", obj.Prop1);
+            Assert.Equal("val", obj.Prop2);
+            Assert.Equal('v', obj.Prop3);
+            Assert.Equal(1, obj.Prop4);
+            Assert.Equal(2, obj.Prop5);
+            Assert.Equal(3, obj.Prop6);
+            Assert.Equal(4, obj.Prop7);
+            Assert.Equal(5, obj.Prop8);
+            Assert.Equal(6, obj.Prop9);
+        }
+
+        public class ClassWithDefaultCtorParams
+        {
+            public string Prop1 { get; }
+            public string Prop2 { get; }
+            public char Prop3 { get; }
+            public double Prop4 { get; }
+            public double Prop5 { get; }
+            public double Prop6 { get; }
+            public float Prop7 { get; }
+            public float Prop8 { get; }
+            public float Prop9 { get; }
+
+            public ClassWithDefaultCtorParams(
+                string prop1 = "abc",
+                string prop2 = "",
+                char prop3 = 'a',
+                double prop4 = double.NegativeInfinity,
+                double prop5 = double.PositiveInfinity,
+                double prop6 = double.NaN,
+                float prop7 = float.NegativeInfinity,
+                float prop8 = float.PositiveInfinity,
+                float prop9 = float.NaN)
+            {
+                Prop1 = prop1;
+                Prop2 = prop2;
+                Prop3 = prop3;
+                Prop4 = prop4;
+                Prop5 = prop5;
+                Prop6 = prop6;
+                Prop7 = prop7;
+                Prop8 = prop8;
+                Prop9 = prop9;
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -1390,51 +1391,142 @@ namespace System.Text.Json.Serialization.Tests
         {
             ClassWithDefaultCtorParams obj = new ClassWithDefaultCtorParams("value", "val", 'v', 1, 2, 3, 4, 5, 6);
             string json = await JsonSerializerWrapperForString.SerializeWrapper(obj);
+        }
 
+        public async Task TestClassWithDefaultCtorParams()
+        {
+            ClassWithDefaultCtorParams obj = new ClassWithDefaultCtorParams(
+                new Point_2D_Struct_WithAttribute(1, 2),
+                DayOfWeek.Sunday,
+                (DayOfWeek)(-2),
+                (DayOfWeek)19,
+                BindingFlags.CreateInstance | BindingFlags.FlattenHierarchy,
+                SampleEnumUInt32.MinZero,
+                "Hello world!",
+                null,
+                "xzy",
+                'c',
+                ' ',
+                23,
+                4,
+                -40,
+                double.Epsilon,
+                23,
+                4,
+                -40,
+                float.MinValue,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10);
+
+            string json = await JsonSerializerWrapperForString.SerializeWrapper(obj);
             obj = await JsonSerializerWrapperForString.DeserializeWrapper<ClassWithDefaultCtorParams>(json);
-            Assert.Equal("value", obj.Prop1);
-            Assert.Equal("val", obj.Prop2);
-            Assert.Equal('v', obj.Prop3);
-            Assert.Equal(1, obj.Prop4);
-            Assert.Equal(2, obj.Prop5);
-            Assert.Equal(3, obj.Prop6);
-            Assert.Equal(4, obj.Prop7);
-            Assert.Equal(5, obj.Prop8);
-            Assert.Equal(6, obj.Prop9);
+            JsonTestHelper.AssertJsonEqual(json, await JsonSerializerWrapperForString.SerializeWrapper(obj));
         }
 
         public class ClassWithDefaultCtorParams
         {
-            public string Prop1 { get; }
-            public string Prop2 { get; }
-            public char Prop3 { get; }
-            public double Prop4 { get; }
-            public double Prop5 { get; }
-            public double Prop6 { get; }
-            public float Prop7 { get; }
-            public float Prop8 { get; }
-            public float Prop9 { get; }
+            public Point_2D_Struct_WithAttribute Struct { get; }
+            public DayOfWeek Enum1 { get; }
+            public DayOfWeek Enum2 { get; }
+            public DayOfWeek Enum3 { get; }
+            public BindingFlags Enum4 { get; }
+            public SampleEnumUInt32 Enum5 { get; }
+            public string Str1 { get; }
+            public string Str2 { get; }
+            public string Str3 { get; }
+            public char Char1 { get; }
+            public char Char2 { get; }
+            public double Double1 { get; }
+            public double Double2 { get; }
+            public double Double3 { get; }
+            public double Double4 { get; }
+            public double Double5 { get; }
+            public float Float1 { get; }
+            public float Float2 { get; }
+            public float Float3 { get; }
+            public float Float4 { get; }
+            public float Float5 { get; }
+            public byte Byte { get; }
+            public decimal Decimal1 { get; }
+            public decimal Decimal2 { get; }
+            public short Short { get; }
+            public sbyte Sbyte { get; }
+            public int Int { get; }
+            public long Long { get; }
+            public ushort UShort { get; }
+            public uint UInt { get; }
+            public ulong ULong { get; }
 
             public ClassWithDefaultCtorParams(
-                string prop1 = "abc",
-                string prop2 = "",
-                char prop3 = 'a',
-                double prop4 = double.NegativeInfinity,
-                double prop5 = double.PositiveInfinity,
-                double prop6 = double.NaN,
-                float prop7 = float.NegativeInfinity,
-                float prop8 = float.PositiveInfinity,
-                float prop9 = float.NaN)
+                Point_2D_Struct_WithAttribute @struct = default,
+                DayOfWeek enum1 = default,
+                DayOfWeek enum2 = DayOfWeek.Sunday,
+                DayOfWeek enum3 = DayOfWeek.Sunday | DayOfWeek.Monday,
+                BindingFlags enum4 = BindingFlags.CreateInstance | BindingFlags.ExactBinding,
+                SampleEnumUInt32 enum5 = SampleEnumUInt32.MinZero,
+                string str1 = "abc",
+                string str2 = "",
+                string str3 = "\n\r⁉️\'\"\u200D\f\t\v\0\a\b\\\'\"",
+                char char1 = 'a',
+                char char2 = '\u200D',
+                double double1 = double.NegativeInfinity,
+                double double2 = double.PositiveInfinity,
+                double double3 = double.NaN,
+                double double4 = double.MaxValue,
+                double double5 = double.Epsilon,
+                float float1 = float.NegativeInfinity,
+                float float2 = float.PositiveInfinity,
+                float float3 = float.NaN,
+                float float4 = float.MinValue,
+                float float5 = float.Epsilon,
+                byte @byte = byte.MinValue,
+                decimal @decimal1 = decimal.MinValue,
+                decimal @decimal2 = decimal.MaxValue,
+                short @short = short.MinValue,
+                sbyte @sbyte = sbyte.MaxValue,
+                int @int = int.MinValue,
+                long @long = long.MaxValue,
+                ushort @ushort = ushort.MinValue,
+                uint @uint = uint.MaxValue,
+                ulong @ulong = ulong.MinValue)
             {
-                Prop1 = prop1;
-                Prop2 = prop2;
-                Prop3 = prop3;
-                Prop4 = prop4;
-                Prop5 = prop5;
-                Prop6 = prop6;
-                Prop7 = prop7;
-                Prop8 = prop8;
-                Prop9 = prop9;
+                Struct = @struct;
+                Enum1 = enum1;
+                Enum2 = enum2;
+                Enum3 = enum3;
+                Enum4 = enum4;
+                Enum5 = enum5;
+                Str1 = str1;
+                Str2 = str2;
+                Str3 = str3;
+                Char1 = char1;
+                Char2 = char2;
+                Double1 = double1;
+                Double2 = double2;
+                Double3 = double3;
+                Double4 = double4;
+                Float1 = float1;
+                Float2 = float2;
+                Float3 = float3;
+                Float4 = float4;
+                Byte = @byte;
+                Decimal1 = @decimal1;
+                Decimal2 = @decimal2;
+                Short = @short;
+                Sbyte = @sbyte;
+                Int = @int;
+                Long = @long;
+                UShort = @ushort;
+                UInt = @uint;
+                ULong = @ulong;
             }
         }
     }

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.ParameterMatching.cs
@@ -1386,12 +1386,6 @@ namespace System.Text.Json.Serialization.Tests
             public long A;
             public StructWithExplicitParameterlessCtor() => A = 42;
         }
-        
-        public async Task TestClassWithEmptyStringDefaultCtorParam()
-        {
-            ClassWithDefaultCtorParams obj = new ClassWithDefaultCtorParams("value", "val", 'v', 1, 2, 3, 4, 5, 6);
-            string json = await JsonSerializerWrapperForString.SerializeWrapper(obj);
-        }
 
         public async Task TestClassWithDefaultCtorParams()
         {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
@@ -130,6 +130,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(LargeType_IgnoredProp_Bind_ParamWithDefaultValue))]
         [JsonSerializable(typeof(LargeType_IgnoredProp_Bind_Param))]
         [JsonSerializable(typeof(ClassWithIgnoredSameType))]
+        [JsonSerializable(typeof(ClassWithDefaultCtorParams))]
         internal sealed partial class ConstructorTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -251,6 +252,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(LargeType_IgnoredProp_Bind_ParamWithDefaultValue))]
         [JsonSerializable(typeof(LargeType_IgnoredProp_Bind_Param))]
         [JsonSerializable(typeof(ClassWithIgnoredSameType))]
+        [JsonSerializable(typeof(ClassWithDefaultCtorParams))]
         internal sealed partial class ConstructorTestsContext_Default : JsonSerializerContext
         {
         }


### PR DESCRIPTION
Fixes source gen issue where invalid code is generated by JSON source-gen when supporting default ctor param values, preventing successful app compilation.
Fixes https://github.com/dotnet/runtime/issues/62766.
Candidate for 6.0.x servicing fix.

cc @333fred