### PR TITLE
[release/6.0] Fix setting timestamp on Windows on readonly files

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FileOperations.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FileOperations.cs
@@ -23,7 +23,8 @@ internal static partial class Interop
             internal const int FILE_FLAG_OVERLAPPED = 0x40000000;
 
             internal const int FILE_LIST_DIRECTORY = 0x0001;
-        }
 
+            internal const int FILE_WRITE_ATTRIBUTES = 0x100;
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -20,7 +20,9 @@ namespace System.IO.Tests
         protected static bool LowTemporalResolution => PlatformDetection.IsBrowser || isHFS;
         protected static bool HighTemporalResolution => !LowTemporalResolution;
 
-        protected abstract T GetExistingItem();
+        protected abstract bool CanBeReadOnly { get; }
+
+        protected abstract T GetExistingItem(bool readOnly = false);
         protected abstract T GetMissingItem();
 
         protected abstract string GetItemPath(T item);
@@ -68,6 +70,18 @@ namespace System.IO.Tests
                     Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
                 }
             });
+        }
+
+        [Fact]
+        public void SettingUpdatesPropertiesWhenReadOnly()
+        {
+            if (!CanBeReadOnly)
+            {
+                return; // directories can't be read only, so automatic pass
+            }
+
+            T item = GetExistingItem(readOnly: true);
+            SettingUpdatesPropertiesCore(item);
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/BaseGetSetTimes.cs
@@ -44,11 +44,8 @@ namespace System.IO.Tests
             public DateTimeKind Kind => Item3;
         }
 
-        [Fact]
-        public void SettingUpdatesProperties()
+        private void SettingUpdatesPropertiesCore(T item)
         {
-            T item = GetExistingItem();
-
             Assert.All(TimeFunctions(requiresRoundtripping: true), (function) =>
             {
                 // Checking that milliseconds are not dropped after setter.
@@ -70,6 +67,13 @@ namespace System.IO.Tests
                     Assert.Equal(dt.ToUniversalTime(), result.ToUniversalTime());
                 }
             });
