### PR TITLE
Reduce size of HttpHeaderValueCollection

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -21,9 +20,6 @@ namespace System.Net.Http.Headers
             new NameValueWithParametersHeaderValue("100-continue");
 
         internal const string BytesUnit = "bytes";
-
-        // Validator
-        internal static readonly Action<HttpHeaderValueCollection<string>, string> TokenValidator = ValidateToken;
 
         internal static void SetQuality(UnvalidatedObjectCollection<NameValueHeaderValue> parameters, double? value)
         {
@@ -370,11 +366,6 @@ namespace System.Net.Http.Headers
             }
 
             sb.Append('}');
-        }
-
-        private static void ValidateToken(HttpHeaderValueCollection<string> collection, string value)
-        {
-            CheckValidToken(value, "item");
         }
 
         internal static UnvalidatedObjectCollection<NameValueHeaderValue>? Clone(this UnvalidatedObjectCollection<NameValueHeaderValue>? source)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
@@ -22,8 +22,7 @@ namespace System.Net.Http.Headers
             {
                 if (_allow == null)
                 {
-                    _allow = new HttpHeaderValueCollection<string>(KnownHeaders.Allow.Descriptor,
-                        this, HeaderUtilities.TokenValidator);
+                    _allow = new HttpHeaderValueCollection<string>(KnownHeaders.Allow.Descriptor, this);
                 }
                 return _allow;
             }
@@ -43,8 +42,7 @@ namespace System.Net.Http.Headers
             {
                 if (_contentEncoding == null)
                 {
-                    _contentEncoding = new HttpHeaderValueCollection<string>(KnownHeaders.ContentEncoding.Descriptor,
-                        this, HeaderUtilities.TokenValidator);
+                    _contentEncoding = new HttpHeaderValueCollection<string>(KnownHeaders.ContentEncoding.Descriptor, this);
                 }
                 return _contentEncoding;
             }
@@ -56,8 +54,7 @@ namespace System.Net.Http.Headers
             {
                 if (_contentLanguage == null)
                 {
-                    _contentLanguage = new HttpHeaderValueCollection<string>(KnownHeaders.ContentLanguage.Descriptor,
-                        this, HeaderUtilities.TokenValidator);
+                    _contentLanguage = new HttpHeaderValueCollection<string>(KnownHeaders.ContentLanguage.Descriptor, this);
                 }
                 return _contentLanguage;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -49,7 +49,7 @@ namespace System.Net.Http.Headers
                 else
                 {
                     _connectionCloseSet = value != null;
-                    // We intentionally ignore in the return value. It's OK if "close" wasn't in the store.
+                    // We intentionally ignore the return value. It's OK if "close" wasn't in the store.
                     _parent.RemoveParsedValue(KnownHeaders.Connection.Descriptor, HeaderUtilities.ConnectionClose);
                 }
             }
@@ -134,7 +134,7 @@ namespace System.Net.Http.Headers
                 else
                 {
                     _transferEncodingChunkedSet = value != null;
-                    // We intentionally ignore in the return value. It's OK if "chunked" wasn't in the store.
+                    // We intentionally ignore the return value. It's OK if "chunked" wasn't in the store.
                     _parent.RemoveParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked);
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -182,8 +182,7 @@ namespace System.Net.Http.Headers
             {
                 if (_connection == null)
                 {
-                    _connection = new HttpHeaderValueCollection<string>(KnownHeaders.Connection.Descriptor,
-                        _parent, HeaderUtilities.ConnectionClose, HeaderUtilities.TokenValidator);
+                    _connection = new HttpHeaderValueCollection<string>(KnownHeaders.Connection.Descriptor, _parent, HeaderUtilities.TokenValidator);
                 }
                 return _connection;
             }
@@ -195,8 +194,7 @@ namespace System.Net.Http.Headers
             {
                 if (_transferEncoding == null)
                 {
-                    _transferEncoding = new HttpHeaderValueCollection<TransferCodingHeaderValue>(
-                        KnownHeaders.TransferEncoding.Descriptor, _parent, HeaderUtilities.TransferEncodingChunked);
+                    _transferEncoding = new HttpHeaderValueCollection<TransferCodingHeaderValue>(KnownHeaders.TransferEncoding.Descriptor, _parent);
                 }
                 return _transferEncoding;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -27,11 +27,6 @@ namespace System.Net.Http.Headers
             set { _parent.SetOrRemoveParsedValue(KnownHeaders.CacheControl.Descriptor, value); }
         }
 
