### PR TITLE
Deduplicate JIT/Methodical/explicit/coverage tests

### DIFF
--- a/src/tests/JIT/Methodical/explicit/coverage/body_byte.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_byte.cs
@@ -488,7 +488,7 @@ internal class TestApp
         return AA.call_target_ref(ref (*((AA*)ptr_init)).q);
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_double.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_double.cs
@@ -362,7 +362,7 @@ internal class TestApp
         return AA.call_target_ref(ref (*((AA*)ptr_init)).q);
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_float.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_float.cs
@@ -362,7 +362,7 @@ internal class TestApp
         return AA.call_target_ref(ref (*((AA*)ptr_init)).q);
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_int.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_int.cs
@@ -488,7 +488,7 @@ internal class TestApp
         return AA.call_target_ref(ref (*((AA*)ptr_init)).q);
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_long.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_long.cs
@@ -488,7 +488,7 @@ internal class TestApp
         return AA.call_target_ref(ref (*((AA*)ptr_init)).q);
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_obj.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_obj.cs
@@ -349,7 +349,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q.val;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_byte.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_byte.cs
@@ -409,7 +409,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_double.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_double.cs
@@ -304,7 +304,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_float.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_float.cs
@@ -304,7 +304,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_int.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_int.cs
@@ -409,7 +409,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_long.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_long.cs
@@ -409,7 +409,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_obj.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_obj.cs
@@ -349,7 +349,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q.val;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_short.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_short.cs
@@ -409,7 +409,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_safe_val.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_safe_val.cs
@@ -349,7 +349,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q.val;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_short.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_short.cs
@@ -488,7 +488,7 @@ internal class TestApp
         return AA.call_target_ref(ref (*((AA*)ptr_init)).q);
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/body_val.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_val.cs
@@ -349,7 +349,7 @@ internal class TestApp
         return __refvalue(tr_init, AA).q.val;
     }
 
-    private static unsafe int Main()
+    internal static unsafe int RunAllTests()
     {
         AA.reset();
         if (test_0_0(100, new AA(100), new AA(0)) != 100)

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal struct AA
@@ -68,6 +69,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1_d.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_byte_1_r.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_double_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal struct AA
@@ -59,6 +60,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_double_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_double_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_double_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_double_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_float_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal struct AA
@@ -59,6 +60,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_float_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_float_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_float_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_float_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal class AA
@@ -62,6 +63,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1_d.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_byte_1_r.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal class AA
@@ -68,6 +69,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_double_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal class AA
@@ -71,6 +72,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_float_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal class AA
@@ -62,6 +63,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_int_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal class AA
@@ -59,6 +60,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_long_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal class QQ
 {
@@ -66,6 +67,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_obj_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal class AA
@@ -68,6 +69,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_short_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal struct QQ
 {
@@ -75,6 +76,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_gc_val_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_int_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal struct AA
@@ -68,6 +69,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_int_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_int_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_int_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_int_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_long_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal struct AA
@@ -71,6 +72,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_long_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_long_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_long_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_long_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal class QQ
 {
@@ -75,6 +76,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_obj_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_short_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 internal struct AA
@@ -62,6 +63,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_short_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_short_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_short_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_short_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_val_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal struct QQ
 {
@@ -75,6 +76,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_val_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_val_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/expl_val_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/expl_val_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct AA
@@ -59,6 +60,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1_d.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_byte_1_r.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_double_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct AA
@@ -58,6 +59,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_double_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_double_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_double_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_double_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_float_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct AA
@@ -58,6 +59,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_float_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_float_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_float_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_float_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal class AA
@@ -62,6 +63,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1_d.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_byte_1_r.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal class AA
@@ -67,6 +68,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_double_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal class AA
@@ -70,6 +71,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_float_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal class AA
@@ -61,6 +62,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_int_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal class AA
@@ -58,6 +59,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_long_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal class QQ
 {
@@ -66,6 +67,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_obj_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal class AA
@@ -68,6 +69,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_short_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal struct QQ
 {
@@ -75,6 +76,12 @@ internal class AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_gc_val_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_int_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_int_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct AA
@@ -67,6 +68,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_int_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_int_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_int_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_int_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_long_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_long_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct AA
@@ -70,6 +71,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_long_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_long_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_long_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_long_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal class QQ
 {
@@ -75,6 +76,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_obj_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_short_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_short_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Sequential)]
 internal struct AA
@@ -62,6 +63,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_short_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_short_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_short_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_short_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_val_1.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_val_1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Xunit;
 
 internal struct QQ
 {
@@ -66,6 +67,12 @@ internal struct AA
         _zero = new AA(0);
         BB.f_init = new AA(100);
         BB.f_zero = new AA(0);
+    }
+
+    [Fact]
+    public static int TestEntrypoint()
+    {
+        return TestApp.RunAllTests();
     }
 }
 

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_val_1_d.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_val_1_d.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/explicit/coverage/seq_val_1_r.csproj
+++ b/src/tests/JIT/Methodical/explicit/coverage/seq_val_1_r.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <RestorePackages>false</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugType>None</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
This test set contains several project groups exercising various
primitive types using explicit and sequential layout. Each group
comprises a variant source file implementing a sequential or
explicit struct / class 'AA' with a field of the given type
(e.g. expl_byte_1.cs / seq_byte_1.cs) and a common source file
(body_byte.cs in this case) implementing a number of tests
manipulating the type 'AA' that is shared by the explicit and
the sequential variant of the project (e.q. expl_byte_1[_d/_r].csproj,
seq_byte_1[_d/_r].csproj).

The problem was that the Main method resided in the common source
file so that it was always present twice - once for the sequential
and once for the explicit variant of the test (ignoring the _d / _r
flavors). After experimenting with several ways to refactor the tests
I have come to the conclusion that the most straightforward way
of deduplicating them is just moving the Main method out of the shared
source code into the variant (explicit / sequential) sources that
aren't shared.

Thanks

Tomas

/cc @dotnet/jit-contrib 