### PR TITLE
Fix HAVE_PTHREAD_CONDATTR_SETCLOCK detection on Android

### DIFF
--- a/src/native/libs/configure.cmake
+++ b/src/native/libs/configure.cmake
@@ -61,6 +61,9 @@ endif()
 # which are not distinguished from the test failing. So no error for that one.
 # For clang-5.0 avoid errors like "unused variable 'err' [-Werror,-Wunused-variable]".
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Werror -Wno-error=unused-value -Wno-error=unused-variable")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Wno-error=builtin-requires-header")
+endif()
 
 # Apple platforms like macOS/iOS allow targeting older operating system versions with a single SDK,
 # the mere presence of a symbol in the SDK doesn't tell us whether the deployment target really supports it.
@@ -675,7 +678,16 @@ check_symbol_exists(
     time.h
     HAVE_CLOCK_GETTIME_NSEC_NP)
 
-check_library_exists(pthread pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
+check_library_exists(pthread pthread_create "" HAVE_LIBPTHREAD)
+check_library_exists(c pthread_create "" HAVE_PTHREAD_IN_LIBC)
+
+if (HAVE_LIBPTHREAD)
+  set(PTHREAD_LIBRARY pthread)
+elseif (HAVE_PTHREAD_IN_LIBC)
+  set(PTHREAD_LIBRARY c)
+endif()
+
+check_library_exists(${PTHREAD_LIBRARY} pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
 
 check_symbol_exists(
     futimes

--- a/src/native/libs/configure.cmake
+++ b/src/native/libs/configure.cmake
@@ -61,7 +61,7 @@ endif()
 # which are not distinguished from the test failing. So no error for that one.
 # For clang-5.0 avoid errors like "unused variable 'err' [-Werror,-Wunused-variable]".
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Werror -Wno-error=unused-value -Wno-error=unused-variable")
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Wno-error=builtin-requires-header")
 endif()
 


### PR DESCRIPTION
This is my second attempt. The first attempt was https://github.com/dotnet/runtime/pull/58701 that got rolled back because it broke gcc build (https://github.com/dotnet/runtime/issues/58744) and I wasn't in a good enough mental state to investigate (and I didn't really need it anymore). I now had a look and the fix was simple enough.

------

Android puts pthread stuff into libc. Because this wasn't detected, we are using some iOS fallbacks in System.Native. I'm propagating how pthreads are detected in the CoreCLR PAL (that was fixed up for Android in the CoreCLR PAL a couple years ago).

Failure to properly detect it here was causing build breaks in CoreCLR on Android (that's how I found this).