-        public HttpHeaderValueCollection<string> Connection
-        {
-            get { return ConnectionCore; }
-        }
-
         public bool? ConnectionClose
         {
             get
@@ -46,30 +41,23 @@ namespace System.Net.Http.Headers
                 if (value == true)
                 {
                     _connectionCloseSet = true;
-                    ConnectionCore.SetSpecialValue();
+                    if (!_parent.ContainsParsedValue(KnownHeaders.Connection.Descriptor, HeaderUtilities.ConnectionClose))
+                    {
+                        _parent.AddParsedValue(KnownHeaders.Connection.Descriptor, HeaderUtilities.ConnectionClose);
+                    }
                 }
                 else
                 {
                     _connectionCloseSet = value != null;
-                    ConnectionCore.RemoveSpecialValue();
+                    // We intentionally ignore in the return value. It's OK if "close" wasn't in the store.
+                    _parent.RemoveParsedValue(KnownHeaders.Connection.Descriptor, HeaderUtilities.ConnectionClose);
                 }
             }
         }
 
         internal static bool? GetConnectionClose(HttpHeaders parent, HttpGeneralHeaders? headers)
         {
-            // If we've already initialized the connection header value collection
-            // and it contains the special value, or if we haven't and the headers contain
-            // the parsed special value, return true.  We don't just access ConnectionCore,
-            // as doing so will unnecessarily initialize the collection even if it's not needed.
-            if (headers?._connection != null)
-            {
-                if (headers._connection.IsSpecialValueSet)
-                {
-                    return true;
-                }
-            }
-            else if (parent.ContainsParsedValue(KnownHeaders.Connection.Descriptor, HeaderUtilities.ConnectionClose))
+            if (parent.ContainsParsedValue(KnownHeaders.Connection.Descriptor, HeaderUtilities.ConnectionClose))
             {
                 return true;
             }
@@ -200,7 +188,7 @@ namespace System.Net.Http.Headers
             }
         }
 
-        private HttpHeaderValueCollection<string> ConnectionCore
+        public HttpHeaderValueCollection<string> Connection
         {
             get
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -99,25 +99,9 @@ namespace System.Net.Http.Headers
             }
         }
 
-        public HttpHeaderValueCollection<TransferCodingHeaderValue> TransferEncoding
-        {
-            get { return TransferEncodingCore; }
-        }
-
         internal static bool? GetTransferEncodingChunked(HttpHeaders parent, HttpGeneralHeaders? headers)
         {
-            // If we've already initialized the transfer encoding header value collection
-            // and it contains the special value, or if we haven't and the headers contain
-            // the parsed special value, return true.  We don't just access TransferEncodingCore,
-            // as doing so will unnecessarily initialize the collection even if it's not needed.
-            if (headers?._transferEncoding != null)
-            {
-                if (headers._transferEncoding.IsSpecialValueSet)
-                {
-                    return true;
-                }
-            }
-            else if (parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked))
+            if (parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked))
             {
                 return true;
             }
@@ -142,12 +126,16 @@ namespace System.Net.Http.Headers
                 if (value == true)
                 {
                     _transferEncodingChunkedSet = true;
-                    TransferEncodingCore.SetSpecialValue();
+                    if (!_parent.ContainsParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked))
+                    {
+                        _parent.AddParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked);
+                    }
                 }
                 else
                 {
                     _transferEncodingChunkedSet = value != null;
-                    TransferEncodingCore.RemoveSpecialValue();
+                    // We intentionally ignore in the return value. It's OK if "chunked" wasn't in the store.
+                    _parent.RemoveParsedValue(KnownHeaders.TransferEncoding.Descriptor, HeaderUtilities.TransferEncodingChunked);
                 }
             }
         }
@@ -201,7 +189,7 @@ namespace System.Net.Http.Headers
             }
         }
 
