### PR TITLE
JIT: yet another OSR stress mode

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -546,6 +546,7 @@ jobs:
           - jitosr
           - jitosr_stress
           - jitosr_pgo
+          - jitosr_stress_random
           - jitpartialcompilation
           - jitpartialcompilation_osr
           - jitpartialcompilation_osr_pgo

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7542,6 +7542,15 @@ void CodeGen::genFnProlog()
 
 #endif // PROFILING_SUPPORTED
 
+    // For OSR we may have a zero-length prolog. That's not supported,
+    // so add a nop if so.
+    //
+    if (compiler->opts.IsOSR() && (GetEmitter()->emitGetPrologOffsetEstimate() == 0))
+    {
+        JITDUMP("OSR: prolog was zero length: adding nop to pad it\n");
+        instGen(INS_nop);
+    }
+
     if (!GetInterruptible())
     {
         // The 'real' prolog ends here for non-interruptible methods.

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7536,12 +7536,13 @@ void CodeGen::genFnProlog()
 
 #endif // PROFILING_SUPPORTED
 
-    // For OSR we may have a zero-length prolog. That's not supported,
-    // so add a nop if so.
+    // For OSR we may have a zero-length prolog. That's not supported
+    // when the method must report a generics context,/ so add a nop if so.
     //
-    if (compiler->opts.IsOSR() && (GetEmitter()->emitGetPrologOffsetEstimate() == 0))
+    if (compiler->opts.IsOSR() && (GetEmitter()->emitGetPrologOffsetEstimate() == 0) &&
+        (compiler->lvaReportParamTypeArg() || compiler->lvaKeepAliveAndReportThis()))
     {
-        JITDUMP("OSR: prolog was zero length: adding nop to pad it\n");
+        JITDUMP("OSR: prolog was zero length and has generic context to report: adding nop to pad prolog.\n");
         instGen(INS_nop);
     }
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -6235,15 +6235,9 @@ void CodeGen::genEnregisterOSRArgsAndLocals()
         // This local was part of the live tier0 state and is enregistered in the
         // OSR method. Initialize the register from the right frame slot.
         //
-        // We currently don't expect to see enregistered multi-reg args in OSR methods,
-        // as struct promotion is disabled. So any struct arg just uses the location
-        // on the tier0 frame.
-        //
         // If we ever enable promotion we'll need to generalize what follows to copy each
         // field from the tier0 frame to its OSR home.
         //
-        assert(!varDsc->lvIsMultiRegArg);
-
         if (!VarSetOps::IsMember(compiler, compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex))
         {
             // This arg or local is not live at entry to the OSR method.

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2786,15 +2786,19 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         verboseDump = (JitConfig.JitDumpTier0() > 0);
     }
 
-    // Optionally suppress dumping some OSR jit requests.
+    // Optionally suppress dumping except for a specific OSR jit request.
     //
-    if (verboseDump && jitFlags->IsSet(JitFlags::JIT_FLAG_OSR))
-    {
-        const int desiredOffset = JitConfig.JitDumpAtOSROffset();
+    const int dumpAtOSROffset = JitConfig.JitDumpAtOSROffset();
 
-        if (desiredOffset != -1)
+    if (verboseDump && (dumpAtOSROffset != -1))
+    {
+        if (jitFlags->IsSet(JitFlags::JIT_FLAG_OSR))
         {
-            verboseDump = (((IL_OFFSET)desiredOffset) == info.compILEntry);
+            verboseDump = (((IL_OFFSET)dumpAtOSROffset) == info.compILEntry);
+        }
+        else
+        {
+            verboseDump = false;
         }
     }
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2151,11 +2151,11 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
     {
         if (block == fgEntryBB)
         {
-            printf("original-entry");
+            printf(" original-entry");
         }
         if (block == fgOSREntryBB)
         {
-            printf("osr-entry");
+            printf(" osr-entry");
         }
     }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11848,7 +11848,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             // Note m_inlineStrategy is always created, even if we're not inlining.
             //
             CLRRandom* const random      = impInlineRoot()->m_inlineStrategy->GetRandom(doRandomOSR);
-            const int        randomValue = (int)random->Next(101);
+            const int        randomValue = (int)random->Next(100);
             if (randomValue < doRandomOSR)
             {
                 JITDUMP("Random patchpoint added to " FMT_BB "\n", block->bbNum);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11792,28 +11792,30 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
 #ifdef FEATURE_ON_STACK_REPLACEMENT
 
-    // Are there any places in the method where we might add a patchpoint?
+    // Is OSR enabled?
     //
-    if (compHasBackwardJump)
+    if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0) && (JitConfig.TC_OnStackReplacement() > 0))
     {
-        // Is OSR enabled?
+        // We don't inline at Tier0, if we do, we may need rethink our approach.
+        // Could probably support inlines that don't introduce flow.
         //
-        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0) && (JitConfig.TC_OnStackReplacement() > 0))
+        assert(!compIsForInlining());
+
+        // OSR is not yet supported for methods with explicit tail calls.
+        //
+        // But we also do not have to switch these methods to be optimized as we should be
+        // able to avoid getting trapped in Tier0 code by normal call counting.
+        // So instead, just suppress adding patchpoints.
+        //
+        if (!compTailPrefixSeen)
         {
-            // OSR is not yet supported for methods with explicit tail calls.
+            assert(compCanHavePatchpoints());
+
+            // The normaly policy is only to add patchpoints to the targets of lexically
+            // backwards branches.
             //
-            // But we also may not switch methods to be optimized as we should be
-            // able to avoid getting trapped in Tier0 code by normal call counting.
-            // So instead, just suppress adding patchpoints.
-            //
-            if (!compTailPrefixSeen)
+            if (compHasBackwardJump)
             {
-                assert(compCanHavePatchpoints());
-
-                // We don't inline at Tier0, if we do, we may need rethink our approach.
-                // Could probably support inlines that don't introduce flow.
-                assert(!compIsForInlining());
-
                 // Is the start of this block a suitable patchpoint?
                 //
                 if (((block->bbFlags & BBF_BACKWARD_JUMP_TARGET) != 0) && (verCurrentState.esStackDepth == 0))
@@ -11826,12 +11828,35 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     setMethodHasPatchpoint();
                 }
             }
