### PR TITLE
Undo breaking change in 6.0 in environment variable configuration prefix support

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -78,17 +78,9 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
                     {
                         prefix = CustomPrefix;
                     }
-                    else if (key.StartsWith(_prefix, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // This prevents the prefix from being normalized.
-                        // We can also do a fast path branch, I guess? No point in reallocating if the prefix is empty.
-                        key = NormalizeKey(key.Substring(_prefix.Length));
-                        data[key] = entry.Value as string;
-
-                        continue;
-                    }
                     else
                     {
+                        AddIfPrefixed(data, NormalizeKey(key), (string?)entry.Value);
                         continue;
                     }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         {
             try
             {
-                Environment.SetEnvironmentVariable(environmentVariable, "myFooValue");
+                Environment.SetEnvironmentVariable(EnvironmentVariable, "myFooValue");
                 var configuration = new ConfigurationBuilder()
                     .AddEnvironmentVariables("Microsoft__Extensions__Configuration__EnvironmentVariables__Test__")
                     .Build();

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -220,7 +220,6 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void AddEnvironmentVariables_Bind_PrefixShouldNormalize()
         {
             try
@@ -242,7 +241,6 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void AddEnvironmentVariables_UsingDoubleUnderscores_Bind_PrefixWontNormalize()
         {
             try

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             }
             finally
             {
-                Environment.SetEnvironmentVariable(environmentVariable, null);
+                Environment.SetEnvironmentVariable(EnvironmentVariable, null);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
 
             envConfigSrc.Load(dict);
 
-            Assert.Equal("connection", envConfigSrc.Get("data:ConnectionString"));
+            Assert.Throws<InvalidOperationException>(() => envConfigSrc.Get("data:ConnectionString"));
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
                 {
                     {"_____EXPERIMENTAL__data__ConnectionString", "connection"}
                 };
-            var envConfigSrc = new EnvironmentVariablesConfigurationProvider("_____EXPERIMENTAL__");
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider("::_EXPERIMENTAL:");
 
             envConfigSrc.Load(dict);
 
@@ -194,7 +194,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
 
             envConfigSrc.Load(dict);
 
-            Assert.Equal("connection", envConfigSrc.Get("test:ConnectionString"));
+            Assert.Throws<InvalidOperationException>(() => envConfigSrc.Get("test:ConnectionString"));
         }
 
         [Fact]
@@ -205,12 +205,62 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
                     {"test__test__ConnectionString", "connection"},
                     {"SQLCONNSTR_db1", "connStr"}
                 };
-            var envConfigSrc = new EnvironmentVariablesConfigurationProvider("test__");
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider("test:");
 
             envConfigSrc.Load(dict);
 
             Assert.Equal("connection", envConfigSrc.Get("test:ConnectionString"));
             Assert.Throws<InvalidOperationException>(() => envConfigSrc.Get("ConnectionStrings:db1_ProviderName"));
+        }
+
+        public const string EnvironmentVariable = "Microsoft__Extensions__Configuration__EnvironmentVariables__Test__Foo";
+        public class SettingsWithFoo
+        {
+            public string? Foo { get; set; }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void AddEnvironmentVariables_Bind_PrefixShouldNormalize()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariable, "myFooValue");
+                var configuration = new ConfigurationBuilder()
+                    .AddEnvironmentVariables("Microsoft:Extensions:Configuration:EnvironmentVariables:Test:")
+                    .Build();
+
+                var settingsWithFoo = new SettingsWithFoo();
+                configuration.Bind(settingsWithFoo);
+
+                Assert.Equal("myFooValue", settingsWithFoo.Foo);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariable, null);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void AddEnvironmentVariables_UsingDoubleUnderscores_Bind_PrefixWontNormalize()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(environmentVariable, "myFooValue");
+                var configuration = new ConfigurationBuilder()
+                    .AddEnvironmentVariables("Microsoft__Extensions__Configuration__EnvironmentVariables__Test__")
+                    .Build();
+
+                var settingsWithFoo = new SettingsWithFoo();
+                configuration.Bind(settingsWithFoo);
+
+                Assert.Null(settingsWithFoo.Foo);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(environmentVariable, null);
+            }
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]


### PR DESCRIPTION
When using environment variable configuration, brings back support for prefix being normalized like it was in dotnet 5.0.

The prefix is expected to use ":" to work (refer to updated tests).

Fixing regression from last release. Revert changes made in https://github.com/dotnet/runtime/pull/42932/files while updating tests to reduce ambiguity.

Fixes #61577