### PR TITLE
Corrected the typo in autogenerated cs file.

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
@@ -886,7 +886,7 @@
     <value>The name can be no more than {0} characters in length.</value>
   </data>
   <data name="ArgumentException_OtherNotArrayOfCorrectLength" xml:space="preserve">
-    <value>Object is not a array with the same number of elements as the array to compare it to.</value>
+    <value>The object is not an array with the same number of elements as the array to compare it to.</value>
   </data>
   <data name="ArgumentException_TupleIncorrectType" xml:space="preserve">
     <value>Argument must be of type {0}.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1550,7 +1550,7 @@
     <value>The buffer is not associated with this pool and may not be returned to it.</value>
   </data>
   <data name="ArgumentException_OtherNotArrayOfCorrectLength" xml:space="preserve">
-    <value>Object is not a array with the same number of elements as the array to compare it to.</value>
+    <value>The object is not an array with the same number of elements as the array to compare it to.</value>
   </data>
   <data name="ArgumentException_NotIsomorphic" xml:space="preserve">
     <value>Object contains non-primitive or non-blittable data.</value>


### PR DESCRIPTION
Changes made:
"Object is not a array..." -> "The object is not an array..."

Fix #62909