+            else
+            {
+                // Should not see backward branch targets w/o backwards branches
+                assert((block->bbFlags & BBF_BACKWARD_JUMP_TARGET) == 0);
+            }
         }
-    }
-    else
-    {
-        // Should not see backward branch targets w/o backwards branches
-        assert((block->bbFlags & BBF_BACKWARD_JUMP_TARGET) == 0);
+
+#ifdef DEBUG
+        // As a stress test, we can place patchpoints at the start of any block
+        // that is a stack empty point and is not within a handler.
+        // Todo: enable for mid-block stack empty points too.
+        //
+        const int doRandomOSR = JitConfig.JitRandomOnStackReplacement();
+        if ((doRandomOSR > 0) && (verCurrentState.esStackDepth == 0) && !block->hasHndIndex() &&
+            ((block->bbFlags & BBF_PATCHPOINT) == 0))
+        {
+            // Reuse the random inliner's random state.
+            // Note m_inlineStrategy is always created, even if we're not inlining.
+            //
+            CLRRandom* const random      = impInlineRoot()->m_inlineStrategy->GetRandom(doRandomOSR);
+            const int        randomValue = (int)random->Next(101);
+            if (randomValue < doRandomOSR)
+            {
+                JITDUMP("Random patchpoint added to " FMT_BB "\n", block->bbNum);
+                block->bbFlags |= BBF_PATCHPOINT;
+                setMethodHasPatchpoint();
+            }
+        }
+#endif // DEBUG
     }
 
     // Mark stack-empty rare blocks to be considered for partial compilation.

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -521,6 +521,10 @@ CONFIG_INTEGER(TC_OnStackReplacement, W("TC_OnStackReplacement"), 0)
 CONFIG_INTEGER(TC_OnStackReplacement_InitialCounter, W("TC_OnStackReplacement_InitialCounter"), 1000)
 // Enable partial compilation for Tier0 methods
 CONFIG_INTEGER(TC_PartialCompilation, W("TC_PartialCompilation"), 0)
