### PR TITLE
RPM package needs to create host symlink

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -4,6 +4,7 @@
     <GenerateInstallers>true</GenerateInstallers>
     <InstallerName>dotnet-host</InstallerName>
     <InstallerName Condition="'$(TargetOS)' == 'OSX'">dotnet-host-internal</InstallerName>
+    <LinuxInstallRoot Condition="'$(BuildRpmPackage)' == 'true'">/</LinuxInstallRoot>
     <PackageBrandNameSuffix>Host</PackageBrandNameSuffix>
     <VSInsertionShortComponentName>NetCore.SharedHost</VSInsertionShortComponentName>
     <UseCustomDirectoryHarvesting>true</UseCustomDirectoryHarvesting>
@@ -18,9 +19,6 @@
     <IncludeVersionInMacOSComponentName>false</IncludeVersionInMacOSComponentName>
     <MacOSScriptsTemplateDirectory>osx_scripts/host</MacOSScriptsTemplateDirectory>
     <MacOSPackageDescription>The .NET Shared Host.</MacOSPackageDescription>
-    <RpmScriptsDirectory>$(MSBuildThisFileDirectory)rpm_scripts/host</RpmScriptsDirectory>
-    <RpmAfterInstallScript>$(RpmScriptsDirectory)/after_install.sh</RpmAfterInstallScript>
-    <RpmAfterRemoveScript>$(RpmScriptsDirectory)/after_remove.sh</RpmAfterRemoveScript>
     <!-- Stabilizes upgrade codes, using values from 6.0.0 release - do not change -->
     <UpgradeCode Condition="'$(TargetArchitecture)' == 'arm64'">{FD6988BF-5CCB-4202-3752-072442B1070B}</UpgradeCode>
     <UpgradeCode Condition="'$(TargetArchitecture)' == 'x64'">{97C9F490-5379-6902-7B80-D2723CA59D95}</UpgradeCode>
@@ -44,21 +42,37 @@
   <Target Name="PublishToDisk">
     <Error Condition="'$(OutputPath)' == ''" Text="Publishing to disk requires the OutputPath to be set to the root of the path to write to." />
 
+    <PropertyGroup>
+      <_DestinationPath>$(OutputPath)</_DestinationPath>
+      <_DestinationPath Condition="'$(BuildRpmPackage)' == 'true'">$(OutputPath)usr/share/dotnet/</_DestinationPath>
+      <_UsrBinPath>$(OutputPath)usr/bin/</_UsrBinPath>
+    </PropertyGroup>
+
+    <MakeDir Condition="'$(BuildRpmPackage)' == 'true'" Directories="$(_DestinationPath)" />
+    <MakeDir Condition="'$(BuildRpmPackage)' == 'true'" Directories="$(_UsrBinPath)" />
+
     <ItemGroup>
       <FilesToPublish Include="$(DotNetHostBinDir)\dotnet$(ExeSuffix)"
-            Destination="$(OutputPath)dotnet$(ExeSuffix)" />
+            Destination="$(_DestinationPath)dotnet$(ExeSuffix)" />
       <FilesToPublish Include="$(InstallerProjectRoot)pkg\THIRD-PARTY-NOTICES.TXT"
-            Destination="$(OutputPath)ThirdPartyNotices.txt" />
+            Destination="$(_DestinationPath)ThirdPartyNotices.txt" />
       <FilesToPublish Include="$(RepoRoot)LICENSE.TXT"
-            Destination="$(OutputPath)LICENSE.txt"
+            Destination="$(_DestinationPath)LICENSE.txt"
             Condition="'$(TargetsUnix)' == 'true'"/>
       <FilesToPublish Include="$(InstallerProjectRoot)pkg\LICENSE-MSFT.TXT"
-            Destination="$(OutputPath)LICENSE.txt"
+            Destination="$(_DestinationPath)LICENSE.txt"
             Condition="'$(TargetsUnix)' != 'true'"/>
     </ItemGroup>
 
     <Copy SourceFiles="@(FilesToPublish)"
           DestinationFiles="%(FilesToPublish.Destination)" />
+
+    <!--
+      Create symlink so the dotnet host is in PATH. It points to where dotnet will be installed, so
+      it may seem to point to the wrong place in the build machine's layout.
+    -->
+    <Exec Condition="'$(BuildRpmPackage)' == 'true'" Command="ln -sf &quot;/usr/share/dotnet/dotnet&quot; &quot;$(_UsrBinPath)dotnet&quot;" />
+
   </Target>
 
   <Target Name="PublishSymbolsToDisk">
@@ -80,8 +94,6 @@
     <ItemGroup>
       <DebJsonProperty Include="symlinks" Object="{ &quot;dotnet&quot;: &quot;/usr/bin/dotnet&quot; }" />
       <RpmJsonProperty Include="directories" Object="[ &quot;/usr/share/dotnet&quot;, &quot;/usr/share/doc/dotnet-host&quot; ]" />
-      <RpmJsonProperty Include="after_install_source" Object="&quot;$(RpmAfterInstallScript)&quot;" />
-      <RpmJsonProperty Include="after_remove_source" Object="&quot;$(RpmAfterRemoveScript)&quot;" />
       <PackageConflictsProperty Include="package_conflicts" Object="[ &quot;dotnet&quot;, &quot;dotnet-nightly&quot; ]" />
       <DebJsonProperty Include="@(PackageConflictsProperty)" />
       <RpmJsonProperty Include="@(PackageConflictsProperty)" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/62455

# Customer impact

Fixes: https://github.com/dotnet/runtime/issues/61849

Symlink, installed using scripts, is not owned by the package, which causes issues with upgrades from 3.1 or 5.0, where symlink will get removed from disk. (RPM installation is done in "install-new then uninstall-old" fashion.)

This PR restores the functionality that was in place for 3.1 and 5.0 releases, where symlink is created during build and installed with RPM package. Consequently, any file installed with package is owned by it, which ensures proper install, upgrade and uninstall behavior.

Dependent Arcade change was merged with: https://github.com/dotnet/arcade/pull/8251 and is usable in dotnet/runtime (runtime/6.0 branch) after: https://github.com/dotnet/runtime/pull/62799

# Testing

Built host RPM package and tested install and upgrade scenarios.

# Risk

Low. This is already present in 7.0 and has been in 3.1 and 5.0. With this change 6.0 will utilize the same model for creation of dotnet symlink.