### PR TITLE
[release/6.0] Fix Microsoft.VisualBasic.Core file version

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/Directory.Build.props
+++ b/src/libraries/Microsoft.VisualBasic.Core/Directory.Build.props
@@ -1,7 +1,13 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>$([MSBuild]::Add($(MajorVersion), 5)).$(MinorVersion).0.0</AssemblyVersion>
+    <!-- We need to set MajorVersion so that FileVersion is set correctly and is
+    greater than the one in the previous release -->
+    <MajorVersion>$([MSBuild]::Add($(MajorVersion), 5))</MajorVersion>
+    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+    <!-- We set the minor version as the major file version is the same as the
+    one in the previous release, so with minor version we make this file version greater -->
+    <MinorVersion>1</MinorVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/62218

## Customer Impact

When doing some refactoring on how we calculate assembly versions we accidentally removed a property that calculated the file version embedded into the assembly.  When an application is compiled as self-contained and bundled into an MSI file, upgrading from a previous (e.g. .NET 5) which can lead to this assembly missing on the installation location or the wrong assembly to be used.

## Testing

VIsual inspection of the assembly to make sure the file version is correct and higher than the ones in previous releases. 

![image](https://user-images.githubusercontent.com/22899328/146410539-58962225-6fe2-4711-8d77-bb1f850ed25c.png)

## Risk

Low, this is just changing the file version embedded into the assembly.
