### PR TITLE
Make `ControlFlowBuilder.Clear` public.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
+++ b/src/libraries/System.Reflection.Metadata/ref/System.Reflection.Metadata.cs
@@ -2533,6 +2533,7 @@ namespace System.Reflection.Metadata.Ecma335
         public void AddFaultRegion(System.Reflection.Metadata.Ecma335.LabelHandle tryStart, System.Reflection.Metadata.Ecma335.LabelHandle tryEnd, System.Reflection.Metadata.Ecma335.LabelHandle handlerStart, System.Reflection.Metadata.Ecma335.LabelHandle handlerEnd) { }
         public void AddFilterRegion(System.Reflection.Metadata.Ecma335.LabelHandle tryStart, System.Reflection.Metadata.Ecma335.LabelHandle tryEnd, System.Reflection.Metadata.Ecma335.LabelHandle handlerStart, System.Reflection.Metadata.Ecma335.LabelHandle handlerEnd, System.Reflection.Metadata.Ecma335.LabelHandle filterStart) { }
         public void AddFinallyRegion(System.Reflection.Metadata.Ecma335.LabelHandle tryStart, System.Reflection.Metadata.Ecma335.LabelHandle tryEnd, System.Reflection.Metadata.Ecma335.LabelHandle handlerStart, System.Reflection.Metadata.Ecma335.LabelHandle handlerEnd) { }
+        public void Clear() { }
     }
     public readonly partial struct CustomAttributeArrayTypeEncoder
     {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/ControlFlowBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Encoding/ControlFlowBuilder.cs
@@ -85,7 +85,10 @@ namespace System.Reflection.Metadata.Ecma335
             _labels = ImmutableArray.CreateBuilder<int>();
         }
 
-        internal void Clear()
+        /// <summary>
+        /// Clears the object's internal state, allowing the same instance to be reused.
+        /// </summary>
+        public void Clear()
         {
             _branches.Clear();
             _labels.Clear();

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/ControlFlowBuilderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/ControlFlowBuilderTests.cs
@@ -418,5 +418,34 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                 (byte)ILOpCode.Ret
             }, builder.ToArray());
         }
+
+        [Fact]
+        public void Clear()
+        {
+            var cfb = new ControlFlowBuilder();
+
+            var il1 = GenerateSampleIL(cfb);
+            cfb.Clear();
+            var il2 = GenerateSampleIL(cfb);
+
+            AssertEx.Equal(il1, il2);
+
+            static byte[] GenerateSampleIL(ControlFlowBuilder cfb)
+            {
+                var code = new BlobBuilder();
+                var il = new InstructionEncoder(code, cfb);
+
+                var label = il.DefineLabel();
+
+                il.MarkLabel(label);
+                il.OpCode(ILOpCode.Nop);
+                il.Branch(ILOpCode.Br_s, label);
+
+                var builder = new BlobBuilder();
+                new MethodBodyStreamEncoder(builder).AddMethodBody(il);
+
+                return builder.ToArray();
+            }
+        }
     }
 }

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/ControlFlowBuilderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Ecma335/Encoding/ControlFlowBuilderTests.cs
@@ -435,11 +435,21 @@ namespace System.Reflection.Metadata.Ecma335.Tests
                 var code = new BlobBuilder();
                 var il = new InstructionEncoder(code, cfb);
 
-                var label = il.DefineLabel();
+                var l1 = il.DefineLabel();
+                var l2 = il.DefineLabel();
+                var l3 = il.DefineLabel();
+                var l4 = il.DefineLabel();
 
-                il.MarkLabel(label);
+                il.MarkLabel(l1);
                 il.OpCode(ILOpCode.Nop);
-                il.Branch(ILOpCode.Br_s, label);
+                il.Branch(ILOpCode.Br_s, l1);
+                il.MarkLabel(l2);
+                il.OpCode(ILOpCode.Nop);
+                il.MarkLabel(l3);
+                il.OpCode(ILOpCode.Nop);
+                il.MarkLabel(l4);
+
+                cfb.AddCatchRegion(l1, l2, l3, l4, MetadataTokens.TypeDefinitionHandle(1));
 
                 var builder = new BlobBuilder();
                 new MethodBodyStreamEncoder(builder).AddMethodBody(il);


### PR DESCRIPTION
This PR makes the `System.Reflection.Metadata.Ecma335.ControlFlowBuilder.Clear()` method public, as just approved. I also added a test that reuses a `ControlFlowBuilder`.

Fixes #58765