### PR TITLE
[wasm] Tweak set timeout

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.Mono.cs
@@ -28,10 +28,9 @@ namespace System.Threading
         }
 
         [DynamicDependency("TimeoutCallback")]
-        // The id argument is unused in netcore
         // This replaces the current pending setTimeout with shorter one
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        private static extern void SetTimeout(int timeout, int id);
+        private static extern void SetTimeout(int timeout);
 
         // Called by mini-wasm.c:mono_set_timeout_exec
         private static void TimeoutCallback()
@@ -78,7 +77,7 @@ namespace System.Threading
                 int shortestWait = Math.Max((int)(shortestDueTimeMs - currentTimeMs), 0);
                 // this would cancel the previous schedule and create shorter one
                 // it is expensive call
-                SetTimeout(shortestWait, 0);
+                SetTimeout(shortestWait);
             }
         }
 

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -585,12 +585,15 @@ mono_set_timeout_exec (int id)
 {
 	ERROR_DECL (error);
 
-	MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "TimerQueue");
-	g_assert (klass);
+	static MonoMethod *method = NULL;
+	if (method == NULL) {
+		MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "TimerQueue");
+		g_assert (klass);
 
-	MonoMethod *method = mono_class_get_method_from_name_checked (klass, "TimeoutCallback", -1, 0, error);
-	mono_error_assert_ok (error);
-	g_assert (method);
+		method = mono_class_get_method_from_name_checked (klass, "TimeoutCallback", -1, 0, error);
+		mono_error_assert_ok (error);
+		g_assert (method);
+	}
 
 	gpointer params[1] = { &id };
 	MonoObject *exc = NULL;
@@ -626,12 +629,15 @@ tp_cb (void)
 {
 	ERROR_DECL (error);
 
-	MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "ThreadPool");
-	g_assert (klass);
+	static MonoMethod *method = NULL;
+	if (method == NULL) {
+		MonoClass *klass = mono_class_load_from_name (mono_defaults.corlib, "System.Threading", "ThreadPool");
+		g_assert (klass);
 
-	MonoMethod *method = mono_class_get_method_from_name_checked (klass, "Callback", -1, 0, error);
-	mono_error_assert_ok (error);
-	g_assert (method);
+		method = mono_class_get_method_from_name_checked (klass, "Callback", -1, 0, error);
+		mono_error_assert_ok (error);
+		g_assert (method);
+	}
 
 	MonoObject *exc = NULL;
 

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -439,10 +439,10 @@ mono_arch_get_delegate_invoke_impl (MonoMethodSignature *sig, gboolean has_targe
 
 //functions exported to be used by JS
 G_BEGIN_DECLS
-EMSCRIPTEN_KEEPALIVE void mono_set_timeout_exec (int id);
+EMSCRIPTEN_KEEPALIVE void mono_set_timeout_exec (void);
 
 //JS functions imported that we use
-extern void mono_set_timeout (int t, int d);
+extern void mono_set_timeout (int t);
 extern void mono_wasm_queue_tp_cb (void);
 G_END_DECLS
 
@@ -581,7 +581,7 @@ mono_thread_state_init_from_handle (MonoThreadUnwindState *tctx, MonoThreadInfo 
 }
 
 EMSCRIPTEN_KEEPALIVE void
-mono_set_timeout_exec (int id)
+mono_set_timeout_exec (void)
 {
 	ERROR_DECL (error);
 
@@ -595,10 +595,9 @@ mono_set_timeout_exec (int id)
 		g_assert (method);
 	}
 
-	gpointer params[1] = { &id };
 	MonoObject *exc = NULL;
 
-	mono_runtime_try_invoke (method, NULL, params, &exc, error);
+	mono_runtime_try_invoke (method, NULL, NULL, &exc, error);
 
 	//YES we swallow exceptions cuz there's nothing much we can do from here.
 	//FIXME Maybe call the unhandled exception function?
@@ -617,10 +616,10 @@ mono_set_timeout_exec (int id)
 #endif
 
 void
-mono_wasm_set_timeout (int timeout, int id)
+mono_wasm_set_timeout (int timeout)
 {
 #ifdef HOST_BROWSER
-	mono_set_timeout (timeout, id);
+	mono_set_timeout (timeout);
 #endif
 }
 

--- a/src/mono/mono/mini/mini-wasm.h
+++ b/src/mono/mono/mini/mini-wasm.h
@@ -100,7 +100,7 @@ typedef struct {
 // sdks/wasm/driver.c is C and uses this
 G_EXTERN_C void mono_wasm_enable_debugging (int log_level);
 
-void mono_wasm_set_timeout (int timeout, int id);
+void mono_wasm_set_timeout (int timeout);
 
 int mono_wasm_assembly_already_added (const char *assembly_name);
 void mono_wasm_print_stack_trace (void);

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -21,7 +21,7 @@ const fn_signatures: [ident: string, returnType: string | null, argTypes?: strin
     ["mono_wasm_parse_runtime_options", null, ["number", "number"]],
     ["mono_wasm_strdup", "number", ["string"]],
     ["mono_background_exec", null, []],
-    ["mono_set_timeout_exec", null, ["number"]],
+    ["mono_set_timeout_exec", null, []],
     ["mono_wasm_load_icu_data", "number", ["number"]],
     ["mono_wasm_get_icudt_name", "string", ["string"]],
     ["mono_wasm_add_assembly", "number", ["string", "number", "number"]],
@@ -82,7 +82,7 @@ export interface t_Cwraps {
     mono_wasm_strdup(value: string): number;
     mono_wasm_parse_runtime_options(length: number, argv: VoidPtr): void;
     mono_background_exec(): void;
-    mono_set_timeout_exec(id: number): void;
+    mono_set_timeout_exec(): void;
     mono_wasm_load_icu_data(offset: VoidPtr): number;
     mono_wasm_get_icudt_name(name: string): string;
     mono_wasm_add_assembly(name: string, data: VoidPtr, size: number): number;

--- a/src/mono/wasm/runtime/scheduling.ts
+++ b/src/mono/wasm/runtime/scheduling.ts
@@ -38,7 +38,7 @@ export function prevent_timer_throttling(): void {
     for (let schedule = next_reach_time; schedule < desired_reach_time; schedule += light_throttling_frequency) {
         const delay = schedule - now;
         setTimeout(() => {
-            cwraps.mono_set_timeout_exec(0);
+            cwraps.mono_set_timeout_exec();
             pump_count++;
             pump_message();
         }, delay);
@@ -52,9 +52,9 @@ export function schedule_background_exec(): void {
 }
 
 let lastScheduledTimeoutId: any = undefined;
-export function mono_set_timeout(timeout: number, id: number): void {
+export function mono_set_timeout(timeout: number): void {
     function mono_wasm_set_timeout_exec() {
-        cwraps.mono_set_timeout_exec(id);
+        cwraps.mono_set_timeout_exec();
     }
     if (lastScheduledTimeoutId) {
         clearTimeout(lastScheduledTimeoutId);


### PR DESCRIPTION
- Cache method lookup for TimerQueue.TimeoutCallback and ThreadPool.Callback.
- Remove unused parameter "id" from timer related functions.