### PR TITLE
corerun: silently ignore directories when building TPA

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.hpp
+++ b/src/coreclr/hosts/corerun/corerun.hpp
@@ -473,6 +473,12 @@ namespace pal
             return false;
         }
 
+        // Ignore directories
+        if (S_ISDIR(sb.st_mode))
+        {
+            return false;
+        }
+
         // Verify that the path points to a file
         if (!S_ISREG(sb.st_mode))
         {


### PR DESCRIPTION
Addresses one of the annoyances in #62760.

corerun no longer prints a long list of directories at startup on linux.