### PR TITLE
Allow building libs against NativeAOT CoreLib

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -245,6 +245,7 @@
     <CoreLibSharedDir>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'System.Private.CoreLib', 'src'))</CoreLibSharedDir>
     <CoreLibProject Condition="'$(RuntimeFlavor)' == 'CoreCLR'">$([MSBuild]::NormalizePath('$(CoreClrProjectRoot)', 'System.Private.CoreLib', 'System.Private.CoreLib.csproj'))</CoreLibProject>
     <CoreLibProject Condition="'$(RuntimeFlavor)' == 'Mono'">$([MSBuild]::NormalizePath('$(MonoProjectRoot)', 'System.Private.CoreLib', 'System.Private.CoreLib.csproj'))</CoreLibProject>
+    <CoreLibProject Condition="'$(UseNativeAotCoreLib)' == 'true'">$([MSBuild]::NormalizePath('$(CoreClrProjectRoot)', 'nativeaot', 'System.Private.CoreLib', 'src', 'System.Private.CoreLib.csproj'))</CoreLibProject>
 
     <!-- this property is used by the SDK to pull in mono-based runtime packs -->
     <UseMonoRuntime Condition="'$(UseMonoRuntime)' == '' and '$(RuntimeFlavor)' == 'Mono'">true</UseMonoRuntime>

--- a/eng/ApiCompatExcludeAttributes.txt
+++ b/eng/ApiCompatExcludeAttributes.txt
@@ -1,3 +1,5 @@
 T:System.CLSCompliantAttribute
 T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute
 T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute
+T:System.Diagnostics.DebuggerGuidedStepThroughAttribute
+T:System.Runtime.CompilerServices.EagerStaticClassConstructionAttribute

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -49,9 +49,12 @@
     <RuntimeFlavor Condition="'$(RuntimeFlavor)' == ''">$(PrimaryRuntimeFlavor)</RuntimeFlavor>
   </PropertyGroup>
 
-  <!-- CLR NativeAot only builds in a subset of the matrix -->
   <PropertyGroup>
+    <!-- CLR NativeAot only builds in a subset of the matrix -->
     <NativeAotSupported Condition="('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and ('$(TargetOS)' != 'OSX' or '$(TargetArchitecture)' != 'arm64') and ('$(__DistroRid)' != 'linux-musl-arm64')">true</NativeAotSupported>
+
+    <!-- If we're building clr.nativeaotlibs and not building the CLR runtime, compile libraries against NativeAOT CoreLib -->
+    <UseNativeAotCoreLib Condition="$(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr+')) and !$(_subset.Contains('+clr.runtime+'))">true</UseNativeAotCoreLib>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/System.Reflection/src/MatchingRefApiCompatBaseline.txt
+++ b/src/libraries/System.Reflection/src/MatchingRefApiCompatBaseline.txt
@@ -1,3 +1,6 @@
 Compat issues with assembly System.Reflection:
 MembersMustExist : Member 'protected System.ModuleHandle System.Reflection.Module.GetModuleHandleImpl()' does not exist in the reference but it does exist in the implementation.
-Total Issues: 1
+MembersMustExist : Member 'public System.Reflection.ParameterInfo[] System.Reflection.MethodBase.GetParametersNoCopy()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Reflection.MethodBase System.Reflection.MethodBase.MetadataDefinitionMethod.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Int32 System.Reflection.MethodInfo.GenericParameterCount.get()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 4

--- a/src/libraries/System.Runtime/src/MatchingRefApiCompatBaseline.txt
+++ b/src/libraries/System.Runtime/src/MatchingRefApiCompatBaseline.txt
@@ -24,4 +24,13 @@ CannotMakeMemberAbstract : Member 'public System.Boolean System.IO.FileSystemInf
 CannotMakeMemberAbstract : Member 'public System.String System.IO.FileSystemInfo.Name.get()' is abstract in the reference but is not abstract in the implementation.
 # C# generates backing fields for fixed buffers as public.
 TypesMustExist : Type 'System.IO.Enumeration.FileSystemEntry.<_fileNameBuffer>e__FixedBuffer' does not exist in the reference but it does exist in the implementation.
-
+MembersMustExist : Member 'public void System.ModuleHandle..ctor(System.Reflection.Module)' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.RuntimeTypeHandle' does not implement interface 'System.IEquatable<System.RuntimeTypeHandle>' in the reference but it does in the implementation.
+MembersMustExist : Member 'public System.String System.String System.Type.DefaultTypeNameWhenMissingMetadata' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.String System.Type.FormatTypeNameForReflection()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.String System.Type.InternalGetNameIfAvailable(System.Type)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.String System.Type.InternalNameIfAvailable.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Boolean System.TypedReference.IsNull.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Reflection.ParameterInfo[] System.Reflection.MethodBase.GetParametersNoCopy()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Reflection.MethodBase System.Reflection.MethodBase.MetadataDefinitionMethod.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'public System.Int32 System.Reflection.MethodInfo.GenericParameterCount.get()' does not exist in the reference but it does exist in the implementation.


### PR DESCRIPTION
To make sure ApiCompat tooling for NativeAOT's CoreLib runs at least in some legs, compile libs against NativeAOT CoreLib if we're building CLR, but not building the JIT flavor of the runtime.

The baselining is necessary because the reflection stack of NativeAOT doesn't live in CoreLib.

The CannotRemoveBaseTypeOrInteface baselining will go away once https://github.com/dotnet/runtime/issues/62944 gets fixed. It's one of the "overall goodness" things we can take out of NativeAOT and put it into all runtimes.