### PR TITLE
[release/6.0] Don't create multiple large files at the same time

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -1318,7 +1318,7 @@ namespace System.Diagnostics.Tests
             string expected = Path.GetFileNameWithoutExtension(filename);
 
             process.WaitForInputIdle(); // Give the file a chance to load
-            Assert.Equal("notepad", process.ProcessName);
+            Assert.Equal("notepad", process.ProcessName.ToLower());
 
             // Notepad calls CreateWindowEx with pWindowName of empty string, then calls SetWindowTextW
             // with "Untitled - Notepad" then finally if you're opening a file, calls SetWindowTextW

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -267,11 +267,16 @@ namespace System.Diagnostics.Tests
                 {
                     if (px != null) // sometimes process is null
                     {
-                        Assert.Equal("notepad", px.ProcessName);
-
-                        px.Kill();
-                        Assert.True(px.WaitForExit(WaitInMS));
-                        px.WaitForExit(); // wait for event handlers to complete
+                        try
+                        {
+                            Assert.Equal("notepad", px.ProcessName.ToLower());
+                        }
+                        finally
+                        {
+                            px.Kill();
+                            Assert.True(px.WaitForExit(WaitInMS));
+                            px.WaitForExit(); // wait for event handlers to complete
+                        }
                     }
                 }
             }

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -58,21 +58,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [OuterLoop]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
-        public void ReadFileOver2GB()
-        {
-            string path = GetTestFilePath();
-            using (FileStream fs = File.Create(path))
-            {
-                fs.SetLength(int.MaxValue + 1L);
-            }
-
-            // File is too large for ReadAllBytes at once
-            Assert.Throws<IOException>(() => File.ReadAllBytes(path));
-        }
-
-        [Fact]
         public void Overwrite()
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using System.IO.Pipes;
-using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.IO.Tests
 {
@@ -68,21 +67,6 @@ namespace System.IO.Tests
             Assert.True(File.WriteAllBytesAsync(path, new byte[0], token).IsCanceled);
             return Assert.ThrowsAsync<TaskCanceledException>(
                 async () => await File.WriteAllBytesAsync(path, new byte[0], token));
-        }
-
-        [Fact]
-        [OuterLoop]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
-        public Task ReadFileOver2GBAsync()
-        {
-            string path = GetTestFilePath();
-            using (FileStream fs = File.Create(path))
-            {
-                fs.SetLength(int.MaxValue + 1L);
-            }
-
-            // File is too large for ReadAllBytes at once
-            return Assert.ThrowsAsync<IOException>(async () => await File.ReadAllBytesAsync(path));
         }
 
         [Fact]

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -14,39 +14,5 @@ namespace System.IO.Tests
             Assert.Throws<UnauthorizedAccessException>(() =>
                 new FileStream(Path.GetPathRoot(Directory.GetCurrentDirectory()), FileMode.Open, FileAccess.Read));
         }
-
-        [Fact]
-        [OuterLoop]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
-        public void NoInt32OverflowInTheBufferingLogic()
-        {
-            const long position1 = 10;
-            const long position2 = (1L << 32) + position1;
-
-            string filePath = GetTestFilePath();
-            byte[] data1 = new byte[] { 1, 2, 3, 4, 5 };
-            byte[] data2 = new byte[] { 6, 7, 8, 9, 10 };
-            byte[] buffer = new byte[5];
-
-            using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
-            {
-                stream.Seek(position1, SeekOrigin.Begin);
-                stream.Write(data1);
-
-                stream.Seek(position2, SeekOrigin.Begin);
-                stream.Write(data2);
-            }
-
-            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-            {
-                stream.Seek(position1, SeekOrigin.Begin);
-                Assert.Equal(buffer.Length, stream.Read(buffer));
-                Assert.Equal(data1, buffer);
-
-                stream.Seek(position2, SeekOrigin.Begin);
-                Assert.Equal(buffer.Length, stream.Read(buffer));
-                Assert.Equal(data2, buffer);
-            }
-        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Read.cs
@@ -15,7 +15,8 @@ namespace System.IO.Tests
                 new FileStream(Path.GetPathRoot(Directory.GetCurrentDirectory()), FileMode.Open, FileAccess.Read));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [Fact]
+        [OuterLoop]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
         public void NoInt32OverflowInTheBufferingLogic()
         {
@@ -30,24 +31,13 @@ namespace System.IO.Tests
             using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
             {
                 stream.Seek(position1, SeekOrigin.Begin);
-                stream.Write(data1, 0, data1.Length);
+                stream.Write(data1);
 
                 stream.Seek(position2, SeekOrigin.Begin);
-                stream.Write(data2, 0, data2.Length);
+                stream.Write(data2);
             }
 
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-            {
-                stream.Seek(position1, SeekOrigin.Begin);
-                Assert.Equal(buffer.Length, stream.Read(buffer));
-                Assert.Equal(data1, buffer);
-
-                stream.Seek(position2, SeekOrigin.Begin);
-                Assert.Equal(buffer.Length, stream.Read(buffer));
-                Assert.Equal(data2, buffer);
-            }
-
-            using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0)))
             {
                 stream.Seek(position1, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));