-        private HttpHeaderValueCollection<TransferCodingHeaderValue> TransferEncodingCore
+        public HttpHeaderValueCollection<TransferCodingHeaderValue> TransferEncoding
         {
             get
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpGeneralHeaders.cs
@@ -92,8 +92,7 @@ namespace System.Net.Http.Headers
             {
                 if (_trailer == null)
                 {
-                    _trailer = new HttpHeaderValueCollection<string>(KnownHeaders.Trailer.Descriptor,
-                        _parent, HeaderUtilities.TokenValidator);
+                    _trailer = new HttpHeaderValueCollection<string>(KnownHeaders.Trailer.Descriptor, _parent);
                 }
                 return _trailer;
             }
@@ -182,7 +181,7 @@ namespace System.Net.Http.Headers
             {
                 if (_connection == null)
                 {
-                    _connection = new HttpHeaderValueCollection<string>(KnownHeaders.Connection.Descriptor, _parent, HeaderUtilities.TokenValidator);
+                    _connection = new HttpHeaderValueCollection<string>(KnownHeaders.Connection.Descriptor, _parent);
                 }
                 return _connection;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
@@ -35,7 +35,6 @@ namespace System.Net.Http.Headers
     {
         private readonly HeaderDescriptor _descriptor;
         private readonly HttpHeaders _store;
-        private readonly T? _specialValue;
         private readonly Action<HttpHeaderValueCollection<T>, T>? _validator;
 
         public int Count
@@ -48,44 +47,10 @@ namespace System.Net.Http.Headers
             get { return false; }
         }
 
-        internal bool IsSpecialValueSet
+        internal HttpHeaderValueCollection(HeaderDescriptor descriptor, HttpHeaders store, Action<HttpHeaderValueCollection<T>, T>? validator = null)
         {
-            get
-            {
-                // If this collection instance has a "special value", then check whether that value was already set.
-                if (_specialValue == null)
-                {
-                    return false;
-                }
-                return _store.ContainsParsedValue(_descriptor, _specialValue);
-            }
-        }
-
-        internal HttpHeaderValueCollection(HeaderDescriptor descriptor, HttpHeaders store)
-            : this(descriptor, store, null, null)
-        {
-        }
-
-        internal HttpHeaderValueCollection(HeaderDescriptor descriptor, HttpHeaders store,
-            Action<HttpHeaderValueCollection<T>, T> validator)
-            : this(descriptor, store, null, validator)
-        {
-        }
-
-        internal HttpHeaderValueCollection(HeaderDescriptor descriptor, HttpHeaders store, T specialValue)
-            : this(descriptor, store, specialValue, null)
-        {
-        }
-
-        internal HttpHeaderValueCollection(HeaderDescriptor descriptor, HttpHeaders store, T? specialValue,
-            Action<HttpHeaderValueCollection<T>, T>? validator)
-        {
-            Debug.Assert(descriptor.Name != null);
-            Debug.Assert(store != null);
-
             _store = store;
             _descriptor = descriptor;
-            _specialValue = specialValue;
             _validator = validator;
         }
 
@@ -202,27 +167,6 @@ namespace System.Net.Http.Headers
         public override string ToString()
         {
             return _store.GetHeaderString(_descriptor);
-        }
-
-        internal void SetSpecialValue()
-        {
-            Debug.Assert(_specialValue != null,
-                "This method can only be used if the collection has a 'special value' set.");
-
-            if (!_store.ContainsParsedValue(_descriptor, _specialValue))
-            {
-                _store.AddParsedValue(_descriptor, _specialValue);
-            }
-        }
-
-        internal void RemoveSpecialValue()
-        {
-            Debug.Assert(_specialValue != null,
-                "This method can only be used if the collection has a 'special value' set.");
-
-            // We're not interested in the return value. It's OK if the "special value" wasn't in the store
-            // before calling RemoveParsedValue().
-            _store.RemoveParsedValue(_descriptor, _specialValue);
         }
 
         private void CheckValue(T item)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderValueCollection.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -49,6 +48,12 @@ namespace System.Net.Http.Headers
 
         internal HttpHeaderValueCollection(HeaderDescriptor descriptor, HttpHeaders store, Action<HttpHeaderValueCollection<T>, T>? validator = null)
         {
+#pragma warning disable CS0252 // Possible unintended reference comparison; left hand side needs cast
+            Debug.Assert(validator is null || validator == HeaderUtilities.TokenValidator, "non token validator??");
+#pragma warning restore CS0252 // Possible unintended reference comparison; left hand side needs cast
+
+            Debug.Assert(validator is not null == (descriptor.Parser == GenericHeaderParser.TokenListParser), "non token list parser??");
+
             _store = store;
             _descriptor = descriptor;
             _validator = validator;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -79,7 +79,7 @@ namespace System.Net.Http.Headers
                 else
                 {
                     _expectContinueSet = value != null;
-                    // We intentionally ignore in the return value. It's OK if "100-continue" wasn't in the store.
+                    // We intentionally ignore the return value. It's OK if "100-continue" wasn't in the store.
                     RemoveParsedValue(KnownHeaders.Expect.Descriptor, HeaderUtilities.ExpectContinue);
                 }
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -51,26 +51,17 @@ namespace System.Net.Http.Headers
             set { SetOrRemoveParsedValue(KnownHeaders.Authorization.Descriptor, value); }
         }
 
-        public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect
-        {
-            get { return ExpectCore; }
-        }
-
         public bool? ExpectContinue
         {
             get
             {
-                // ExpectCore will force the collection into existence, so avoid accessing it if possible.
-                if (_expectContinueSet || ContainsParsedValue(KnownHeaders.Expect.Descriptor, HeaderUtilities.ExpectContinue))
+                if (ContainsParsedValue(KnownHeaders.Expect.Descriptor, HeaderUtilities.ExpectContinue))
                 {
-                    if (ExpectCore.IsSpecialValueSet)
-                    {
-                        return true;
-                    }
-                    if (_expectContinueSet)
-                    {
-                        return false;
-                    }
+                    return true;
+                }
+                if (_expectContinueSet)
+                {
+                    return false;
                 }
 
                 return null;
@@ -80,12 +71,16 @@ namespace System.Net.Http.Headers
                 if (value == true)
                 {
                     _expectContinueSet = true;
-                    ExpectCore.SetSpecialValue();
+                    if (!ContainsParsedValue(KnownHeaders.Expect.Descriptor, HeaderUtilities.ExpectContinue))
+                    {
+                        AddParsedValue(KnownHeaders.Expect.Descriptor, HeaderUtilities.ExpectContinue);
+                    }
                 }
                 else
                 {
                     _expectContinueSet = value != null;
-                    ExpectCore.RemoveSpecialValue();
+                    // We intentionally ignore in the return value. It's OK if "100-continue" wasn't in the store.
+                    RemoveParsedValue(KnownHeaders.Expect.Descriptor, HeaderUtilities.ExpectContinue);
                 }
             }
         }
@@ -189,7 +184,7 @@ namespace System.Net.Http.Headers
         public HttpHeaderValueCollection<ProductInfoHeaderValue> UserAgent =>
             GetSpecializedCollection(UserAgentSlot, static thisRef => new HttpHeaderValueCollection<ProductInfoHeaderValue>(KnownHeaders.UserAgent.Descriptor, thisRef));
 
-        private HttpHeaderValueCollection<NameValueWithParametersHeaderValue> ExpectCore =>
+        public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect =>
             _expect ??= new HttpHeaderValueCollection<NameValueWithParametersHeaderValue>(KnownHeaders.Expect.Descriptor, this, HeaderUtilities.ExpectContinue);
 
         #endregion

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -185,7 +185,7 @@ namespace System.Net.Http.Headers
             GetSpecializedCollection(UserAgentSlot, static thisRef => new HttpHeaderValueCollection<ProductInfoHeaderValue>(KnownHeaders.UserAgent.Descriptor, thisRef));
 
         public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect =>
-            _expect ??= new HttpHeaderValueCollection<NameValueWithParametersHeaderValue>(KnownHeaders.Expect.Descriptor, this, HeaderUtilities.ExpectContinue);
+            _expect ??= new HttpHeaderValueCollection<NameValueWithParametersHeaderValue>(KnownHeaders.Expect.Descriptor, this);
 
         #endregion
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http.Headers
         }
 
         public HttpHeaderValueCollection<string> AcceptRanges =>
-            GetSpecializedCollection(AcceptRangesSlot, static thisRef => new HttpHeaderValueCollection<string>(KnownHeaders.AcceptRanges.Descriptor, thisRef, HeaderUtilities.TokenValidator));
+            GetSpecializedCollection(AcceptRangesSlot, static thisRef => new HttpHeaderValueCollection<string>(KnownHeaders.AcceptRanges.Descriptor, thisRef));
 
         public TimeSpan? Age
         {
@@ -68,7 +68,7 @@ namespace System.Net.Http.Headers
             GetSpecializedCollection(ServerSlot, static thisRef => new HttpHeaderValueCollection<ProductInfoHeaderValue>(KnownHeaders.Server.Descriptor, thisRef));
 
         public HttpHeaderValueCollection<string> Vary =>
-            GetSpecializedCollection(VarySlot, static thisRef => new HttpHeaderValueCollection<string>(KnownHeaders.Vary.Descriptor, thisRef, HeaderUtilities.TokenValidator));
+            GetSpecializedCollection(VarySlot, static thisRef => new HttpHeaderValueCollection<string>(KnownHeaders.Vary.Descriptor, thisRef));
 
         public HttpHeaderValueCollection<AuthenticationHeaderValue> WwwAuthenticate =>
             GetSpecializedCollection(WwwAuthenticateSlot, static thisRef => new HttpHeaderValueCollection<AuthenticationHeaderValue>(KnownHeaders.WWWAuthenticate.Descriptor, thisRef));

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
@@ -498,32 +498,6 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
-        public void Ctor_ProvideValidator_ValidatorIsUsedWhenAddingValues()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                MockValidator);
-
-            // Adding an arbitrary Uri should not throw.
-            collection.Add(new Uri("http://some/"));
-
-            // When we add 'invalidValue' our MockValidator will throw.
-            Assert.Throws<MockException>(() => { collection.Add(invalidValue); });
-        }
-
-        [Fact]
-        public void Ctor_ProvideValidator_ValidatorIsUsedWhenRemovingValues()
-        {
-            // Use different ctor overload than in previous test to make sure all ctor overloads work correctly.
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                MockValidator);
-
-            // When we remove 'invalidValue' our MockValidator will throw.
-            Assert.Throws<MockException>(() => { collection.Remove(invalidValue); });
-        }
-
-        [Fact]
         public void ToString_SpecialValues_Success()
         {
             HttpRequestMessage request = new HttpRequestMessage();
@@ -588,14 +562,6 @@ namespace System.Net.Http.Tests
         }
 
         #region Helper methods
