### PR TITLE
Handle RunClassConstructor with nonreflectable cctor

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -22,6 +22,7 @@ namespace ILCompiler
     public sealed class AnalysisBasedMetadataManager : GeneratingMetadataManager, ICompilationRootProvider
     {
         private readonly List<ModuleDesc> _modulesWithMetadata;
+        private readonly List<MetadataType> _typesWithRootedCctorContext = new List<MetadataType>();
 
         private readonly Dictionary<TypeDesc, MetadataCategory> _reflectableTypes = new Dictionary<TypeDesc, MetadataCategory>();
         private readonly Dictionary<MethodDesc, MetadataCategory> _reflectableMethods = new Dictionary<MethodDesc, MetadataCategory>();
@@ -33,7 +34,8 @@ namespace ILCompiler
                 new FullyBlockedManifestResourceBlockingPolicy(), null, new NoStackTraceEmissionPolicy(),
                 new NoDynamicInvokeThunkGenerationPolicy(), Array.Empty<ModuleDesc>(),
                 Array.Empty<ReflectableEntity<TypeDesc>>(), Array.Empty<ReflectableEntity<MethodDesc>>(),
-                Array.Empty<ReflectableEntity<FieldDesc>>(), Array.Empty<ReflectableCustomAttribute>())
+                Array.Empty<ReflectableEntity<FieldDesc>>(), Array.Empty<ReflectableCustomAttribute>(),
+                Array.Empty<MetadataType>())
         {
         }
 
@@ -48,10 +50,12 @@ namespace ILCompiler
             IEnumerable<ReflectableEntity<TypeDesc>> reflectableTypes,
             IEnumerable<ReflectableEntity<MethodDesc>> reflectableMethods,
             IEnumerable<ReflectableEntity<FieldDesc>> reflectableFields,
-            IEnumerable<ReflectableCustomAttribute> reflectableAttributes)
+            IEnumerable<ReflectableCustomAttribute> reflectableAttributes,
+            IEnumerable<MetadataType> rootedCctorContexts)
             : base(typeSystemContext, blockingPolicy, resourceBlockingPolicy, logFile, stackTracePolicy, invokeThunkGenerationPolicy)
         {
             _modulesWithMetadata = new List<ModuleDesc>(modulesWithMetadata);
+            _typesWithRootedCctorContext = new List<MetadataType>(rootedCctorContexts);
             
             foreach (var refType in reflectableTypes)
             {
@@ -208,6 +212,11 @@ namespace ILCompiler
                             rootProvider.RootNonGCStaticBaseForType(field.OwningType, reason);
                     }
                 }
+            }
+
+            foreach (var type in _typesWithRootedCctorContext)
+            {
+                rootProvider.RootNonGCStaticBaseForType(type, reason);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -22,7 +22,7 @@ namespace ILCompiler
     public sealed class AnalysisBasedMetadataManager : GeneratingMetadataManager, ICompilationRootProvider
     {
         private readonly List<ModuleDesc> _modulesWithMetadata;
-        private readonly List<MetadataType> _typesWithRootedCctorContext = new List<MetadataType>();
+        private readonly List<MetadataType> _typesWithRootedCctorContext;
 
         private readonly Dictionary<TypeDesc, MetadataCategory> _reflectableTypes = new Dictionary<TypeDesc, MetadataCategory>();
         private readonly Dictionary<MethodDesc, MetadataCategory> _reflectableMethods = new Dictionary<MethodDesc, MetadataCategory>();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -794,10 +794,28 @@ namespace ILCompiler
                 }
             }
 
+            var rootedCctorContexts = new List<MetadataType>();
+            foreach (NonGCStaticsNode cctorContext in GetCctorContextMapping())
+            {
+                // If we generated a static constructor and the owning type, this might be something
+                // that gets fed to RuntimeHelpers.RunClassConstructor. RunClassConstructor
+                // also works on reflection blocked types and there is a possibility that we
+                // wouldn't have generated the cctor otherwise.
+                //
+                // This is a heuristic and we'll possibly root more cctor contexts than
+                // strictly necessary, but it's not worth introducing a new node type
+                // in the compiler just so we can propagate this knowledge from dataflow analysis
+                // (that detects RunClassConstructor usage) and this spot.
+                if (!TypeGeneratesEEType(cctorContext.Type))
+                    continue;
+
+                rootedCctorContexts.Add(cctorContext.Type);
+            }
+
             return new AnalysisBasedMetadataManager(
                 _typeSystemContext, _blockingPolicy, _resourceBlockingPolicy, _metadataLogFile, _stackTraceEmissionPolicy, _dynamicInvokeThunkGenerationPolicy,
                 _modulesWithMetadata, reflectableTypes.ToEnumerable(), reflectableMethods.ToEnumerable(),
-                reflectableFields.ToEnumerable(), _customAttributesWithMetadata);
+                reflectableFields.ToEnumerable(), _customAttributesWithMetadata, rootedCctorContexts);
         }
 
         private struct ReflectableEntityBuilder<T>

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -27,6 +27,7 @@ internal class ReflectionTest
         //
         // Tests for dependency graph in the compiler
         //
+        TestRunClassConstructor.Run();
 #if !OPTIMIZED_MODE_WITHOUT_SCANNER
         TestContainment.Run();
         TestInterfaceMethod.Run();
@@ -1651,6 +1652,26 @@ internal class ReflectionTest
                 throw new Exception();
 
             if (typeof(TypeWithCodelessMethods).GetMethods(BindingFlags.Public | BindingFlags.Static).Length != 1)
+                throw new Exception();
+        }
+    }
+
+    class TestRunClassConstructor
+    {
+        static class TypeWithNoStaticFieldsButACCtor
+        {
+            static TypeWithNoStaticFieldsButACCtor()
+            {
+                s_cctorRan = true;
+            }
+        }
+
+        private static bool s_cctorRan;
+
+        public static void Run()
+        {
+            RuntimeHelpers.RunClassConstructor(typeof(TypeWithNoStaticFieldsButACCtor).TypeHandle);
+            if (!s_cctorRan)
                 throw new Exception();
         }
     }


### PR DESCRIPTION
This is now getting hit in #62927, so it's somewhat more urgent. (The feature switches from the SDK put us into the situation that triggers this bug around `RunClassConstructor` on an otherwise unused type.)

Fixes dotnet/runtimelab#987.

Remember what class constructor contexts we saw during scanning phase and if the owning type is also generated, assume `RunClassConstructor` could be used and ensure the cctor context is also generated in the compilation phase.

This is somewhat less precise, but introducing a new node type for "a type used with `RunClassConstructor`" that dataflow analysis could report doesn't seem worth it.