### PR TITLE
disable failing HTTP3 interop test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1349,7 +1349,9 @@ namespace System.Net.Http.Functional.Tests
             new TheoryData<string>
             {
                 { "https://cloudflare-quic.com/" }, // Cloudflare with content
-                { "https://pgjones.dev/" }, // aioquic with content
+                // This endpoint is consistently failing.
+                // ISSUE: https://github.com/dotnet/runtime/issues/63009
+                //{ "https://pgjones.dev/" }, // aioquic with content
             };
     }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1350,7 +1350,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 { "https://cloudflare-quic.com/" }, // Cloudflare with content
                 // This endpoint is consistently failing.
-                // ISSUE: https://github.com/dotnet/runtime/issues/63009
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/63009")]
                 //{ "https://pgjones.dev/" }, // aioquic with content
             };
     }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/63009
