### PR TITLE
setInternalRegsDelayFree only for candidate lclVars

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3456,8 +3456,12 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
             {
                 // Need an additional register to create a SIMD8 from EAX/EDX without SSE4.1.
                 buildInternalFloatRegisterDefForNode(storeLoc, allSIMDRegs());
-                // This internal register must be different from the target register.
-                setInternalRegsDelayFree = true;
+
+                if (isCandidateVar(varDsc))
+                {
+                    // This internal register must be different from the target register.
+                    setInternalRegsDelayFree = true;
+                }
             }
         }
 #endif // FEATURE_SIMD && TARGET_X86


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/58914 , we partially fixed the https://github.com/dotnet/runtime/issues/58899, but it should have taken into account it only for candidate lclVars. Without this, we would end up having a `delayFree` on last use and when we see the new refposition, we would assert because there was a pending `delayRegFree` without reference.

Fixes: https://github.com/dotnet/runtime/issues/61579