### PR TITLE
Deduplicate JIT/Methodical/tailcall tests and make them mergeable

### DIFF
--- a/src/tests/JIT/Methodical/tailcall/Desktop/thread-race.cs
+++ b/src/tests/JIT/Methodical/tailcall/Desktop/thread-race.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Threading;
+using Xunit;
 
-internal class Repro
+public class Repro
 {
     private static volatile bool s_threadsCompleted;
     private static volatile Mutex s_myMutex;
@@ -12,7 +13,8 @@ internal class Repro
     private const int FibSeriesMax = 35;
     private const int FibSeriesMin = 20;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntrypoint()
     {
         // Compute the expected value for a single thread
         int expectedSingle = 0;

--- a/src/tests/JIT/Methodical/tailcall/Desktop/thread-race_r.csproj
+++ b/src/tests/JIT/Methodical/tailcall/Desktop/thread-race_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <!-- NOTE: this test simply takes too long to complete under heap verify or GCStress. It is not fundamentally incompatible. -->
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
     <GCStressIncompatible>true</GCStressIncompatible>

--- a/src/tests/JIT/Methodical/tailcall/compat_enum.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_enum.il
@@ -9,20 +9,20 @@
 }
 .assembly compat_enum { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_enum
 {
   .class private auto ansi serializable sealed TestEnum extends [mscorlib]System.Enum
   {
     .field public specialname rtspecialname int32 value__
-    .field public static literal value class JitTest.TestEnum v = int32(0x00000000)
-    .field public static literal value class JitTest.TestEnum w = int32(0x00000001)
+    .field public static literal value class JitTest_compat_enum.TestEnum v = int32(0x00000000)
+    .field public static literal value class JitTest_compat_enum.TestEnum w = int32(0x00000001)
   }
-  .class private auto ansi beforefieldinit TestClass extends [mscorlib]System.Object
+  .class public auto ansi beforefieldinit TestClass extends [mscorlib]System.Object
   {
-    .method private hidebysig static value class JitTest.TestEnum callee() il managed
+    .method private hidebysig static value class JitTest_compat_enum.TestEnum callee() il managed
     {
 		.maxstack  8
-		.locals (value class JitTest.TestEnum V_0)
+		.locals (value class JitTest_compat_enum.TestEnum V_0)
 		ldc.i4.1
 		stloc.0
 		ldloc.0
@@ -32,11 +32,11 @@
     {
       // Code size       10 (0xa)
       .maxstack  8
-      tail. call       value class JitTest.TestEnum JitTest.TestClass::callee()
+      tail. call       value class JitTest_compat_enum.TestEnum JitTest_compat_enum.TestClass::callee()
       ret
     } // end of method TestClass::caller
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -46,7 +46,7 @@
       // Code size       40 (0x28)
       .maxstack  2
       .locals (int32 V_0)
-      IL_0000:  call       int32 JitTest.TestClass::caller()
+      IL_0000:  call       int32 JitTest_compat_enum.TestClass::caller()
       IL_0005:  ldc.i4.1
       IL_0006:  bne.un.s   IL_0017
 
@@ -78,6 +78,6 @@
 
   } // end of class TestClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_enum
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/compat_enum_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_enum_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_enum_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_enum_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i2_bool.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_i2_bool.il
@@ -9,9 +9,9 @@
 }
 .assembly compat_i2_bool { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_i2_bool
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig  static 
@@ -65,11 +65,11 @@
       IL_0050:  call       void [mscorlib]System.GC::Collect()
       IL_0055:  call       void [mscorlib]System.GC::Collect()
       IL_005a:  tail.
-      IL_005c:  call       int16 JitTest.Test::Method1()
+      IL_005c:  call       int16 JitTest_compat_i2_bool.Test::Method1()
       IL_0061:  ret
     } // end of method Test::Method2
 
-    .method private hidebysig  static 
+    .method public hidebysig  static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -79,7 +79,7 @@
       // Code size       40 (0x28)
       .maxstack  2
       .locals (int32 V_0)
-      IL_0000:  call       bool JitTest.Test::Method2()
+      IL_0000:  call       bool JitTest_compat_i2_bool.Test::Method2()
       IL_0005:  ldc.i4.s   10
       IL_0007:  beq.s      IL_0017
 
@@ -111,6 +111,6 @@
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_i2_bool
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/compat_i2_bool_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i2_bool_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i2_bool_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i2_bool_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i4_i1.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_i4_i1.il
@@ -9,9 +9,9 @@
 }
 .assembly compat_i4_i1 { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_i4_i1
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig  static 
@@ -65,11 +65,11 @@
       IL_0050:  call       void [mscorlib]System.GC::Collect()
       IL_0055:  call       void [mscorlib]System.GC::Collect()
       IL_005a:  tail.
-      IL_005c:  call       int32 JitTest.Test::Method1()
+      IL_005c:  call       int32 JitTest_compat_i4_i1.Test::Method1()
       IL_0061:  ret
     } // end of method Test::Method2
 
-    .method private hidebysig  static 
+    .method public hidebysig  static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -79,7 +79,7 @@
       // Code size       40 (0x28)
       .maxstack  2
       .locals (int32 V_0)
-      IL_0000:  call       int8 JitTest.Test::Method2()
+      IL_0000:  call       int8 JitTest_compat_i4_i1.Test::Method2()
       IL_0005:  ldc.i4.s   10
       IL_0007:  beq.s      IL_0017
 
@@ -111,6 +111,6 @@
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_i4_i1
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/compat_i4_i1_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i4_i1_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i4_i1_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i4_i1_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i4_u.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_i4_u.il
@@ -9,9 +9,9 @@
 }
 .assembly compat_i4_u { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_i4_u
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static 
@@ -65,11 +65,11 @@
       IL_0050:  call       void [mscorlib]System.GC::Collect()
       IL_0055:  call       void [mscorlib]System.GC::Collect()
       IL_005a:  tail.
-      IL_005c:  call       int32 JitTest.Test::Method1()
+      IL_005c:  call       int32 JitTest_compat_i4_u.Test::Method1()
       IL_0061:  ret
     } // end of method Test::Method2
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -79,7 +79,7 @@
       // Code size       40 (0x28)
       .maxstack  2
       .locals (int32 V_0)
-      IL_0000:  call       native unsigned int JitTest.Test::Method2()
+      IL_0000:  call       native unsigned int JitTest_compat_i4_u.Test::Method2()
       IL_0005:  ldc.i4.s   10
       IL_0007:  beq.s      IL_0017
 
@@ -111,6 +111,6 @@
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_i4_u
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/compat_i4_u_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i4_u_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i4_u_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i4_u_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i_u2.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_i_u2.il
@@ -9,9 +9,9 @@
 }
 .assembly compat_i_u2 { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_i_u2
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig  static 
@@ -65,11 +65,11 @@
       IL_0050:  call       void [mscorlib]System.GC::Collect()
       IL_0055:  call       void [mscorlib]System.GC::Collect()
       IL_005a:  tail.
-      IL_005c:  call       native int JitTest.Test::Method1()
+      IL_005c:  call       native int JitTest_compat_i_u2.Test::Method1()
       IL_0061:  ret
     } // end of method Test::Method2
 
-    .method private hidebysig  static 
+    .method public hidebysig  static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -79,7 +79,7 @@
       // Code size       40 (0x28)
       .maxstack  2
       .locals (int32 V_0)
-      IL_0000:  call       unsigned int16 JitTest.Test::Method2()
+      IL_0000:  call       unsigned int16 JitTest_compat_i_u2.Test::Method2()
       IL_0005:  ldc.i4.s   10
       IL_0007:  beq.s      IL_0017
 
