### PR TITLE
[mono][wasm] Allow methods with finally clauses to be AOTed.

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -17,6 +17,11 @@
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true' and '$(RunAOTCompilation)' == 'true' and '$(BrowserHost)' != 'Windows'">
     <!-- Exceeds VM resources in CI on compilation: https://github.com/dotnet/runtime/issues/61339 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Abstractions\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Roslyn3.11.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Abstractions\tests\Microsoft.Extensions.Logging.Generators.Tests\Microsoft.Extensions.Logging.Generators.Roslyn4.0.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.
+Roslyn4.0.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Unit.Tests\System.Text.Json.SourceGeneration.Roslyn4.0.Unit.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Generators.Tests\System.Text.RegularExpressions.Generators.Tests.csproj" />
 
     <!-- https://github.com/dotnet/runtime/issues/61756 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />

--- a/src/mono/mono/metadata/object-offsets.h
+++ b/src/mono/mono/metadata/object-offsets.h
@@ -149,11 +149,18 @@ DECL_OFFSET(SgenThreadInfo, tlab_temp_end)
 #ifndef DISABLE_JIT_OFFSETS
 DECL_SIZE(MonoMethodRuntimeGenericContext)
 DECL_SIZE(MonoLMF)
+DECL_SIZE(MonoLMFExt)
 DECL_SIZE(MonoTypedRef)
 DECL_SIZE(CallContext)
 DECL_SIZE(MonoContext)
 
 DECL_OFFSET(MonoLMF, previous_lmf)
+DECL_OFFSET(MonoLMFExt, kind)
+DECL_OFFSET(MonoLMFExt, il_state)
+
+DECL_OFFSET(MonoMethodILState, method)
+DECL_OFFSET(MonoMethodILState, il_offset)
+DECL_OFFSET(MonoMethodILState, data)
 
 DECL_OFFSET(MonoMethodRuntimeGenericContext, class_vtable)
 

--- a/src/mono/mono/mini/ee.h
+++ b/src/mono/mono/mini/ee.h
@@ -14,7 +14,7 @@
 #ifndef __MONO_EE_H__
 #define __MONO_EE_H__
 
-#define MONO_EE_API_VERSION 0x14
+#define MONO_EE_API_VERSION 0x15
 
 typedef struct _MonoInterpStackIter MonoInterpStackIter;
 
@@ -38,6 +38,7 @@ typedef gpointer MonoInterpFrameHandle;
 	MONO_EE_CALLBACK (void, get_resume_state, (const MonoJitTlsData *jit_tls, gboolean *has_resume_state, MonoInterpFrameHandle *interp_frame, gpointer *handler_ip)) \
 	MONO_EE_CALLBACK (gboolean, run_finally, (StackFrameInfo *frame, int clause_index, gpointer handler_ip, gpointer handler_ip_end)) \
 	MONO_EE_CALLBACK (gboolean, run_filter, (StackFrameInfo *frame, MonoException *ex, int clause_index, gpointer handler_ip, gpointer handler_ip_end)) \
+	MONO_EE_CALLBACK (gboolean, run_finally_with_il_state, (gpointer il_state, int clause_index, gpointer handler_ip, gpointer handler_ip_end)) \
 	MONO_EE_CALLBACK (void, frame_iter_init, (MonoInterpStackIter *iter, gpointer interp_exit_data)) \
 	MONO_EE_CALLBACK (gboolean, frame_iter_next, (MonoInterpStackIter *iter, StackFrameInfo *frame)) \
 	MONO_EE_CALLBACK (MonoJitInfo*, find_jit_info, (MonoMethod *method)) \
@@ -63,6 +64,7 @@ typedef gpointer MonoInterpFrameHandle;
 	MONO_EE_CALLBACK (gboolean, sufficient_stack, (gsize size)) \
 	MONO_EE_CALLBACK (void, entry_llvmonly, (gpointer res, gpointer *args, gpointer imethod)) \
 	MONO_EE_CALLBACK (gpointer, get_interp_method, (MonoMethod *method, MonoError *error)) \