+        }
+
+        [Fact]
+        public void SettingUpdatesProperties()
+        {
+            T item = GetExistingItem();
+            SettingUpdatesPropertiesCore(item);
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetSetTimes.cs
@@ -7,7 +7,9 @@ namespace System.IO.Tests
 {
     public class Directory_GetSetTimes : StaticGetSetTimes
     {
-        protected override string GetExistingItem() => Directory.CreateDirectory(GetTestFilePath()).FullName;
+        protected override bool CanBeReadOnly => false;
+
+        protected override string GetExistingItem(bool _) => Directory.CreateDirectory(GetTestFilePath()).FullName;
 
         public override IEnumerable<TimeFunction> TimeFunctions(bool requiresRoundtripping = false)
         {

--- a/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/GetSetTimes.cs
@@ -7,7 +7,9 @@ namespace System.IO.Tests
 {
     public class DirectoryInfo_GetSetTimes : InfoGetSetTimes<DirectoryInfo>
     {
-        protected override DirectoryInfo GetExistingItem() => Directory.CreateDirectory(GetTestFilePath());
+        protected override bool CanBeReadOnly => false;
+
+        protected override DirectoryInfo GetExistingItem(bool _) => Directory.CreateDirectory(GetTestFilePath());
 
         protected override DirectoryInfo GetMissingItem() => new DirectoryInfo(GetTestFilePath());
 

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -11,14 +11,22 @@ namespace System.IO.Tests
 {
     public class File_GetSetTimes : StaticGetSetTimes
     {
+        protected override bool CanBeReadOnly => true;
+
         // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
         // 32bit Unix has time_t up to ~ 2038.
         private static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (!PlatformDetection.Is32BitProcess && !PlatformDetection.IsOSXLike);
 
-        protected override string GetExistingItem()
+        protected override string GetExistingItem(bool readOnly = false)
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
+
+            if (readOnly)
+            {
+                File.SetAttributes(path, FileAttributes.ReadOnly);
+            }
+
             return path;
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -10,10 +10,18 @@ namespace System.IO.Tests
 {
     public class FileInfo_GetSetTimes : InfoGetSetTimes<FileInfo>
     {
-        protected override FileInfo GetExistingItem()
+        protected override bool CanBeReadOnly => true;
+
+        protected override FileInfo GetExistingItem(bool readOnly = false)
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
+
+            if (readOnly)
+            {
+                File.SetAttributes(path, FileAttributes.ReadOnly);
+            }
+
             return new FileInfo(path);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -147,7 +147,7 @@ namespace System.IO
 
         private static SafeFileHandle OpenHandleToWriteAttributes(string fullPath, bool asDirectory)
         {
-            if (fullPath.Length == PathInternal.GetRootLength(fullPath) && fullPath[1] == Path.VolumeSeparatorChar)
+            if (fullPath.Length == PathInternal.GetRootLength(fullPath.AsSpan()) && fullPath[1] == Path.VolumeSeparatorChar)
             {
                 // intentionally not fullpath, most upstack public APIs expose this as path.
                 throw new ArgumentException(SR.Arg_PathIsVolume, "path");

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -145,10 +145,9 @@ namespace System.IO
             }
         }
 
-        private static SafeFileHandle OpenHandle(string fullPath, bool asDirectory)
+        private static SafeFileHandle OpenHandleToWriteAttributes(string fullPath, bool asDirectory)
         {
-            string root = fullPath.Substring(0, PathInternal.GetRootLength(fullPath.AsSpan()));
-            if (root == fullPath && root[1] == Path.VolumeSeparatorChar)
+            if (fullPath.Length == PathInternal.GetRootLength(fullPath) && fullPath[1] == Path.VolumeSeparatorChar)
             {
                 // intentionally not fullpath, most upstack public APIs expose this as path.
                 throw new ArgumentException(SR.Arg_PathIsVolume, "path");
@@ -156,7 +155,7 @@ namespace System.IO
 
             SafeFileHandle handle = Interop.Kernel32.CreateFile(
                 fullPath,
-                Interop.Kernel32.GenericOperations.GENERIC_WRITE,
+                Interop.Kernel32.FileOperations.FILE_WRITE_ATTRIBUTES,
                 FileShare.ReadWrite | FileShare.Delete,
                 FileMode.Open,
                 asDirectory ? Interop.Kernel32.FileOperations.FILE_FLAG_BACKUP_SEMANTICS : 0);
@@ -382,7 +381,7 @@ namespace System.IO
             long changeTime = -1,
             uint fileAttributes = 0)
         {
-            using (SafeFileHandle handle = OpenHandle(fullPath, asDirectory))
+            using (SafeFileHandle handle = OpenHandleToWriteAttributes(fullPath, asDirectory))
             {
                 var basicInfo = new Interop.Kernel32.FILE_BASIC_INFO()
                 {


### PR DESCRIPTION
Backport of #62638
Fix #62602

## Customer Impact

Addresses a DTS bug that has been reported [internally](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1443139). Attempting to modify the timestamp of a read-only file on Windows with an API like `File.SetXXTimeXX` throws UnauthorizedAccessException. 

This is not a regression. The exception is thrown on.NET Framework as well. It’s clearly a bug (we’re passing the wrong flag) and it has always succeeded on Linux. We already fixed it for 7.0. In theory a customer could be depending on the current behavior, but our assumption is that this is unlikely. 

## Testing

A regression test has been added and it's passing.

## Risk

Low, as the fix is about using less restrictive access rights when opening a file handle to modify the file attributes (`FILE_WRITE_ATTRIBUTES` instead `GENERIC_WRITE` which combines `FILE_WRITE_ATTRIBUTES` and many other flags) .

cc @ericstj