### PR TITLE
Remove forward-sub for hw intrinsics during inlining

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -20838,33 +20838,8 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
             // TODO-1stClassStructs: We currently do not reuse an existing lclVar
             // if it is a struct, because it requires some additional handling.
 
-            bool substitute = false;
-            switch (argNode->OperGet())
-            {
-#ifdef FEATURE_HW_INTRINSICS
-                case GT_HWINTRINSIC:
-                {
-                    // Enable for all parameterless (=invariant) hw intrinsics such as
-                    // Vector128<>.Zero and Vector256<>.AllBitSets. We might consider
-                    // doing that for Vector.Create(cns) as well.
-                    if (argNode->AsHWIntrinsic()->GetOperandCount() == 0)
-                    {
-                        substitute = true;
-                    }
-                    break;
-                }
-#endif
-
-                // TODO: Enable substitution for CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE (typeof(T))
-                // but in order to benefit from that, we need to move various "typeof + IsValueType"
-                // optimizations from importer to morph.
-
-                default:
-                    break;
-            }
-
-            if (substitute || (!varTypeIsStruct(lclTyp) && !argInfo.argHasSideEff && !argInfo.argHasGlobRef &&
-                               !argInfo.argHasCallerLocalRef))
+            if ((!varTypeIsStruct(lclTyp) && !argInfo.argHasSideEff && !argInfo.argHasGlobRef &&
+                 !argInfo.argHasCallerLocalRef))
             {
                 /* Get a *LARGE* LCL_VAR node */
                 op1 = gtNewLclLNode(tmpNum, genActualType(lclTyp) DEBUGARG(lclNum));


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/60330

it needs a better forward-sub pass (I am planning to come up with a prototype soon) to properly substitute struct types, currently we might end up with:
```
               [000021] n----------- arg1         +--*  OBJ       simd12<System.Numerics.Vector3>
               [000020] ------------              |  \--*  ADDR      byref
               [000009] ------------              |     \--*  LCL_VAR

after fsub:

               [000021] n----------- arg1         +--*  OBJ       simd12<System.Numerics.Vector3>
               [000020] ------------              |  \--*  ADDR      byref
               [000009] ------------              |     \--*  HWINTRINSIC simd12 float get_Zero

while expected to be:

               [000009] ------------              +--*  HWINTRINSIC simd12 float get_Zero
```
cc @kunalspathak 