### PR TITLE
Fixing regression for AuthType.Anonymous  which leads to a NullReferenceException be thrown.

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -111,7 +111,7 @@ namespace System.DirectoryServices.Protocols
                 passwordPtr = LdapPal.StringToPtr(passwd);
                 BerVal passwordBerval = new BerVal
                 {
-                    bv_len = passwd.Length,
+                    bv_len = passwd?.Length ?? 0,
                     bv_val = passwordPtr,
                 };
 

--- a/src/libraries/System.DirectoryServices.Protocols/tests/LdapConnectionTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/LdapConnectionTests.cs
@@ -112,6 +112,16 @@ namespace System.DirectoryServices.Protocols.Tests
             Assert.Equal(AuthType.Basic, connection.AuthType);
         }
 
+        [Fact]
+        public void AuthType_Anonymous_DoesNotThrowNull()
+        {
+            var connection = new LdapConnection("server");
+            connection.AuthType = AuthType.Anonymous;
+            // When calling Bind we make sure that the exception thrown is not that there was a NullReferenceException
+            // trying to retrive a null password's lenght, but instead an LdapException given the server cannot be reached.
+            Assert.Throws<LdapException>(() => connection.Bind());
+        }
+
         [Theory]
         [InlineData(AuthType.Anonymous - 1)]
         [InlineData(AuthType.Kerberos + 1)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/61683 regression.

When we added support for LDAPS https://github.com/dotnet/runtime/pull/52904 we accidentally regressed the scenario for AuthType.Anonymous since you would have passed in a null password, and we would later try to dereference it. This change fixes that by setting the value length of the struct to 0, and I have validated that this does work for the anonymous scenario.