### PR TITLE
Increase iteration count in the FinalizeTest

### DIFF
--- a/src/tests/nativeaot/SmokeTests/BasicThreading/BasicThreading.cs
+++ b/src/tests/nativeaot/SmokeTests/BasicThreading/BasicThreading.cs
@@ -45,7 +45,7 @@ class FinalizeTest
     public static int Run()
     {
         int iterationCount = 0;
-        while (!visited && iterationCount++ < 10000)
+        while (!visited && iterationCount++ < 1000000)
         {
             GC.KeepAlive(new Dummy());
             GC.Collect();


### PR DESCRIPTION
Iteration count was dropped to a smaller number in https://github.com/dotnet/corert/pull/2867. Looks like it's not enough because we see this test fail in the CI.