-
-        private static void MockValidator(HttpHeaderValueCollection<Uri> collection, Uri value)
-        {
-            if (value == invalidValue)
-            {
-                throw new MockException();
-            }
-        }
 
         public class MockException : Exception
         {

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
@@ -18,7 +18,6 @@ namespace System.Net.Http.Tests
         private static readonly HeaderDescriptor knownStringHeader = (new KnownHeader("known-string-header", HttpHeaderType.General, new MockHeaderParser(typeof(string)))).Descriptor;
         private static readonly HeaderDescriptor knownUriHeader = (new KnownHeader("known-uri-header", HttpHeaderType.General, new MockHeaderParser(typeof(Uri)))).Descriptor;
 
-        private static readonly Uri specialValue = new Uri("http://special/");
         private static readonly Uri invalidValue = new Uri("http://invalid/");
         private static readonly TransferCodingHeaderValue specialChunked = new TransferCodingHeaderValue("chunked");
 
@@ -35,45 +34,6 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
-        public void Count_AddSingleValueThenQueryCount_ReturnsValueCountWithSpecialValues()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownStringHeader, headers,
-                "special");
-
-            Assert.Equal(0, collection.Count);
-
-            headers.Add(knownStringHeader, "value2");
-            Assert.Equal(1, collection.Count);
-
-            headers.Clear();
-            headers.Add(knownStringHeader, "special");
-            Assert.Equal(1, collection.Count);
-            headers.Add(knownStringHeader, "special");
-            headers.Add(knownStringHeader, "special");
-            Assert.Equal(3, collection.Count);
-        }
-
-        [Fact]
-        public void Count_AddMultipleValuesThenQueryCount_ReturnsValueCountWithSpecialValues()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownStringHeader, headers,
-                "special");
-
-            Assert.Equal(0, collection.Count);
-
-            collection.Add("value1");
-            headers.Add(knownStringHeader, "special");
-            Assert.Equal(2, collection.Count);
-
-            headers.Add(knownStringHeader, "special");
-            headers.Add(knownStringHeader, "value2");
-            headers.Add(knownStringHeader, "special");
-            Assert.Equal(5, collection.Count);
-        }
-
-        [Fact]
         public void Add_CallWithNullValue_Throw()
         {
             MockHeaders headers = new MockHeaders();
@@ -86,8 +46,7 @@ namespace System.Net.Http.Tests
         public void Add_AddValues_AllValuesAdded()
         {
             MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers);
 
             collection.Add(new Uri("http://www.example.org/1/"));
             collection.Add(new Uri("http://www.example.org/2/"));
@@ -150,7 +109,6 @@ namespace System.Net.Http.Tests
             HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers);
 
             collection.ParseAdd(null);