+	MONO_EE_CALLBACK (MonoJitInfo*, compile_interp_method, (MonoMethod *method, MonoError *error)) \
 
 typedef struct _MonoEECallbacks {
 

--- a/src/mono/mono/mini/interp-stubs.c
+++ b/src/mono/mono/mini/interp-stubs.c
@@ -114,6 +114,12 @@ stub_run_filter (StackFrameInfo *frame, MonoException *ex, int clause_index, gpo
 	return FALSE;
 }
 
+static gboolean
+stub_run_finally_with_il_state (gpointer il_state, int clause_index, gpointer handler_ip, gpointer handler_ip_end)
+{
+	g_assert_not_reached ();
+}
+
 static void
 stub_frame_iter_init (MonoInterpStackIter *iter, gpointer interp_exit_data)
 {
@@ -234,6 +240,13 @@ stub_entry_llvmonly (gpointer res, gpointer *args, gpointer imethod)
 
 static gpointer
 stub_get_interp_method (MonoMethod *method, MonoError *error)
+{
+	g_assert_not_reached ();
+	return NULL;
+}
+
+static MonoJitInfo*
+stub_compile_interp_method (MonoMethod *method, MonoError *error)
 {
 	g_assert_not_reached ();
 	return NULL;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -758,6 +758,70 @@ get_virtual_method_fast (InterpMethod *imethod, MonoVTable *vtable, int offset)
 
 // Returns the size it uses on the interpreter stack
 static int
+stackval_size (MonoType *type, gboolean pinvoke)
+{
+	type = mini_native_type_replace_type (type);
+	if (m_type_is_byref (type))
+		return MINT_STACK_SLOT_SIZE;
+	switch (type->type) {
+	case MONO_TYPE_VOID:
+		return 0;
+	case MONO_TYPE_I1:
+	case MONO_TYPE_U1:
+	case MONO_TYPE_BOOLEAN:
+	case MONO_TYPE_I2:
+	case MONO_TYPE_U2:
+	case MONO_TYPE_CHAR:
+	case MONO_TYPE_I4:
+	case MONO_TYPE_U:
+	case MONO_TYPE_I:
+	case MONO_TYPE_PTR:
+	case MONO_TYPE_FNPTR:
+	case MONO_TYPE_U4:
+		return MINT_STACK_SLOT_SIZE;
+	case MONO_TYPE_R4:
+		return MINT_STACK_SLOT_SIZE;
+	case MONO_TYPE_I8:
+	case MONO_TYPE_U8:
+		return MINT_STACK_SLOT_SIZE;
+	case MONO_TYPE_R8:
+		return MINT_STACK_SLOT_SIZE;
+	case MONO_TYPE_STRING:
+	case MONO_TYPE_SZARRAY:
+	case MONO_TYPE_CLASS:
+	case MONO_TYPE_OBJECT:
+	case MONO_TYPE_ARRAY:
+		return MINT_STACK_SLOT_SIZE;
+	case MONO_TYPE_VALUETYPE:
+		if (m_class_is_enumtype (type->data.klass)) {
+			return stackval_size (mono_class_enum_basetype_internal (type->data.klass), pinvoke);
+		} else {
+			int size;
+			if (pinvoke)
+				size = mono_class_native_size (type->data.klass, NULL);
+			else
+				size = mono_class_value_size (type->data.klass, NULL);
+			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+		}
+	case MONO_TYPE_GENERICINST: {
+		if (mono_type_generic_inst_is_valuetype (type)) {
+			MonoClass *klass = mono_class_from_mono_type_internal (type);
+			int size;
+			if (pinvoke)
+				size = mono_class_native_size (klass, NULL);
+			else
+				size = mono_class_value_size (klass, NULL);
+			return ALIGN_TO (size, MINT_STACK_SLOT_SIZE);
+		}
+		return stackval_size (m_class_get_byval_arg (type->data.generic_class->container_class), pinvoke);
+	}
+	default:
+		g_error ("got type 0x%02x", type->type);
+	}
+}
+
+// Returns the size it uses on the interpreter stack
+static int
 stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean pinvoke)
 {
 	type = mini_native_type_replace_type (type);
@@ -2857,6 +2921,18 @@ static gpointer
 interp_get_interp_method (MonoMethod *method, MonoError *error)
 {
     return mono_interp_get_imethod (method, error);
+}
+
+static MonoJitInfo*
+interp_compile_interp_method (MonoMethod *method, MonoError *error)
+{
+	InterpMethod *imethod = mono_interp_get_imethod (method, error);
+	return_val_if_nok (error, NULL);
+
+	mono_interp_transform_method (imethod, get_context (), error);
+	return_val_if_nok (error, NULL);
+
+	return imethod->jinfo;
 }
 
 static InterpMethod*
@@ -7185,6 +7261,112 @@ interp_run_filter (StackFrameInfo *frame, MonoException *ex, int clause_index, g
 
 	/* ENDFILTER stores the result into child_frame->retval */
 	return retval.data.i ? TRUE : FALSE;
+}
+
+static gboolean
+interp_run_finally_with_il_state (gpointer il_state_ptr, int clause_index, gpointer handler_ip, gpointer handler_ip_end)
+{
+	MonoMethodILState *il_state = (MonoMethodILState*)il_state_ptr;
+	MonoMethodSignature *sig;
+	ThreadContext *context = get_context ();
+	stackval *sp, *sp_args;
+	InterpMethod *imethod;
+	FrameClauseArgs clause_args;
+	ERROR_DECL (error);
+
+	// FIXME: Optimize this ? Its only used during EH
+
+	sig = mono_method_signature_internal (il_state->method);
+	g_assert (sig);
+
+	imethod = mono_interp_get_imethod (il_state->method, error);
+	mono_error_assert_ok (error);
+
+	sp_args = sp = (stackval*)context->stack_pointer;
+
+	int findex = 0;
+	if (sig->hasthis) {
+		if (il_state->data [findex])
+			sp_args->data.p = *(gpointer*)il_state->data [findex];
+		sp_args++;
+		findex ++;
+	}
+
+	for (int i = 0; i < sig->param_count; ++i) {
+		if (il_state->data [findex]) {
+			int size = stackval_from_data (sig->params [i], sp_args, il_state->data [findex], FALSE);
+			sp_args = STACK_ADD_BYTES (sp_args, size);
+		} else {
+			int size = stackval_size (sig->params [i], FALSE);
+			sp_args = STACK_ADD_BYTES (sp_args, size);
+		}
+		findex ++;
+	}
+
+	/* Allocate frame */
+	InterpFrame frame = {0};
+	frame.imethod = imethod;
+	frame.stack = sp;
+	frame.retval = sp;
+
+	context->stack_pointer = (guchar*)sp_args;
+	context->stack_pointer += imethod->alloca_size;
+
+	MonoMethodHeader *header = mono_method_get_header_internal (il_state->method, error);
+	mono_error_assert_ok (error);
+
+	/* Init locals */
+	if (header->num_locals)
+		memset (frame_locals (&frame) + imethod->local_offsets [0], 0, imethod->locals_size);
+	/* Copy locals from il_state */
+	int locals_start = sig->hasthis + sig->param_count;
+	for (int i = 0; i < header->num_locals; ++i) {
+		if (il_state->data [locals_start + i])
+			stackval_from_data (header->locals [i], (stackval*)(frame_locals (&frame) + imethod->local_offsets [i]), il_state->data [locals_start + i], FALSE);
+	}
+
+	memset (&clause_args, 0, sizeof (FrameClauseArgs));
+	clause_args.start_with_ip = (const guint16*)handler_ip;
+	clause_args.end_at_ip = (const guint16*)handler_ip_end;
+	clause_args.exit_clause = clause_index;
+	clause_args.exec_frame = &frame;
+
+	// this informs MINT_ENDFINALLY to return to EH
+	*(guint16**)(frame_locals (&frame) + imethod->clause_data_offsets [clause_index]) = NULL;
+
+	interp_exec_method (&frame, context, &clause_args);
+
+	/* Write back args */
+	sp_args = sp;
+	findex = 0;
+	if (sig->hasthis) {
+		// FIXME: This
+		sp_args++;
+		findex ++;
+	}
+	findex = sig->hasthis ? 1 : 0;
+	for (int i = 0; i < sig->param_count; ++i) {
+		if (il_state->data [findex]) {
+			int size = stackval_to_data (sig->params [i], sp_args, il_state->data [findex], FALSE);
+			sp_args = STACK_ADD_BYTES (sp_args, size);
+		} else {
+			int size = stackval_size (sig->params [i], FALSE);
+			sp_args = STACK_ADD_BYTES (sp_args, size);
+		}
+		findex ++;
+	}
+	/* Write back locals */
+	for (int i = 0; i < header->num_locals; ++i) {
+		if (il_state->data [locals_start + i])
+			stackval_to_data (header->locals [i], (stackval*)(frame_locals (&frame) + imethod->local_offsets [i]), il_state->data [locals_start + i], FALSE);
+	}
+	mono_metadata_free_mh (header);
+
+	// FIXME: Restore stack ?
+	if (context->has_resume_state)
+		return TRUE;
+	else
+		return FALSE;
 }
 
 typedef struct {

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -1774,6 +1774,9 @@ emit_push_lmf (MonoCompile *cfg)
 	prev_lmf_reg = alloc_preg (cfg);
 	/* Save previous_lmf */
 	EMIT_NEW_LOAD_MEMBASE (cfg, ins, OP_LOAD_MEMBASE, prev_lmf_reg, cfg->lmf_addr_var->dreg, 0);
+	if (cfg->deopt)
+		/* Mark this as an LMFExt */
+		EMIT_NEW_BIALU_IMM (cfg, ins, OP_POR_IMM, prev_lmf_reg, prev_lmf_reg, 2);
 	EMIT_NEW_STORE_MEMBASE (cfg, ins, OP_STORE_MEMBASE_REG, lmf_reg, MONO_STRUCT_OFFSET (MonoLMF, previous_lmf), prev_lmf_reg);
 	/* Set new lmf */
 	EMIT_NEW_STORE_MEMBASE (cfg, ins, OP_STORE_MEMBASE_REG, cfg->lmf_addr_var->dreg, 0, lmf_reg);
@@ -1808,6 +1811,9 @@ emit_pop_lmf (MonoCompile *cfg)
 
 	prev_lmf_reg = alloc_preg (cfg);
 	EMIT_NEW_LOAD_MEMBASE (cfg, ins, OP_LOAD_MEMBASE, prev_lmf_reg, lmf_reg, MONO_STRUCT_OFFSET (MonoLMF, previous_lmf));
+	if (cfg->deopt)
+		/* Clear out the bit set by push_lmf () to mark this as LMFExt */
+		EMIT_NEW_BIALU_IMM (cfg, ins, OP_PXOR_IMM, prev_lmf_reg, prev_lmf_reg, 2);
 	EMIT_NEW_STORE_MEMBASE (cfg, ins, OP_STORE_MEMBASE_REG, lmf_addr_reg, 0, prev_lmf_reg);
 }
 
@@ -3449,8 +3455,11 @@ method_needs_stack_walk (MonoCompile *cfg, MonoMethod *cmethod)
 		const char *cname = m_class_get_name (cmethod->klass);
 		if (!strcmp (cname, "Assembly") ||
 			!strcmp (cname, "AssemblyLoadContext") ||
-			(!strcmp (cname, "Activator")))
+			(!strcmp (cname, "Activator"))) {
+			if (!strcmp (cmethod->name, "op_Equality"))
+				return FALSE;
 			return TRUE;
+		}
 	}
 
 	return FALSE;
@@ -3504,6 +3513,18 @@ mini_handle_enum_has_flag (MonoCompile *cfg, MonoClass *klass, MonoInst *enum_th
 
 		return ceq;
 	}
+}
+
+static void
+emit_set_deopt_il_offset (MonoCompile *cfg, int offset)
+{
+	MonoInst *ins;
+
+	if (!(cfg->deopt && cfg->method == cfg->current_method))
+		return;
+
+	EMIT_NEW_VARLOADA (cfg, ins, cfg->il_state_var, NULL);
+	MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI4_MEMBASE_IMM, ins->dreg, MONO_STRUCT_OFFSET (MonoMethodILState, il_offset), offset);
 }
 
 static MonoInst*
