### PR TITLE
Use System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -28,14 +28,6 @@
     <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
       <method name="LoadInMemoryAssembly" />
     </type>
-
-    <!-- Native hosting accesses managed methods in the ComponentActivator class.
-         These are always rooted to ensure native calls get trimmer related errors
-         but will be trimmed away by the related feature switch -->
-    <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
-      <method name="LoadAssemblyAndGetFunctionPointer" />
-      <method name="GetFunctionPointer" />
-    </type>
   </assembly>
 
   <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -28,6 +28,14 @@
     <type fullname="Internal.Runtime.InteropServices.InMemoryAssemblyLoader">
       <method name="LoadInMemoryAssembly" />
     </type>
+
+    <!-- Native hosting accesses managed methods in the ComponentActivator class.
+         These are always rooted to ensure native calls get trimmer related errors
+         but will be trimmed away by the related feature switch -->
+    <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
+      <method name="LoadAssemblyAndGetFunctionPointer" />
+      <method name="GetFunctionPointer" />
+    </type>
   </assembly>
 
   <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -6,10 +6,14 @@
              https://github.com/mono/linker/pull/649 -->
       <method name=".ctor" />
     </type>
+  </assembly>
 
-    <!-- Native hosting accesses managed methods in the ComponentActivator class.
-         These are always rooted to ensure native calls get trimmer related errors
-         but will be trimmed away by the related feature switch -->
+  <assembly fullname="System.Private.CoreLib" feature="System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting" featurevalue="true">
+    <!-- Native hosting accesses managed methods from
+    https://github.com/dotnet/runtime/blob/bbc898f3e5678135b242faeb6eefd8b24bf04f3c/src/native/corehost/hostpolicy/hostpolicy.cpp#L527-L538
+    but ComponentActivator is not trimming safe. We persist the methods only when `_EnableConsumingManagedCodeFromNativeHosting` setting
+    is enabled and only then we show the trimming warnings about possibly missing dependencies.
+    -->
     <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
       <method name="LoadAssemblyAndGetFunctionPointer" />
       <method name="GetFunctionPointer" />

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -6,6 +6,14 @@
              https://github.com/mono/linker/pull/649 -->
       <method name=".ctor" />
     </type>
+
+    <!-- Native hosting accesses managed methods in the ComponentActivator class.
+         These are always rooted to ensure native calls get trimmer related errors
+         but will be trimmed away by the related feature switch -->
+    <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
+      <method name="LoadAssemblyAndGetFunctionPointer" />
+      <method name="GetFunctionPointer" />
+    </type>
   </assembly>
   
   <!-- Properties and methods used by a debugger. -->

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -6,14 +6,6 @@
              https://github.com/mono/linker/pull/649 -->
       <method name=".ctor" />
     </type>
-
-    <!-- Native hosting accesses managed methods in the ComponentActivator class.
-         These are always rooted to ensure native calls get trimmer related errors
-         but will be trimmed away by the related feature switch -->
-    <type fullname="Internal.Runtime.InteropServices.ComponentActivator">
-      <method name="LoadAssemblyAndGetFunctionPointer" />
-      <method name="GetFunctionPointer" />
-    </type>
   </assembly>
   
   <!-- Properties and methods used by a debugger. -->


### PR DESCRIPTION
feature switch to keep native hosting ComponentActivator dependencies to bring back no trimming warnings for  System.Private.Corelib.

`System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting` is by default  disabled (false) when apps are trimmed. Users will need to pass `_EnableConsumingManagedCodeFromNativeHosting` to re-enable native hosting with `ComponentActivator` I think that's fine because `ComponentActivator` is marked as never trimming safe, effectively making trimming + native hosting risky configuration.