### PR TITLE
NativeAOT: Do not run Vector version of Hardware Intrinsics when AVX2…

### DIFF
--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
@@ -32,10 +32,7 @@ $(BashCLRTestPreCommands)
         fi
     fi
     if [[ "$OSTYPE" == "linux"* ]]; then
-        more /proc/cpuinfo
-
-        grep avx2 /proc/cpuinfo >/dev/null
-        if [ $? -ne 0 ]; then
+        if ! grep -q '^flags.*avx2' /proc/cpuinfo 2>/dev/null; then
           echo No support for AVX2, test not applicable.
           exit 0
         fi

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
@@ -31,6 +31,15 @@ $(BashCLRTestPreCommands)
           exit 0
         fi
     fi
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        more /proc/cpuinfo
+
+        grep avx2 /proc/cpuinfo >/dev/null
+        if [ $? -ne 0 ]; then
+          echo No support for AVX2, test not applicable.
+          exit 0
+        fi
+    fi
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 


### PR DESCRIPTION
… is not supported