@@ -5238,9 +5259,8 @@ emit_stloc_ir (MonoCompile *cfg, MonoInst **sp, MonoMethodHeader *header, int n)
 		}
 	}
 
-
 	guint32 opcode = mono_type_to_regmove (cfg, header->locals [n]);
-	if ((opcode == OP_MOVE) && cfg->cbb->last_ins == sp [0]  &&
+	if (!cfg->deopt && (opcode == OP_MOVE) && cfg->cbb->last_ins == sp [0]  &&
 			((sp [0]->opcode == OP_ICONST) || (sp [0]->opcode == OP_I8CONST))) {
 		/* Optimize reg-reg moves away */
 		/* 
@@ -6140,7 +6160,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 	gboolean detached_before_ret = FALSE;
 	gboolean ins_has_side_effect;
 
-	cfg->disable_inline = (method->iflags & METHOD_IMPL_ATTRIBUTE_NOOPTIMIZATION) || is_jit_optimizer_disabled (method);
+	if (!cfg->disable_inline)
+		cfg->disable_inline = (method->iflags & METHOD_IMPL_ATTRIBUTE_NOOPTIMIZATION) || is_jit_optimizer_disabled (method);
 	cfg->current_method = method;
 
 	image = m_class_get_image (method->klass);
@@ -6468,8 +6489,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		}
 	}
 
-	if (cfg->llvm_only && cfg->interp && cfg->method == method) {
-		if (!cfg->method->wrapper_type && header->num_clauses) {
+	if (cfg->llvm_only && cfg->interp && cfg->method == method && !cfg->deopt) {
+		if (header->num_clauses) {
 			for (int i = 0; i < header->num_clauses; ++i) {
 				MonoExceptionClause *clause = &header->clauses [i];
 				/* Finally clauses are checked after the remove_finally pass */
@@ -6528,6 +6549,40 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		if (init_locals)
 			ins->flags |= MONO_INST_INIT;
 		*/
+		if (cfg->llvm_only) {
+			init_localsbb = cfg->cbb;
+			init_localsbb2 = cfg->cbb;
+		}
+	}
+
+	if (cfg->deopt) {
+		/*
+		 * Push an LMFExt frame which points to a MonoMethodILState structure.
+		 */
+		emit_push_lmf (cfg);
+
+		/* The type doesn't matter, the llvm backend will use the correct type */
+		MonoInst *il_state_var = mono_compile_create_var (cfg, mono_get_int_type (), OP_LOCAL);
+		il_state_var->flags |= MONO_INST_VOLATILE;
+		cfg->il_state_var = il_state_var;
+
+		EMIT_NEW_VARLOADA (cfg, ins, cfg->il_state_var, NULL);
+		int il_state_addr_reg = ins->dreg;
+
+		/* il_state->method = method */
+		MonoInst *method_ins = emit_get_rgctx_method (cfg, -1, cfg->method, MONO_RGCTX_INFO_METHOD);
+		MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, il_state_addr_reg, MONO_STRUCT_OFFSET (MonoMethodILState, method), method_ins->dreg);
+
+		EMIT_NEW_VARLOADA (cfg, ins, cfg->lmf_var, NULL);
+		int lmf_reg = ins->dreg;
+
+		/* lmf->kind = MONO_LMFEXT_IL_STATE */
+		MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI4_MEMBASE_IMM, lmf_reg, MONO_STRUCT_OFFSET (MonoLMFExt, kind), MONO_LMFEXT_IL_STATE);
+
+		/* lmf->il_state = il_state */
+		MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, lmf_reg, MONO_STRUCT_OFFSET (MonoLMFExt, il_state), il_state_addr_reg);
+
+		/* emit_get_rgctx_method () might create new bblocks */
 		if (cfg->llvm_only) {
 			init_localsbb = cfg->cbb;
 			init_localsbb2 = cfg->cbb;
@@ -6649,6 +6704,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 			if (class_inits)
 				g_slist_free (class_inits);
 			class_inits = NULL;
+			emit_set_deopt_il_offset (cfg, ip - cfg->cil_start);
 		} else {
 			if ((tblock = cfg->cil_offset_to_bb [ip - cfg->cil_start]) && (tblock != cfg->cbb)) {
 				link_bblock (cfg, cfg->cbb, tblock);
@@ -6667,6 +6723,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				}
 				g_slist_free (class_inits);
 				class_inits = NULL;
+				emit_set_deopt_il_offset (cfg, ip - cfg->cil_start);
 			}
 		}
 