-            Assert.False(collection.IsSpecialValueSet);
             Assert.Equal(0, collection.Count);
             Assert.Equal(string.Empty, collection.ToString());
         }
@@ -159,27 +117,13 @@ namespace System.Net.Http.Tests
         public void ParseAdd_AddValues_AllValuesAdded()
         {
             MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers);
 
             collection.ParseAdd("http://www.example.org/1/");
             collection.ParseAdd("http://www.example.org/2/");
             collection.ParseAdd("http://www.example.org/3/");
 
             Assert.Equal(3, collection.Count);
-        }
-
-        [Fact]
-        public void ParseAdd_UseSpecialValue_Added()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.ParseAdd(specialValue.AbsoluteUri);
-
-            Assert.True(collection.IsSpecialValueSet);
-            Assert.Equal(specialValue.ToString(), collection.ToString());
         }
 
         [Fact]
@@ -198,7 +142,6 @@ namespace System.Net.Http.Tests
 
             Assert.True(headers.WwwAuthenticate.TryParseAdd(null));
 
-            Assert.False(headers.WwwAuthenticate.IsSpecialValueSet);
             Assert.Equal(0, headers.WwwAuthenticate.Count);
             Assert.Equal(string.Empty, headers.WwwAuthenticate.ToString());
         }