+#if defined(DEBUG)
+// Randomly sprinkle patchpoints. Value is the likelyhood any given stack-empty point becomes a patchpoint.
+CONFIG_INTEGER(JitRandomOnStackReplacement, W("JitRandomOnStackReplacement"), 0)
+#endif // debug
 
 #if defined(DEBUG)
 CONFIG_STRING(JitEnableOsrRange, W("JitEnableOsrRange")) // Enable osr for only some methods

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -524,6 +524,8 @@ CONFIG_INTEGER(TC_PartialCompilation, W("TC_PartialCompilation"), 0)
 #if defined(DEBUG)
 // Randomly sprinkle patchpoints. Value is the likelyhood any given stack-empty point becomes a patchpoint.
 CONFIG_INTEGER(JitRandomOnStackReplacement, W("JitRandomOnStackReplacement"), 0)
+// Place patchpoint at the specified IL offset, if possible. Overrides random placement.
+CONFIG_INTEGER(JitOffsetOnStackReplacement, W("JitOffsetOnStackReplacement"), -1)
 #endif // debug
 
 #if defined(DEBUG)

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -305,7 +305,9 @@ void Compiler::lvaInitTypeRef()
             JITDUMP("-- V%02u is OSR exposed\n", varNum);
             varDsc->lvHasLdAddrOp = 1;
 
-            if (varDsc->lvType != TYP_STRUCT) // Why does it apply only to non-structs?
+            // todo: Why does it apply only to non-structs?
+            //
+            if (!varTypeIsStruct(varDsc) && !varTypeIsSIMD(varDsc))
             {
                 lvaSetVarAddrExposed(varNum DEBUGARG(AddressExposedReason::OSR_EXPOSED));
             }

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -62,6 +62,7 @@
       COMPlus_JitEdgeProfiling;
       COMPlus_JitRandomGuardedDevirtualization;
       COMPlus_JitRandomEdgeCounts;
+      COMPlus_JitRandomOnStackReplacement;
       RunningIlasmRoundTrip
     </COMPlusVariables>
   </PropertyGroup>
@@ -187,6 +188,7 @@
     <TestEnvironment Include="gcstress0xc_jitminopts_heapverify1" GCStress="0xC" JITMinOpts="1" HeapVerify="1" />
     <TestEnvironment Include="jitosr" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
     <TestEnvironment Include="jitosr_stress" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TC_OnStackReplacement_InitialCounter="1" OSR_HitLimit="1" TieredCompilation="1" />
+    <TestEnvironment Include="jitosr_stress_random" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TC_OnStackReplacement_InitialCounter="1" OSR_HitLimit="2" TieredCompilation="1" JitRandomOnStackReplacement="15"/>
     <TestEnvironment Include="jitosr_pgo" TC_OnStackReplacement="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />
     <TestEnvironment Include="jitpartialcompilation" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" />
     <TestEnvironment Include="jitpartialcompilation_pgo" TC_PartialCompilation="1" TC_QuickJitForLoops="1" TieredCompilation="1" TieredPGO="1" />


### PR DESCRIPTION
Existing OSR stress use existing patchpoint placement logic and alter the
policy settings so that OSR methods are created more eagerly.

This new version of OSR stress alters the patchpoint placement logic, to
add patchpoints to more places. In conjunction with the eager policy stress
above this leads to creation and execution of large numbers of OSR methods.

Any IL offset in the method with an empty stack (and not in a handler) is fair
game for a patchpoint, so this new method randomly adds patchpoints to the
starts of blocks when stack empty (future work may extend this to mid-block
stack empty points).

The new mode is enabled by setting `COMPlus_JitRandomOnStackReplacement` to a
non-zero value; this value represents the likelihood of adding a patchpoint
at a stack-empty block start, and also factors into the random seed. (Recall
this is parsed in hex, so 0x64 == 100 or larger will put a patchpoint at the
start of every stack empty block).

Various values are interesting because once a method reaches a patchpoint
and triggers OSR, the remainder of that method's execution is in the OSR method,
so later patchpoints in the original method may never be reached. So some sort
of random/selective patchpoint approach (in conjunction with varying policy
settings) is needed to ensure that we create an execute as many different OSR
variants as possible.

This PR also includes a couple of fixes exposed by local testing of this new
stress mode:
* The OSR prolog may end up empty, which gcencoder doesn't like. Detect this
and add a `nop` for the prolog.
* If we're importing the `fgEntryBB` during OSR, we don't need to schedule it
for re-importation. This happens if we put a patchpoint at IL offset zero.
* Update the selective dumping policy `COMPlus_JitDumpAtOSROoffset` to only
dump OSR method compilations.

A new test leg is added to `jit-experimental` to run with this mode enabled
with a probability of 21% (0x15) and quick OSR triggers.