### PR TITLE
Arm64: Memory barrier improvements

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1429,8 +1429,9 @@ public:
 
     enum BarrierKind
     {
-        BARRIER_FULL,      // full barrier
-        BARRIER_LOAD_ONLY, // load barier
+        BARRIER_FULL,       // full barrier
+        BARRIER_LOAD_ONLY,  // load barier
+        BARRIER_STORE_ONLY, // store barrier
     };
 
     void instGen_MemoryBarrier(BarrierKind barrierKind = BARRIER_FULL);

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1429,9 +1429,8 @@ public:
 
     enum BarrierKind
     {
-        BARRIER_FULL,       // full barrier
-        BARRIER_LOAD_ONLY,  // load barier
-        BARRIER_STORE_ONLY, // store barrier
+        BARRIER_FULL,      // full barrier
+        BARRIER_LOAD_ONLY, // load barier
     };
 
     void instGen_MemoryBarrier(BarrierKind barrierKind = BARRIER_FULL);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4083,6 +4083,12 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                                 }
                             }
                         }
+                        if (tree->gtFlags & GTF_IND_VOLATILE)
+                        {
+                            // For volatile store/loads when address is contained we always emit `dmb`
+                            // if it's not - we emit stlr/ldlr
+                            doAddrMode = false;
+                        }
                         if (doAddrMode && gtMarkAddrMode(addr, &costEx, &costSz, tree->TypeGet()))
                         {
                             goto DONE;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4083,12 +4083,14 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                                 }
                             }
                         }
+#ifdef TARGET_ARM64
                         if (tree->gtFlags & GTF_IND_VOLATILE)
                         {
                             // For volatile store/loads when address is contained we always emit `dmb`
-                            // if it's not - we emit stlr/ldlr
+                            // if it's not - we emit one-way barriers i.e. ldar/stlr
                             doAddrMode = false;
                         }
+#endif // TARGET_ARM64
                         if (doAddrMode && gtMarkAddrMode(addr, &costEx, &costSz, tree->TypeGet()))
                         {
                             goto DONE;


### PR DESCRIPTION
- Generate store barriers wherever possible. Currently, we generate full barriers for stores.
- Generate one-way barriers for `volatile` variable which makes the speed of `volatile` declared variables as observed in https://github.com/dotnet/runtime/issues/60232. Thanks @EgorBo  for suggesting the solution as well.
