### PR TITLE
Fix for a rare race condition in System.IO.Packaging

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.cs
@@ -684,13 +684,15 @@ namespace System.IO.Packaging
                 {
                     if (_partUriExtension == null)
                     {
-                        _partUriExtension = Path.GetExtension(_partUriString);
+                        string partUriExtension = Path.GetExtension(_partUriString);
 
                         //If extension is absent just return the empty string
                         //else remove the leading "." from the returned extension
                         //string
-                        if (_partUriExtension.Length > 0)
-                            _partUriExtension = _partUriExtension.Substring(1);
+                        if (partUriExtension.Length > 0)
+                            partUriExtension = partUriExtension.Substring(1);
+
+                        _partUriExtension = partUriExtension;
                     }
                     return _partUriExtension;
                 }


### PR DESCRIPTION
Fix for a rare race condition when initializing System.IO.Packaging.PackageRelationship.s_containerRelationshipPartName._partUriExtension

In rare circumstances, when there are at least two ooxml packages created in parallel for the first time in application's lifetime, it is possible that PackageRelationship.s_containerRelationshipPartName._partUriExtension will be initialized to "els" instead of "rels". Once it's initialized like that, every Package is saved with an invalid extension for package relationships content type in [Content_Types].xml:
`<Default ContentType="application/vnd.openxmlformats-package.relationships+xml" Extension="els"/>`
When reading such damaged package later, the relationships are not to be found.

As this is extremely non-deterministic, no unit tests were provided. I developed a tiny app to reproduce this issue, launching it in a loop I was able to get the issue 3 times over 8000 runs.