@@ -111,6 +111,6 @@
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_i_u2
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/compat_i_u2_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i_u2_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_i_u2_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_i_u2_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_obj.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_obj.il
@@ -9,24 +9,24 @@
 }
 .assembly compat_obj { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_obj
 {
   .class public auto ansi beforefieldinit BaseClass
          extends [mscorlib]System.Object
   {
     .method public hidebysig  static 
-            class JitTest.BaseClass  caller(bool which) il managed
+            class JitTest_compat_obj.BaseClass  caller(bool which) il managed
     {
       // Code size       18 (0x12)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_000a
 
-      IL_0003:  newobj     instance void JitTest.BaseClass::.ctor()
+      IL_0003:  newobj     instance void JitTest_compat_obj.BaseClass::.ctor()
       IL_0008:  br.s       IL_0011
 
       IL_000a:  tail.
-      IL_000c:  call       class JitTest.DerivedClass JitTest.DerivedClass::callee()
+      IL_000c:  call       class JitTest_compat_obj.DerivedClass JitTest_compat_obj.DerivedClass::callee()
       IL_0011:  ret
     } // end of method BaseClass::caller
 
@@ -43,14 +43,14 @@
   } // end of class BaseClass
 
   .class public auto ansi beforefieldinit DerivedClass
-         extends JitTest.BaseClass
+         extends JitTest_compat_obj.BaseClass
   {
     .method public hidebysig  static 
-            class JitTest.DerivedClass callee() il managed
+            class JitTest_compat_obj.DerivedClass callee() il managed
     {
       // Code size       6 (0x6)
       .maxstack  8
-      IL_0000:  newobj     instance void JitTest.DerivedClass::.ctor()
+      IL_0000:  newobj     instance void JitTest_compat_obj.DerivedClass::.ctor()
       IL_0005:  ret
     } // end of method DerivedClass::callee
 
@@ -65,10 +65,10 @@
       .maxstack  1
       .locals (int32 V_0)
       IL_0000:  ldc.i4.0
-      IL_0001:  call       class JitTest.BaseClass JitTest.BaseClass::caller(bool)
+      IL_0001:  call       class JitTest_compat_obj.BaseClass JitTest_compat_obj.BaseClass::caller(bool)
       IL_0006:  call       void [System.Console]System.Console::WriteLine(class System.Object)
       IL_000b:  ldc.i4.1
-      IL_000c:  call       class JitTest.BaseClass JitTest.BaseClass::caller(bool)
+      IL_000c:  call       class JitTest_compat_obj.BaseClass JitTest_compat_obj.BaseClass::caller(bool)
       IL_0011:  call       void [System.Console]System.Console::WriteLine(class System.Object)
       IL_0016:  ldstr      "passed"
       IL_001b:  call       void [System.Console]System.Console::WriteLine(class System.String)
@@ -86,12 +86,12 @@
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.0
-      IL_0001:  call       instance void JitTest.BaseClass::.ctor()
+      IL_0001:  call       instance void JitTest_compat_obj.BaseClass::.ctor()
       IL_0006:  ret
     } // end of method DerivedClass::.ctor
 
   } // end of class DerivedClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_obj
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/compat_obj_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_obj_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_obj_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_obj_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r4_r8.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_r4_r8.il
@@ -9,9 +9,9 @@
 .assembly extern mscorlib { }
 .assembly compat_r4_r8 { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_r4_r8
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig  static 
@@ -63,11 +63,11 @@
       IL_0050:  call       void [mscorlib]System.GC::Collect()
       IL_0055:  call       void [mscorlib]System.GC::Collect()
       IL_005a:  tail.
-      IL_005c:  call       float32 JitTest.Test::Method1()
+      IL_005c:  call       float32 JitTest_compat_r4_r8.Test::Method1()
       IL_0061:  ret
     } 
 
-    .method private hidebysig  static 
+    .method public hidebysig  static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -76,7 +76,7 @@
       .entrypoint
       .maxstack  8
       .locals (int32 V_0)
-      IL_0000:  call       float64 JitTest.Test::Method2()
+      IL_0000:  call       float64 JitTest_compat_r4_r8.Test::Method2()
       IL_0005:  dup
       IL_0006:  ldc.r8     10.
       IL_000f:  beq.s      IL_001a

--- a/src/tests/JIT/Methodical/tailcall/compat_r4_r8_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r4_r8_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r4_r8_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r4_r8_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r4_r8_inl.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_r4_r8_inl.il
@@ -9,9 +9,9 @@
 .assembly extern mscorlib { }
 .assembly compat_r4_r8_inl { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_r4_r8_inl
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static 
@@ -27,11 +27,11 @@
     {
       .maxstack  8
       IL_0000:  tail.
-      IL_0002:  call       float32 JitTest.Test::Method1()
+      IL_0002:  call       float32 JitTest_compat_r4_r8_inl.Test::Method1()
       IL_0007:  ret
     } 
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -40,7 +40,7 @@
       .entrypoint
       .maxstack  8
       .locals (int32 V_0)
-      IL_0000:  call       float64 JitTest.Test::Method2()
+      IL_0000:  call       float64 JitTest_compat_r4_r8_inl.Test::Method2()
       IL_0005:  dup
       IL_0006:  ldc.r8     10.
       IL_000f:  beq.s      IL_001a

--- a/src/tests/JIT/Methodical/tailcall/compat_r4_r8_inl_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r4_r8_inl_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r4_r8_inl_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r4_r8_inl_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r8_r4.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_r8_r4.il
@@ -9,9 +9,9 @@
 .assembly extern mscorlib { }
 .assembly compat_r8_r4 { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_r8_r4
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static 
@@ -63,11 +63,11 @@
       IL_0050:  call       void [mscorlib]System.GC::Collect()
       IL_0055:  call       void [mscorlib]System.GC::Collect()
       IL_005a:  tail.
-      IL_005c:  call       float64 JitTest.Test::Method1()
+      IL_005c:  call       float64 JitTest_compat_r8_r4.Test::Method1()
       IL_0061:  ret
     } 
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -76,7 +76,7 @@
       .entrypoint
       .maxstack  8
       .locals (int32 V_0)
-      IL_0000:  call       float32 JitTest.Test::Method2()
+      IL_0000:  call       float32 JitTest_compat_r8_r4.Test::Method2()
       IL_0005:  dup
       IL_0006:  ldc.r4     10.
       IL_000b:  beq.s      IL_0016

--- a/src/tests/JIT/Methodical/tailcall/compat_r8_r4_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r8_r4_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r8_r4_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r8_r4_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r8_r4_inl.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_r8_r4_inl.il
@@ -9,9 +9,9 @@
 .assembly extern mscorlib { }
 .assembly compat_r8_r4_inl { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_r8_r4_inl
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .method private hidebysig static 
@@ -27,11 +27,11 @@
     {
       .maxstack  8
       IL_0000:  tail.
-      IL_0002:  call       float64 JitTest.Test::Method1()
+      IL_0002:  call       float64 JitTest_compat_r8_r4_inl.Test::Method1()
       IL_0007:  ret
     } 
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -40,7 +40,7 @@
       .entrypoint
       .maxstack  8
       .locals (int32 V_0)
-      IL_0000:  call       float32 JitTest.Test::Method2()
+      IL_0000:  call       float32 JitTest_compat_r8_r4_inl.Test::Method2()
       IL_0005:  dup
       IL_0006:  ldc.r4     10.
       IL_000b:  beq.s      IL_0016

--- a/src/tests/JIT/Methodical/tailcall/compat_r8_r4_inl_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r8_r4_inl_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_r8_r4_inl_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_r8_r4_inl_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_v.il
+++ b/src/tests/JIT/Methodical/tailcall/compat_v.il
@@ -9,7 +9,7 @@
 }
 .assembly compat_v { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_v
 {
   .class public sequential ansi sealed beforefieldinit BaseStruct
          extends [mscorlib]System.ValueType
@@ -17,36 +17,36 @@
     .pack 1
     .size 1024
     .method public hidebysig  static 
-            value class JitTest.BaseStruct 
+            value class JitTest_compat_v.BaseStruct 
             caller(bool which) il managed
     {
       // Code size       22 (0x16)
       .maxstack  1
-      .locals (value class JitTest.BaseStruct V_0,
-               value class JitTest.BaseStruct V_1)
+      .locals (value class JitTest_compat_v.BaseStruct V_0,
+               value class JitTest_compat_v.BaseStruct V_1)
       IL_0000:  ldarg.0
       IL_0001:  brfalse.s  IL_000e
 
       IL_0003:  ldloca.s   V_1
-      IL_0005:  initobj    JitTest.BaseStruct
+      IL_0005:  initobj    JitTest_compat_v.BaseStruct
       IL_000b:  ldloc.1
       IL_000c:  br.s       IL_0015
 
       IL_000e:  tail.
-      IL_0010:  call       value class JitTest.BaseStruct JitTest.BaseStruct::callee()
+      IL_0010:  call       value class JitTest_compat_v.BaseStruct JitTest_compat_v.BaseStruct::callee()
       IL_0015:  ret
     } // end of method BaseStruct::caller
 
     .method public hidebysig  static 
-            value class JitTest.BaseStruct
+            value class JitTest_compat_v.BaseStruct
             callee() il managed
     {
       // Code size       14 (0xe)
       .maxstack  1
-      .locals (value class JitTest.BaseStruct V_0,
-               value class JitTest.BaseStruct V_1)
+      .locals (value class JitTest_compat_v.BaseStruct V_0,
+               value class JitTest_compat_v.BaseStruct V_1)
       IL_0000:  ldloca.s   V_1
-      IL_0002:  initobj    JitTest.BaseStruct
+      IL_0002:  initobj    JitTest_compat_v.BaseStruct
       IL_0008:  ldloc.1
       IL_0009:  stloc.0
       IL_000a:  br.s       IL_000c
@@ -66,16 +66,16 @@
       .maxstack  1
       .locals (int32 V_0)
       IL_0000:  ldc.i4.0
-      IL_0001:  call       value class JitTest.BaseStruct JitTest.BaseStruct::caller(bool)
+      IL_0001:  call       value class JitTest_compat_v.BaseStruct JitTest_compat_v.BaseStruct::caller(bool)
       //IL_0006:  stloc.1
       //IL_0007:  ldloc.s   V_1
-      IL_0009:  box        JitTest.BaseStruct
+      IL_0009:  box        JitTest_compat_v.BaseStruct
       IL_000e:  call       void [System.Console]System.Console::WriteLine(class System.Object)
       IL_0013:  ldc.i4.1
-      IL_0014:  call       value class JitTest.BaseStruct JitTest.BaseStruct::caller(bool)
+      IL_0014:  call       value class JitTest_compat_v.BaseStruct JitTest_compat_v.BaseStruct::caller(bool)
       //IL_0019:  stloc.1
       //IL_001a:  ldloc.s   V_1
-      IL_001c:  box        JitTest.BaseStruct
+      IL_001c:  box        JitTest_compat_v.BaseStruct
       IL_0021:  call       void [System.Console]System.Console::WriteLine(class System.Object)
       IL_0026:  ldstr      "passed"
       IL_002b:  call       void [System.Console]System.Console::WriteLine(class System.String)
@@ -85,6 +85,6 @@
 
   } // end of class BaseStruct
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_v
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/compat_v_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_v_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/compat_v_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/compat_v_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_array.il
+++ b/src/tests/JIT/Methodical/tailcall/deep_array.il
@@ -9,7 +9,7 @@
 }
 .assembly deep_array { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_deep_array
 {
   .class public auto ansi beforefieldinit TestClass extends [mscorlib]System.Object
   {
@@ -23,12 +23,12 @@
   ldc.i4 2
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method1(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method1(int32[])
   ldstr " 2"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method1(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method1(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method1(int32[]) il managed {
@@ -40,13 +40,13 @@ REM:
   ldc.i4 3
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method2(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method2(int32[])
   ldstr " 3"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method2(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method2(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method2(int32[]) il managed {
   .maxstack 8
@@ -57,12 +57,12 @@ REM:
   ldc.i4 4
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method3(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method3(int32[])
   ldstr " 4"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method3(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method3(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method3(int32[]) il managed {
@@ -74,13 +74,13 @@ REM:
   ldc.i4 5
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method4(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method4(int32[])
   ldstr " 5"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method4(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method4(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method4(int32[]) il managed {
   .maxstack 8
@@ -91,12 +91,12 @@ REM:
   ldc.i4 6
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method5(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method5(int32[])
   ldstr " 6"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method5(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method5(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method5(int32[]) il managed {
@@ -108,13 +108,13 @@ REM:
   ldc.i4 7
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method6(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method6(int32[])
   ldstr " 7"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method6(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method6(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method6(int32[]) il managed {
   .maxstack 8
@@ -125,12 +125,12 @@ REM:
   ldc.i4 8
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method7(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method7(int32[])
   ldstr " 8"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method7(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method7(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method7(int32[]) il managed {
@@ -142,13 +142,13 @@ REM:
   ldc.i4 9
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method8(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method8(int32[])
   ldstr " 9"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method8(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method8(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method8(int32[]) il managed {
   .maxstack 8
@@ -159,12 +159,12 @@ REM:
   ldc.i4 10
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method9(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method9(int32[])
   ldstr " 10"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method9(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method9(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method9(int32[]) il managed {
@@ -176,13 +176,13 @@ REM:
   ldc.i4 11
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method10(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method10(int32[])
   ldstr " 11"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method10(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method10(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method10(int32[]) il managed {
   .maxstack 8
@@ -193,12 +193,12 @@ REM:
   ldc.i4 12
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method11(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method11(int32[])
   ldstr " 12"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method11(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method11(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method11(int32[]) il managed {
@@ -210,13 +210,13 @@ REM:
   ldc.i4 13
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method12(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method12(int32[])
   ldstr " 13"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method12(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method12(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method12(int32[]) il managed {
   .maxstack 8
@@ -227,12 +227,12 @@ REM:
   ldc.i4 14
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method13(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method13(int32[])
   ldstr " 14"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method13(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method13(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method13(int32[]) il managed {
@@ -244,13 +244,13 @@ REM:
   ldc.i4 15
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method14(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method14(int32[])
   ldstr " 15"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method14(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method14(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method14(int32[]) il managed {
   .maxstack 8
@@ -261,12 +261,12 @@ REM:
   ldc.i4 16
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method15(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method15(int32[])
   ldstr " 16"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method15(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method15(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method15(int32[]) il managed {
@@ -278,13 +278,13 @@ REM:
   ldc.i4 17
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method16(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method16(int32[])
   ldstr " 17"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method16(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method16(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method16(int32[]) il managed {
   .maxstack 8
@@ -295,12 +295,12 @@ REM:
   ldc.i4 18
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method17(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method17(int32[])
   ldstr " 18"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method17(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method17(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method17(int32[]) il managed {
@@ -312,13 +312,13 @@ REM:
   ldc.i4 19
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method18(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method18(int32[])
   ldstr " 19"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method18(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method18(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method18(int32[]) il managed {
   .maxstack 8
@@ -329,12 +329,12 @@ REM:
   ldc.i4 20
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method19(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method19(int32[])
   ldstr " 20"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method19(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method19(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method19(int32[]) il managed {
@@ -346,13 +346,13 @@ REM:
   ldc.i4 21
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method20(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method20(int32[])
   ldstr " 21"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method20(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method20(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method20(int32[]) il managed {
   .maxstack 8
@@ -363,12 +363,12 @@ REM:
   ldc.i4 22
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method21(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method21(int32[])
   ldstr " 22"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method21(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method21(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method21(int32[]) il managed {
@@ -380,13 +380,13 @@ REM:
   ldc.i4 23
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method22(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method22(int32[])
   ldstr " 23"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method22(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method22(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method22(int32[]) il managed {
   .maxstack 8
@@ -397,12 +397,12 @@ REM:
   ldc.i4 24
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method23(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method23(int32[])
   ldstr " 24"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method23(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method23(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method23(int32[]) il managed {
@@ -414,13 +414,13 @@ REM:
   ldc.i4 25
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method24(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method24(int32[])
   ldstr " 25"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method24(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method24(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method24(int32[]) il managed {
   .maxstack 8
@@ -431,12 +431,12 @@ REM:
   ldc.i4 26
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method25(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method25(int32[])
   ldstr " 26"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method25(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method25(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method25(int32[]) il managed {
@@ -448,13 +448,13 @@ REM:
   ldc.i4 27
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method26(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method26(int32[])
   ldstr " 27"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method26(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method26(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method26(int32[]) il managed {
   .maxstack 8
@@ -465,12 +465,12 @@ REM:
   ldc.i4 28
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method27(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method27(int32[])
   ldstr " 28"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method27(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method27(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method27(int32[]) il managed {
@@ -482,13 +482,13 @@ REM:
   ldc.i4 29
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method28(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method28(int32[])
   ldstr " 29"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method28(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method28(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method28(int32[]) il managed {
   .maxstack 8
@@ -499,12 +499,12 @@ REM:
   ldc.i4 30
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method29(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method29(int32[])
   ldstr " 30"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method29(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method29(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method29(int32[]) il managed {
@@ -516,13 +516,13 @@ REM:
   ldc.i4 31
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method30(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method30(int32[])
   ldstr " 31"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method30(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method30(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method30(int32[]) il managed {
   .maxstack 8
@@ -533,12 +533,12 @@ REM:
   ldc.i4 32
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method31(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method31(int32[])
   ldstr " 32"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method31(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method31(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method31(int32[]) il managed {
@@ -550,13 +550,13 @@ REM:
   ldc.i4 33
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method32(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method32(int32[])
   ldstr " 33"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method32(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method32(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method32(int32[]) il managed {
   .maxstack 8
@@ -567,12 +567,12 @@ REM:
   ldc.i4 34
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method33(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method33(int32[])
   ldstr " 34"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method33(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method33(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method33(int32[]) il managed {
@@ -584,13 +584,13 @@ REM:
   ldc.i4 35
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method34(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method34(int32[])
   ldstr " 35"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method34(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method34(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method34(int32[]) il managed {
   .maxstack 8
@@ -601,12 +601,12 @@ REM:
   ldc.i4 36
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method35(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method35(int32[])
   ldstr " 36"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method35(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method35(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method35(int32[]) il managed {
@@ -618,13 +618,13 @@ REM:
   ldc.i4 37
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method36(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method36(int32[])
   ldstr " 37"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method36(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method36(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method36(int32[]) il managed {
   .maxstack 8
@@ -635,12 +635,12 @@ REM:
   ldc.i4 38
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method37(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method37(int32[])
   ldstr " 38"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method37(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method37(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method37(int32[]) il managed {
@@ -652,13 +652,13 @@ REM:
   ldc.i4 39
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method38(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method38(int32[])
   ldstr " 39"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method38(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method38(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method38(int32[]) il managed {
   .maxstack 8
@@ -669,12 +669,12 @@ REM:
   ldc.i4 40
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method39(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method39(int32[])
   ldstr " 40"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method39(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method39(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method39(int32[]) il managed {
@@ -686,13 +686,13 @@ REM:
   ldc.i4 41
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method40(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method40(int32[])
   ldstr " 41"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method40(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method40(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method40(int32[]) il managed {
   .maxstack 8
@@ -703,12 +703,12 @@ REM:
   ldc.i4 42
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method41(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method41(int32[])
   ldstr " 42"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method41(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method41(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method41(int32[]) il managed {
@@ -720,13 +720,13 @@ REM:
   ldc.i4 43
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method42(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method42(int32[])
   ldstr " 43"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method42(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method42(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method42(int32[]) il managed {
   .maxstack 8
@@ -737,12 +737,12 @@ REM:
   ldc.i4 44
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method43(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method43(int32[])
   ldstr " 44"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method43(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method43(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method43(int32[]) il managed {
@@ -754,13 +754,13 @@ REM:
   ldc.i4 45
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method44(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method44(int32[])
   ldstr " 45"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method44(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method44(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method44(int32[]) il managed {
   .maxstack 8
@@ -771,12 +771,12 @@ REM:
   ldc.i4 46
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method45(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method45(int32[])
   ldstr " 46"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method45(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method45(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method45(int32[]) il managed {
@@ -788,13 +788,13 @@ REM:
   ldc.i4 47
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method46(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method46(int32[])
   ldstr " 47"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method46(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method46(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method46(int32[]) il managed {
   .maxstack 8
@@ -805,12 +805,12 @@ REM:
   ldc.i4 48
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method47(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method47(int32[])
   ldstr " 48"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method47(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method47(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method47(int32[]) il managed {
@@ -822,13 +822,13 @@ REM:
   ldc.i4 49
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method48(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method48(int32[])
   ldstr " 49"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method48(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method48(int32[])
 }
 .method private hidebysig static class [mscorlib]System.String Method48(int32[]) il managed {
   .maxstack 8
@@ -839,12 +839,12 @@ REM:
   ldc.i4 50
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method49(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method49(int32[])
   ldstr " 50"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method49(int32[])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method49(int32[])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method49(int32[]) il managed {
@@ -856,13 +856,13 @@ REM:
   ldc.i4 51
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method50(int32[])
+  call class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method50(int32[])
   ldstr " 51"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method50(int32[])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array.TestClass::Method50(int32[])
 }
 //-----END AUTO GENERATED CODE-----//
 
@@ -873,7 +873,7 @@ REM:
       ret
     }
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -894,7 +894,7 @@ REM:
       
 IL_0007:
       ldloc.0
-      call       class System.String JitTest.TestClass::Method0(int32[])
+      call       class System.String JitTest_compat_deep_array.TestClass::Method0(int32[])
       brtrue     IL_0027
 
       ldloc.0
@@ -939,6 +939,6 @@ IL_0027:
 
   } // end of class TestClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_deep_array
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/deep_array_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_array_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_array_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_array_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_array_nz.il
+++ b/src/tests/JIT/Methodical/tailcall/deep_array_nz.il
@@ -9,7 +9,7 @@
 }
 .assembly deep_array_nz { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_deep_array_nz
 {
   .class public auto ansi beforefieldinit TestClass extends [mscorlib]System.Object
   {
@@ -23,12 +23,12 @@
   ldc.i4 2
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method1(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method1(int32[100...])
   ldstr " 2"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method1(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method1(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method1(int32[100...]) il managed {
@@ -40,13 +40,13 @@ REM:
   ldc.i4 3
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method2(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method2(int32[100...])
   ldstr " 3"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method2(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method2(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method2(int32[100...]) il managed {
   .maxstack 8
@@ -57,12 +57,12 @@ REM:
   ldc.i4 4
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method3(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method3(int32[100...])
   ldstr " 4"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method3(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method3(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method3(int32[100...]) il managed {
@@ -74,13 +74,13 @@ REM:
   ldc.i4 5
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method4(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method4(int32[100...])
   ldstr " 5"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method4(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method4(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method4(int32[100...]) il managed {
   .maxstack 8
@@ -91,12 +91,12 @@ REM:
   ldc.i4 6
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method5(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method5(int32[100...])
   ldstr " 6"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method5(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method5(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method5(int32[100...]) il managed {
@@ -108,13 +108,13 @@ REM:
   ldc.i4 7
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method6(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method6(int32[100...])
   ldstr " 7"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method6(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method6(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method6(int32[100...]) il managed {
   .maxstack 8
@@ -125,12 +125,12 @@ REM:
   ldc.i4 8
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method7(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method7(int32[100...])
   ldstr " 8"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method7(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method7(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method7(int32[100...]) il managed {
@@ -142,13 +142,13 @@ REM:
   ldc.i4 9
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method8(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method8(int32[100...])
   ldstr " 9"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method8(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method8(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method8(int32[100...]) il managed {
   .maxstack 8
@@ -159,12 +159,12 @@ REM:
   ldc.i4 10
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method9(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method9(int32[100...])
   ldstr " 10"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method9(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method9(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method9(int32[100...]) il managed {
@@ -176,13 +176,13 @@ REM:
   ldc.i4 11
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method10(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method10(int32[100...])
   ldstr " 11"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method10(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method10(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method10(int32[100...]) il managed {
   .maxstack 8
@@ -193,12 +193,12 @@ REM:
   ldc.i4 12
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method11(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method11(int32[100...])
   ldstr " 12"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method11(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method11(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method11(int32[100...]) il managed {
@@ -210,13 +210,13 @@ REM:
   ldc.i4 13
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method12(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method12(int32[100...])
   ldstr " 13"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method12(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method12(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method12(int32[100...]) il managed {
   .maxstack 8
@@ -227,12 +227,12 @@ REM:
   ldc.i4 14
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method13(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method13(int32[100...])
   ldstr " 14"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method13(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method13(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method13(int32[100...]) il managed {
@@ -244,13 +244,13 @@ REM:
   ldc.i4 15
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method14(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method14(int32[100...])
   ldstr " 15"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method14(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method14(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method14(int32[100...]) il managed {
   .maxstack 8
@@ -261,12 +261,12 @@ REM:
   ldc.i4 16
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method15(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method15(int32[100...])
   ldstr " 16"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method15(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method15(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method15(int32[100...]) il managed {
@@ -278,13 +278,13 @@ REM:
   ldc.i4 17
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method16(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method16(int32[100...])
   ldstr " 17"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method16(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method16(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method16(int32[100...]) il managed {
   .maxstack 8
@@ -295,12 +295,12 @@ REM:
   ldc.i4 18
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method17(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method17(int32[100...])
   ldstr " 18"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method17(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method17(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method17(int32[100...]) il managed {
@@ -312,13 +312,13 @@ REM:
   ldc.i4 19
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method18(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method18(int32[100...])
   ldstr " 19"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method18(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method18(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method18(int32[100...]) il managed {
   .maxstack 8
@@ -329,12 +329,12 @@ REM:
   ldc.i4 20
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method19(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method19(int32[100...])
   ldstr " 20"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method19(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method19(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method19(int32[100...]) il managed {
@@ -346,13 +346,13 @@ REM:
   ldc.i4 21
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method20(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method20(int32[100...])
   ldstr " 21"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method20(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method20(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method20(int32[100...]) il managed {
   .maxstack 8
@@ -363,12 +363,12 @@ REM:
   ldc.i4 22
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method21(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method21(int32[100...])
   ldstr " 22"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method21(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method21(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method21(int32[100...]) il managed {
@@ -380,13 +380,13 @@ REM:
   ldc.i4 23
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method22(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method22(int32[100...])
   ldstr " 23"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method22(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method22(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method22(int32[100...]) il managed {
   .maxstack 8
@@ -397,12 +397,12 @@ REM:
   ldc.i4 24
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method23(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method23(int32[100...])
   ldstr " 24"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method23(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method23(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method23(int32[100...]) il managed {
@@ -414,13 +414,13 @@ REM:
   ldc.i4 25
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method24(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method24(int32[100...])
   ldstr " 25"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method24(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method24(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method24(int32[100...]) il managed {
   .maxstack 8
@@ -431,12 +431,12 @@ REM:
   ldc.i4 26
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method25(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method25(int32[100...])
   ldstr " 26"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method25(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method25(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method25(int32[100...]) il managed {
@@ -448,13 +448,13 @@ REM:
   ldc.i4 27
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method26(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method26(int32[100...])
   ldstr " 27"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method26(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method26(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method26(int32[100...]) il managed {
   .maxstack 8
@@ -465,12 +465,12 @@ REM:
   ldc.i4 28
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method27(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method27(int32[100...])
   ldstr " 28"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method27(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method27(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method27(int32[100...]) il managed {
@@ -482,13 +482,13 @@ REM:
   ldc.i4 29
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method28(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method28(int32[100...])
   ldstr " 29"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method28(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method28(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method28(int32[100...]) il managed {
   .maxstack 8
@@ -499,12 +499,12 @@ REM:
   ldc.i4 30
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method29(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method29(int32[100...])
   ldstr " 30"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method29(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method29(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method29(int32[100...]) il managed {
@@ -516,13 +516,13 @@ REM:
   ldc.i4 31
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method30(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method30(int32[100...])
   ldstr " 31"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method30(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method30(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method30(int32[100...]) il managed {
   .maxstack 8
@@ -533,12 +533,12 @@ REM:
   ldc.i4 32
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method31(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method31(int32[100...])
   ldstr " 32"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method31(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method31(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method31(int32[100...]) il managed {
@@ -550,13 +550,13 @@ REM:
   ldc.i4 33
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method32(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method32(int32[100...])
   ldstr " 33"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method32(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method32(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method32(int32[100...]) il managed {
   .maxstack 8
@@ -567,12 +567,12 @@ REM:
   ldc.i4 34
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method33(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method33(int32[100...])
   ldstr " 34"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method33(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method33(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method33(int32[100...]) il managed {
@@ -584,13 +584,13 @@ REM:
   ldc.i4 35
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method34(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method34(int32[100...])
   ldstr " 35"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method34(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method34(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method34(int32[100...]) il managed {
   .maxstack 8
@@ -601,12 +601,12 @@ REM:
   ldc.i4 36
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method35(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method35(int32[100...])
   ldstr " 36"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method35(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method35(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method35(int32[100...]) il managed {
@@ -618,13 +618,13 @@ REM:
   ldc.i4 37
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method36(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method36(int32[100...])
   ldstr " 37"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method36(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method36(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method36(int32[100...]) il managed {
   .maxstack 8
@@ -635,12 +635,12 @@ REM:
   ldc.i4 38
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method37(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method37(int32[100...])
   ldstr " 38"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method37(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method37(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method37(int32[100...]) il managed {
@@ -652,13 +652,13 @@ REM:
   ldc.i4 39
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method38(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method38(int32[100...])
   ldstr " 39"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method38(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method38(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method38(int32[100...]) il managed {
   .maxstack 8
@@ -669,12 +669,12 @@ REM:
   ldc.i4 40
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method39(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method39(int32[100...])
   ldstr " 40"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method39(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method39(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method39(int32[100...]) il managed {
@@ -686,13 +686,13 @@ REM:
   ldc.i4 41
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method40(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method40(int32[100...])
   ldstr " 41"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method40(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method40(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method40(int32[100...]) il managed {
   .maxstack 8
@@ -703,12 +703,12 @@ REM:
   ldc.i4 42
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method41(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method41(int32[100...])
   ldstr " 42"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method41(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method41(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method41(int32[100...]) il managed {
@@ -720,13 +720,13 @@ REM:
   ldc.i4 43
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method42(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method42(int32[100...])
   ldstr " 43"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method42(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method42(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method42(int32[100...]) il managed {
   .maxstack 8
@@ -737,12 +737,12 @@ REM:
   ldc.i4 44
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method43(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method43(int32[100...])
   ldstr " 44"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method43(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method43(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method43(int32[100...]) il managed {
@@ -754,13 +754,13 @@ REM:
   ldc.i4 45
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method44(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method44(int32[100...])
   ldstr " 45"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method44(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method44(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method44(int32[100...]) il managed {
   .maxstack 8
@@ -771,12 +771,12 @@ REM:
   ldc.i4 46
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method45(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method45(int32[100...])
   ldstr " 46"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method45(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method45(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method45(int32[100...]) il managed {
@@ -788,13 +788,13 @@ REM:
   ldc.i4 47
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method46(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method46(int32[100...])
   ldstr " 47"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method46(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method46(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method46(int32[100...]) il managed {
   .maxstack 8
@@ -805,12 +805,12 @@ REM:
   ldc.i4 48
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method47(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method47(int32[100...])
   ldstr " 48"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method47(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method47(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method47(int32[100...]) il managed {
@@ -822,13 +822,13 @@ REM:
   ldc.i4 49
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method48(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method48(int32[100...])
   ldstr " 49"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method48(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method48(int32[100...])
 }
 .method private hidebysig static class [mscorlib]System.String Method48(int32[100...]) il managed {
   .maxstack 8
@@ -839,12 +839,12 @@ REM:
   ldc.i4 50
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method49(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method49(int32[100...])
   ldstr " 50"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
-  tail. call class [mscorlib]System.String JitTest.TestClass::Method49(int32[100...])
+  tail. call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method49(int32[100...])
   ret
 }
 .method private hidebysig static class [mscorlib]System.String Method49(int32[100...]) il managed {
@@ -856,13 +856,13 @@ REM:
   ldc.i4 51
   rem
   brtrue.s REM
-  call class [mscorlib]System.String JitTest.TestClass::Method50(int32[100...])
+  call class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method50(int32[100...])
   ldstr " 51"
   call class [mscorlib]System.String [mscorlib]System.String::Concat(class [mscorlib]System.String, class [mscorlib]System.String)
   ret
 REM:
   pop
-  jmp class [mscorlib]System.String JitTest.TestClass::Method50(int32[100...])
+  jmp class [mscorlib]System.String JitTest_compat_deep_array_nz.TestClass::Method50(int32[100...])
 }
 //-----END AUTO GENERATED CODE-----//
 
@@ -873,7 +873,7 @@ REM:
       ret
     }
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -895,7 +895,7 @@ REM:
       
 IL_0007:
       ldloc.0
-      call       class System.String JitTest.TestClass::Method0(int32[100...])
+      call       class System.String JitTest_compat_deep_array_nz.TestClass::Method0(int32[100...])
       brtrue     IL_0027
 
       ldloc.0
@@ -940,6 +940,6 @@ IL_0027:
 
   } // end of class TestClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_deep_array_nz
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/deep_array_nz_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_array_nz_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_array_nz_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_array_nz_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_gc.il
+++ b/src/tests/JIT/Methodical/tailcall/deep_gc.il
@@ -9,1139 +9,1139 @@
 }
 .assembly deep_gc { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_deep_gc
 {
   .class public auto ansi beforefieldinit TestClass
          extends [mscorlib]System.Object
   {
     .field public int32 m_fld
     .method private hidebysig static 
-            class System.String  Method0(class JitTest.TestClass A_0) il managed
+            class System.String  Method0(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x2
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method1(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method1(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 2"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method1(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method1(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method0
 
     .method private hidebysig static 
-            class System.String  Method1(class JitTest.TestClass A_0) il managed
+            class System.String  Method1(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x3
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method2(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method2(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 3"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method2(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method2(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method1
 
     .method private hidebysig static 
-            class System.String  Method2(class JitTest.TestClass A_0) il managed
+            class System.String  Method2(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x4
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method3(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method3(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 4"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method3(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method3(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method2
 
     .method private hidebysig static 
-            class System.String  Method3(class JitTest.TestClass A_0) il managed
+            class System.String  Method3(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x5
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method4(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method4(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 5"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method4(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method4(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method3
 
     .method private hidebysig static 
-            class System.String  Method4(class JitTest.TestClass A_0) il managed
+            class System.String  Method4(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x6
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method5(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method5(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 6"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method5(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method5(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method4
 
     .method private hidebysig static 
-            class System.String  Method5(class JitTest.TestClass A_0) il managed
+            class System.String  Method5(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x7
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method6(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method6(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 7"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method6(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method6(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method5
 
     .method private hidebysig static 
-            class System.String  Method6(class JitTest.TestClass A_0) il managed
+            class System.String  Method6(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x8
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method7(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method7(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 8"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method7(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method7(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method6
 
     .method private hidebysig static 
-            class System.String  Method7(class JitTest.TestClass A_0) il managed
+            class System.String  Method7(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x9
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method8(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method8(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 9"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method8(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method8(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method7
 
     .method private hidebysig static 
-            class System.String  Method8(class JitTest.TestClass A_0) il managed
+            class System.String  Method8(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0xa
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method9(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method9(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 10"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method9(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method9(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method8
 
     .method private hidebysig static 
-            class System.String  Method9(class JitTest.TestClass A_0) il managed
+            class System.String  Method9(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0xb
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method10(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method10(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 11"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method10(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method10(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method9
 
     .method private hidebysig static 
-            class System.String  Method10(class JitTest.TestClass A_0) il managed
+            class System.String  Method10(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0xc
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method11(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method11(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 12"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method11(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method11(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method10
 
     .method private hidebysig static 
-            class System.String  Method11(class JitTest.TestClass A_0) il managed
+            class System.String  Method11(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0xd
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method12(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method12(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 13"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method12(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method12(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method11
 
     .method private hidebysig static 
-            class System.String  Method12(class JitTest.TestClass A_0) il managed
+            class System.String  Method12(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0xe
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method13(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method13(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 14"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method13(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method13(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method12
 
     .method private hidebysig static 
-            class System.String  Method13(class JitTest.TestClass A_0) il managed
+            class System.String  Method13(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0xf
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method14(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method14(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 15"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method14(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method14(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method13
 
     .method private hidebysig static 
-            class System.String  Method14(class JitTest.TestClass A_0) il managed
+            class System.String  Method14(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x10
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method15(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method15(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 16"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method15(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method15(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method14
 
     .method private hidebysig static 
-            class System.String  Method15(class JitTest.TestClass A_0) il managed
+            class System.String  Method15(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x11
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method16(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method16(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 17"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method16(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method16(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method15
 
     .method private hidebysig static 
-            class System.String  Method16(class JitTest.TestClass A_0) il managed
+            class System.String  Method16(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x12
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method17(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method17(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 18"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method17(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method17(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method16
 
     .method private hidebysig static 
-            class System.String  Method17(class JitTest.TestClass A_0) il managed
+            class System.String  Method17(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x13
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method18(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method18(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 19"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method18(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method18(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method17
 
     .method private hidebysig static 
-            class System.String  Method18(class JitTest.TestClass A_0) il managed
+            class System.String  Method18(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x14
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method19(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method19(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 20"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method19(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method19(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method18
 
     .method private hidebysig static 
-            class System.String  Method19(class JitTest.TestClass A_0) il managed
+            class System.String  Method19(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x15
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method20(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method20(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 21"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method20(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method20(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method19
 
     .method private hidebysig static 
-            class System.String  Method20(class JitTest.TestClass A_0) il managed
+            class System.String  Method20(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x16
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method21(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method21(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 22"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method21(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method21(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method20
 
     .method private hidebysig static 
-            class System.String  Method21(class JitTest.TestClass A_0) il managed
+            class System.String  Method21(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x17
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method22(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method22(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 23"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method22(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method22(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method21
 
     .method private hidebysig static 
-            class System.String  Method22(class JitTest.TestClass A_0) il managed
+            class System.String  Method22(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x18
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method23(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method23(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 24"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method23(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method23(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method22
 
     .method private hidebysig static 
-            class System.String  Method23(class JitTest.TestClass A_0) il managed
+            class System.String  Method23(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x19
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method24(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method24(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 25"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method24(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method24(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method23
 
     .method private hidebysig static 
-            class System.String  Method24(class JitTest.TestClass A_0) il managed
+            class System.String  Method24(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x1a
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method25(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method25(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 26"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method25(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method25(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method24
 
     .method private hidebysig static 
-            class System.String  Method25(class JitTest.TestClass A_0) il managed
+            class System.String  Method25(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x1b
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method26(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method26(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 27"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method26(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method26(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method25
 
     .method private hidebysig static 
-            class System.String  Method26(class JitTest.TestClass A_0) il managed
+            class System.String  Method26(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x1c
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method27(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method27(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 28"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method27(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method27(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method26
 
     .method private hidebysig static 
-            class System.String  Method27(class JitTest.TestClass A_0) il managed
+            class System.String  Method27(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x1d
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method28(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method28(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 29"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method28(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method28(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method27
 
     .method private hidebysig static 
-            class System.String  Method28(class JitTest.TestClass A_0) il managed
+            class System.String  Method28(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x1e
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method29(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method29(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 30"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method29(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method29(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method28
 
     .method private hidebysig static 
-            class System.String  Method29(class JitTest.TestClass A_0) il managed
+            class System.String  Method29(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x1f
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method30(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method30(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 31"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method30(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method30(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method29
 
     .method private hidebysig static 
-            class System.String  Method30(class JitTest.TestClass A_0) il managed
+            class System.String  Method30(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x20
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method31(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method31(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 32"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method31(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method31(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method30
 
     .method private hidebysig static 
-            class System.String  Method31(class JitTest.TestClass A_0) il managed
+            class System.String  Method31(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x21
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method32(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method32(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 33"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method32(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method32(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method31
 
     .method private hidebysig static 
-            class System.String  Method32(class JitTest.TestClass A_0) il managed
+            class System.String  Method32(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x22
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method33(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method33(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 34"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method33(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method33(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method32
 
     .method private hidebysig static 
-            class System.String  Method33(class JitTest.TestClass A_0) il managed
+            class System.String  Method33(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x23
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method34(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method34(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 35"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method34(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method34(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method33
 
     .method private hidebysig static 
-            class System.String  Method34(class JitTest.TestClass A_0) il managed
+            class System.String  Method34(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x24
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method35(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method35(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 36"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method35(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method35(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method34
 
     .method private hidebysig static 
-            class System.String  Method35(class JitTest.TestClass A_0) il managed
+            class System.String  Method35(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x25
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method36(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method36(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 37"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method36(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method36(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method35
 
     .method private hidebysig static 
-            class System.String  Method36(class JitTest.TestClass A_0) il managed
+            class System.String  Method36(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x26
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method37(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method37(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 38"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method37(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method37(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method36
 
     .method private hidebysig static 
-            class System.String  Method37(class JitTest.TestClass A_0) il managed
+            class System.String  Method37(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x27
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method38(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method38(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 39"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method38(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method38(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method37
 
     .method private hidebysig static 
-            class System.String  Method38(class JitTest.TestClass A_0) il managed
+            class System.String  Method38(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x28
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method39(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method39(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 40"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method39(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method39(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method38
 
     .method private hidebysig static 
-            class System.String  Method39(class JitTest.TestClass A_0) il managed
+            class System.String  Method39(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x29
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method40(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method40(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 41"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method40(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method40(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method39
 
     .method private hidebysig static 
-            class System.String  Method40(class JitTest.TestClass A_0) il managed
+            class System.String  Method40(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x2a
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method41(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method41(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 42"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method41(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method41(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method40
 
     .method private hidebysig static 
-            class System.String  Method41(class JitTest.TestClass A_0) il managed
+            class System.String  Method41(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x2b
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method42(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method42(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 43"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method42(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method42(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method41
 
     .method private hidebysig static 
-            class System.String  Method42(class JitTest.TestClass A_0) il managed
+            class System.String  Method42(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x2c
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method43(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method43(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 44"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method43(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method43(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method42
 
     .method private hidebysig static 
-            class System.String  Method43(class JitTest.TestClass A_0) il managed
+            class System.String  Method43(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x2d
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method44(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method44(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 45"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method44(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method44(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method43
 
     .method private hidebysig static 
-            class System.String  Method44(class JitTest.TestClass A_0) il managed
+            class System.String  Method44(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x2e
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method45(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method45(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 46"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method45(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method45(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method44
 
     .method private hidebysig static 
-            class System.String  Method45(class JitTest.TestClass A_0) il managed
+            class System.String  Method45(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x2f
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method46(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method46(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 47"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method46(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method46(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method45
 
     .method private hidebysig static 
-            class System.String  Method46(class JitTest.TestClass A_0) il managed
+            class System.String  Method46(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x30
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method47(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method47(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 48"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method47(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method47(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method46
 
     .method private hidebysig static 
-            class System.String  Method47(class JitTest.TestClass A_0) il managed
+            class System.String  Method47(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x31
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method48(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method48(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 49"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method48(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method48(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method47
 
     .method private hidebysig static 
-            class System.String  Method48(class JitTest.TestClass A_0) il managed
+            class System.String  Method48(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       39 (0x27)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x32
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method49(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method49(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 50"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       class System.String JitTest.TestClass::Method49(class JitTest.TestClass)
+      IL_0021:  call       class System.String JitTest_compat_deep_gc.TestClass::Method49(class JitTest_compat_deep_gc.TestClass)
       IL_0026:  ret
     } // end of method TestClass::Method48
 
     .method private hidebysig static 
-            class System.String  Method49(class JitTest.TestClass A_0) il managed
+            class System.String  Method49(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       37 (0x25)
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0007:  ldc.i4     0x33
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       class System.String JitTest.TestClass::Method50(class JitTest.TestClass)
+      IL_000f:  call       class System.String JitTest_compat_deep_gc.TestClass::Method50(class JitTest_compat_deep_gc.TestClass)
       IL_0014:  ldstr      " 51"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        class System.String JitTest.TestClass::Method50(class JitTest.TestClass)
+      IL_0020:  jmp        class System.String JitTest_compat_deep_gc.TestClass::Method50(class JitTest_compat_deep_gc.TestClass)
     } // end of method TestClass::Method49
 
     .method private hidebysig static 
-            class System.String  Method50(class JitTest.TestClass A_0) il managed
+            class System.String  Method50(class JitTest_compat_deep_gc.TestClass A_0) il managed
     {
       // Code size       2 (0x2)
       .maxstack  8
@@ -1149,7 +1149,7 @@
       IL_0001:  ret
     } // end of method TestClass::Method50
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -1158,33 +1158,33 @@
       .entrypoint
       // Code size       78 (0x4e)
       .maxstack  8
-      .locals (class JitTest.TestClass V_0)
+      .locals (class JitTest_compat_deep_gc.TestClass V_0)
       IL_0000:  ldc.i4.2
-      IL_0001:  newobj     instance void JitTest.TestClass::.ctor(int32)
+      IL_0001:  newobj     instance void JitTest_compat_deep_gc.TestClass::.ctor(int32)
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
-      IL_0008:  call       class System.String JitTest.TestClass::Method0(class JitTest.TestClass)
+      IL_0008:  call       class System.String JitTest_compat_deep_gc.TestClass::Method0(class JitTest_compat_deep_gc.TestClass)
       IL_000d:  brtrue     IL_0027
 
       IL_0012:  ldloc.0
-      IL_0013:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0013:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0018:  call       void [System.Console]System.Console::Write(int32)
       IL_001d:  ldstr      " - prime!"
       IL_0022:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_0027:  ldloc.0
       IL_0028:  dup
-      IL_0029:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0029:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_002e:  ldc.i4.1
       IL_002f:  add
-      IL_0030:  stfld      int32 JitTest.TestClass::m_fld
+      IL_0030:  stfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_0035:  ldloc.0
-      IL_0036:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0036:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_003b:  ldc.i4     0x64
       IL_0040:  ceq
       IL_0042:  brfalse    IL_0007
 
       IL_0047:  ldloc.0
-      IL_0048:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0048:  ldfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_004d:  ret
     } // end of method TestClass::Main
 
@@ -1197,10 +1197,10 @@
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
-      IL_0008:  stfld      int32 JitTest.TestClass::m_fld
+      IL_0008:  stfld      int32 JitTest_compat_deep_gc.TestClass::m_fld
       IL_000d:  ret
     } // end of method TestClass::.ctor
 
   } // end of class TestClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_deep_gc

--- a/src/tests/JIT/Methodical/tailcall/deep_gc_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_gc_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_gc_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_gc_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_inst.il
+++ b/src/tests/JIT/Methodical/tailcall/deep_inst.il
@@ -9,7 +9,7 @@
 }
 .assembly deep_inst { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_deep_inst
 {
   .class public auto ansi beforefieldinit TestClass
          extends [mscorlib]System.Object
@@ -22,19 +22,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x2
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method1()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method1()
       IL_0014:  ldstr      " 2"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method1()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method1()
       IL_0026:  ret
     } // end of method TestClass::Method0
 
@@ -45,19 +45,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x3
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method2()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method2()
       IL_0014:  ldstr      " 3"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method2()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method2()
     } // end of method TestClass::Method1
 
     .method private hidebysig  instance class System.String
@@ -67,19 +67,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x4
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method3()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method3()
       IL_0014:  ldstr      " 4"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method3()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method3()
       IL_0026:  ret
     } // end of method TestClass::Method2
 
@@ -90,19 +90,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x5
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method4()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method4()
       IL_0014:  ldstr      " 5"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method4()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method4()
     } // end of method TestClass::Method3
 
     .method private hidebysig  instance class System.String
@@ -112,19 +112,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x6
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method5()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method5()
       IL_0014:  ldstr      " 6"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method5()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method5()
       IL_0026:  ret
     } // end of method TestClass::Method4
 
@@ -135,19 +135,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x7
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method6()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method6()
       IL_0014:  ldstr      " 7"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method6()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method6()
     } // end of method TestClass::Method5
 
     .method private hidebysig  instance class System.String
@@ -157,19 +157,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x8
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method7()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method7()
       IL_0014:  ldstr      " 8"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method7()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method7()
       IL_0026:  ret
     } // end of method TestClass::Method6
 
@@ -180,19 +180,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x9
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method8()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method8()
       IL_0014:  ldstr      " 9"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method8()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method8()
     } // end of method TestClass::Method7
 
     .method private hidebysig  instance class System.String
@@ -202,19 +202,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0xa
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method9()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method9()
       IL_0014:  ldstr      " 10"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method9()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method9()
       IL_0026:  ret
     } // end of method TestClass::Method8
 
@@ -225,19 +225,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0xb
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method10()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method10()
       IL_0014:  ldstr      " 11"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method10()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method10()
     } // end of method TestClass::Method9
 
     .method private hidebysig  instance class System.String
@@ -247,19 +247,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0xc
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method11()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method11()
       IL_0014:  ldstr      " 12"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method11()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method11()
       IL_0026:  ret
     } // end of method TestClass::Method10
 
@@ -270,19 +270,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0xd
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method12()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method12()
       IL_0014:  ldstr      " 13"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method12()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method12()
     } // end of method TestClass::Method11
 
     .method private hidebysig  instance class System.String
@@ -292,19 +292,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0xe
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method13()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method13()
       IL_0014:  ldstr      " 14"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method13()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method13()
       IL_0026:  ret
     } // end of method TestClass::Method12
 
@@ -315,19 +315,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0xf
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method14()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method14()
       IL_0014:  ldstr      " 15"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method14()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method14()
     } // end of method TestClass::Method13
 
     .method private hidebysig  instance class System.String
@@ -337,19 +337,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x10
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method15()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method15()
       IL_0014:  ldstr      " 16"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method15()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method15()
       IL_0026:  ret
     } // end of method TestClass::Method14
 
@@ -360,19 +360,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x11
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method16()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method16()
       IL_0014:  ldstr      " 17"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method16()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method16()
     } // end of method TestClass::Method15
 
     .method private hidebysig  instance class System.String
@@ -382,19 +382,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x12
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method17()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method17()
       IL_0014:  ldstr      " 18"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method17()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method17()
       IL_0026:  ret
     } // end of method TestClass::Method16
 
@@ -405,19 +405,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x13
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method18()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method18()
       IL_0014:  ldstr      " 19"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method18()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method18()
     } // end of method TestClass::Method17
 
     .method private hidebysig  instance class System.String
@@ -427,19 +427,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x14
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method19()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method19()
       IL_0014:  ldstr      " 20"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method19()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method19()
       IL_0026:  ret
     } // end of method TestClass::Method18
 
@@ -450,19 +450,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x15
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method20()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method20()
       IL_0014:  ldstr      " 21"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method20()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method20()
     } // end of method TestClass::Method19
 
     .method private hidebysig  instance class System.String
@@ -472,19 +472,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x16
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method21()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method21()
       IL_0014:  ldstr      " 22"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method21()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method21()
       IL_0026:  ret
     } // end of method TestClass::Method20
 
@@ -495,19 +495,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x17
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method22()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method22()
       IL_0014:  ldstr      " 23"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method22()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method22()
     } // end of method TestClass::Method21
 
     .method private hidebysig  instance class System.String
@@ -517,19 +517,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x18
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method23()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method23()
       IL_0014:  ldstr      " 24"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method23()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method23()
       IL_0026:  ret
     } // end of method TestClass::Method22
 
@@ -540,19 +540,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x19
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method24()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method24()
       IL_0014:  ldstr      " 25"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method24()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method24()
     } // end of method TestClass::Method23
 
     .method private hidebysig  instance class System.String
@@ -562,19 +562,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x1a
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method25()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method25()
       IL_0014:  ldstr      " 26"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method25()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method25()
       IL_0026:  ret
     } // end of method TestClass::Method24
 
@@ -585,19 +585,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x1b
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method26()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method26()
       IL_0014:  ldstr      " 27"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method26()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method26()
     } // end of method TestClass::Method25
 
     .method private hidebysig  instance class System.String
@@ -607,19 +607,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x1c
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method27()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method27()
       IL_0014:  ldstr      " 28"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method27()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method27()
       IL_0026:  ret
     } // end of method TestClass::Method26
 
@@ -630,19 +630,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x1d
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method28()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method28()
       IL_0014:  ldstr      " 29"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method28()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method28()
     } // end of method TestClass::Method27
 
     .method private hidebysig  instance class System.String
@@ -652,19 +652,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x1e
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method29()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method29()
       IL_0014:  ldstr      " 30"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method29()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method29()
       IL_0026:  ret
     } // end of method TestClass::Method28
 
@@ -675,19 +675,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x1f
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method30()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method30()
       IL_0014:  ldstr      " 31"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method30()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method30()
     } // end of method TestClass::Method29
 
     .method private hidebysig  instance class System.String
@@ -697,19 +697,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x20
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method31()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method31()
       IL_0014:  ldstr      " 32"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method31()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method31()
       IL_0026:  ret
     } // end of method TestClass::Method30
 
@@ -720,19 +720,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x21
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method32()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method32()
       IL_0014:  ldstr      " 33"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method32()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method32()
     } // end of method TestClass::Method31
 
     .method private hidebysig  instance class System.String
@@ -742,19 +742,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x22
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method33()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method33()
       IL_0014:  ldstr      " 34"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method33()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method33()
       IL_0026:  ret
     } // end of method TestClass::Method32
 
@@ -765,19 +765,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x23
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method34()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method34()
       IL_0014:  ldstr      " 35"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method34()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method34()
     } // end of method TestClass::Method33
 
     .method private hidebysig  instance class System.String
@@ -787,19 +787,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x24
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method35()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method35()
       IL_0014:  ldstr      " 36"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method35()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method35()
       IL_0026:  ret
     } // end of method TestClass::Method34
 
@@ -810,19 +810,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x25
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method36()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method36()
       IL_0014:  ldstr      " 37"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method36()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method36()
     } // end of method TestClass::Method35
 
     .method private hidebysig  instance class System.String
@@ -832,19 +832,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x26
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method37()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method37()
       IL_0014:  ldstr      " 38"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method37()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method37()
       IL_0026:  ret
     } // end of method TestClass::Method36
 
@@ -855,19 +855,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x27
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method38()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method38()
       IL_0014:  ldstr      " 39"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method38()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method38()
     } // end of method TestClass::Method37
 
     .method private hidebysig  instance class System.String
@@ -877,19 +877,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x28
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method39()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method39()
       IL_0014:  ldstr      " 40"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method39()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method39()
       IL_0026:  ret
     } // end of method TestClass::Method38
 
@@ -900,19 +900,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x29
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method40()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method40()
       IL_0014:  ldstr      " 41"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method40()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method40()
     } // end of method TestClass::Method39
 
     .method private hidebysig  instance class System.String
@@ -922,19 +922,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x2a
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method41()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method41()
       IL_0014:  ldstr      " 42"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method41()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method41()
       IL_0026:  ret
     } // end of method TestClass::Method40
 
@@ -945,19 +945,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x2b
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method42()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method42()
       IL_0014:  ldstr      " 43"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method42()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method42()
     } // end of method TestClass::Method41
 
     .method private hidebysig  instance class System.String
@@ -967,19 +967,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x2c
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method43()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method43()
       IL_0014:  ldstr      " 44"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method43()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method43()
       IL_0026:  ret
     } // end of method TestClass::Method42
 
@@ -990,19 +990,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x2d
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method44()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method44()
       IL_0014:  ldstr      " 45"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method44()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method44()
     } // end of method TestClass::Method43
 
     .method private hidebysig  instance class System.String
@@ -1012,19 +1012,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x2e
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method45()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method45()
       IL_0014:  ldstr      " 46"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method45()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method45()
       IL_0026:  ret
     } // end of method TestClass::Method44
 
@@ -1035,19 +1035,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x2f
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method46()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method46()
       IL_0014:  ldstr      " 47"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method46()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method46()
     } // end of method TestClass::Method45
 
     .method private hidebysig  instance class System.String
@@ -1057,19 +1057,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x30
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method47()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method47()
       IL_0014:  ldstr      " 48"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method47()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method47()
       IL_0026:  ret
     } // end of method TestClass::Method46
 
@@ -1080,19 +1080,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x31
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method48()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method48()
       IL_0014:  ldstr      " 49"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method48()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method48()
     } // end of method TestClass::Method47
 
     .method private hidebysig  instance class System.String
@@ -1102,19 +1102,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x32
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method49()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method49()
       IL_0014:  ldstr      " 50"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method49()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method49()
       IL_0026:  ret
     } // end of method TestClass::Method48
 
@@ -1125,19 +1125,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0007:  ldc.i4     0x33
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method50()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method50()
       IL_0014:  ldstr      " 51"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method50()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_inst.TestClass::Method50()
     } // end of method TestClass::Method49
 
     .method private hidebysig  instance class System.String
@@ -1149,7 +1149,7 @@
       IL_0001:  ret
     } // end of method TestClass::Method50
 
-    .method private hidebysig  static 
+    .method public hidebysig  static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -1158,33 +1158,33 @@
       .entrypoint
       // Code size       78 (0x4e)
       .maxstack  8
-      .locals (class JitTest.TestClass V_0)
+      .locals (class JitTest_compat_deep_inst.TestClass V_0)
       IL_0000:  ldc.i4.2
-      IL_0001:  newobj     instance void JitTest.TestClass::.ctor(int32)
+      IL_0001:  newobj     instance void JitTest_compat_deep_inst.TestClass::.ctor(int32)
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
-      IL_0008:  call       instance class System.String JitTest.TestClass::Method0()
+      IL_0008:  call       instance class System.String JitTest_compat_deep_inst.TestClass::Method0()
       IL_000d:  brtrue     IL_0027
 
       IL_0012:  ldloc.0
-      IL_0013:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0013:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0018:  call       void [System.Console]System.Console::Write(int32)
       IL_001d:  ldstr      " - prime!"
       IL_0022:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_0027:  ldloc.0
       IL_0028:  dup
-      IL_0029:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0029:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_002e:  ldc.i4.1
       IL_002f:  add
-      IL_0030:  stfld      int32 JitTest.TestClass::m_fld
+      IL_0030:  stfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_0035:  ldloc.0
-      IL_0036:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0036:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_003b:  ldc.i4     0x64
       IL_0040:  ceq
       IL_0042:  brfalse    IL_0007
 
       IL_0047:  ldloc.0
-      IL_0048:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0048:  ldfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_004d:  ret
     } // end of method TestClass::Main
 
@@ -1197,12 +1197,12 @@
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
-      IL_0008:  stfld      int32 JitTest.TestClass::m_fld
+      IL_0008:  stfld      int32 JitTest_compat_deep_inst.TestClass::m_fld
       IL_000d:  ret
     } // end of method TestClass::.ctor
 
   } // end of class TestClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_deep_inst
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/deep_inst_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_inst_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_inst_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_inst_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_value.il
+++ b/src/tests/JIT/Methodical/tailcall/deep_value.il
@@ -9,7 +9,7 @@
 }
 .assembly deep_value { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_deep_value
 {
   .class public auto ansi sealed ValueClass
          extends [mscorlib]System.ValueType
@@ -21,1207 +21,1207 @@
          extends [mscorlib]System.Object
   {
     .method private hidebysig static 
-            class System.String  Method0(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method0(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x2
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method1(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method1(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 2"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method1(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method1(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method0
 
     .method private hidebysig static 
-            class System.String  Method1(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method1(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x3
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method2(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method2(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 3"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method2(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method2(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method1
 
     .method private hidebysig static 
-            class System.String  Method2(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method2(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x4
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method3(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method3(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 4"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method3(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method3(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method2
 
     .method private hidebysig static 
-            class System.String  Method3(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method3(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x5
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method4(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method4(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 5"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method4(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method4(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method3
 
     .method private hidebysig static 
-            class System.String  Method4(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method4(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x6
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method5(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method5(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 6"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method5(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method5(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method4
 
     .method private hidebysig static 
-            class System.String  Method5(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method5(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x7
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method6(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method6(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 7"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method6(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method6(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method5
 
     .method private hidebysig static 
-            class System.String  Method6(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method6(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x8
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method7(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method7(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 8"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method7(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method7(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method6
 
     .method private hidebysig static 
-            class System.String  Method7(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method7(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x9
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method8(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method8(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 9"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method8(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method8(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method7
 
     .method private hidebysig static 
-            class System.String  Method8(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method8(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0xa
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method9(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method9(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 10"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method9(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method9(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method8
 
     .method private hidebysig static 
-            class System.String  Method9(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method9(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0xb
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method10(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method10(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 11"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method10(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method10(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method9
 
     .method private hidebysig static 
-            class System.String  Method10(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method10(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0xc
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method11(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method11(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 12"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method11(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method11(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method10
 
     .method private hidebysig static 
-            class System.String  Method11(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method11(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0xd
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method12(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method12(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 13"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method12(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method12(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method11
 
     .method private hidebysig static 
-            class System.String  Method12(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method12(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0xe
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method13(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method13(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 14"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method13(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method13(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method12
 
     .method private hidebysig static 
-            class System.String  Method13(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method13(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0xf
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method14(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method14(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 15"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method14(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method14(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method13
 
     .method private hidebysig static 
-            class System.String  Method14(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method14(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x10
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method15(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method15(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 16"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method15(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method15(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method14
 
     .method private hidebysig static 
-            class System.String  Method15(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method15(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x11
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method16(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method16(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 17"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method16(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method16(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method15
 
     .method private hidebysig static 
-            class System.String  Method16(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method16(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x12
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method17(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method17(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 18"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method17(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method17(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method16
 
     .method private hidebysig static 
-            class System.String  Method17(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method17(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x13
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method18(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method18(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 19"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method18(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method18(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method17
 
     .method private hidebysig static 
-            class System.String  Method18(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method18(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x14
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method19(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method19(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 20"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method19(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method19(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method18
 
     .method private hidebysig static 
-            class System.String  Method19(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method19(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x15
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method20(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method20(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 21"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method20(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method20(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method19
 
     .method private hidebysig static 
-            class System.String  Method20(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method20(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x16
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method21(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method21(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 22"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method21(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method21(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method20
 
     .method private hidebysig static 
-            class System.String  Method21(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method21(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x17
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method22(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method22(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 23"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method22(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method22(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method21
 
     .method private hidebysig static 
-            class System.String  Method22(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method22(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x18
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method23(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method23(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 24"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method23(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method23(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method22
 
     .method private hidebysig static 
-            class System.String  Method23(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method23(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x19
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method24(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method24(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 25"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method24(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method24(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method23
 
     .method private hidebysig static 
-            class System.String  Method24(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method24(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x1a
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method25(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method25(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 26"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method25(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method25(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method24
 
     .method private hidebysig static 
-            class System.String  Method25(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method25(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x1b
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method26(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method26(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 27"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method26(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method26(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method25
 
     .method private hidebysig static 
-            class System.String  Method26(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method26(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x1c
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method27(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method27(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 28"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method27(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method27(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method26
 
     .method private hidebysig static 
-            class System.String  Method27(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method27(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x1d
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method28(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method28(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 29"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method28(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method28(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method27
 
     .method private hidebysig static 
-            class System.String  Method28(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method28(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x1e
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method29(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method29(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 30"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method29(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method29(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method28
 
     .method private hidebysig static 
-            class System.String  Method29(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method29(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x1f
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method30(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method30(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 31"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method30(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method30(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method29
 
     .method private hidebysig static 
-            class System.String  Method30(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method30(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x20
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method31(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method31(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 32"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method31(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method31(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method30
 
     .method private hidebysig static 
-            class System.String  Method31(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method31(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x21
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method32(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method32(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 33"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method32(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method32(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method31
 
     .method private hidebysig static 
-            class System.String  Method32(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method32(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x22
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method33(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method33(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 34"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method33(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method33(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method32
 
     .method private hidebysig static 
-            class System.String  Method33(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method33(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x23
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method34(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method34(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 35"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method34(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method34(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method33
 
     .method private hidebysig static 
-            class System.String  Method34(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method34(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x24
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method35(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method35(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 36"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method35(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method35(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method34
 
     .method private hidebysig static 
-            class System.String  Method35(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method35(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x25
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method36(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method36(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 37"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method36(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method36(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method35
 
     .method private hidebysig static 
-            class System.String  Method36(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method36(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x26
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method37(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method37(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 38"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method37(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method37(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method36
 
     .method private hidebysig static 
-            class System.String  Method37(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method37(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x27
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method38(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method38(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 39"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method38(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method38(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method37
 
     .method private hidebysig static 
-            class System.String  Method38(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method38(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x28
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method39(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method39(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 40"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method39(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method39(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method38
 
     .method private hidebysig static 
-            class System.String  Method39(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method39(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x29
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method40(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method40(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 41"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method40(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method40(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method39
 
     .method private hidebysig static 
-            class System.String  Method40(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method40(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x2a
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method41(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method41(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 42"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method41(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method41(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method40
 
     .method private hidebysig static 
-            class System.String  Method41(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method41(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x2b
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method42(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method42(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 43"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method42(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method42(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method41
 
     .method private hidebysig static 
-            class System.String  Method42(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method42(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x2c
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method43(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method43(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 44"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method43(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method43(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method42
 
     .method private hidebysig static 
-            class System.String  Method43(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method43(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x2d
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method44(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method44(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 45"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method44(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method44(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method43
 
     .method private hidebysig static 
-            class System.String  Method44(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method44(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x2e
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method45(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method45(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 46"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method45(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method45(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method44
 
     .method private hidebysig static 
-            class System.String  Method45(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method45(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x2f
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method46(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method46(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 47"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method46(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method46(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method45
 
     .method private hidebysig static 
-            class System.String  Method46(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method46(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x30
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method47(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method47(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 48"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method47(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method47(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method46
 
     .method private hidebysig static 
-            class System.String  Method47(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method47(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x31
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method48(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method48(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 49"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method48(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method48(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method47
 
     .method private hidebysig static 
-            class System.String  Method48(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method48(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       52 (0x34)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x32
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method49(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method49(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 50"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
-      IL_0027:  ldobj      JitTest.ValueClass
+      IL_0027:  ldobj      JitTest_compat_deep_value.ValueClass
       IL_002c:  tail.
-      IL_002e:  call       class System.String JitTest.TestClass::Method49(value class JitTest.ValueClass)
+      IL_002e:  call       class System.String JitTest_compat_deep_value.TestClass::Method49(value class JitTest_compat_deep_value.ValueClass)
       IL_0033:  ret
     } // end of method TestClass::Method48
 
     .method private hidebysig static 
-            class System.String  Method49(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method49(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       45 (0x2d)
       .maxstack  8
       IL_0000:  ldarga     A_0
       IL_0004:  dup
-      IL_0005:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldc.i4     0x33
       IL_000f:  rem
       IL_0010:  brtrue.s   IL_0027
 
-      IL_0012:  ldobj      JitTest.ValueClass
-      IL_0017:  call       class System.String JitTest.TestClass::Method50(value class JitTest.ValueClass)
+      IL_0012:  ldobj      JitTest_compat_deep_value.ValueClass
+      IL_0017:  call       class System.String JitTest_compat_deep_value.TestClass::Method50(value class JitTest_compat_deep_value.ValueClass)
       IL_001c:  ldstr      " 51"
       IL_0021:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0026:  ret
 
       IL_0027:  pop
-      IL_0028:  jmp        class System.String JitTest.TestClass::Method50(value class JitTest.ValueClass)
+      IL_0028:  jmp        class System.String JitTest_compat_deep_value.TestClass::Method50(value class JitTest_compat_deep_value.ValueClass)
     } // end of method TestClass::Method49
 
     .method private hidebysig static 
-            class System.String  Method50(value class JitTest.ValueClass A_0) il managed
+            class System.String  Method50(value class JitTest_compat_deep_value.ValueClass A_0) il managed
     {
       // Code size       2 (0x2)
       .maxstack  8
@@ -1229,7 +1229,7 @@
       IL_0001:  ret
     } // end of method TestClass::Method50
 
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -1238,33 +1238,33 @@
       .entrypoint
       // Code size       93 (0x5d)
       .maxstack  8
-      .locals init (value class JitTest.ValueClass V_0)
+      .locals init (value class JitTest_compat_deep_value.ValueClass V_0)
       IL_0000:  ldloca     V_0
       IL_0004:  ldc.i4.2
-      IL_0005:  stfld      int32 JitTest.ValueClass::m_fld
+      IL_0005:  stfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_000a:  ldloc.0
-      IL_000b:  call       class System.String JitTest.TestClass::Method0(value class JitTest.ValueClass)
+      IL_000b:  call       class System.String JitTest_compat_deep_value.TestClass::Method0(value class JitTest_compat_deep_value.ValueClass)
       IL_0010:  brtrue     IL_002d
 
       IL_0015:  ldloca     V_0
-      IL_0019:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0019:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_001e:  call       void [System.Console]System.Console::Write(int32)
       IL_0023:  ldstr      " - prime!"
       IL_0028:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_002d:  ldloca     V_0
       IL_0031:  dup
-      IL_0032:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0032:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_0037:  ldc.i4.1
       IL_0038:  add
-      IL_0039:  stfld      int32 JitTest.ValueClass::m_fld
+      IL_0039:  stfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_003e:  ldloca     V_0
-      IL_0042:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0042:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_0047:  ldc.i4     0x64
       IL_004c:  ceq
       IL_004e:  brfalse    IL_000a
 
       IL_0053:  ldloca     V_0
-      IL_0057:  ldfld      int32 JitTest.ValueClass::m_fld
+      IL_0057:  ldfld      int32 JitTest_compat_deep_value.ValueClass::m_fld
       IL_005c:  ret
     } // end of method TestClass::Main
 
@@ -1280,4 +1280,4 @@
 
   } // end of class TestClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_deep_value

--- a/src/tests/JIT/Methodical/tailcall/deep_value_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_value_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_value_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_value_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_virt.il
+++ b/src/tests/JIT/Methodical/tailcall/deep_virt.il
@@ -9,7 +9,7 @@
 }
 .assembly deep_virt { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_deep_virt
 {
   .class public auto ansi beforefieldinit TestClass
          extends [mscorlib]System.Object
@@ -22,19 +22,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x2
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method1()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method1()
       IL_0014:  ldstr      " 2"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method1()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method1()
       IL_0026:  ret
     } // end of method TestClass::Method0
 
@@ -45,19 +45,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x3
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method2()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method2()
       IL_0014:  ldstr      " 3"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method2()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method2()
     } // end of method TestClass::Method1
 
     .method private hidebysig  virtual 
@@ -67,19 +67,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x4
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method3()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method3()
       IL_0014:  ldstr      " 4"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method3()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method3()
       IL_0026:  ret
     } // end of method TestClass::Method2
 
@@ -90,19 +90,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x5
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method4()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method4()
       IL_0014:  ldstr      " 5"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method4()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method4()
     } // end of method TestClass::Method3
 
     .method private hidebysig  virtual 
@@ -112,19 +112,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x6
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method5()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method5()
       IL_0014:  ldstr      " 6"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method5()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method5()
       IL_0026:  ret
     } // end of method TestClass::Method4
 
@@ -135,19 +135,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x7
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method6()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method6()
       IL_0014:  ldstr      " 7"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method6()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method6()
     } // end of method TestClass::Method5
 
     .method private hidebysig  virtual 
@@ -157,19 +157,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x8
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method7()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method7()
       IL_0014:  ldstr      " 8"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method7()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method7()
       IL_0026:  ret
     } // end of method TestClass::Method6
 
@@ -180,19 +180,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x9
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method8()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method8()
       IL_0014:  ldstr      " 9"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method8()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method8()
     } // end of method TestClass::Method7
 
     .method private hidebysig  virtual 
@@ -202,19 +202,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0xa
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method9()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method9()
       IL_0014:  ldstr      " 10"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method9()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method9()
       IL_0026:  ret
     } // end of method TestClass::Method8
 
@@ -225,19 +225,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0xb
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method10()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method10()
       IL_0014:  ldstr      " 11"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method10()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method10()
     } // end of method TestClass::Method9
 
     .method private hidebysig  virtual 
@@ -247,19 +247,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0xc
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method11()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method11()
       IL_0014:  ldstr      " 12"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method11()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method11()
       IL_0026:  ret
     } // end of method TestClass::Method10
 
@@ -270,19 +270,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0xd
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method12()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method12()
       IL_0014:  ldstr      " 13"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method12()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method12()
     } // end of method TestClass::Method11
 
     .method private hidebysig  virtual 
@@ -292,19 +292,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0xe
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method13()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method13()
       IL_0014:  ldstr      " 14"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method13()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method13()
       IL_0026:  ret
     } // end of method TestClass::Method12
 
@@ -315,19 +315,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0xf
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method14()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method14()
       IL_0014:  ldstr      " 15"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method14()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method14()
     } // end of method TestClass::Method13
 
     .method private hidebysig  virtual 
@@ -337,19 +337,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x10
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method15()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method15()
       IL_0014:  ldstr      " 16"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method15()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method15()
       IL_0026:  ret
     } // end of method TestClass::Method14
 
@@ -360,19 +360,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x11
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method16()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method16()
       IL_0014:  ldstr      " 17"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method16()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method16()
     } // end of method TestClass::Method15
 
     .method private hidebysig  virtual 
@@ -382,19 +382,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x12
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method17()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method17()
       IL_0014:  ldstr      " 18"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method17()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method17()
       IL_0026:  ret
     } // end of method TestClass::Method16
 
@@ -405,19 +405,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x13
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method18()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method18()
       IL_0014:  ldstr      " 19"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method18()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method18()
     } // end of method TestClass::Method17
 
     .method private hidebysig  virtual 
@@ -427,19 +427,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x14
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method19()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method19()
       IL_0014:  ldstr      " 20"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method19()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method19()
       IL_0026:  ret
     } // end of method TestClass::Method18
 
@@ -450,19 +450,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x15
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method20()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method20()
       IL_0014:  ldstr      " 21"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method20()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method20()
     } // end of method TestClass::Method19
 
     .method private hidebysig  virtual 
@@ -472,19 +472,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x16
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method21()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method21()
       IL_0014:  ldstr      " 22"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method21()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method21()
       IL_0026:  ret
     } // end of method TestClass::Method20
 
@@ -495,19 +495,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x17
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method22()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method22()
       IL_0014:  ldstr      " 23"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method22()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method22()
     } // end of method TestClass::Method21
 
     .method private hidebysig  virtual 
@@ -517,19 +517,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x18
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method23()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method23()
       IL_0014:  ldstr      " 24"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method23()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method23()
       IL_0026:  ret
     } // end of method TestClass::Method22
 
@@ -540,19 +540,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x19
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method24()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method24()
       IL_0014:  ldstr      " 25"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method24()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method24()
     } // end of method TestClass::Method23
 
     .method private hidebysig  virtual 
@@ -562,19 +562,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x1a
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method25()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method25()
       IL_0014:  ldstr      " 26"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method25()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method25()
       IL_0026:  ret
     } // end of method TestClass::Method24
 
@@ -585,19 +585,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x1b
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method26()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method26()
       IL_0014:  ldstr      " 27"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method26()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method26()
     } // end of method TestClass::Method25
 
     .method private hidebysig  virtual 
@@ -607,19 +607,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x1c
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method27()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method27()
       IL_0014:  ldstr      " 28"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method27()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method27()
       IL_0026:  ret
     } // end of method TestClass::Method26
 
@@ -630,19 +630,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x1d
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method28()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method28()
       IL_0014:  ldstr      " 29"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method28()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method28()
     } // end of method TestClass::Method27
 
     .method private hidebysig  virtual 
@@ -652,19 +652,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x1e
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method29()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method29()
       IL_0014:  ldstr      " 30"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method29()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method29()
       IL_0026:  ret
     } // end of method TestClass::Method28
 
@@ -675,19 +675,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x1f
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method30()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method30()
       IL_0014:  ldstr      " 31"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method30()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method30()
     } // end of method TestClass::Method29
 
     .method private hidebysig  virtual 
@@ -697,19 +697,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x20
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method31()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method31()
       IL_0014:  ldstr      " 32"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method31()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method31()
       IL_0026:  ret
     } // end of method TestClass::Method30
 
@@ -720,19 +720,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x21
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method32()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method32()
       IL_0014:  ldstr      " 33"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method32()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method32()
     } // end of method TestClass::Method31
 
     .method private hidebysig  virtual 
@@ -742,19 +742,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x22
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method33()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method33()
       IL_0014:  ldstr      " 34"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method33()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method33()
       IL_0026:  ret
     } // end of method TestClass::Method32
 
@@ -765,19 +765,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x23
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method34()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method34()
       IL_0014:  ldstr      " 35"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method34()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method34()
     } // end of method TestClass::Method33
 
     .method private hidebysig  virtual 
@@ -787,19 +787,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x24
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method35()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method35()
       IL_0014:  ldstr      " 36"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method35()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method35()
       IL_0026:  ret
     } // end of method TestClass::Method34
 
@@ -810,19 +810,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x25
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method36()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method36()
       IL_0014:  ldstr      " 37"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method36()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method36()
     } // end of method TestClass::Method35
 
     .method private hidebysig  virtual 
@@ -832,19 +832,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x26
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method37()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method37()
       IL_0014:  ldstr      " 38"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method37()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method37()
       IL_0026:  ret
     } // end of method TestClass::Method36
 
@@ -855,19 +855,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x27
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method38()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method38()
       IL_0014:  ldstr      " 39"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method38()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method38()
     } // end of method TestClass::Method37
 
     .method private hidebysig  virtual 
@@ -877,19 +877,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x28
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method39()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method39()
       IL_0014:  ldstr      " 40"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method39()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method39()
       IL_0026:  ret
     } // end of method TestClass::Method38
 
@@ -900,19 +900,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x29
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method40()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method40()
       IL_0014:  ldstr      " 41"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method40()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method40()
     } // end of method TestClass::Method39
 
     .method private hidebysig  virtual 
@@ -922,19 +922,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x2a
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method41()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method41()
       IL_0014:  ldstr      " 42"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method41()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method41()
       IL_0026:  ret
     } // end of method TestClass::Method40
 
@@ -945,19 +945,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x2b
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method42()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method42()
       IL_0014:  ldstr      " 43"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method42()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method42()
     } // end of method TestClass::Method41
 
     .method private hidebysig  virtual 
@@ -967,19 +967,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x2c
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method43()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method43()
       IL_0014:  ldstr      " 44"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method43()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method43()
       IL_0026:  ret
     } // end of method TestClass::Method42
 
@@ -990,19 +990,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x2d
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method44()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method44()
       IL_0014:  ldstr      " 45"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method44()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method44()
     } // end of method TestClass::Method43
 
     .method private hidebysig  virtual 
@@ -1012,19 +1012,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x2e
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method45()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method45()
       IL_0014:  ldstr      " 46"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method45()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method45()
       IL_0026:  ret
     } // end of method TestClass::Method44
 
@@ -1035,19 +1035,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x2f
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method46()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method46()
       IL_0014:  ldstr      " 47"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method46()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method46()
     } // end of method TestClass::Method45
 
     .method private hidebysig  virtual 
@@ -1057,19 +1057,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x30
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method47()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method47()
       IL_0014:  ldstr      " 48"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method47()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method47()
       IL_0026:  ret
     } // end of method TestClass::Method46
 
@@ -1080,19 +1080,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x31
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method48()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method48()
       IL_0014:  ldstr      " 49"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method48()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method48()
     } // end of method TestClass::Method47
 
     .method private hidebysig  virtual 
@@ -1102,19 +1102,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x32
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method49()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method49()
       IL_0014:  ldstr      " 50"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  tail.
-      IL_0021:  call       instance class System.String JitTest.TestClass::Method49()
+      IL_0021:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method49()
       IL_0026:  ret
     } // end of method TestClass::Method48
 
@@ -1125,19 +1125,19 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  dup
-      IL_0002:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0002:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0007:  ldc.i4     0x33
       IL_000c:  rem
       IL_000d:  brtrue.s   IL_001f
 
-      IL_000f:  call       instance class System.String JitTest.TestClass::Method50()
+      IL_000f:  call       instance class System.String JitTest_compat_deep_virt.TestClass::Method50()
       IL_0014:  ldstr      " 51"
       IL_0019:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_001e:  ret
 
       IL_001f:  pop
-      IL_0020:  jmp        instance class System.String JitTest.TestClass::Method50()
+      IL_0020:  jmp        instance class System.String JitTest_compat_deep_virt.TestClass::Method50()
     } // end of method TestClass::Method49
 
     .method private hidebysig  virtual 
@@ -1149,7 +1149,7 @@
       IL_0001:  ret
     } // end of method TestClass::Method50
 
-    .method private hidebysig  static 
+    .method public hidebysig  static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -1158,33 +1158,33 @@
       .entrypoint
       // Code size       78 (0x4e)
       .maxstack  8
-      .locals (class JitTest.TestClass V_0)
+      .locals (class JitTest_compat_deep_virt.TestClass V_0)
       IL_0000:  ldc.i4.2
-      IL_0001:  newobj     instance void JitTest.TestClass::.ctor(int32)
+      IL_0001:  newobj     instance void JitTest_compat_deep_virt.TestClass::.ctor(int32)
       IL_0006:  stloc.0
       IL_0007:  ldloc.0
-      IL_0008:  callvirt   instance class System.String JitTest.TestClass::Method0()
+      IL_0008:  callvirt   instance class System.String JitTest_compat_deep_virt.TestClass::Method0()
       IL_000d:  brtrue     IL_0027
 
       IL_0012:  ldloc.0
-      IL_0013:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0013:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0018:  call       void [System.Console]System.Console::Write(int32)
       IL_001d:  ldstr      " - prime!"
       IL_0022:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_0027:  ldloc.0
       IL_0028:  dup
-      IL_0029:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0029:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_002e:  ldc.i4.1
       IL_002f:  add
-      IL_0030:  stfld      int32 JitTest.TestClass::m_fld
+      IL_0030:  stfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_0035:  ldloc.0
-      IL_0036:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0036:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_003b:  ldc.i4     0x64
       IL_0040:  ceq
       IL_0042:  brfalse    IL_0007
 
       IL_0047:  ldloc.0
-      IL_0048:  ldfld      int32 JitTest.TestClass::m_fld
+      IL_0048:  ldfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_004d:  ret
     } // end of method TestClass::Main
 
@@ -1197,12 +1197,12 @@
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ldarg.0
       IL_0007:  ldarg.1
-      IL_0008:  stfld      int32 JitTest.TestClass::m_fld
+      IL_0008:  stfld      int32 JitTest_compat_deep_virt.TestClass::m_fld
       IL_000d:  ret
     } // end of method TestClass::.ctor
 
   } // end of class TestClass
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_deep_virt
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/deep_virt_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_virt_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/deep_virt_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/deep_virt_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/gcval.il
+++ b/src/tests/JIT/Methodical/tailcall/gcval.il
@@ -9,20 +9,20 @@
 }
 .assembly gcval { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_gcval
 {
-  .class private sequential ansi sealed beforefieldinit LargeVT
+  .class public sequential ansi sealed beforefieldinit LargeVT
          extends [mscorlib]System.ValueType
   {
     .field private int32[] 'value'
-    .method private hidebysig static value class JitTest.LargeVT 
+    .method private hidebysig static value class JitTest_compat_gcval.LargeVT 
             callee(int32 retcode) il managed
     {
       // Code size       33 (0x21)
       .maxstack  8
-      .locals (value class JitTest.LargeVT lv)
+      .locals (value class JitTest_compat_gcval.LargeVT lv)
       ldloca.s   lv
-      initobj    JitTest.LargeVT
+      initobj    JitTest_compat_gcval.LargeVT
       ldloca.s   lv
       ldc.i4.1
       newarr     [mscorlib]System.Int32
@@ -30,22 +30,22 @@
       ldc.i4.0
       ldarg.0
       stelem.i4
-      stfld      int32[] JitTest.LargeVT::'value'
+      stfld      int32[] JitTest_compat_gcval.LargeVT::'value'
       ldloc.0
       ret
     } // end of method LargeVT::callee
 
-    .method private hidebysig static value class JitTest.LargeVT 
+    .method private hidebysig static value class JitTest_compat_gcval.LargeVT 
             caller(int32 retcode) il managed
     {
 		// Code size       11 (0xb)
 		.maxstack  8
 		ldarg.0
-		tail. call value class JitTest.LargeVT JitTest.LargeVT::callee(int32)
+		tail. call value class JitTest_compat_gcval.LargeVT JitTest_compat_gcval.LargeVT::callee(int32)
 		ret
     } // end of method LargeVT::caller
 
-    .method private hidebysig static int32
+    .method public hidebysig static int32
             Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -56,12 +56,12 @@
       .maxstack  2
       .locals (int32 V_0,
                int32 V_1,
-               value class JitTest.LargeVT V_2)
+               value class JitTest_compat_gcval.LargeVT V_2)
       IL_0000:  ldc.i4.s   100
-      IL_0002:  call       value class JitTest.LargeVT JitTest.LargeVT::caller(int32)
+      IL_0002:  call       value class JitTest_compat_gcval.LargeVT JitTest_compat_gcval.LargeVT::caller(int32)
       IL_0007:  stloc.2
       IL_0008:  ldloca.s   V_2
-      IL_000a:  ldfld      int32[] JitTest.LargeVT::'value'
+      IL_000a:  ldfld      int32[] JitTest_compat_gcval.LargeVT::'value'
       IL_000f:  ldc.i4.0
       IL_0010:  ldelem.i4
       IL_0011:  stloc.0
@@ -84,6 +84,6 @@
 
   } // end of class LargeVT
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_gcval
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/gcval_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/gcval_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/gcval_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/gcval_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/gcval_nested.il
+++ b/src/tests/JIT/Methodical/tailcall/gcval_nested.il
@@ -9,55 +9,55 @@
 }
 .assembly 'gcval_nested' { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_gcval_nested
 {
-  .class private sequential ansi sealed beforefieldinit LargeVT
+  .class public sequential ansi sealed beforefieldinit LargeVT
          extends [mscorlib]System.ValueType
   {
     .field private int32[] 'value'
-    .field private valuetype JitTest.LargeVT[] next
+    .field private valuetype JitTest_compat_gcval_nested.LargeVT[] next
     
-    .method private hidebysig static value class JitTest.LargeVT 
+    .method private hidebysig static value class JitTest_compat_gcval_nested.LargeVT 
             callee(int32 retcode) il managed
     {
       // Code size       33 (0x21)
       .maxstack  8
-      .locals (value class JitTest.LargeVT lv)
+      .locals (value class JitTest_compat_gcval_nested.LargeVT lv)
       ldloca lv
-      initobj JitTest.LargeVT
+      initobj JitTest_compat_gcval_nested.LargeVT
       ldloca lv
       
       ldc.i4.1
-      newarr value class JitTest.LargeVT
+      newarr value class JitTest_compat_gcval_nested.LargeVT
       dup
       ldc.i4.0
-      ldelema value class JitTest.LargeVT
+      ldelema value class JitTest_compat_gcval_nested.LargeVT
       dup
-      initobj    JitTest.LargeVT
+      initobj    JitTest_compat_gcval_nested.LargeVT
       ldc.i4.1
       newarr     [mscorlib]System.Int32
       dup
       ldc.i4.0
       ldarg.0
       stelem.i4
-      stfld      int32[] JitTest.LargeVT::'value'
+      stfld      int32[] JitTest_compat_gcval_nested.LargeVT::'value'
 
-      stfld      valuetype JitTest.LargeVT[] JitTest.LargeVT::next
+      stfld      valuetype JitTest_compat_gcval_nested.LargeVT[] JitTest_compat_gcval_nested.LargeVT::next
       ldloc.0
       ret
     } // end of method LargeVT::callee
 
-    .method private hidebysig static value class JitTest.LargeVT 
+    .method private hidebysig static value class JitTest_compat_gcval_nested.LargeVT 
             caller(int32 retcode) il managed
     {
 		// Code size       11 (0xb)
 		.maxstack  8
 		ldarg.0
-		tail. call value class JitTest.LargeVT JitTest.LargeVT::callee(int32)
+		tail. call value class JitTest_compat_gcval_nested.LargeVT JitTest_compat_gcval_nested.LargeVT::callee(int32)
 		ret
     } // end of method LargeVT::caller
 
-    .method private hidebysig static int32
+    .method public hidebysig static int32
             Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -68,15 +68,15 @@
       .maxstack  2
       .locals (int32 V_0,
                int32 V_1,
-               value class JitTest.LargeVT V_2)
+               value class JitTest_compat_gcval_nested.LargeVT V_2)
       ldc.i4.s   100
-      call       value class JitTest.LargeVT JitTest.LargeVT::caller(int32)
+      call       value class JitTest_compat_gcval_nested.LargeVT JitTest_compat_gcval_nested.LargeVT::caller(int32)
       stloc.2
       ldloca.s   V_2
-      ldfld      value class JitTest.LargeVT[] JitTest.LargeVT::next
+      ldfld      value class JitTest_compat_gcval_nested.LargeVT[] JitTest_compat_gcval_nested.LargeVT::next
       ldc.i4.0
-      ldelema value class JitTest.LargeVT
-      ldfld      int32[] JitTest.LargeVT::'value'
+      ldelema value class JitTest_compat_gcval_nested.LargeVT
+      ldfld      int32[] JitTest_compat_gcval_nested.LargeVT::'value'
       
       ldc.i4.0
       ldelem.i4
@@ -98,6 +98,6 @@
 
   } // end of class LargeVT
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_gcval_nested
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/gcval_nested_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/gcval_nested_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/gcval_nested_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/gcval_nested_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/gcval_sideeffect.il
+++ b/src/tests/JIT/Methodical/tailcall/gcval_sideeffect.il
@@ -9,20 +9,20 @@
 }
 .assembly gcval_sideeffect { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_compat_gcval_sideeffect
 {
-  .class private sequential ansi sealed beforefieldinit LargeVT
+  .class public sequential ansi sealed beforefieldinit LargeVT
          extends [mscorlib]System.ValueType
   {
     .field private int32[] 'value'
-    .method private hidebysig static value class JitTest.LargeVT 
+    .method private hidebysig static value class JitTest_compat_gcval_sideeffect.LargeVT 
             callee(int32 retcode) il managed
     {
       // Code size       33 (0x21)
       .maxstack  8
-      .locals (value class JitTest.LargeVT lv)
+      .locals (value class JitTest_compat_gcval_sideeffect.LargeVT lv)
       ldloca.s   lv
-      initobj    JitTest.LargeVT
+      initobj    JitTest_compat_gcval_sideeffect.LargeVT
       ldloca.s   lv
       ldc.i4.1
       newarr     [mscorlib]System.Int32
@@ -30,25 +30,25 @@
       ldc.i4.0
       ldarg.0
       stelem.i4
-      stfld      int32[] JitTest.LargeVT::'value'
+      stfld      int32[] JitTest_compat_gcval_sideeffect.LargeVT::'value'
       ldloc.0
       ldloca lv
       ldnull
-      stfld      int32[] JitTest.LargeVT::'value'
+      stfld      int32[] JitTest_compat_gcval_sideeffect.LargeVT::'value'
       ret
     } // end of method LargeVT::callee
 
-    .method private hidebysig static value class JitTest.LargeVT 
+    .method private hidebysig static value class JitTest_compat_gcval_sideeffect.LargeVT 
             caller(int32 retcode) il managed
     {
 		// Code size       11 (0xb)
 		.maxstack  8
 		ldarg.0
-		tail. call value class JitTest.LargeVT JitTest.LargeVT::callee(int32)
+		tail. call value class JitTest_compat_gcval_sideeffect.LargeVT JitTest_compat_gcval_sideeffect.LargeVT::callee(int32)
 		ret
     } // end of method LargeVT::caller
 
-    .method private hidebysig static int32
+    .method public hidebysig static int32
             Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -59,12 +59,12 @@
       .maxstack  2
       .locals (int32 V_0,
                int32 V_1,
-               value class JitTest.LargeVT V_2)
+               value class JitTest_compat_gcval_sideeffect.LargeVT V_2)
       IL_0000:  ldc.i4.s   100
-      IL_0002:  call       value class JitTest.LargeVT JitTest.LargeVT::caller(int32)
+      IL_0002:  call       value class JitTest_compat_gcval_sideeffect.LargeVT JitTest_compat_gcval_sideeffect.LargeVT::caller(int32)
       IL_0007:  stloc.2
       IL_0008:  ldloca.s   V_2
-      IL_000a:  ldfld      int32[] JitTest.LargeVT::'value'
+      IL_000a:  ldfld      int32[] JitTest_compat_gcval_sideeffect.LargeVT::'value'
       IL_000f:  ldc.i4.0
       IL_0010:  ldelem.i4
       IL_0011:  stloc.0
@@ -87,6 +87,6 @@
 
   } // end of class LargeVT
 
-} // end of namespace JitTest
+} // end of namespace JitTest_compat_gcval_sideeffect
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/gcval_sideeffect_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/gcval_sideeffect_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/gcval_sideeffect_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/gcval_sideeffect_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/pointer.il
+++ b/src/tests/JIT/Methodical/tailcall/pointer.il
@@ -7,6 +7,7 @@
   .ver 4:0:0:0
 }
 .assembly extern mscorlib { }
+.assembly extern xunit.core {}
 .assembly pointer { }
 .field public static int32 temp at D_00004000
 .method public static class System.String 
@@ -56,8 +57,13 @@
   IL_0047:  ret
 } 
 
+.class public auto ansi beforefieldinit Test_pointer extends [mscorlib]System.Object
+{
 .method public static int32 main() il managed
 {
+  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+      01 00 00 00
+  )
   .entrypoint
   .maxstack  2
   .locals (int32 V_0,
@@ -95,6 +101,16 @@
   IL_003c:  ldc.i4 0x64
   			ret
 } 
+
+.method public hidebysig  specialname rtspecialname
+        instance void .ctor() il managed
+{
+  .maxstack  8
+  IL_0000:  ldarg.0
+  IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+  IL_0006:  ret
+}
+}
 
 .data D_00004000 = bytearray (
                  00 00 00 00) 

--- a/src/tests/JIT/Methodical/tailcall/pointer_i.il
+++ b/src/tests/JIT/Methodical/tailcall/pointer_i.il
@@ -7,6 +7,7 @@
   .ver 4:0:0:0
 }
 .assembly extern mscorlib { }
+.assembly extern xunit.core {}
 .assembly pointer_i { }
 .field public static int32 temp at D_00004000
 .method public static class System.String 
@@ -57,8 +58,13 @@
   IL_004e:  ret
 } 
 
+.class public auto ansi beforefieldinit Test_pointer_i extends [mscorlib]System.Object
+{
 .method public static int32 main() il managed
 {
+  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+      01 00 00 00
+  )
   .entrypoint
   .maxstack  2
   .locals (int32 V_0,
@@ -95,7 +101,17 @@
   IL_0037:  call       void [System.Console]System.Console::WriteLine()
   			ldc.i4     0x64
   			ret
-} 
+}
+
+.method public hidebysig  specialname rtspecialname
+        instance void .ctor() il managed
+{
+  .maxstack  8
+  IL_0000:  ldarg.0
+  IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+  IL_0006:  ret
+}
+}
 
 .data D_00004000 = bytearray (
                  00 00 00 00) 

--- a/src/tests/JIT/Methodical/tailcall/pointer_i_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/pointer_i_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test relies on rva_statics support see #2451 -->
     <DisableProjectBuild>true</DisableProjectBuild>

--- a/src/tests/JIT/Methodical/tailcall/pointer_i_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/pointer_i_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test relies on rva_statics support see #2451 -->
     <DisableProjectBuild>true</DisableProjectBuild>

--- a/src/tests/JIT/Methodical/tailcall/pointer_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/pointer_il_d.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test relies on rva_statics support see #2451 -->
     <DisableProjectBuild>true</DisableProjectBuild>

--- a/src/tests/JIT/Methodical/tailcall/pointer_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/pointer_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test relies on rva_statics support see #2451 -->
     <DisableProjectBuild>true</DisableProjectBuild>

--- a/src/tests/JIT/Methodical/tailcall/recurse_ep.il
+++ b/src/tests/JIT/Methodical/tailcall/recurse_ep.il
@@ -9,14 +9,14 @@
 }
 .assembly recurse_ep { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_recurse_ep
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
-    .method private hidebysig static 
+    .method public hidebysig static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -26,11 +26,11 @@
       // Code size       93 (0x5d)
       .maxstack  4
       .locals (int32 V_0)
-      IL_0000:  ldsfld     int32 JitTest.Test::n
+      IL_0000:  ldsfld     int32 JitTest_recurse_ep.Test::n
       IL_0005:  ldc.i4.1
       IL_0006:  bne.un.s   IL_003d
 
-      IL_0008:  ldsfld     int32 JitTest.Test::m
+      IL_0008:  ldsfld     int32 JitTest_recurse_ep.Test::m
       IL_000d:  ldc.i4     0x375f00
       IL_0012:  bne.un.s   IL_0021
 
@@ -40,7 +40,7 @@
       IL_0020:  ret
 
       IL_0021:  ldstr      "FAILED: 10! != "
-      IL_0026:  ldsflda    int32 JitTest.Test::m
+      IL_0026:  ldsflda    int32 JitTest_recurse_ep.Test::m
       IL_002b:  call       instance class System.String [mscorlib]System.Int32::ToString()
       IL_0030:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -48,16 +48,16 @@
       IL_003a:  ldc.i4.s   101
       IL_003c:  ret
 
-      IL_003d:  ldsfld     int32 JitTest.Test::m
-      IL_0042:  ldsfld     int32 JitTest.Test::n
+      IL_003d:  ldsfld     int32 JitTest_recurse_ep.Test::m
+      IL_0042:  ldsfld     int32 JitTest_recurse_ep.Test::n
       IL_0047:  dup
       IL_0048:  ldc.i4.1
       IL_0049:  sub
-      IL_004a:  stsfld     int32 JitTest.Test::n
+      IL_004a:  stsfld     int32 JitTest_recurse_ep.Test::n
       IL_004f:  mul
-      IL_0050:  stsfld     int32 JitTest.Test::m
+      IL_0050:  stsfld     int32 JitTest_recurse_ep.Test::m
       IL_0055:  tail.
-      IL_0057:  call       int32 JitTest.Test::Main()
+      IL_0057:  call       int32 JitTest_recurse_ep.Test::Main()
       IL_005c:  ret
     } // end of method Test::Main
 
@@ -67,9 +67,9 @@
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_recurse_ep.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_recurse_ep.Test::n
       IL_000d:  ret
     } // end of method Test::.cctor
 
@@ -85,6 +85,6 @@
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_recurse_ep
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/recurse_ep_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/recurse_ep_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/recurse_ep_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/recurse_ep_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/recurse_ep_void.il
+++ b/src/tests/JIT/Methodical/tailcall/recurse_ep_void.il
@@ -8,56 +8,67 @@
 
 .assembly recurse_ep_void { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_recurse_ep_void
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
+    .field private static int32 returnValue
     .method private hidebysig static
             void Main() il managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
-      .entrypoint
       .maxstack  4
       .locals (int32 V_0)
-      IL_0000:  ldsfld     int32 JitTest.Test::n
+      IL_0000:  ldsfld     int32 JitTest_recurse_ep_void.Test::n
       IL_0005:  ldc.i4.1
       IL_0006:  bne.un.s   IL_0049
 
-      IL_0008:  ldsfld     int32 JitTest.Test::m
+      IL_0008:  ldsfld     int32 JitTest_recurse_ep_void.Test::m
       IL_000d:  ldc.i4     0x375f00
       IL_0012:  bne.un.s   IL_0025
 
       IL_0014:  ldstr      "PASSED: 10! == 3628800"
       IL_0019:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_001e:  ldc.i4     0x64
-      IL_0023:  br.s       IL_0043
+                stsfld     int32 JitTest_recurse_ep_void.Test::returnValue
+                ret
 
       IL_0025:  ldstr      "FAILED: 10! != "
-      IL_002a:  ldsflda    int32 JitTest.Test::m
+      IL_002a:  ldsflda    int32 JitTest_recurse_ep_void.Test::m
       IL_002f:  call       instance class System.String [mscorlib]System.Int32::ToString()
       IL_0034:  call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
       IL_0039:  call       void [System.Console]System.Console::WriteLine(class System.String)
       IL_003e:  ldc.i4     0x65
-      IL_0043:  call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
-      IL_0048:  ret
+                stsfld     int32 JitTest_recurse_ep_void.Test::returnValue
+                ret
 
-      IL_0049:  ldsfld     int32 JitTest.Test::m
-      IL_004e:  ldsfld     int32 JitTest.Test::n
+      IL_0049:  ldsfld     int32 JitTest_recurse_ep_void.Test::m
+      IL_004e:  ldsfld     int32 JitTest_recurse_ep_void.Test::n
       IL_0053:  dup
       IL_0054:  ldc.i4.1
       IL_0055:  sub
-      IL_0056:  stsfld     int32 JitTest.Test::n
+      IL_0056:  stsfld     int32 JitTest_recurse_ep_void.Test::n
       IL_005b:  mul
-      IL_005c:  stsfld     int32 JitTest.Test::m
+      IL_005c:  stsfld     int32 JitTest_recurse_ep_void.Test::m
       IL_0061:  tail.
-      IL_0063:  call       void JitTest.Test::Main()
+      IL_0063:  call       void JitTest_recurse_ep_void.Test::Main()
       IL_0068:  ret
+    }
+
+    .method public hidebysig static
+            int32 TestEntrypoint() il managed
+    {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
+      .maxstack  4
+                call       void JitTest_recurse_ep_void.Test::Main()
+                ldsfld     int32 JitTest_recurse_ep_void.Test::returnValue
+                ret
     }
 
     .method private hidebysig specialname rtspecialname static
@@ -65,9 +76,9 @@
     {
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_recurse_ep_void.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_recurse_ep_void.Test::n
       IL_000d:  ret
     }
 

--- a/src/tests/JIT/Methodical/tailcall/recurse_ep_void_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/recurse_ep_void_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/recurse_ep_void_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/recurse_ep_void_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/reference_i.il
+++ b/src/tests/JIT/Methodical/tailcall/reference_i.il
@@ -7,6 +7,7 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
+.assembly extern xunit.core {}
 .assembly reference_i { }
 .method public static class System.String 
         rems(int32& n,
@@ -68,8 +69,13 @@
   IL_005c:  ret
 } // end of global method rems
 
+.class public auto ansi beforefieldinit Test_reference_i extends [mscorlib]System.Object
+{
 .method public static int32 main() il managed
 {
+  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+      01 00 00 00
+  )
   .entrypoint
   // Code size       66 (0x42)
   .maxstack  2
@@ -107,6 +113,17 @@
   IL_0037:  call       void [System.Console]System.Console::WriteLine()
   IL_003c:  ldc.i4     0x64
   IL_0041:  ret
-} // end of global method main
+} // end of method main
+
+
+.method public hidebysig  specialname rtspecialname
+        instance void .ctor() il managed
+{
+  .maxstack  8
+  IL_0000:  ldarg.0
+  IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+  IL_0006:  ret
+}
+}
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/reference_i_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/reference_i_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/reference_i_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/reference_i_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_2a.il
+++ b/src/tests/JIT/Methodical/tailcall/test_2a.il
@@ -8,14 +8,14 @@
 
 .assembly test_2a { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_2a
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
-    .method private hidebysig  static int32 Main() il managed
+    .method public hidebysig  static int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
@@ -25,11 +25,11 @@
       .locals (int32 V_0)
       ldc.i4.1
       call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2a.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_2a.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -39,12 +39,12 @@
       ret
 
 OUT:
-      tail. call       int32 JitTest.Test::Main()
+      tail. call       int32 JitTest_test_2a.Test::Main()
       ret
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_2a.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -53,14 +53,14 @@ IL_0029:
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2a.Test::m
+      ldsfld     int32 JitTest_test_2a.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_2a.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
+      stsfld     int32 JitTest_test_2a.Test::m
       br.s OUT
     } // end of method Test::Main
 
@@ -70,9 +70,9 @@ IL_0047:
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_test_2a.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_test_2a.Test::n
       IL_000d:  ret
     } // end of method Test::.cctor
 
@@ -88,6 +88,6 @@ IL_0047:
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_test_2a
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/test_2a_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_2a_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_2a_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_2a_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_2b.il
+++ b/src/tests/JIT/Methodical/tailcall/test_2b.il
@@ -9,14 +9,14 @@
 
 .assembly test_2b { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_2b
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
-    .method private hidebysig  static int32 Main() il managed
+    .method public hidebysig  static int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
@@ -26,11 +26,11 @@
       .locals (int32 V_0)
       ldc.i4.1
       call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2b.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_2b.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -41,7 +41,7 @@
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_2b.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -50,20 +50,20 @@ IL_0029:
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2b.Test::n
       ldc.i4.1
       beq        MERGE
 
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2b.Test::m
+      ldsfld     int32 JitTest_test_2b.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_2b.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
+      stsfld     int32 JitTest_test_2b.Test::m
 MERGE:
-      tail. call       int32 JitTest.Test::Main()
+      tail. call       int32 JitTest_test_2b.Test::Main()
       ret
     } // end of method Test::Main
 
@@ -73,9 +73,9 @@ MERGE:
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_test_2b.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_test_2b.Test::n
       IL_000d:  ret
     } // end of method Test::.cctor
 
@@ -91,6 +91,6 @@ MERGE:
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_test_2b
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/test_2b_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_2b_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_2b_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_2b_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_2c.il
+++ b/src/tests/JIT/Methodical/tailcall/test_2c.il
@@ -8,14 +8,14 @@
 
 .assembly test_2c { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_2c
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
-    .method private hidebysig  static int32 Main() il managed
+    .method public hidebysig  static int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
@@ -25,11 +25,11 @@
       .locals (int32 V_0)
       ldc.i4.1
       call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2c.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_2c.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -40,7 +40,7 @@
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_2c.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -50,20 +50,20 @@ IL_0029:
 
 IL_0047:
       nop
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2c.Test::n
       ldc.i4.1
       beq        MERGE
 
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_2c.Test::m
+      ldsfld     int32 JitTest_test_2c.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_2c.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
+      stsfld     int32 JitTest_test_2c.Test::m
 MERGE:
-      tail. call       int32 JitTest.Test::Main()
+      tail. call       int32 JitTest_test_2c.Test::Main()
 RET:
       ret
     } // end of method Test::Main
@@ -74,9 +74,9 @@ RET:
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_test_2c.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_test_2c.Test::n
       IL_000d:  ret
     } // end of method Test::.cctor
 
@@ -92,6 +92,6 @@ RET:
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_test_2c
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/test_2c_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_2c_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_2c_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_2c_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_3b.il
+++ b/src/tests/JIT/Methodical/tailcall/test_3b.il
@@ -9,26 +9,26 @@
 }
 .assembly test_3b { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_3b
 {
   .class private value sealed ansi beforefieldinit ValueClass
   		extends [mscorlib]System.ValueType
   {
   		.field public float64 m_fld
   }
-  .class private auto ansi beforefieldinit TestClass
+  .class public auto ansi beforefieldinit TestClass
          extends [mscorlib]System.Object
   {
     .method private hidebysig  static 
-            int32 TestFunc2(value class JitTest.ValueClass) il managed
+            int32 TestFunc2(value class JitTest_test_3b.ValueClass) il managed
     {
       // Code size       10 (0xa)
       .maxstack  8
       .locals init (int32 V_0)
-      sizeof value class JitTest.ValueClass
+      sizeof value class JitTest_test_3b.ValueClass
       localloc
       ldarg.0
-      stobj value class JitTest.ValueClass
+      stobj value class JitTest_test_3b.ValueClass
       ldc.i4.0
       ret
     } // end of method TestClass::TestFunc2
@@ -38,17 +38,17 @@
     {
       // Code size       22 (0x16)
       .maxstack  8
-      sizeof value class JitTest.ValueClass
+      sizeof value class JitTest_test_3b.ValueClass
       localloc
       dup
-      initobj value class JitTest.ValueClass
-      ldobj value class JitTest.ValueClass
+      initobj value class JitTest_test_3b.ValueClass
+      ldobj value class JitTest_test_3b.ValueClass
       tail.
-      call int32 JitTest.TestClass::TestFunc2(value class JitTest.ValueClass)
+      call int32 JitTest_test_3b.TestClass::TestFunc2(value class JitTest_test_3b.ValueClass)
       ret
     } // end of method TestClass::TestFunc1
 
-    .method private hidebysig  static 
+    .method public hidebysig  static 
             int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
@@ -58,7 +58,7 @@
       // Code size       38 (0x26)
       .maxstack  1
       .locals (int32 V_0)
-      IL_0000:  call       int32 JitTest.TestClass::TestFunc1()
+      IL_0000:  call       int32 JitTest_test_3b.TestClass::TestFunc1()
       IL_0005:  brfalse.s  IL_0015
 
       IL_0007:  ldstr      "failed"

--- a/src/tests/JIT/Methodical/tailcall/test_3b_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_3b_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_3b_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_3b_il_r.ilproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_implicit_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_implicit_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_implicit_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_implicit_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_mutual_rec.il
+++ b/src/tests/JIT/Methodical/tailcall/test_mutual_rec.il
@@ -8,14 +8,14 @@
 
 .assembly test_mutual_rec { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_mutual_rec
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
-    .method private hidebysig  static int32 Main() il managed
+    .method public hidebysig  static int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
@@ -25,11 +25,11 @@
       .locals (int32 V_0)
       ldc.i4.1
       call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_mutual_rec.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_mutual_rec.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -40,7 +40,7 @@
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_mutual_rec.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -49,26 +49,26 @@ IL_0029:
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_mutual_rec.Test::m
+      ldsfld     int32 JitTest_test_mutual_rec.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_mutual_rec.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
+      stsfld     int32 JitTest_test_mutual_rec.Test::m
 
-      ldsfld int32 JitTest.Test::n
+      ldsfld int32 JitTest_test_mutual_rec.Test::n
       ldc.i4.3
       rem
       switch (CASE1, CASE2)
-      ldftn int32 JitTest.Test::Main()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main()
       br.s MERGE1
 CASE1:
-      ldftn int32 JitTest.Test::Main1()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main1()
       br.s MERGE1
 CASE2:
-      ldftn int32 JitTest.Test::Main2()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main2()
 MERGE1:
       tail. calli int32()
       ret
@@ -79,11 +79,11 @@ MERGE1:
       .locals (int32 V_0)
       ldc.i4.1
       call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_mutual_rec.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_mutual_rec.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -94,7 +94,7 @@ MERGE1:
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_mutual_rec.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -103,26 +103,26 @@ IL_0029:
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_mutual_rec.Test::m
+      ldsfld     int32 JitTest_test_mutual_rec.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_mutual_rec.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
+      stsfld     int32 JitTest_test_mutual_rec.Test::m
 
-      ldsfld int32 JitTest.Test::n
+      ldsfld int32 JitTest_test_mutual_rec.Test::n
       ldc.i4.3
       rem
       switch (CASE1, CASE2)
-      ldftn int32 JitTest.Test::Main()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main()
       br.s MERGE1
 CASE1:
-      ldftn int32 JitTest.Test::Main1()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main1()
       br.s MERGE1
 CASE2:
-      ldftn int32 JitTest.Test::Main2()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main2()
 MERGE1:
       tail. calli int32()
       ret
@@ -133,11 +133,11 @@ MERGE1:
       .locals (int32 V_0)
       ldc.i4.1
       call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_mutual_rec.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_mutual_rec.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -148,7 +148,7 @@ MERGE1:
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_mutual_rec.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -157,26 +157,26 @@ IL_0029:
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_mutual_rec.Test::m
+      ldsfld     int32 JitTest_test_mutual_rec.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_mutual_rec.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
+      stsfld     int32 JitTest_test_mutual_rec.Test::m
 
-      ldsfld int32 JitTest.Test::n
+      ldsfld int32 JitTest_test_mutual_rec.Test::n
       ldc.i4.3
       rem
       switch (CASE1, CASE2)
-      ldftn int32 JitTest.Test::Main()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main()
       br.s MERGE1
 CASE1:
-      ldftn int32 JitTest.Test::Main1()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main1()
       br.s MERGE1
 CASE2:
-      ldftn int32 JitTest.Test::Main2()
+      ldftn int32 JitTest_test_mutual_rec.Test::Main2()
 MERGE1:
       tail. calli int32()
       ret
@@ -188,9 +188,9 @@ MERGE1:
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_test_mutual_rec.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_test_mutual_rec.Test::n
       IL_000d:  ret
     } // end of method Test::.cctor
 
@@ -206,6 +206,6 @@ MERGE1:
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_test_mutual_rec
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/test_mutual_rec_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_mutual_rec_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_mutual_rec_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_mutual_rec_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_switch.il
+++ b/src/tests/JIT/Methodical/tailcall/test_switch.il
@@ -8,9 +8,9 @@
 
 .assembly test_switch { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_switch
 {
-  .class private auto ansi beforefieldinit Test
+  .class public auto ansi beforefieldinit Test
          extends [mscorlib]System.Object
   {
     .field private static int32 m
@@ -18,22 +18,22 @@
     .method private hidebysig static int32 Main1() il managed
     {
         .maxstack  4
-        tail. call       int32 JitTest.Test::Main2()
+        tail. call       int32 JitTest_test_switch.Test::Main2()
         ret
     }
     .method private hidebysig static int32 Main2() il managed
     {
         .maxstack  4
-        tail. call       int32 JitTest.Test::Main3()
+        tail. call       int32 JitTest_test_switch.Test::Main3()
         ret
     }
     .method private hidebysig static int32 Main3() il managed
     {
         .maxstack  4
-        tail. call       int32 JitTest.Test::Main()
+        tail. call       int32 JitTest_test_switch.Test::Main()
         ret
     }
-    .method private hidebysig static int32 Main() il managed
+    .method public hidebysig static int32 Main() il managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
@@ -43,11 +43,11 @@
       .locals (int32 V_0)
       ldc.i4.1
       call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_switch.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_switch.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -58,7 +58,7 @@
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_switch.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String, class System.String)
       call       void [System.Console]System.Console::WriteLine(class System.String)
@@ -66,31 +66,31 @@ IL_0029:
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_switch.Test::n
       ldc.i4.1
       beq        MERGE
 
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_switch.Test::m
+      ldsfld     int32 JitTest_test_switch.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_switch.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
+      stsfld     int32 JitTest_test_switch.Test::m
 MERGE:
-      ldsfld int32 JitTest.Test::n
+      ldsfld int32 JitTest_test_switch.Test::n
       switch (CASE1, CASE2, CASE3)
-      ldftn int32 JitTest.Test::Main()
+      ldftn int32 JitTest_test_switch.Test::Main()
       br.s MERGE1
 CASE1:
-      ldftn int32 JitTest.Test::Main1()
+      ldftn int32 JitTest_test_switch.Test::Main1()
       br.s MERGE1
 CASE2:
-      ldftn int32 JitTest.Test::Main2()
+      ldftn int32 JitTest_test_switch.Test::Main2()
       br.s MERGE1
 CASE3:
-      ldftn int32 JitTest.Test::Main3()
+      ldftn int32 JitTest_test_switch.Test::Main3()
 MERGE1:
       tail. calli int32()
       ret
@@ -102,9 +102,9 @@ MERGE1:
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_test_switch.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_test_switch.Test::n
       IL_000d:  ret
     } // end of method Test::.cctor
 
@@ -120,6 +120,6 @@ MERGE1:
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_test_switch
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/test_switch_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_switch_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_switch_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_switch_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_virt.il
+++ b/src/tests/JIT/Methodical/tailcall/test_virt.il
@@ -8,26 +8,21 @@
 
 .assembly test_virt { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_virt
 {
-  .class private auto ansi beforefieldinit TestClass extends [mscorlib]System.Object
+  .class public auto ansi beforefieldinit TestClass extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
     .method private hidebysig virtual  instance int32 Main() il managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
       .maxstack  4
       .locals (int32 V_0)
-      ldc.i4.1
-      call       void [System.Runtime.Extensions]System.Environment::set_ExitCode(int32)
-      ldsfld     int32 JitTest.TestClass::n
+      ldsfld     int32 JitTest_test_virt.TestClass::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.TestClass::m
+      ldsfld     int32 JitTest_test_virt.TestClass::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
@@ -38,7 +33,7 @@
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.TestClass::m
+      ldsflda    int32 JitTest_test_virt.TestClass::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String,
                                                                                class System.String)
@@ -47,25 +42,28 @@ IL_0029:
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.TestClass::m
-      ldsfld     int32 JitTest.TestClass::n
+      ldsfld     int32 JitTest_test_virt.TestClass::m
+      ldsfld     int32 JitTest_test_virt.TestClass::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.TestClass::n
+      stsfld     int32 JitTest_test_virt.TestClass::n
       mul
-      stsfld     int32 JitTest.TestClass::m
+      stsfld     int32 JitTest_test_virt.TestClass::m
       ldarg.0
-      tail. call instance int32 JitTest.TestClass::Main()
+      tail. call instance int32 JitTest_test_virt.TestClass::Main()
       ret
     } // end of method Test::Main
 
-    .method private hidebysig  static int32 Main1() il managed
+    .method public hidebysig  static int32 Main1() il managed
     {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
       .entrypoint
       .maxstack  4
-      newobj instance void JitTest.TestClass::.ctor()
-      tail. callvirt instance int32 JitTest.TestClass::Main()
+      newobj instance void JitTest_test_virt.TestClass::.ctor()
+      tail. callvirt instance int32 JitTest_test_virt.TestClass::Main()
       ret
      }
     .method private hidebysig  specialname rtspecialname static
@@ -74,9 +72,9 @@ IL_0047:
       // Code size       14 (0xe)
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.TestClass::m
+      IL_0001:  stsfld     int32 JitTest_test_virt.TestClass::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.TestClass::n
+      IL_0008:  stsfld     int32 JitTest_test_virt.TestClass::n
       IL_000d:  ret
     } // end of method Test::.cctor
 
@@ -92,6 +90,6 @@ IL_0047:
 
   } // end of class Test
 
-} // end of namespace JitTest
+} // end of namespace JitTest_test_virt
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Methodical/tailcall/test_virt_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_virt_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_virt_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_virt_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_void.il
+++ b/src/tests/JIT/Methodical/tailcall/test_void.il
@@ -8,55 +8,64 @@
 
 .assembly test_void { }
 .assembly extern xunit.core {}
-.namespace JitTest
+.namespace JitTest_test_void
 {
-  .class private auto ansi beforefieldinit Test extends [mscorlib]System.Object
+  .class public auto ansi beforefieldinit Test extends [mscorlib]System.Object
   {
     .field private static int32 m
     .field private static int32 n
+    .field private static int32 returnValue
     .method private hidebysig static void Main() il managed
     {
-      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-          01 00 00 00
-      )
-      .entrypoint
       .maxstack  4
       .locals (int32 V_0)
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_void.Test::n
       ldc.i4.1
       bne.un.s   IL_0047
 
-      ldsfld     int32 JitTest.Test::m
+      ldsfld     int32 JitTest_test_void.Test::m
       ldc.i4     0x375f00
       bne.un.s   IL_0029
 
       ldstr      "PASSED: 10! == 3628800"
       call       void [System.Console]System.Console::WriteLine(class System.String)
       ldc.i4.s   100
-      call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
+      stsfld     int32 JitTest_test_void.Test::returnValue
       ret
 
 IL_0029:
       ldstr      "FAILED: 10! != "
-      ldsflda    int32 JitTest.Test::m
+      ldsflda    int32 JitTest_test_void.Test::m
       call       instance class System.String [mscorlib]System.Int32::ToString()
       call       class System.String [mscorlib]System.String::Concat(class System.String, class System.String)
       call       void [System.Console]System.Console::WriteLine(class System.String)
       ldc.i4.s   101
-      call       void [System.Runtime.Extensions]System.Environment::Exit(int32)
+      stsfld     int32 JitTest_test_void.Test::returnValue
       ret
 
 IL_0047:
-      ldsfld     int32 JitTest.Test::m
-      ldsfld     int32 JitTest.Test::n
+      ldsfld     int32 JitTest_test_void.Test::m
+      ldsfld     int32 JitTest_test_void.Test::n
       dup
       ldc.i4.1
       sub
-      stsfld     int32 JitTest.Test::n
+      stsfld     int32 JitTest_test_void.Test::n
       mul
-      stsfld     int32 JitTest.Test::m
-      tail. call void JitTest.Test::Main()
+      stsfld     int32 JitTest_test_void.Test::m
+      tail. call void JitTest_test_void.Test::Main()
       ret
+    }
+
+    .method public hidebysig static int32 TestEntrypoint() il managed
+    {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
+      .maxstack  4
+                call       void JitTest_test_void.Test::Main()
+                ldsfld     int32 JitTest_test_void.Test::returnValue
+                ret
     }
 
     .method private hidebysig  specialname rtspecialname static
@@ -64,9 +73,9 @@ IL_0047:
     {
       .maxstack  8
       IL_0000:  ldc.i4.1
-      IL_0001:  stsfld     int32 JitTest.Test::m
+      IL_0001:  stsfld     int32 JitTest_test_void.Test::m
       IL_0006:  ldc.i4.s   10
-      IL_0008:  stsfld     int32 JitTest.Test::n
+      IL_0008:  stsfld     int32 JitTest_test_void.Test::n
       IL_000d:  ret
     }
 

--- a/src/tests/JIT/Methodical/tailcall/test_void_il_d.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_void_il_d.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/test_void_il_r.ilproj
+++ b/src/tests/JIT/Methodical/tailcall/test_void_il_r.ilproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/tailcall/widen.cs
+++ b/src/tests/JIT/Methodical/tailcall/widen.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Runtime.CompilerServices;
+using Xunit;
 
-public class Program
+public class Program_widen
 {
     // Random field we assign some bogus values to to trick the inliner below.
     // We cannot use NoInlining as the runtime disables tailcalls from such functions.
     private static int s_val;
 
-    public static int Main()
+    [Fact]
+    public static int TestEntrypoint()
     {
         bool result = true;
         Console.Write("Test1U1S: ");

--- a/src/tests/JIT/Methodical/tailcall/widen_r.csproj
+++ b/src/tests/JIT/Methodical/tailcall/widen_r.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>


### PR DESCRIPTION
This change fixes mergeability of tailcall tests: apart from simple
deduplication of the test class names and visibility fixes
I have modified the pointer and reference tests to stop using
Environment.Exit for exiting the test as that kills the merged
wrapper in in-proc execution; I have also fixed them to have main
within a class. In two cases (recurse_ep_void and test_virt)
I found out that I had previously put the Fact attribute on the
wrong method so I fixed that too. I renamed the two C# test
projects to better match the test of tests (widen to widen_r to
indicate it's a release test and thread-race_il_r to thread-race_r
as it's not an IL test).

Thanks

Tomas

/cc @dotnet/jit-contrib 