### PR TITLE
Make test System.Data.Tests.AppDomainsAndFormatInfo.Bug55978 more robust

### DIFF
--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -3573,27 +3573,32 @@ Assert.False(true);
             dt.Columns.Add("StartDate", typeof(DateTime));
 
             DataRow dr;
-            DateTime date = DateTime.Now;
+            DateTime now = DateTime.Now;
+
+            // In RowFilter we have a string containing only seconds,
+            // but in rows we have a DateTime which also contains milliseconds.
+            // The test would fail without this extra minute, when now.Millisecond is 0.
+            DateTime rowDate = now.AddMinutes(1);
 
             for (int i = 0; i < 10; i++)
             {
                 dr = dt.NewRow();
-                dr["StartDate"] = date.AddDays(i);
+                dr["StartDate"] = rowDate.AddDays(i);
                 dt.Rows.Add(dr);
             }
 
             DataView dv = dt.DefaultView;
             dv.RowFilter = string.Format(CultureInfo.InvariantCulture,
                                 "StartDate >= #{0}# and StartDate <= #{1}#",
-                                DateTime.Now.AddDays(2),
-                                DateTime.Now.AddDays(4));
+                                now.AddDays(2),
+                                now.AddDays(4));
             Assert.Equal(10, dt.Rows.Count);
 
             int expectedRowCount = 2;
             if (dv.Count != expectedRowCount)
             {
                 StringBuilder sb = new();
-                sb.AppendLine($"DataView.Rows.Count: Expected: {expectedRowCount}, Actual: {dv.Count}. Debug data: RowFilter: {dv.RowFilter}, date: {date}");
+                sb.AppendLine($"DataView.Rows.Count: Expected: {expectedRowCount}, Actual: {dv.Count}. Debug data: RowFilter: {dv.RowFilter}, date: {now}");
                 for (int i = 0; i < dv.Count; i++)
                 {
                     sb.Append($"row#{i}: ");

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -3566,7 +3566,6 @@ Assert.False(true);
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/62965", TestPlatforms.Browser)] // fails on NodeJS on windows
         public void Bug55978()
         {
             DataTable dt = new DataTable();


### PR DESCRIPTION
Before this change, the test would fail when current milliseconds are 0.

- `RowFilter` has only seconds, as it is a string.
- `DateTime` in rows have also fractions of second. 
- Condition in the `RowFilter` have equality on both ends (`>=` and `<=`).
- When current milliseconds are 0, the `RowFilter` matches 1 extra row.

Example RowFilter
```
StartDate >= #12/22/2021 17:25:42# and StartDate <= #12/24/2021 17:25:42#
```

I have added an explicit 1 minute to the tested datetime so the fractions of second don't play a role.

Fixes https://github.com/dotnet/runtime/issues/62965.