### PR TITLE
Replace name with type and codepage in EncodingConversionOverflow exception

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1021,7 +1021,7 @@
     <value>Must complete Convert() operation or call Encoder.Reset() before calling GetBytes() or GetByteCount(). Encoder '{0}' fallback '{1}'.</value>
   </data>
   <data name="Argument_EncodingConversionOverflowBytes" xml:space="preserve">
-    <value>The output byte buffer is too small to contain the encoded data, encoding '{0}' with codepage '{1}' and fallback '{1}'.</value>
+    <value>The output byte buffer is too small to contain the encoded data, encoding '{0}' with codepage '{1}' and fallback '{2}'.</value>
   </data>
   <data name="Argument_EncodingConversionOverflowChars" xml:space="preserve">
     <value>The output char buffer is too small to contain the decoded characters, encoding '{0}' with codepage '{1}' and fallback '{2}'.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1021,10 +1021,10 @@
     <value>Must complete Convert() operation or call Encoder.Reset() before calling GetBytes() or GetByteCount(). Encoder '{0}' fallback '{1}'.</value>
   </data>
   <data name="Argument_EncodingConversionOverflowBytes" xml:space="preserve">
-    <value>The output byte buffer is too small to contain the encoded data, encoding '{0}' fallback '{1}'.</value>
+    <value>The output byte buffer is too small to contain the encoded data, encoding '{0}' with codepage '{1}' and fallback '{1}'.</value>
   </data>
   <data name="Argument_EncodingConversionOverflowChars" xml:space="preserve">
-    <value>The output char buffer is too small to contain the decoded characters, encoding '{0}' fallback '{1}'.</value>
+    <value>The output char buffer is too small to contain the decoded characters, encoding '{0}' with codepage '{1}' and fallback '{2}'.</value>
   </data>
   <data name="Argument_EncodingNotSupported" xml:space="preserve">
     <value>'{0}' is not a supported encoding name. For information on defining a custom encoding, see the documentation for the Encoding.RegisterProvider method.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1021,10 +1021,10 @@
     <value>Must complete Convert() operation or call Encoder.Reset() before calling GetBytes() or GetByteCount(). Encoder '{0}' fallback '{1}'.</value>
   </data>
   <data name="Argument_EncodingConversionOverflowBytes" xml:space="preserve">
-    <value>The output byte buffer is too small to contain the encoded data, encoding '{0}' with codepage '{1}' and fallback '{1}'.</value>
+    <value>The output byte buffer is too small to contain the encoded data, encoding codepage '{0}' and fallback '{1}'.</value>
   </data>
   <data name="Argument_EncodingConversionOverflowChars" xml:space="preserve">
-    <value>The output char buffer is too small to contain the decoded characters, encoding '{0}' with codepage '{1}' and fallback '{2}'.</value>
+    <value>The output char buffer is too small to contain the decoded characters, encoding codepage '{0}' and fallback '{1}'.</value>
   </data>
   <data name="Argument_EncodingNotSupported" xml:space="preserve">
     <value>'{0}' is not a supported encoding name. For information on defining a custom encoding, see the documentation for the Encoding.RegisterProvider method.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -1140,7 +1140,7 @@ namespace System.Text
             // Special message to include fallback type in case fallback's GetMaxCharCount is broken
             // This happens if user has implemented an encoder fallback with a broken GetMaxCharCount
             throw new ArgumentException(
-                SR.Format(SR.Argument_EncodingConversionOverflowBytes, EncodingName, EncoderFallback.GetType()), "bytes");
+                SR.Format(SR.Argument_EncodingConversionOverflowBytes, GetType(), _codePage, EncoderFallback.GetType()), "bytes");
 
         internal void ThrowBytesOverflow(EncoderNLS? encoder, bool nothingEncoded)
         {
@@ -1168,7 +1168,7 @@ namespace System.Text
             // Special message to include fallback type in case fallback's GetMaxCharCount is broken
             // This happens if user has implemented a decoder fallback with a broken GetMaxCharCount
             throw new ArgumentException(
-                SR.Format(SR.Argument_EncodingConversionOverflowChars, EncodingName, DecoderFallback.GetType()), "chars");
+                SR.Format(SR.Argument_EncodingConversionOverflowChars, GetType(), _codePage, DecoderFallback.GetType()), "chars");
 
         internal void ThrowCharsOverflow(DecoderNLS? decoder, bool nothingDecoded)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -1140,7 +1140,7 @@ namespace System.Text
             // Special message to include fallback type in case fallback's GetMaxCharCount is broken
             // This happens if user has implemented an encoder fallback with a broken GetMaxCharCount
             throw new ArgumentException(
-                SR.Format(SR.Argument_EncodingConversionOverflowBytes, GetType(), _codePage, EncoderFallback.GetType()), "bytes");
+                SR.Format(SR.Argument_EncodingConversionOverflowBytes, _codePage, EncoderFallback.GetType()), "bytes");
 
         internal void ThrowBytesOverflow(EncoderNLS? encoder, bool nothingEncoded)
         {
@@ -1168,7 +1168,7 @@ namespace System.Text
             // Special message to include fallback type in case fallback's GetMaxCharCount is broken
             // This happens if user has implemented a decoder fallback with a broken GetMaxCharCount
             throw new ArgumentException(
-                SR.Format(SR.Argument_EncodingConversionOverflowChars, GetType(), _codePage, DecoderFallback.GetType()), "chars");
+                SR.Format(SR.Argument_EncodingConversionOverflowChars, _codePage, DecoderFallback.GetType()), "chars");
 
         internal void ThrowCharsOverflow(DecoderNLS? decoder, bool nothingDecoded)
         {


### PR DESCRIPTION
Encoding::name is virtual property that can throw during exception reporting. It also has large dependencies (~4k) on rarely used data.