### PR TITLE
[wasm] callback to make waiting on module load easier

### DIFF
--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.extpost.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.extpost.js
@@ -4,3 +4,6 @@ let ENVIRONMENT_IS_GLOBAL = typeof globalThis.Module === "object" && globalThis.
 if (ENVIRONMENT_IS_GLOBAL) {
     createDotnetRuntime(() => { return globalThis.Module; }).then((exports) => exports);
 }
+else if (typeof globalThis.__onDotnetRuntimeLoaded === "function") {
+    globalThis.__onDotnetRuntimeLoaded(createDotnetRuntime);
+}

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -371,9 +371,7 @@ async function loadDotnet(file) {
                     if (createDotnetRuntime) {
                         resolve(createDotnetRuntime);
                     }
-                }).catch((err) => {
-                    reject(err);
-                });
+                }, reject);
             });
             return loaded;
         }

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -160,8 +160,7 @@ loadDotnet("./dotnet.js").then((createDotnetRuntime) => {
     }))
 }).catch(function (err) {
     console.error(err);
-    set_exit_code(1, "failed to load the dotnet.js file");
-    throw err;
+    set_exit_code(1, "failed to load the dotnet.js file.\n" + err);
 });
 
 const App = {
@@ -363,20 +362,18 @@ async function loadDotnet(file) {
     } else if (is_browser) { // vanila JS in browser
         loadScript = function (file) {
             var loaded = new Promise((resolve, reject) => {
-                try {
-                    globalThis.__onDotnetRuntimeLoaded = (createDotnetRuntime) => {
-                        // this is callback we have in CJS version of the runtime
+                globalThis.__onDotnetRuntimeLoaded = (createDotnetRuntime) => {
+                    // this is callback we have in CJS version of the runtime
+                    resolve(createDotnetRuntime);
+                };
+                import(file).then(({ default: createDotnetRuntime }) => {
+                    // this would work with ES6 default export
+                    if (createDotnetRuntime) {
                         resolve(createDotnetRuntime);
-                    };
-                    import(file).then(({ default: createDotnetRuntime }) => {
-                        // this would work with ES6 default export
-                        if (createDotnetRuntime) {
-                            resolve(createDotnetRuntime);
-                        }
-                    });
-                } catch (err) {
+                    }
+                }).catch((err) => {
                     reject(err);
-                }
+                });
             });
             return loaded;
         }

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -361,7 +361,7 @@ async function loadDotnet(file) {
             return require(file);
         };
     } else if (is_browser) { // vanila JS in browser
-        loadScript = async function (file) {
+        loadScript = function (file) {
             var loaded = new Promise((resolve, reject) => {
                 try {
                     globalThis.__onDotnetRuntimeLoaded = (createDotnetRuntime) => {

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -361,14 +361,19 @@ async function loadDotnet(file) {
             return require(file);
         };
     } else if (is_browser) { // vanila JS in browser
-        loadScript = function (file) {
-            // this is callback we have in CJS version of the runtime
+        loadScript = async function (file) {
             var loaded = new Promise((resolve, reject) => {
                 try {
                     globalThis.__onDotnetRuntimeLoaded = (createDotnetRuntime) => {
+                        // this is callback we have in CJS version of the runtime
                         resolve(createDotnetRuntime);
                     };
-                    import(file);
+                    import(file).then(({ default: createDotnetRuntime }) => {
+                        // this would work with ES6 default export
+                        if (createDotnetRuntime) {
+                            resolve(createDotnetRuntime);
+                        }
+                    });
                 } catch (err) {
                     reject(err);
                 }


### PR DESCRIPTION
This would simplify loading of CJS for Blazor