@@ -207,27 +150,13 @@ namespace System.Net.Http.Tests
         public void TryParseAdd_AddValues_AllAdded()
         {
             MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers);
 
             Assert.True(collection.TryParseAdd("http://www.example.org/1/"));
             Assert.True(collection.TryParseAdd("http://www.example.org/2/"));
             Assert.True(collection.TryParseAdd("http://www.example.org/3/"));
 
             Assert.Equal(3, collection.Count);
-        }
-
-        [Fact]
-        public void TryParseAdd_UseSpecialValue_Added()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            Assert.True(collection.TryParseAdd(specialValue.AbsoluteUri));
-
-            Assert.True(collection.IsSpecialValueSet);
-            Assert.Equal(specialValue.ToString(), collection.ToString());
         }
 
         [Fact]
@@ -266,27 +195,6 @@ namespace System.Net.Http.Tests
             collection.Clear();
 
             Assert.Equal(0, collection.Count);
-        }
-
-        [Fact]
-        public void Clear_AddValuesAndSpecialValueThenClear_EverythingCleared()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.SetSpecialValue();
-            collection.Add(new Uri("http://www.example.org/1/"));
-            collection.Add(new Uri("http://www.example.org/2/"));
-            collection.Add(new Uri("http://www.example.org/3/"));
-
-            Assert.Equal(4, collection.Count);
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-
-            collection.Clear();
-
-            Assert.Equal(0, collection.Count);
-            Assert.False(collection.IsSpecialValueSet, "Special value was removed by Clear().");
         }
 
         [Fact]
@@ -389,21 +297,13 @@ namespace System.Net.Http.Tests
         public void CopyTo_AddSingleValue_ContainsSingleValue()
         {
             MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
+            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers);
 
             collection.Add(new Uri("http://www.example.org/"));
 
             Uri[] array = new Uri[1];
             collection.CopyTo(array, 0);
             Assert.Equal(new Uri("http://www.example.org/"), array[0]);
