### PR TITLE
Extend CPU capabilities detection for osx-arm64 (#62832)

### DIFF
--- a/src/coreclr/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/pal/src/misc/jitsupport.cpp
@@ -260,11 +260,26 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
     int64_t valueFromSysctl = 0;
     size_t sz = sizeof(valueFromSysctl);
 
-    if ((sysctlbyname("hw.optional.armv8_1_atomics", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
-        flags->Set(InstructionSet_Atomics);
+    if ((sysctlbyname("hw.optional.arm.FEAT_AES", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
+        flags->Set(InstructionSet_Aes);
 
     if ((sysctlbyname("hw.optional.armv8_crc32", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
         flags->Set(InstructionSet_Crc32);
+
+    if ((sysctlbyname("hw.optional.arm.FEAT_DotProd", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
+        flags->Set(InstructionSet_Dp);
+
+    if ((sysctlbyname("hw.optional.arm.FEAT_RDM", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
+        flags->Set(InstructionSet_Rdm);
+
+    if ((sysctlbyname("hw.optional.arm.FEAT_SHA1", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
+        flags->Set(InstructionSet_Sha1);
+
+    if ((sysctlbyname("hw.optional.arm.FEAT_SHA256", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
+        flags->Set(InstructionSet_Sha256);
+
+    if ((sysctlbyname("hw.optional.armv8_1_atomics", &valueFromSysctl, &sz, nullptr, 0) == 0) && (valueFromSysctl != 0))
+        flags->Set(InstructionSet_Atomics);
 #endif // HAVE_SYSCTLBYNAME
     // CoreCLR SIMD and FP support is included in ARM64 baseline
     // On exceptional basis platforms may leave out support, but CoreCLR does not
@@ -272,6 +287,12 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
     // Set baseline flags if OS has not exposed mechanism for us to determine CPU capabilities
     flags->Set(InstructionSet_ArmBase);
     flags->Set(InstructionSet_AdvSimd);
+
+#if defined(TARGET_OSX) && defined(TARGET_ARM64)
+    // osx-arm64 never traps DC ZVA execution
+    flags->Set(InstructionSet_Dczva);
+#endif
+
     //    flags->Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_FP);
 #endif // HAVE_AUXV_HWCAP_H
 #elif defined(TARGET_ARM64)

--- a/src/coreclr/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/pal/src/misc/jitsupport.cpp
@@ -287,12 +287,6 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
     // Set baseline flags if OS has not exposed mechanism for us to determine CPU capabilities
     flags->Set(InstructionSet_ArmBase);
     flags->Set(InstructionSet_AdvSimd);
-
-#if defined(TARGET_OSX) && defined(TARGET_ARM64)
-    // osx-arm64 never traps DC ZVA execution
-    flags->Set(InstructionSet_Dczva);
-#endif
-
     //    flags->Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_FP);
 #endif // HAVE_AUXV_HWCAP_H
 #elif defined(TARGET_ARM64)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/62832

This change adds support for detection of CPU capabilities on targets like `osx-arm64` which do not have `getauxval(AT_HWCAP)` as recommended in https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code.

In addition, we also opportunistically assume that the environment does not support the scenario in which the execution of `DC ZVA` memory zeroing instructions can be trapped by the kernel or host system. However, if https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/codeman.cpp#L1485 completely overrides this flag, then the change is unnecessary. Please let me know what is the best way to handle it.

Otherwise, on M1, `DC ZVA` zeroing completely saturates data bandwidth which makes it fully efficient. 
References: https://www.realworldtech.com/forum/?threadid=192122&curpostid=192321 and https://twitter.com/polydron/status/1458890243336138771?s=21