### PR TITLE
[release/6.0] [wasm][debugger] Avoiding assert on mono runtime

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DebugStore.cs
@@ -514,12 +514,13 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal PEReader peReader;
         internal MemoryStream asmStream;
         internal MemoryStream pdbStream;
-        public int DebugId { get; set; }
+        private int debugId;
 
         public bool TriedToLoadSymbolsOnDemand { get; set; }
 
         public unsafe AssemblyInfo(string url, byte[] assembly, byte[] pdb)
         {
+            debugId = -1;
             this.id = Interlocked.Increment(ref next_id);
             asmStream = new MemoryStream(assembly);
             peReader = new PEReader(asmStream);
@@ -542,7 +543,19 @@ namespace Microsoft.WebAssembly.Diagnostics
             AssemblyNameUnqualified = asmMetadataReader.GetAssemblyDefinition().GetAssemblyName().Name + ".dll";
             Populate();
         }
+        public async Task<int> GetDebugId(SessionId sessionId, MonoSDBHelper sdbAgent, CancellationToken token)
+        {
+            if (debugId > 0)
+                return debugId;
+            debugId = await sdbAgent.GetAssemblyId(sessionId, Name, token);
+            return debugId;
+        }
 
+        public void SetDebugId(int id)
+        {
+            if (debugId <= 0 && debugId != id)
+                debugId = id;
+        }
         public bool EnC(byte[] meta, byte[] pdb)
         {
             var asmStream = new MemoryStream(meta);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -124,7 +124,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     var type = asm.GetTypeByName(classNameToFind);
                     if (type != null)
                     {
-                        typeId = await sdbHelper.GetTypeIdFromToken(sessionId, asm.DebugId, type.Token, token);
+                        typeId = await sdbHelper.GetTypeIdFromToken(sessionId, await asm.GetDebugId(sessionId, sdbHelper, token), type.Token, token);
                     }
                 }
             }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -710,7 +710,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                     return null;
                 }
             }
-            asm.DebugId = assemblyId;
+            asm.SetDebugId(assemblyId);
             assemblies[assemblyId] = asm;
             return asm;
         }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -641,6 +641,28 @@ namespace DebuggerTests
                 );
             });
 
+        [Fact]
+        public async Task EvaluateStaticAttributeInAssemblyNotRelatedButLoaded() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateTestsClass/TestEvaluate", "EvaluateLocalsFromAnotherAssembly", 5, "EvaluateLocalsFromAnotherAssembly",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateTestsClass:EvaluateLocalsFromAnotherAssembly'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+               await EvaluateOnCallFrameAndCheck(id, 
+                   ("DebuggerTests.ClassToBreak.valueToCheck", TNumber(10)));
+           });
+
+        [Fact]
+        public async Task EvaluateLocalObjectFromAssemblyNotRelatedButLoaded()
+         => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateTestsClass/TestEvaluate", "EvaluateLocalsFromAnotherAssembly", 5, "EvaluateLocalsFromAnotherAssembly",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateTestsClass:EvaluateLocalsFromAnotherAssembly'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+               await EvaluateOnCallFrameAndCheck(id, 
+                   ("a.valueToCheck", TNumber(20)));
+           });
     }
 
 }

--- a/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test-with-source-link/test.cs
@@ -8,5 +8,14 @@ namespace DebuggerTests
         {
             return 50;
         }
+        public static int valueToCheck = 10;
+    }
+    public class ClassToCheckFieldValue
+    {
+        public int valueToCheck;
+        public ClassToCheckFieldValue()
+        {
+            valueToCheck = 20;
+        }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -28,6 +28,13 @@ namespace DebuggerTests
                 b = b + 1;
                 c = c + 1;
             }
+            public void EvaluateLocalsFromAnotherAssembly()
+            {
+                var asm = System.Reflection.Assembly.LoadFrom("debugger-test-with-source-link.dll");
+                var myType = asm.GetType("DebuggerTests.ClassToCheckFieldValue");
+                var myMethod = myType.GetConstructor(new Type[] { });
+                var a = myMethod.Invoke(new object[]{});
+            }
         }
 
         public static void EvaluateLocals()
@@ -40,6 +47,11 @@ namespace DebuggerTests
 
             var f_g_s = new EvaluateTestsGenericStruct<int>();
             f_g_s.EvaluateTestsGenericStructInstanceMethod(100, 200, "test");
+        }
+        public static void EvaluateLocalsFromAnotherAssembly()
+        {
+            TestEvaluate eval = new TestEvaluate();
+            eval.EvaluateLocalsFromAnotherAssembly();
         }
 
     }


### PR DESCRIPTION
Backport of #62601 to release/6.0

/cc @thaystg

## Customer Impact
As VS tries to evaluate a lot of things while hover the mouse on variables while debugging, could be causing assert on runtime in the case of trying to evaluate in a static class that is in a loaded assembly but not added any breakpoint on it.

## Testing
Unit tests and manual tests on Blazor.

## Risk
Low Risk, only checking the debugId of the assembly and getting the correct one before send to debugger-agent.