### PR TITLE
improve TLS resume on server

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -122,7 +122,7 @@ internal static partial class Interop
         }
 
         // This essentially wraps SSL_CTX* aka SSL_CTX_new + setting
-        internal static SafeSslContextHandle AllocateSslContext(SafeFreeSslCredentials credential, SslAuthenticationOptions sslAuthenticationOptions, SslProtocols protocols)
+        internal static SafeSslContextHandle AllocateSslContext(SafeFreeSslCredentials credential, SslAuthenticationOptions sslAuthenticationOptions, SslProtocols protocols, bool enableResume)
         {
             SafeX509Handle? certHandle = credential.CertHandle;
             SafeEvpPKeyHandle? certKeyHandle = credential.CertKeyHandle;
@@ -181,6 +181,8 @@ internal static partial class Interop
                 // https://www.openssl.org/docs/manmaster/ssl/SSL_shutdown.html
                 Ssl.SslCtxSetQuietShutdown(sslCtx);
 
+                Ssl.SslCtxSetCaching(sslCtx, enableResume ? 1 : 0);
+
                 if (sslAuthenticationOptions.IsServer && sslAuthenticationOptions.ApplicationProtocols != null && sslAuthenticationOptions.ApplicationProtocols.Count != 0)
                 {
                     unsafe
@@ -222,24 +224,24 @@ internal static partial class Interop
             SafeSslContextHandle? sslCtxHandle = null;
             SafeSslContextHandle? newCtxHandle = null;
             SslProtocols protocols = CalculateEffectiveProtocols(sslAuthenticationOptions);
+            bool hasAlpn = sslAuthenticationOptions.ApplicationProtocols != null && sslAuthenticationOptions.ApplicationProtocols.Count != 0;
             bool cacheSslContext = !DisableTlsResume && sslAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.RequireEncryption &&
+                    sslAuthenticationOptions.IsServer &&
                     sslAuthenticationOptions.CertificateContext != null &&
                     sslAuthenticationOptions.CertificateContext.SslContexts != null &&
-                    sslAuthenticationOptions.CipherSuitesPolicy == null &&
-                    (!sslAuthenticationOptions.IsServer ||
-                    (sslAuthenticationOptions.ApplicationProtocols != null && sslAuthenticationOptions.ApplicationProtocols.Count != 0));
+                    sslAuthenticationOptions.CipherSuitesPolicy == null;
 
             if (cacheSslContext)
             {
-               sslAuthenticationOptions.CertificateContext!.SslContexts!.TryGetValue(protocols, out sslCtxHandle);
+               sslAuthenticationOptions.CertificateContext!.SslContexts!.TryGetValue(protocols | (SslProtocols)(hasAlpn ? 1 : 0), out sslCtxHandle);
             }
 
             if (sslCtxHandle == null)
             {
                 // We did not get SslContext from cache
-                sslCtxHandle = newCtxHandle = AllocateSslContext(credential, sslAuthenticationOptions, protocols);
+                sslCtxHandle = newCtxHandle = AllocateSslContext(credential, sslAuthenticationOptions, protocols, cacheSslContext);
 
-                if (cacheSslContext && sslAuthenticationOptions.CertificateContext!.SslContexts!.TryAdd(protocols, newCtxHandle))
+                if (cacheSslContext && sslAuthenticationOptions.CertificateContext!.SslContexts!.TryAdd(protocols | (SslProtocols)(hasAlpn ? 1 : 0), newCtxHandle))
                 {
                     newCtxHandle = null;
                 }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -78,7 +78,7 @@ internal static partial class Interop
         // This is helper function to adjust requested protocols based on CipherSuitePolicy and system capability.
         private static SslProtocols CalculateEffectiveProtocols(SslAuthenticationOptions sslAuthenticationOptions)
         {
-            SslProtocols protocols = sslAuthenticationOptions.EnabledSslProtocols;
+            SslProtocols protocols = sslAuthenticationOptions.EnabledSslProtocols & ~((SslProtocols)1);
 
             if (!Interop.Ssl.Tls13Supported)
             {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -78,6 +78,8 @@ internal static partial class Interop
         // This is helper function to adjust requested protocols based on CipherSuitePolicy and system capability.
         private static SslProtocols CalculateEffectiveProtocols(SslAuthenticationOptions sslAuthenticationOptions)
         {
+            // make sure low bit is not set since we use it in context dictionary to distinguish use with ALPN
+            Debug.Assert(((int)sslAuthenticationOptions.EnabledSslProtocols & 1) == 0);
             SslProtocols protocols = sslAuthenticationOptions.EnabledSslProtocols & ~((SslProtocols)1);
 
             if (!Interop.Ssl.Tls13Supported)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -22,6 +22,9 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetAlpnSelectCb")]
         internal static unsafe partial void SslCtxSetAlpnSelectCb(SafeSslContextHandle ctx, delegate* unmanaged<IntPtr, byte**, byte*, byte*, uint, IntPtr, int> callback, IntPtr arg);
 
+        [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetCaching")]
+        internal static unsafe partial void SslCtxSetCaching(SafeSslContextHandle ctx, int mode);
+
         internal static bool AddExtraChainCertificates(SafeSslContextHandle ctx, X509Certificate2[] chain)
         {
             // send pre-computed list of intermediates.

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -287,6 +287,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_IsSslRenegotiatePending)
     DllImportEntry(CryptoNative_IsSslStateOK)
     DllImportEntry(CryptoNative_SslCtxAddExtraChainCert)
+    DllImportEntry(CryptoNative_SslCtxSetCaching)
     DllImportEntry(CryptoNative_SslCtxSetCiphers)
     DllImportEntry(CryptoNative_SslCtxSetEncryptionPolicy)
     DllImportEntry(CryptoNative_SetCiphers)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -475,6 +475,16 @@ void CryptoNative_SslSetVerifyPeer(SSL* ssl)
     SSL_set_verify(ssl, SSL_VERIFY_PEER, verify_callback);
 }
 
+void CryptoNative_SslCtxSetCaching(SSL_CTX* ctx, int mode)
+{
+    // We never reuse same CTX for both client and server
+    SSL_CTX_ctrl(ctx, SSL_CTRL_SET_SESS_CACHE_MODE,  mode ? SSL_SESS_CACHE_BOTH : SSL_SESS_CACHE_OFF, NULL);
+    if (mode == 0)
+    {
+        SSL_CTX_set_options(ctx, SSL_OP_NO_TICKET);
+    }
+}
+
 int32_t CryptoNative_SslCtxSetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
 {
     switch (policy)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
@@ -145,6 +145,11 @@ Sets the specified protocols in the SSL_CTX options.
 PALEXPORT void CryptoNative_SslCtxSetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols);
 
 /*
+Sets session caching. 0 is disabled.
+*/
+PALEXPORT void CryptoNative_SslCtxSetCaching(SSL_CTX* ctx, int mode);
+
+/*
 Shims the SSL_new method.
 
 Returns the new SSL instance.


### PR DESCRIPTION
This is follow-up on #57079.

When I did the original change, I run to problem that once ALPN callback is set it MUST return some valid value and that breaks use case when server does not wish to use ALPN. To keep the lookup simple I simply avoided resume with no ALPN. That of course bit me now in testing and I realized there is easy fix.

Each member of SslProtocols uses 2 bits starting with Ssl2 -> 12 -> 1100 and going up. The lover two bits are never used. 
This change use the lowest bit to separate contexts with and without ALPN. With that, we can keep `SslProtocols` as only key for the hash lookup. 

Second part I realized is that Server caching is on by default (even prior) #57079
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_session_cache_mode.html
So even in cases we know resume will not work, we would calculate the ticket, send New Ticket message on wire and possibly cause burden on client to store session that will never be resumable. 

So second part of this change is to turn caching off explicitly in case we use ephemeral context and resume will not be possible. Aside from resource saving it also makes it more obvious in packet capture if TLS resume is possible or not.

Note that client resume is coming soon. I wanted to split this part to make that change smaller and easier to review. 

contributes to #22977