--- a/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Tests;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    [OuterLoop]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
+    [Collection(nameof(DisableParallelization))] // don't create multiple large files at the same time
+    public class LargeFileTests : FileSystemTest
+    {
+        [Fact]
+        public async Task ReadAllBytesOverLimit()
+        {
+            using FileStream fs = new (GetTestFilePath(), FileMode.Create, FileAccess.Write, FileShare.Read, 4096, FileOptions.DeleteOnClose);
+
+            foreach (long lengthOverLimit in new long[] { Array.MaxLength + 1L, int.MaxValue + 1L })
+            {
+                fs.SetLength(lengthOverLimit);
+
+                Assert.Throws<IOException>(() => File.ReadAllBytes(fs.Name));
+                await Assert.ThrowsAsync<IOException>(async () => await File.ReadAllBytesAsync(fs.Name));
+            }
+        }
+
+        [Fact]
+        public void NoInt32OverflowInTheBufferingLogic()
+        {
+            const long position1 = 10;
+            const long position2 = (1L << 32) + position1;
+
+            string filePath = GetTestFilePath();
+            byte[] data1 = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] data2 = new byte[] { 6, 7, 8, 9, 10 };
+            byte[] buffer = new byte[5];
+
+            using (FileStream stream = File.Create(filePath))
+            {
+                stream.Seek(position1, SeekOrigin.Begin);
+                stream.Write(data1);
+
+                stream.Seek(position2, SeekOrigin.Begin);
+                stream.Write(data2);
+            }
+
+            using (FileStream stream = new (filePath, FileMode.Open, FileAccess.Read, FileShare.None, 4096, FileOptions.DeleteOnClose))
+            {
+                stream.Seek(position1, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data1, buffer);
+
+                stream.Seek(position2, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data2, buffer);
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.FileSystem.Tests
 {
     [OuterLoop]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
-    [Collection("NoParallelTests")] // don't create multiple large files at the same time
+    [Collection(nameof(NoParallelTests))] // don't create multiple large files at the same time
     public class LargeFileTests : FileSystemTest
     {
         [Fact]
@@ -17,7 +17,7 @@ namespace System.IO.FileSystem.Tests
         {
             using FileStream fs = new (GetTestFilePath(), FileMode.Create, FileAccess.Write, FileShare.Read, 4096, FileOptions.DeleteOnClose);
 
-            foreach (long lengthOverLimit in new long[] { Array.MaxLength + 1L, int.MaxValue + 1L })
+            foreach (long lengthOverLimit in new long[] { int.MaxValue + 1L })
             {
                 fs.SetLength(lengthOverLimit);
 

--- a/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.FileSystem.Tests
 {
     [OuterLoop]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
-    [Collection(nameof(DisableParallelization))] // don't create multiple large files at the same time
+    [Collection("NoParallelTests")] // don't create multiple large files at the same time
     public class LargeFileTests : FileSystemTest
     {
         [Fact]
@@ -58,4 +58,7 @@ namespace System.IO.FileSystem.Tests
             }
         }
     }
+
+    [CollectionDefinition("NoParallelTests", DisableParallelization = true)]
+    public partial class NoParallelTests { }
 }

--- a/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/LargeFileTests.cs
@@ -59,6 +59,6 @@ namespace System.IO.FileSystem.Tests
         }
     }
 
-    [CollectionDefinition("NoParallelTests", DisableParallelization = true)]
+    [CollectionDefinition(nameof(NoParallelTests), DisableParallelization = true)]
     public partial class NoParallelTests { }
 }

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Enumeration\ExampleTests.cs" />
     <Compile Include="Enumeration\RemovedDirectoryTests.cs" />
     <Compile Include="Enumeration\SymbolicLinksTests.cs" />
+    <Compile Include="LargeFileTests.cs" />
     <Compile Include="PathInternalTests.cs" />
     <Compile Include="RandomAccess\Base.cs" />
     <Compile Include="RandomAccess\GetLength.cs" />

--- a/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -346,7 +346,7 @@ namespace System.IO.Tests
                 stream.Write(data2);
             }
 
-            using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0)))
+            using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0, FileOptions.DeleteOnClose)))
             {
                 stream.Seek(position1, SeekOrigin.Begin);
                 Assert.Equal(buffer.Length, stream.Read(buffer));

--- a/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -323,6 +323,40 @@ namespace System.IO.Tests
             Array.Copy(data, 1, expected, 0, expected.Length);
             Assert.Equal(expected, dst.ToArray());
         }
+
+        [Fact]
+        [OuterLoop]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45954", TestPlatforms.Browser)]
+        public void NoInt32OverflowInTheBufferingLogic()
+        {
+            const long position1 = 10;
+            const long position2 = (1L << 32) + position1;
+
+            string filePath = Path.GetTempFileName();
+            byte[] data1 = new byte[] { 1, 2, 3, 4, 5 };
+            byte[] data2 = new byte[] { 6, 7, 8, 9, 10 };
+            byte[] buffer = new byte[5];
+
+            using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write))
+            {
+                stream.Seek(position1, SeekOrigin.Begin);
+                stream.Write(data1);
+
+                stream.Seek(position2, SeekOrigin.Begin);
+                stream.Write(data2);
+            }
+
+            using (var stream = new BufferedStream(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize: 0)))
+            {
+                stream.Seek(position1, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data1, buffer);
+
+                stream.Seek(position2, SeekOrigin.Begin);
+                Assert.Equal(buffer.Length, stream.Read(buffer));
+                Assert.Equal(data2, buffer);
+            }
+        }
     }
 
     public class BufferedStream_TestLeaveOpen : TestLeaveOpen


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/60606 and https://github.com/dotnet/runtime/pull/62519.
Move tests that create large files (~4 gb) to OuterLoop and disables parallelization to avoid running into out of memory and time out errors.

## Customer Impact

None, this is required to have a clean CI in 6.0 branch.

## Testing

Changes have been tested in main for a while.

## Risk

Low.