-
-            // Now only set the special value: nothing should be added to the array.
-            headers.Clear();
-            headers.Add(knownUriHeader, specialValue.ToString());
-            array[0] = null;
-            collection.CopyTo(array, 0);
-            Assert.Equal(specialValue, array[0]);
         }
 
         [Fact]
@@ -427,78 +327,10 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
-        public void CopyTo_AddValuesAndSpecialValue_AllValuesCopied()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.Add(new Uri("http://www.example.org/1/"));
-            collection.Add(new Uri("http://www.example.org/2/"));
-            collection.SetSpecialValue();
-            collection.Add(new Uri("http://www.example.org/3/"));
-
-            Uri[] array = new Uri[5];
-            collection.CopyTo(array, 1);
-
-            Assert.Null(array[0]);
-            Assert.Equal(new Uri("http://www.example.org/1/"), array[1]);
-            Assert.Equal(new Uri("http://www.example.org/2/"), array[2]);
-            Assert.Equal(specialValue, array[3]);
-            Assert.Equal(new Uri("http://www.example.org/3/"), array[4]);
-
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-        }
-
-        [Fact]
-        public void CopyTo_OnlySpecialValue_Copied()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.SetSpecialValue();
-            headers.Add(knownUriHeader, specialValue.ToString());
-            headers.Add(knownUriHeader, specialValue.ToString());
-            headers.Add(knownUriHeader, specialValue.ToString());
-
-            Uri[] array = new Uri[4];
-            array[0] = null;
-            collection.CopyTo(array, 0);
-
-            Assert.Equal(specialValue, array[0]);
-            Assert.Equal(specialValue, array[1]);
-            Assert.Equal(specialValue, array[2]);
-            Assert.Equal(specialValue, array[3]);
-
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-        }
-
-        [Fact]
-        public void CopyTo_OnlySpecialValueEmptyDestination_Copied()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.SetSpecialValue();
-            headers.Add(knownUriHeader, specialValue.ToString());
-
-            Uri[] array = new Uri[2];
-            collection.CopyTo(array, 0);
-
-            Assert.Equal(specialValue, array[0]);
-            Assert.Equal(specialValue, array[1]);
-
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-        }
-
-        [Fact]
         public void CopyTo_ArrayTooSmall_Throw()
         {
             MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownStringHeader, headers,
-                "special");
+            HttpHeaderValueCollection<string> collection = new HttpHeaderValueCollection<string>(knownStringHeader, headers);
 
             string[] array = new string[1];
             array[0] = null;
@@ -666,144 +498,6 @@ namespace System.Net.Http.Tests
         }
 
         [Fact]
