### PR TITLE
Include Microsoft.NETCore.App.Ref pack as part of 6.0.2 release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     manually enabled by updating the metadata.
   -->
   <ItemGroup>
-    <!-- Targeting packs are only patched in extreme cases. -->
+    <!-- Targeting packs are only patched when we need to patch reference assemblies, intellisense, or source generators. -->
     <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="2" />
   </ItemGroup>
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
   -->
   <ItemGroup>
     <!-- Targeting packs are only patched in extreme cases. -->
-    <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="1" />
+    <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="2" />
   </ItemGroup>
   <PropertyGroup>
     <!-- For source generator support we need to target multiple versions of Rolsyn in order to be able to run on older versions of Roslyn -->


### PR DESCRIPTION
There are a bunch of source generator fixes that ship with the ref pack so we need to build it for 6.0.2.