### PR TITLE
Manifest DllImportSourceGenerator as a generator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Directory.Build.props
+++ b/src/libraries/System.Runtime.InteropServices/gen/Directory.Build.props
@@ -8,5 +8,6 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <CLSCompliant>false</CLSCompliant>
     <ILLinkTrimAssembly>false</ILLinkTrimAssembly>
+    <IsGeneratorProject>true</IsGeneratorProject>
   </PropertyGroup>
 </Project>

--- a/src/tests/Common/Directory.Build.targets
+++ b/src/tests/Common/Directory.Build.targets
@@ -176,12 +176,7 @@
       <AotCompilerCopyLocal Include="$(CoreCLRArtifactsPath)aotsdk/**/*" TargetDir="nativeaot/sdk/" />
       <AotCompilerCopyLocal Include="$(CoreCLRArtifactsPath)build/**/*" TargetDir="nativeaot/build/" />
       <AotCompilerCopyLocal Include="$(TargetingPackPath)/*" TargetDir="nativeaot/framework/" />
-
-      <!-- Works around https://github.com/dotnet/runtime/issues/62372 -->
-      <_FixedRuntimeCopyLocalItems Include="@(RuntimeCopyLocalItems)" />
-      <_FixedRuntimeCopyLocalItems Remove="@(_FixedRuntimeCopyLocalItems)" Condition="'%(Filename)' == 'Microsoft.Interop.DllImportGenerator'" />
-
-      <AotCompilerCopyLocal Include="@(_FixedRuntimeCopyLocalItems)" TargetDir="nativeaot/framework/" />
+      <AotCompilerCopyLocal Include="@(RuntimeCopyLocalItems)" TargetDir="nativeaot/framework/" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and '$(IsDesktopOS)' == 'true' " >

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -122,10 +122,7 @@
     </RemoveDuplicates>
     <ItemGroup>
       <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/*.dll" />
-      <CoreRootDlls Include="$(CORE_ROOT)/*.dll"
-        Exclude="$(CORE_ROOT)/xunit.performance.api.dll;
-                 $(CORE_ROOT)/Microsoft.Interop.DllImportGenerator.dll;
-                 $(CORE_ROOT)/Microsoft.Interop.SourceGeneration.dll" />
+      <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll" />
       <AllDlls Condition="'$(MonoFullAot)' == 'true'" Include="@(TestsAndAssociatedAssemblies);@(CoreRootDlls)" />
       <AllDlls Condition="'$(MonoFullAot)' != 'true'" Include="@(TestsAndAssociatedAssemblies)" />
     </ItemGroup>


### PR DESCRIPTION
The libraries build infra normally does this automatically but the interop source generator doesn't follow the path convention.

Without this manifestation, the build considers the generator part of framework and it gets binplaced into places where it shouldn't be.

Fixes #62372.