-        public void GetEnumerator_AddValuesAndSpecialValueAndGetEnumeratorFromInterface_AllValuesReturned()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.Add(new Uri("http://www.example.org/1/"));
-            collection.Add(new Uri("http://www.example.org/2/"));
-            collection.Add(new Uri("http://www.example.org/3/"));
-            collection.SetSpecialValue();
-
-            System.Collections.IEnumerable enumerable = collection;
-
-            // The "special value" should be ignored and not part of the resulting collection.
-            int i = 1;
-            bool specialFound = false;
-            foreach (var item in enumerable)
-            {
-                if (item.Equals(specialValue))
-                {
-                    specialFound = true;
-                }
-                else
-                {
-                    Assert.Equal(new Uri("http://www.example.org/" + i + "/"), item);
-                    i++;
-                }
-            }
-
-            Assert.True(specialFound);
-
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-        }
-
-        [Fact]
-        public void GetEnumerator_AddValuesAndSpecialValue_AllValuesReturned()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.Add(new Uri("http://www.example.org/1/"));
-            collection.Add(new Uri("http://www.example.org/2/"));
-            collection.SetSpecialValue();
-            collection.Add(new Uri("http://www.example.org/3/"));
-
-            System.Collections.IEnumerable enumerable = collection;
-
-            // The special value we added above, must be part of the collection returned by GetEnumerator().
-            int i = 1;
-            bool specialFound = false;
-            foreach (var item in enumerable)
-            {
-                if (item.Equals(specialValue))
-                {
-                    specialFound = true;
-                }
-                else
-                {
-                    Assert.Equal(new Uri("http://www.example.org/" + i + "/"), item);
-                    i++;
-                }
-            }
-
-            Assert.True(specialFound);
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-        }
-
-        [Fact]
-        public void IsSpecialValueSet_NoSpecialValueUsed_ReturnsFalse()
-        {
-            // Create a new collection _without_ specifying a special value.
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                null, null);
-
-            Assert.False(collection.IsSpecialValueSet,
-                "Special value is set even though collection doesn't define a special value.");
-        }
-
-        [Fact]
-        public void RemoveSpecialValue_AddRemoveSpecialValue_SpecialValueGetsRemoved()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.SetSpecialValue();
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-            Assert.Equal(1, headers.GetValues(knownUriHeader).Count());
-
-            collection.RemoveSpecialValue();
-            Assert.False(collection.IsSpecialValueSet, "Special value is set.");
-
-            // Since the only header value was the "special value", removing it will remove the whole header
-            // from the collection.
-            Assert.False(headers.Contains(knownUriHeader));
-        }
-
-        [Fact]
-        public void RemoveSpecialValue_AddValueAndSpecialValueThenRemoveSpecialValue_SpecialValueGetsRemoved()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.Add(new Uri("http://www.example.org/"));
-            collection.SetSpecialValue();
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-            Assert.Equal(2, headers.GetValues(knownUriHeader).Count());
-
-            collection.RemoveSpecialValue();
-            Assert.False(collection.IsSpecialValueSet, "Special value is set.");
-            Assert.Equal(1, headers.GetValues(knownUriHeader).Count());
-        }
-
-        [Fact]
-        public void RemoveSpecialValue_AddTwoValuesAndSpecialValueThenRemoveSpecialValue_SpecialValueGetsRemoved()
-        {
-            MockHeaders headers = new MockHeaders();
-            HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue);
-
-            collection.Add(new Uri("http://www.example.org/1/"));
-            collection.Add(new Uri("http://www.example.org/2/"));
-            collection.SetSpecialValue();
-            Assert.True(collection.IsSpecialValueSet, "Special value not set.");
-            Assert.Equal(3, headers.GetValues(knownUriHeader).Count());
-
-            // The difference between this test and the previous one is that HttpHeaders in this case will use
-            // a List<T> to store the two remaining values, whereas in the previous case it will just store
-            // the remaining value (no list).
-            collection.RemoveSpecialValue();
-            Assert.False(collection.IsSpecialValueSet, "Special value is set.");
-            Assert.Equal(2, headers.GetValues(knownUriHeader).Count());
-        }
-
-        [Fact]
         public void Ctor_ProvideValidator_ValidatorIsUsedWhenAddingValues()
         {
             MockHeaders headers = new MockHeaders();
@@ -823,7 +517,7 @@ namespace System.Net.Http.Tests
             // Use different ctor overload than in previous test to make sure all ctor overloads work correctly.
             MockHeaders headers = new MockHeaders();
             HttpHeaderValueCollection<Uri> collection = new HttpHeaderValueCollection<Uri>(knownUriHeader, headers,
-                specialValue, MockValidator);
+                MockValidator);
 
             // When we remove 'invalidValue' our MockValidator will throw.
             Assert.Throws<MockException>(() => { collection.Remove(invalidValue); });

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeaderValueCollectionTest.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
-using System.Text;
 
 using Xunit;
 
@@ -18,7 +16,6 @@ namespace System.Net.Http.Tests
         private static readonly HeaderDescriptor knownStringHeader = (new KnownHeader("known-string-header", HttpHeaderType.General, new MockHeaderParser(typeof(string)))).Descriptor;
         private static readonly HeaderDescriptor knownUriHeader = (new KnownHeader("known-uri-header", HttpHeaderType.General, new MockHeaderParser(typeof(Uri)))).Descriptor;
 
-        private static readonly Uri invalidValue = new Uri("http://invalid/");
         private static readonly TransferCodingHeaderValue specialChunked = new TransferCodingHeaderValue("chunked");
 
         // Note that this type just forwards calls to HttpHeaders. So this test method focuses on making sure


### PR DESCRIPTION
Remove the _validator field by replacing with a check for GenericHeaderParser.TokenListParser, since this is the only thing validators were used for.

Remove the _specialValue field by pushing handling of special values to callers.

Fixes https://github.com/dotnet/runtime/issues/63054
Fixes https://github.com/dotnet/runtime/issues/63050