### PR TITLE
Simplify alignment block marking

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1685,22 +1685,3 @@ BBswtDesc::BBswtDesc(Compiler* comp, const BBswtDesc* other)
         bbsDstTab[i] = other->bbsDstTab[i];
     }
 }
-
-//------------------------------------------------------------------------
-// unmarkLoopAlign: Unmarks the LOOP_ALIGN flag from the block and reduce the
-//                  loop alignment count.
-//
-// Arguments:
-//    compiler - Compiler instance
-//    reason - Reason to print in JITDUMP
-//
-void BasicBlock::unmarkLoopAlign(Compiler* compiler DEBUG_ARG(const char* reason))
-{
-    // Make sure we unmark and count just once.
-    if (isLoopAlign())
-    {
-        compiler->loopAlignCandidates--;
-        bbFlags &= ~BBF_LOOP_ALIGN;
-        JITDUMP("Unmarking LOOP_ALIGN from " FMT_BB ". Reason= %s.\n", bbNum, reason);
-    }
-}

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -657,8 +657,6 @@ struct BasicBlock : private LIR::Range
         return ((bbFlags & BBF_LOOP_ALIGN) != 0);
     }
 
-    void unmarkLoopAlign(Compiler* comp DEBUG_ARG(const char* reason));
-
     bool hasAlign() const
     {
         return ((bbFlags & BBF_HAS_ALIGN) != 0);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3670,6 +3670,8 @@ public:
 #endif
 
     BasicBlock* bbNewBasicBlock(BBjumpKinds jumpKind);
+
+    void optIdentifyLoopsForAlignment();
     void placeLoopAlignInstructions();
 
     /*
@@ -6987,6 +6989,8 @@ public:
                        BasicBlock*   exit,
                        unsigned char exitCnt);
 
+    void optClearLoopIterInfo();
+
 #ifdef DEBUG
     void optPrintLoopInfo(unsigned lnum, bool printVerbose = false);
     void optPrintLoopInfo(const LoopDsc* loop, bool printVerbose = false);
@@ -7024,8 +7028,6 @@ protected:
         BasicBlock* head, BasicBlock* bottom, BasicBlock* exit, GenTree** ppInit, GenTree** ppTest, GenTree** ppIncr);
 
     void optFindNaturalLoops();
-
-    void optIdentifyLoopsForAlignment();
 
     // Ensures that all the loops in the loop nest rooted at "loopInd" (an index into the loop table) are 'canonical' --
     // each loop has a unique "top."  Returns "true" iff the flowgraph has been modified.
@@ -9754,7 +9756,7 @@ public:
 // based on experimenting with various benchmarks.
 
 // Default minimum loop block weight required to enable loop alignment.
-#define DEFAULT_ALIGN_LOOP_MIN_BLOCK_WEIGHT 4
+#define DEFAULT_ALIGN_LOOP_MIN_BLOCK_WEIGHT 3
 
 // By default a loop will be aligned at 32B address boundary to get better
 // performance as per architecture manuals.

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -61,6 +61,7 @@ CompPhaseNameMacro(PHASE_ZERO_INITS,             "Redundant zero Inits",        
 CompPhaseNameMacro(PHASE_FIND_LOOPS,             "Find loops",                     "LOOP-FND", false, -1, false)
 CompPhaseNameMacro(PHASE_CLONE_LOOPS,            "Clone loops",                    "LP-CLONE", false, -1, false)
 CompPhaseNameMacro(PHASE_UNROLL_LOOPS,           "Unroll loops",                   "UNROLL",   false, -1, false)
+CompPhaseNameMacro(PHASE_CLEAR_LOOP_INFO,        "Clear loop info",                "LP-CLEAR", false, -1, false)
 CompPhaseNameMacro(PHASE_HOIST_LOOP_CODE,        "Hoist loop code",                "LP-HOIST", false, -1, false)
 CompPhaseNameMacro(PHASE_MARK_LOCAL_VARS,        "Mark local vars",                "MARK-LCL", false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_BOOLS,         "Optimize bools",                 "OPT-BOOL", false, -1, false)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4712,14 +4712,6 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         {
             succBlock->bbFlags |= BBF_LOOP_HEAD;
 
-            if (block->isLoopAlign())
-            {
-                loopAlignCandidates++;
-                succBlock->bbFlags |= BBF_LOOP_ALIGN;
-                JITDUMP("Propagating LOOP_ALIGN flag from " FMT_BB " to " FMT_BB " for " FMT_LP "\n ", block->bbNum,
-                        succBlock->bbNum, block->bbNatLoopNum);
-            }
-
             if (fgDomsComputed && fgReachable(succBlock, block))
             {
                 // Mark all the reachable blocks between 'succBlock' and 'bPrev'
@@ -4866,9 +4858,6 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         fgUnlinkBlock(block);
         block->bbFlags |= BBF_REMOVED;
     }
-
-    // If this was marked for alignment, remove it
-    block->unmarkLoopAlign(this DEBUG_ARG("Removed block"));
 
     if (bPrev != nullptr)
     {

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2147,13 +2147,6 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
     }
 
-    if (bNext->isLoopAlign())
-    {
-        block->bbFlags |= BBF_LOOP_ALIGN;
-        JITDUMP("Propagating LOOP_ALIGN flag from " FMT_BB " to " FMT_BB " during compacting.\n", bNext->bbNum,
-                block->bbNum);
-    }
-
     // If we're collapsing a block created after the dominators are
     // computed, copy block number the block and reuse dominator
     // information from bNext to block.
@@ -5992,9 +5985,6 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication)
 
                         // Update the loop table if we removed the bottom of a loop, for example.
                         fgUpdateLoopsAfterCompacting(block, bNext);
-
-                        // If this block was aligned, unmark it
-                        bNext->unmarkLoopAlign(this DEBUG_ARG("Optimized jump"));
 
                         // If this is the first Cold basic block update fgFirstColdBlock
                         if (bNext == fgFirstColdBlock)

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1956,18 +1956,7 @@ void Compiler::optCloneLoop(unsigned loopInd, LoopCloneContext* context)
         newBlk->scaleBBWeight(slowPathWeightScaleFactor);
         blk->scaleBBWeight(fastPathWeightScaleFactor);
 
-// TODO: scale the pred edges of `blk`?
-
-#if FEATURE_LOOP_ALIGN
-        // If the original loop is aligned, do not align the cloned loop because cloned loop will be executed in
-        // rare scenario. Additionally, having to align cloned loop will force us to disable some VEX prefix encoding
-        // and adding compensation for over-estimated instructions.
-        if (blk->isLoopAlign())
-        {
-            newBlk->bbFlags &= ~BBF_LOOP_ALIGN;
-            JITDUMP("Removing LOOP_ALIGN flag from cloned loop in " FMT_BB "\n", newBlk->bbNum);
-        }
-#endif
+        // TODO: scale the pred edges of `blk`?
 
         // TODO-Cleanup: The above clones the bbNatLoopNum, which is incorrect.  Eventually, we should probably insert
         // the cloned loop in the loop table.  For now, however, we'll just make these blocks be part of the surrounding

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -15366,8 +15366,6 @@ bool Compiler::fgFoldConditional(BasicBlock* block)
 
                         optMarkLoopRemoved(loopNum);
 
-                        optLoopTable[loopNum].lpTop->unmarkLoopAlign(this DEBUG_ARG("Bogus loop"));
-
 #ifdef DEBUG
                         if (verbose)
                         {


### PR DESCRIPTION
Currently, loops that are candidates for alignment are determined
immediately after loop recognition. The top block of these loops
are marked by setting the `BBF_LOOP_ALIGN` flag. Later, just before
codegen, the `placeLoopAlignInstructions` phase is called to mark
the blocks where the actual align instructions will be placed.
Between these two phases, the `BBF_LOOP_ALIGN` flag needs to be maintained
through various optimization phases.

We can simplify this by deferring marking the loops to align until
we call the `placeLoopAlignInstructions` phase. Then, we don't need
to worry about maintaining the `BBF_LOOP_ALIGN` flag. The loop table
is still valid, so can be used. (Note that if we ever want to "kill"
the loop table earlier in compilation, we could simply move the
`BBF_LOOP_ALIGN` marking to that point, and still avoid all the
flag maintenance.) This PR makes that change.

To avoid too many diffs, `DEFAULT_ALIGN_LOOP_MIN_BLOCK_WEIGHT` is
reduced from 4 to 3. This is because many loops (without profile data)
end up with a weight of 4, and if those loops are cloned, the weight
of the hot path gets reduced to 3.96 (so the cold path gets at least
some non-zero weight). We still want these hot path cloned loops to
be aligned. However, decreasing this does cause some more ASP.NET
loops with profile data and weights between 3 and 4 to be aligned.

Additionally, I added a trivial phase `optClearLoopIterInfo` to clear
out all the loop table info related to `LPFLG_ITER`. This data is used
by loop cloning and unrolling, but not afterwards. I still want to be
able to dump the loop table without hitting asserts about improper
`LPFLG_ITER` form data, and don't want downstream phases to take a dependency
on this data, so clearing it out enables that.

There are a few diffs where we align more loops even without profile
data because the weight of loop top blocks increases due to various
flow optimizations (like block compaction), and now we see the larger
weight before making the alignment decision.