### PR TITLE
HttpConnectionPool improvements

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -2184,7 +2184,6 @@ namespace System.Net.Http
                 return waiter;
             }
 
-<<<<<<< HEAD
             public bool TryDequeueSpecificRequest(HttpRequestMessage request, [MaybeNullWhen(false)] out TaskCompletionSourceWithCancellation<T> waiter)
             {
                 if (_queue is not null && _queue.TryPeek(out QueueItem item) && item.Request == request)
@@ -2199,14 +2198,13 @@ namespace System.Net.Http
             }
 
             // TODO: Remove
-=======
+
             // TODO: TryDequeueNextRequest below was changed to not handle request cancellation.
             // TryFailNextRequest should probably be changed similarly -- or rather, callers should just use the new
             // TryDequeueRequest call below and then handle canceled requests themselves.
             // However, we should fix the issue re cancellation failure first because that will affect this code too.
             // TODO: Link cancellation failure issue here.
 
->>>>>>> b178c595973... add TryDequeueRequest
             public bool TryFailNextRequest(Exception e)
             {
                 Debug.Assert(e is HttpRequestException or OperationCanceledException, "Unexpected exception type for connection failure");

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1817,7 +1817,6 @@ namespace System.Net.Http
                         Debug.Assert(_availableHttp2Connections is null || !_availableHttp2Connections.Contains(connection), $"HTTP2 connection already in available list");
                         Debug.Assert(_associatedHttp2ConnectionCount > (_availableHttp2Connections?.Count ?? 0),
                             $"Expected _associatedHttp2ConnectionCount={_associatedHttp2ConnectionCount} > _availableHttp2Connections.Count={(_availableHttp2Connections?.Count ?? 0)}");
-                        // TODO: Update HTTP/1.1 assertion similarly
 
                         if (isNewConnection)
                         {
@@ -2027,6 +2026,7 @@ namespace System.Net.Http
         {
             TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
             TimeSpan pooledConnectionIdleTimeout = _poolManager.Settings._pooledConnectionIdleTimeout;
+            long nowTicks = Environment.TickCount64;
 
             List<HttpConnectionBase>? toDispose = null;
 
@@ -2046,8 +2046,6 @@ namespace System.Net.Http
                 // Reset the cleanup flag.  Any pools that are empty and not used since the last cleanup
                 // will be purged next time around.
                 _usedSinceLastCleanup = false;
-
-                long nowTicks = Environment.TickCount64;
 
                 ScavengeConnectionList(_availableHttp11Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
                 if (_availableHttp2Connections is not null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1883,7 +1883,6 @@ namespace System.Net.Http
                 // or because it immediately set the max concurrent streams limit to 0.
                 // We don't want to get stuck in a loop where we keep trying to create new connections for the same request.
                 // So, treat this as a connection failure.
-                // TODO: Need to flow the request
 
                 if (NetEventSource.Log.IsEnabled()) connection.Trace("New HTTP2 connection is unusable due to no available streams.");
                 connection.Dispose();
@@ -2202,7 +2201,7 @@ namespace System.Net.Http
 
         private struct RequestQueue<T>
         {
-            public struct QueueItem
+            private struct QueueItem
             {
                 public HttpRequestMessage Request;
                 public TaskCompletionSourceWithCancellation<T> Waiter;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -160,8 +160,8 @@ namespace System.Net.Http.Functional.Tests
                     };
 
                     using CancellationTokenSource cts = new CancellationTokenSource();
-                    Task<HttpResponseMessage> t1 = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion }, cts.Token);
-                    Task<HttpResponseMessage> t2 = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion }, default);
+                    Task<HttpResponseMessage> t1 = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion, VersionPolicy = HttpVersionPolicy.RequestVersionExact }, cts.Token);
+                    Task<HttpResponseMessage> t2 = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion, VersionPolicy = HttpVersionPolicy.RequestVersionExact }, default);
 
                     // Cancel the first message and wait for it to complete
                     cts.Cancel();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -141,8 +141,6 @@ namespace System.Net.Http.Functional.Tests
 
                         if (Interlocked.Increment(ref connectCount) == 1)
                         {
-                            Console.WriteLine("First connection failed");
-
                             // Fail the first connection attempt
                             throw new Exception("Failing first connection");
                         }
@@ -151,10 +149,6 @@ namespace System.Net.Http.Functional.Tests
                             // Succeed the second connection attempt
                             Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
                             await socket.ConnectAsync(context.DnsEndPoint, token);
-
-
-                            Console.WriteLine("Second connection succeeded");
-
                             return new NetworkStream(socket, ownsSocket: true);
                         }
                     };
@@ -166,8 +160,6 @@ namespace System.Net.Http.Functional.Tests
                     // Cancel the first message and wait for it to complete
                     cts.Cancel();
                     await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t1);
-
-                    Console.WriteLine("First request canceled");
 
                     // Signal connections to proceed
                     tcsFirstRequestCanceled.SetResult();


### PR DESCRIPTION
Two related improvements:

(1) Reduce contention on the pool lock. This is done mainly by (a) not calling TrySetResult on the queued waiter under the lock -- instead, do this outside the lock and retry as necessary for canceled requests; (b) avoid doing diagnostic logging under the lock.
(2) Improve handling of failed connection attempts so we don't fail requests unnecessarily. See https://github.com/dotnet/runtime/issues/60654 for details.

Fixes https://github.com/dotnet/runtime/issues/60654
