### PR TITLE
Suppress OSR for crossgen2 execution

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -107,13 +107,13 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         cat $__ResponseFile
 
         # Suppress some COMPlus variables for the duration of Crossgen2 execution
-        export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
+        export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
 
         echo "Running CrossGen2: $__Command"
         $__Command
         __cg2ExitCode=$?
 
-        export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
+        export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
       }
 
       if [ ! -z ${CompositeBuildMode+x} ]%3B then
@@ -245,6 +245,9 @@ if defined RunCrossGen2 (
     set "COMPlus_GCStress="
     set "COMPlus_HeapVerify="
     set "COMPlus_ReadyToRun="
+    REM work around problems in 6.0 OSR
+    set "COMPlus_TC_OnStackReplacement="
+    set "COMPlus_TC_PartialCompilation="
 
     echo "!__Command!"
     call !__Command!

--- a/src/tests/readytorun/multifolder/multifolder.csproj
+++ b/src/tests/readytorun/multifolder/multifolder.csproj
@@ -53,6 +53,10 @@ $(CLRTestBatchPreCommands)
     set __Command=%__Command% "%CORE_ROOT%\crossgen2\crossgen2.dll"
     set __Command=%__Command% @"%__ResponseFile%"
 
+    REM work around problems in 6.0 OSR
+    set "COMPlus_TC_OnStackReplacement="
+    set "COMPlus_TC_PartialCompilation="
+
     echo Response file: %__ResponseFile%
     type %__ResponseFile%
     echo ------------------
@@ -85,9 +89,8 @@ $(BashCLRTestPreCommands)
     echo $__OutputDir/../FolderA/FolderA/FolderA.dll>>$__ResponseFile
     echo $__OutputDir/../FolderB/FolderB/FolderB.dll>>$__ResponseFile
 
-    # Suppress GC standalone mode for the duration of Crossgen2 execution
-    local gcstandaloneModeToRestore=$COMPlus_GCName;
-    unset COMPlus_GCName
+    # Suppress some COMPlus variables for the duration of Crossgen2 execution
+    export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
 
     __Command=$_DebuggerFullPath
     # Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
@@ -105,9 +108,10 @@ $(BashCLRTestPreCommands)
     echo Running crossgen2: $__Command
     $__Command
 
+    export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun COMPlus_TC_OnStackReplacement COMPlus_TC_PartialCompilation
+
     ExePath=multifolder/multifolder.dll
     export COMPlus_NativeImageSearchPaths=$__OutputDir
-    export COMPlus_GCName=$gcstandaloneModeToRestore
 
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>


### PR DESCRIPTION
In CI testing, crossgen2 currently is run via a .NET 6 runtime, and
that runtime has some bugs in OSR.

Work around by suppressing OSR for the duration of the run. We should
be able to revert this once we update the crossgen2 runtime
to a .NET 7 version.