### PR TITLE
Override same attributes found at class and property level in ApplicationSettingsBase

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs
@@ -519,7 +519,7 @@ namespace System.Configuration
                     //       level and also property level, the latter overrides the former
                     //       for a given setting. This is exactly the behavior we want.
 
-                    settingsProperty.Attributes.Add(attribute.GetType(), attribute);
+                    settingsProperty.Attributes[attribute.GetType()] = attribute;
                 }
             }
 

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -347,6 +347,7 @@ namespace System.ConfigurationTests
             Assert.True(loadedFired);
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Not fixed on NetFX")]
         [Fact]
         public void SettingsProperty_SettingsWithNullableAttributes_Ok()
         {

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ApplicationSettingsBaseTests.cs
@@ -96,6 +96,37 @@ namespace System.ConfigurationTests
 
         }
 
+#nullable enable
+        public class SettingsWithNullableAttribute : ApplicationSettingsBase
+        {
+            [ApplicationScopedSetting]
+            public string StringProperty
+            {
+                get
+                {
+                    return (string)this[nameof(StringProperty)];
+                }
+                set
+                {
+                    this[nameof(StringProperty)] = value;
+                }
+            }
+
+            [UserScopedSetting]
+            public string? NullableStringProperty
+            {
+                get
+                {
+                    return (string)this[nameof(NullableStringProperty)];
+                }
+                set
+                {
+                    this[nameof(NullableStringProperty)] = value;
+                }
+            }
+        }
+#nullable disable
+
         private class PersistedSimpleSettings : SimpleSettings
         {
         }
@@ -314,6 +345,27 @@ namespace System.ConfigurationTests
 
             Assert.Equal(newStringPropertyValue, settings.StringProperty);
             Assert.True(loadedFired);
+        }
+
+        [Fact]
+        public void SettingsProperty_SettingsWithNullableAttributes_Ok()
+        {
+            SettingsWithNullableAttribute settings = new SettingsWithNullableAttribute();
+
+            Assert.Null(settings.NullableStringProperty);
+
+            string newValue = null;
+
+            settings.SettingChanging += (object sender, SettingChangingEventArgs e)
+                =>
+            {
+                newValue = (string)e.NewValue;
+            };
+
+            settings.NullableStringProperty = "test";
+
+            Assert.Equal("test", newValue);
+            Assert.Equal(newValue, settings.NullableStringProperty);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/62593

Looks by the design when the existing attribute is found at property level it should override the class level attribute, but the code is not really overriding, https://github.com/dotnet/runtime/blob/89857ea4e28ef7f372ea0207ae0770c6d70b0509/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ApplicationSettingsBase.cs#L518-L522

The bug found with nullable attributes added by compiler