@@ -8023,7 +8080,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 #ifdef TARGET_WASM
 			/* Push an LMF so these frames can be enumerated during stack walks by mono_arch_unwind_frame () */
-			if (needs_stack_walk) {
+			if (needs_stack_walk && !cfg->deopt) {
 				MonoInst *method_ins;
 				int lmf_reg;
 
@@ -8060,7 +8117,7 @@ call_end:
 				ins = handle_call_res_devirt (cfg, cmethod, ins);
 
 #ifdef TARGET_WASM
-			if (common_call && needs_stack_walk)
+			if (common_call && needs_stack_walk && !cfg->deopt)
 				/* If an exception is thrown, the LMF is popped by a call to mini_llvmonly_pop_lmf () */
 				emit_pop_lmf (cfg);
 #endif
@@ -8187,7 +8244,7 @@ calli_end:
 					cfg->ret_var_set = TRUE;
 				} 
 			} else {
-				if (cfg->lmf_var && cfg->cbb->in_count && !cfg->llvm_only)
+				if (cfg->lmf_var && cfg->cbb->in_count && (!cfg->llvm_only || cfg->deopt))
 					emit_pop_lmf (cfg);
 
 				if (cfg->ret) {
@@ -11605,7 +11662,7 @@ mono_ldptr:
 #endif
 
 #ifdef TARGET_WASM
-	if (cfg->lmf_var) {
+	if (cfg->lmf_var && !cfg->deopt) {
 		// mini_llvmonly_pop_lmf () might be called before emit_push_lmf () so initialize the LMF
 		cfg->cbb = init_localsbb;
 		EMIT_NEW_VARLOADA (cfg, ins, cfg->lmf_var, NULL);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -437,6 +437,40 @@ arch_unwind_frame (MonoJitTlsData *jit_tls,
 				}
 			} else if (ext->kind == MONO_LMFEXT_JIT_ENTRY) {
 				frame->type = FRAME_TYPE_JIT_ENTRY;
+			} else if (ext->kind == MONO_LMFEXT_IL_STATE) {
+				frame->type = FRAME_TYPE_IL_STATE;
+				frame->method = ext->il_state->method;
+				frame->actual_method = ext->il_state->method;
+				frame->il_state = ext->il_state;
+
+				// FIXME: Do this somewhere else ?
+				ERROR_DECL (error);
+				frame->ji = mini_get_interp_callbacks ()->compile_interp_method (frame->method, error);
+				mono_error_assert_ok (error);
+				g_assert (frame->ji);
+
+				MonoMethodHeader *header = mono_method_get_header_checked (frame->method, error);
+				mono_error_assert_ok (error);
+
+				/* Find try clause containing IL offset */
+				int il_offset = ((MonoMethodILState*)frame->il_state)->il_offset;
+				int clause_index = -1;
+				for (int i = 0; i < header->num_clauses; ++i) {
+					if (il_offset >= header->clauses [i].try_offset && il_offset < header->clauses [i].try_offset + header->clauses [i].try_len) {
+						clause_index = i;
+						break;
+					}
+				}
+
+				mono_metadata_free_mh (header);
+
+				if (clause_index == -1) {
+					frame->native_offset = 0xffffff;
+				} else {
+					/* Set ctx->ip to the beginning of the corresponding interpreter try clause */
+					g_assert (clause_index < frame->ji->num_clauses);
+					frame->native_offset = (guint8*)frame->ji->clauses [clause_index].try_start - (guint8*)frame->ji->code_start;
+				}
 			} else {
 				g_assert_not_reached ();
 			}
@@ -663,7 +697,8 @@ mono_find_jit_info_ext (MonoJitTlsData *jit_tls,
 		frame->method = NULL;
 	}
 
-	frame->native_offset = -1;
+	if (frame->type != FRAME_TYPE_IL_STATE)
+		frame->native_offset = -1;
 	frame->async_context = async;
 	frame->frame_addr = MONO_CONTEXT_GET_SP (ctx);
 
@@ -682,10 +717,12 @@ mono_find_jit_info_ext (MonoJitTlsData *jit_tls,
 			/* ctx->ip points into native code */
 			real_ip = (const char*)MONO_CONTEXT_GET_IP (new_ctx);
 
-		if ((real_ip >= start) && (real_ip <= start + ji->code_size))
-			frame->native_offset = real_ip - start;
-		else {
-			frame->native_offset = -1;
+		if (frame->type != FRAME_TYPE_IL_STATE) {
+			if ((real_ip >= start) && (real_ip <= start + ji->code_size))
+				frame->native_offset = real_ip - start;
+			else {
+				frame->native_offset = -1;
+			}
 		}
 
 		if (trace)
@@ -1855,12 +1892,14 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 		case FRAME_TYPE_INTERP:
 		case FRAME_TYPE_MANAGED:
 			break;
+		case FRAME_TYPE_IL_STATE:
+			break;
 		default:
 			g_assert_not_reached ();
 			break;
 		}
 
-		in_interp = frame.type == FRAME_TYPE_INTERP;
+		in_interp = (frame.type == FRAME_TYPE_INTERP) || (frame.type == FRAME_TYPE_IL_STATE);
 		ji = frame.ji;
 
 		gpointer ip;
@@ -1900,8 +1939,7 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 		if (method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED && ftnptr_eh_callback) {
 			result = MONO_FIRST_PASS_CALLBACK_TO_NATIVE;
 		}
-				
-				
+
 		for (i = clause_index_start; i < ji->num_clauses; i++) {
 			MonoJitExceptionInfo *ei = &ji->clauses [i];
 			gboolean filtered = FALSE;
@@ -2285,6 +2323,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 				jit_tls->abort_func (obj);
 				g_assert_not_reached ();
 			}
+			in_interp = FALSE;
 			switch (frame.type) {
 			case FRAME_TYPE_DEBUGGER_INVOKE:
 			case FRAME_TYPE_MANAGED_TO_NATIVE:
@@ -2296,14 +2335,16 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 				continue;
 			case FRAME_TYPE_INTERP_TO_MANAGED:
 				continue;
-			case FRAME_TYPE_INTERP:
 			case FRAME_TYPE_MANAGED:
+				break;
+			case FRAME_TYPE_INTERP:
+			case FRAME_TYPE_IL_STATE:
+				in_interp = TRUE;
 				break;
 			default:
 				g_assert_not_reached ();
 				break;
 			}
-			in_interp = frame.type == FRAME_TYPE_INTERP;
 			ji = frame.ji;
 		}
 
@@ -2514,7 +2555,11 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 						return 0;
 					} else {
 						mini_set_abort_threshold (&frame);
-						if (in_interp) {
+						if (frame.type == FRAME_TYPE_IL_STATE) {
+							if (mono_trace_is_enabled () && mono_trace_eval (method))
+								g_print ("EXCEPTION: clause found in AOTed code, running clause with interpreter.\n");
+							mini_get_interp_callbacks ()->run_finally_with_il_state (frame.il_state, i, ei->handler_start, ei->data.handler_end);
+						} else if (in_interp) {
 							gboolean has_ex = mini_get_interp_callbacks ()->run_finally (&frame, i, ei->handler_start, ei->data.handler_end);
 							if (has_ex) {
 								/*
@@ -3398,6 +3443,20 @@ throw_exception (MonoObject *ex, gboolean rethrow)
 void
 mono_llvm_throw_exception (MonoObject *ex)
 {
+	g_assert (mono_llvm_only);
+
+	/*
+	 * There are native frames above us, possibly followed by
+	 * interpreter frames. Handle the exception here to
+	 * allow the finally clauses in the native frames to be ran.
+	 * Then throw the c++ exception to unwind back to the interpreter.
+	 */
+	MonoContext ctx;
+	memset (&ctx, 0, sizeof (MonoContext));
+	MONO_CONTEXT_SET_SP (&ctx, &ctx);
+
+	mono_handle_exception (&ctx, (MonoObject*)ex);
+
 	throw_exception (ex, FALSE);
 }
 

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -195,6 +195,7 @@ typedef struct {
 	LLVMValueRef long_bb_break_var;
 	int *gc_var_indexes;
 	LLVMValueRef gc_pin_area;
+	LLVMValueRef il_state;
 } EmitContext;
 
 typedef struct {
@@ -2371,7 +2372,7 @@ emit_call (EmitContext *ctx, MonoBasicBlock *bb, LLVMBuilderRef *builder_ref, LL
 	if (ctx->llvm_only) {
 		clause = get_most_deep_clause (cfg, ctx, bb);
 
-		if (clause) {
+		if (!ctx->cfg->deopt && clause) {
 			g_assert (clause->flags == MONO_EXCEPTION_CLAUSE_NONE || clause->flags == MONO_EXCEPTION_CLAUSE_FINALLY || clause->flags == MONO_EXCEPTION_CLAUSE_FAULT);
 
 			/*
@@ -3816,11 +3817,15 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 				return;
 			/* Could be already created by an OP_VPHI */
 			if (!ctx->addresses [var->dreg]) {
-				if (var->flags & MONO_INST_LMF)
-					ctx->addresses [var->dreg] = build_alloca_llvm_type_name (ctx, LLVMArrayType (LLVMInt8Type (), MONO_ABI_SIZEOF (MonoLMF)), sizeof (target_mgreg_t), "entry_lmf");
-				else
-					ctx->addresses [var->dreg] = build_named_alloca (ctx, var->inst_vtype, "entry");
-				//LLVMSetValueName (ctx->addresses [var->dreg], g_strdup_printf ("vreg_loc_%d", var->dreg));
+				if (var->flags & MONO_INST_LMF) {
+					// FIXME: Allocate a smaller struct in the deopt case
+					int size = cfg->deopt ? MONO_ABI_SIZEOF (MonoLMFExt) : MONO_ABI_SIZEOF (MonoLMF);
+					ctx->addresses [var->dreg] = build_alloca_llvm_type_name (ctx, LLVMArrayType (LLVMInt8Type (), size), sizeof (target_mgreg_t), "lmf");
+				} else {
+					char *name = g_strdup_printf ("vreg_loc_%d", var->dreg);
+					ctx->addresses [var->dreg] = build_named_alloca (ctx, var->inst_vtype, name);
+					g_free (name);
+				}
 			}
 			ctx->vreg_cli_types [var->dreg] = var->inst_vtype;
 		}
@@ -4029,6 +4034,72 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 			emit_gc_pin (ctx, builder, var->dreg);
 	}
 #endif
+
+	if (cfg->deopt) {
+		LLVMValueRef addr, index [2];
+		MonoMethodHeader *header = cfg->header;
+		int nfields = sig->hasthis + sig->param_count + header->num_locals + 2;
+		LLVMTypeRef *types = g_alloca (nfields * sizeof (LLVMTypeRef));
+		int findex = 0;
+		/* method */
+		types [findex ++] = IntPtrType ();
+		/* il_offset */
+		types [findex ++] = LLVMInt32Type ();
+		int data_start = findex;
+		/* data */
+		if (sig->hasthis)
+			types [findex ++] = IntPtrType ();
+		for (int i = 0; i < sig->param_count; ++i)
+			types [findex ++] = LLVMPointerType (type_to_llvm_type (ctx, sig->params [i]), 0);
+		for (int i = 0; i < header->num_locals; ++i)
+			types [findex ++] = LLVMPointerType (type_to_llvm_type (ctx, header->locals [i]), 0);
+		g_assert (findex == nfields);
+		char *name = g_strdup_printf ("%s_il_state", ctx->method_name);
+		LLVMTypeRef il_state_type = LLVMStructCreateNamed (ctx->module->context, name);
+		LLVMStructSetBody (il_state_type, types, nfields, FALSE);
+		g_free (name);
+
+		ctx->il_state = build_alloca_llvm_type_name (ctx, il_state_type, 0, "il_state");
+		g_assert (cfg->il_state_var);
+		ctx->addresses [cfg->il_state_var->dreg] = ctx->il_state;
+
+		/* Set il_state->il_offset = -1 */
+		index [0] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
+		index [1] = LLVMConstInt (LLVMInt32Type (), 1, FALSE);
+		addr = LLVMBuildGEP (builder, ctx->il_state, index, 2, "");
+		LLVMBuildStore (ctx->builder, LLVMConstInt (types [1], -1, FALSE), addr);
+
+		/*
+		 * Set il_state->data [i] to either the address of the arg/local, or NULL.
+		 * Because of mono_liveness_handle_exception_clauses (), all locals used/reachable from
+		 * clauses are supposed to be volatile, so they have an address.
+		 */
+		findex = data_start;
+		for (int i = 0; i < sig->hasthis + sig->param_count; ++i) {
+			LLVMValueRef var_addr = ctx->addresses [cfg->args [i]->dreg];
+
+			index [0] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
+			index [1] = LLVMConstInt (LLVMInt32Type (), findex, FALSE);
+			addr = LLVMBuildGEP (builder, ctx->il_state, index, 2, "");
+			if (var_addr)
+				LLVMBuildStore (ctx->builder, var_addr, convert (ctx, addr, LLVMPointerType (LLVMTypeOf (var_addr), 0)));
+			else
+				LLVMBuildStore (ctx->builder, LLVMConstNull (types [findex]), addr);
+			findex ++;
+		}
+		for (int i = 0; i < header->num_locals; ++i) {
+			LLVMValueRef var_addr = ctx->addresses [cfg->locals [i]->dreg];
+
+			index [0] = LLVMConstInt (LLVMInt32Type (), 0, FALSE);
+			index [1] = LLVMConstInt (LLVMInt32Type (), findex, FALSE);
+			addr = LLVMBuildGEP (builder, ctx->il_state, index, 2, "");
+			if (var_addr)
+				LLVMBuildStore (ctx->builder, LLVMBuildBitCast (builder, var_addr, types [findex], ""), addr);
+			else
+				LLVMBuildStore (ctx->builder, LLVMConstNull (types [findex]), addr);
+			findex ++;
+		}
+	}
 
 	/* Initialize the method if needed */
 	if (cfg->compile_aot) {
@@ -11005,7 +11076,12 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 			}
 
 			if (ctx->llvm_only) {
-				emit_resume_eh (ctx, bb);
+				if (!cfg->deopt) {
+					emit_resume_eh (ctx, bb);
+				} else {
+					/* Not needed */
+					LLVMBuildUnreachable (builder);
+				}
 			} else {
 				LLVMTypeRef icall_sig = LLVMFunctionType (LLVMVoidType (), NULL, 0, FALSE);
 				if (ctx->cfg->compile_aot) {

--- a/src/mono/mono/mini/mini-ops.h
+++ b/src/mono/mono/mini/mini-ops.h
@@ -290,6 +290,7 @@ MINI_OP(OP_LCONV_TO_I,    "long_conv_to_i", LREG, LREG, NONE)
 MINI_OP(OP_LCONV_TO_OVF_I,"long_conv_to_ovf_i", LREG, LREG, NONE)
 MINI_OP(OP_LCONV_TO_OVF_U,"long_conv_to_ovf_u", LREG, LREG, NONE)
 
+/* inst_exc_name contains the exception name to throw */
 MINI_OP(OP_LADD_OVF,      "long_add_ovf", LREG, LREG, LREG)
 MINI_OP(OP_LADD_OVF_UN,   "long_add_ovf_un", LREG, LREG, LREG)
 MINI_OP(OP_LMUL_OVF,      "long_mul_ovf", LREG, LREG, LREG)
@@ -395,6 +396,8 @@ MINI_OP(OP_ICONV_TO_U1,   "int_conv_to_u1", IREG, IREG, NONE)
 MINI_OP(OP_ICONV_TO_I,    "int_conv_to_i", IREG, IREG, NONE)
 MINI_OP(OP_ICONV_TO_OVF_I,"int_conv_to_ovf_i", IREG, IREG, NONE)
 MINI_OP(OP_ICONV_TO_OVF_U,"int_conv_to_ovf_u", IREG, IREG, NONE)
+
+/* inst_exc_name contains the exception name to throw */
 MINI_OP(OP_IADD_OVF,      "int_add_ovf", IREG, IREG, IREG)
 MINI_OP(OP_IADD_OVF_UN,   "int_add_ovf_un", IREG, IREG, IREG)
 MINI_OP(OP_IMUL_OVF,      "int_mul_ovf", IREG, IREG, IREG)

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -201,10 +201,19 @@ struct MonoJitTlsData {
 #endif
 };
 
+typedef struct {
+	MonoMethod *method;
+	/* Either the IL offset of the currently executing code, or -1 */
+	int il_offset;
+	/* For every arg+local, either its address on the stack, or NULL */
+	gpointer data [1];
+} MonoMethodILState;
+
 #define MONO_LMFEXT_DEBUGGER_INVOKE 1
 #define MONO_LMFEXT_INTERP_EXIT 2
 #define MONO_LMFEXT_INTERP_EXIT_WITH_CTX 3
 #define MONO_LMFEXT_JIT_ENTRY 4
+#define MONO_LMFEXT_IL_STATE 5
 
 /*
  * The MonoLMF structure is arch specific, it includes at least these fields.
@@ -232,6 +241,7 @@ typedef struct {
 	int kind;
 	MonoContext ctx; /* valid if kind == DEBUGGER_INVOKE || kind == INTERP_EXIT_WITH_CTX */
 	gpointer interp_exit_data; /* valid if kind == INTERP_EXIT || kind == INTERP_EXIT_WITH_CTX */
+	MonoMethodILState *il_state; /* valid if kind == IL_STATE */
 #if defined (_MSC_VER)
 	gboolean interp_exit_label_set;
 #endif

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1399,6 +1399,7 @@ typedef struct {
 
 	MonoInst *lmf_var;
 	MonoInst *lmf_addr_var;
+	MonoInst *il_state_var;
 
 	MonoInst *stack_inbalance_var;
 
@@ -1452,10 +1453,6 @@ typedef struct {
 	 * instead of being generated in emit_prolog ()/emit_epilog ().
 	 */
 	guint            lmf_ir : 1;
-	/*
-	 * Whenever to use the mono_lmf TLS variable instead of indirection through the
-	 * mono_lmf_addr TLS variable.
-	 */
 	guint            gen_write_barriers : 1;
 	guint            init_ref_vars : 1;
 	guint            extend_live_ranges : 1;
@@ -1493,6 +1490,7 @@ typedef struct {
 	guint            interp_entry_only : 1;
 	guint            after_method_to_ir : 1;
 	guint            disable_inline_rgctx_fetch : 1;
+	guint            deopt : 1;
 	guint8           uses_simd_intrinsics;
 	int              r4_stack_type;
 	gpointer         debug_info;
@@ -1802,6 +1800,7 @@ enum {
 #define OP_PSUB OP_LSUB
 #define OP_PMUL OP_LMUL
 #define OP_PMUL_IMM OP_LMUL_IMM
+#define OP_POR_IMM OP_LOR_IMM
 #define OP_PNEG OP_LNEG
 #define OP_PCONV_TO_I1 OP_LCONV_TO_I1
 #define OP_PCONV_TO_U1 OP_LCONV_TO_U1
@@ -1832,6 +1831,7 @@ enum {
 #define OP_PSUB OP_ISUB
 #define OP_PMUL OP_IMUL
 #define OP_PMUL_IMM OP_IMUL_IMM
+#define OP_POR_IMM OP_IOR_IMM
 #define OP_PNEG OP_INEG
 #define OP_PCONV_TO_I1 OP_ICONV_TO_I1
 #define OP_PCONV_TO_U1 OP_ICONV_TO_U1
@@ -2855,7 +2855,6 @@ typedef enum {
 	MONO_CPU_X86_LZCNT	= 1 << 13,
 	MONO_CPU_X86_BMI1	= 1 << 14,
 	MONO_CPU_X86_BMI2	= 1 << 15,
-
 
 	//
 	// Dependencies (based on System.Runtime.Intrinsics.X86 class hierarchy):

--- a/src/mono/mono/tools/offsets-tool/offsets-tool.py
+++ b/src/mono/mono/tools/offsets-tool/offsets-tool.py
@@ -252,6 +252,8 @@ class OffsetsTool:
 		]
 		self.jit_type_names = [
 			"MonoLMF",
+			"MonoLMFExt",
+			"MonoMethodILState",
 			"MonoMethodRuntimeGenericContext",
 			"MonoJitTlsData",
 			"MonoGSharedVtMethodRuntimeInfo",

--- a/src/mono/mono/utils/mono-stack-unwinding.h
+++ b/src/mono/mono/utils/mono-stack-unwinding.h
@@ -32,7 +32,9 @@ typedef enum {
 	FRAME_TYPE_INTERP_ENTRY = 7,
 	/* Frame marking transition to native JIT compiler */
 	FRAME_TYPE_JIT_ENTRY = 8,
-	FRAME_TYPE_NUM = 9
+	/* Compiled method with IL state */
+	FRAME_TYPE_IL_STATE = 9,
+	FRAME_TYPE_NUM = 10
 } MonoStackFrameType;
 
 typedef enum {
@@ -103,6 +105,9 @@ typedef struct {
 	guint8 *unwind_info;
 
 	host_mgreg_t **reg_locations;
+
+	/* For FRAME_TYPE_IL_STATE */
+	gpointer il_state; /* MonoMethodILState */
 } MonoStackFrameInfo;
 
 /*Index into MonoThreadState::unwind_data. */


### PR DESCRIPTION
This is implemented by running the finally clause with the interpreter.
Methods with clauses have additional code generated, which:
* Saves the IL state (pc+arguments+locals) into a MonoMethodILState
structure.
* Pushes an LMF frame on the LMF stack of type MONO_LMFEXT_IL_STATE.
  The LMF frame points to the il state.

During EH, if such an LMF frame is found, and the IL pc in the
il state points inside a clause, then an interpreted version
of the method is created, and the finally clause is ran using
the interpreter using the il state as the starting state.