### PR TITLE
Allow empty IGs when allocating unwind info for a fragment

### DIFF
--- a/src/coreclr/jit/unwindarm.cpp
+++ b/src/coreclr/jit/unwindarm.cpp
@@ -1628,7 +1628,8 @@ void UnwindFragmentInfo::Allocate(
         endOffset = ufiNext->GetStartOffset();
     }
 
-    assert(endOffset > startOffset);
+    // Either we have valid codeSize or the IG is empty.
+    assert((endOffset > startOffset) || (this->ufiEmitLoc->GetIG()->igSize == 0));
     codeSize = endOffset - startOffset;
 
     // Finalize the fragment unwind block to hand to the VM


### PR DESCRIPTION
The empty IGs are sometimes created before the loop that we are trying to align to ensure the loop size calculation is correct.

Fixes: #62250