### PR TITLE
Disable some tests failing on Android x86/arm

### DIFF
--- a/src/libraries/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
@@ -42,6 +42,7 @@ namespace System.Collections.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63079", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
         public static void Capacity_Excessive ()
         {
             Assert.Throws<OutOfMemoryException>(() => new MyCollection(int.MaxValue)); // Capacity is too large

--- a/src/libraries/System.Collections.NonGeneric/tests/SortedListTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/SortedListTests.cs
@@ -1300,6 +1300,7 @@ namespace System.Collections.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63079", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
         public void Capacity_Excessive()
         {
             var sortList1 = new SortedList();

--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -1035,6 +1035,7 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/63079", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
         private static void AllocateArrayTooLarge()
         {
             Assert.Throws<OutOfMemoryException>(() => GC.AllocateUninitializedArray<double>(int.MaxValue));


### PR DESCRIPTION
- System.Tests.GCExtendedTests.AllocateArrayTooLarge
- System.Collections.Tests.SortedListTests.Capacity_Excessive
- System.Collections.Tests.CollectionBaseTests.Capacity_Excessive


Details in https://github.com/dotnet/runtime/issues/63079