### PR TITLE
[mono] Don't access MonoClassField:parent directly

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -2932,7 +2932,7 @@ static gint32 isFixedSizeArray (MonoClassField *f)
 	MonoCustomAttrEntry *attr;
 	int aindex;
 	gint32 ret = 1;
-	cinfo = mono_custom_attrs_from_field_checked (f->parent, f, error);
+	cinfo = mono_custom_attrs_from_field_checked (m_field_get_parent (f), f, error);
 	goto_if_nok (error, leave);
 	attr = NULL;
 	if (cinfo) {
@@ -7734,12 +7734,12 @@ field_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 		MonoClassField *f = decode_fieldid (p, &p, end, &domain, &err);
 
 		buffer_add_string (buf, f->name);
-		buffer_add_typeid (buf, domain, f->parent);
+		buffer_add_typeid (buf, domain, m_field_get_parent (f));
 		buffer_add_typeid (buf, domain, mono_class_from_mono_type_internal (f->type));
 		buffer_add_int (buf, f->type->attrs);
 		if (CHECK_PROTOCOL_VERSION (2, 59)) {
 			buffer_add_int (buf, f->type->type);
-			buffer_add_int (buf, m_class_get_type_token (f->parent));
+			buffer_add_int (buf, m_class_get_type_token (m_field_get_parent (f)));
 			buffer_add_int (buf, m_class_get_type_token (mono_class_from_mono_type_internal (f->type)));
 		}
 		break;
@@ -7796,7 +7796,7 @@ static int get_static_field_value(MonoClassField* f, MonoClass* klass, MonoDomai
 	/* Check that the field belongs to the object */
 	found = FALSE;
 	for (k = klass; k; k = m_class_get_parent(k)) {
-		if (k == f->parent) {
+		if (k == m_field_get_parent (f)) {
 			found = TRUE;
 			break;
 		}
@@ -7804,7 +7804,7 @@ static int get_static_field_value(MonoClassField* f, MonoClass* klass, MonoDomai
 	if (!found)
 		return -1;
 
-	vtable = mono_class_vtable_checked(f->parent, error);
+	vtable = mono_class_vtable_checked(m_field_get_parent (f), error);
 	if (!is_ok(error))
 		return -1;
 
@@ -8127,7 +8127,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 			/* Check that the field belongs to the object */
 			found = FALSE;
 			for (k = klass; k; k = m_class_get_parent (k)) {
-				if (k == f->parent) {
+				if (k == m_field_get_parent (f)) {
 					found = TRUE;
 					break;
 				}
@@ -8137,7 +8137,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 
 			// FIXME: Check for literal/const
 
-			vtable = mono_class_vtable_checked (f->parent, error);
+			vtable = mono_class_vtable_checked (m_field_get_parent (f), error);
 			goto_if_nok (error, invalid_fieldid);
 
 			val = (guint8 *)g_malloc (mono_class_instance_size (mono_class_from_mono_type_internal (f->type)));
@@ -9634,7 +9634,7 @@ object_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			/* Check that the field belongs to the object */
 			found = FALSE;
 			for (k = obj_type; k; k = m_class_get_parent (k)) {
-				if (k == f->parent) {
+				if (k == m_field_get_parent (f)) {
 					found = TRUE;
 					break;
 				}
@@ -9650,7 +9650,7 @@ get_field_value:
 					goto invalid_fieldid;
 
 				g_assert (f->type->attrs & FIELD_ATTRIBUTE_STATIC);
-				vtable = mono_class_vtable_checked (f->parent, error);
+				vtable = mono_class_vtable_checked (m_field_get_parent (f), error);
 				if (!is_ok (error)) {
 					mono_error_cleanup (error);
 					goto invalid_object;
@@ -9681,7 +9681,7 @@ get_field_value:
 			/* Check that the field belongs to the object */
 			found = FALSE;
 			for (k = obj_type; k; k = m_class_get_parent (k)) {
-				if (k == f->parent) {
+				if (k == m_field_get_parent (f)) {
 					found = TRUE;
 					break;
 				}
@@ -9697,7 +9697,7 @@ get_field_value:
 					goto invalid_fieldid;
 
 				g_assert (f->type->attrs & FIELD_ATTRIBUTE_STATIC);
-				vtable = mono_class_vtable_checked (f->parent, error);
+				vtable = mono_class_vtable_checked (m_field_get_parent (f), error);
 				if (!is_ok (error)) {
 					mono_error_cleanup (error);
 					goto invalid_fieldid;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -204,7 +204,7 @@ mono_class_setup_basic_field_info (MonoClass *klass)
 	int first_field_idx = mono_class_has_static_metadata (klass) ? mono_class_get_first_field_idx (klass) : 0;
 	for (i = 0; i < top; i++) {
 		field = &fields [i];
-		field->parent = klass;
+		m_field_set_parent (field, klass);
 
 		if (gtd) {
 			field->name = mono_field_get_name (&gtd->fields [i]);
@@ -2399,7 +2399,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				guint32 field_idx = first_field_idx + (field - p->fields);
 				if (MONO_TYPE_IS_REFERENCE (field->type) && mono_assembly_is_weak_field (p->image, field_idx + 1)) {
 					has_weak_fields = TRUE;
-					mono_trace_message (MONO_TRACE_TYPE, "Field %s:%s at offset %x is weak.", field->parent->name, field->name, field->offset);
+					mono_trace_message (MONO_TRACE_TYPE, "Field %s:%s at offset %x is weak.", m_field_get_parent (field)->name, field->name, field->offset);
 				}
 			}
 		}
@@ -4079,4 +4079,10 @@ mono_classes_init (void)
 							MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &inflated_classes_size);
 	mono_counters_register ("MonoClass size",
 							MONO_COUNTER_METADATA | MONO_COUNTER_INT, &classes_size);
+}
+
+void
+m_field_set_parent (MonoClassField *field, MonoClass *klass)
+{
+	field->parent_ = klass;
 }

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -146,7 +146,8 @@ struct _MonoClassField {
 	const char      *name;
 
 	/* Type where the field was defined */
-	MonoClass       *parent;
+	/* Do not access directly, use m_field_get_parent */
+	MonoClass       *parent_;
 
 	/*
 	 * Offset where this field is stored; if it is an instance
@@ -1535,10 +1536,19 @@ mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method);
 		}								\
 	}									\
 
+static inline MonoClass *
+m_field_get_parent (MonoClassField *field)
+{
+	return field->parent_;
+}
+
+void
+m_field_set_parent (MonoClassField *field, MonoClass *klass);
+
 static inline gboolean
 m_field_get_offset (MonoClassField *field)
 {
-	g_assert (m_class_is_fields_inited (field->parent));
+	g_assert (m_class_is_fields_inited (m_field_get_parent (field)));
 	return field->offset;
 }
 

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -2132,7 +2132,7 @@ mono_reflection_get_custom_attrs_info_checked (MonoObjectHandle obj, MonoError *
 	} else if (strcmp ("RuntimeFieldInfo", klass_name) == 0) {
 		MonoReflectionFieldHandle rfield = MONO_HANDLE_CAST (MonoReflectionField, obj);
 		MonoClassField *field = MONO_HANDLE_GETVAL (rfield, field);
-		cinfo = mono_custom_attrs_from_field_checked (field->parent, field, error);
+		cinfo = mono_custom_attrs_from_field_checked (m_field_get_parent (field), field, error);
 		goto_if_nok (error, leave);
 	} else if ((strcmp ("RuntimeMethodInfo", klass_name) == 0) || (strcmp ("RuntimeConstructorInfo", klass_name) == 0)) {
 		MonoReflectionMethodHandle rmethod = MONO_HANDLE_CAST (MonoReflectionMethod, obj);

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -868,10 +868,10 @@ char *
 mono_field_full_name (MonoClassField *field)
 {
 	char *res;
-	const char *nspace = field->parent->name_space;
+	const char *nspace = m_field_get_parent (field)->name_space;
 
 	res = g_strdup_printf ("%s%s%s:%s", nspace, *nspace ? "." : "",
-						   field->parent->name, mono_field_get_name (field));
+						   m_field_get_parent (field)->name, mono_field_get_name (field));
 
 	return res;
 }

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -350,12 +350,12 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 			mono_error_set_bad_image (error, image, "Bad field token 0x%08x", token);
 			return NULL;
 		}
-		*retklass = result->parent;
+		*retklass = m_field_get_parent (result);
 		return result;
 	}
 
 	if ((field = (MonoClassField *)mono_conc_hashtable_lookup (image->field_cache, GUINT_TO_POINTER (token)))) {
-		*retklass = field->parent;
+		*retklass = m_field_get_parent (field);
 		return field;
 	}
 
@@ -387,7 +387,8 @@ mono_field_from_token_checked (MonoImage *image, guint32 token, MonoClass **retk
 		}
 	}
 
-	if (field && field->parent && !mono_class_is_ginst (field->parent) && !mono_class_is_gtd (field->parent)) {
+	MonoClass *field_parent = NULL;
+	if (field && ((field_parent = m_field_get_parent (field))) && !mono_class_is_ginst (field_parent) && !mono_class_is_gtd (field_parent)) {
 		mono_image_lock (image);
 		mono_conc_hashtable_insert (image->field_cache, GUINT_TO_POINTER (token), field);
 		mono_image_unlock (image);

--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -175,7 +175,7 @@ get_fixed_buffer_attr (MonoClassField *field, MonoType **out_etype, int *out_len
 	MonoCustomAttrEntry *attr;
 	int aindex;
 
-	cinfo = mono_custom_attrs_from_field_checked (field->parent, field, error);
+	cinfo = mono_custom_attrs_from_field_checked (m_field_get_parent (field), field, error);
 	if (!is_ok (error))
 		return FALSE;
 	attr = NULL;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -7568,11 +7568,11 @@ mono_metadata_get_corresponding_field_from_generic_type_definition (MonoClassFie
 	MonoClass *gtd;
 	int offset;
 
-	if (!mono_class_is_ginst (field->parent))
+	if (!mono_class_is_ginst (m_field_get_parent (field)))
 		return field;
 
-	gtd = mono_class_get_generic_class (field->parent)->container_class;
-	offset = field - m_class_get_fields (field->parent);
+	gtd = mono_class_get_generic_class (m_field_get_parent (field))->container_class;
+	offset = field - m_class_get_fields (m_field_get_parent (field));
 	return m_class_get_fields (gtd) + offset;
 }
 

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -908,7 +908,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 			case MONO_TYPE_CHAR:
 				break;
 			default:
-				g_error ("compute_class_bitmap: Invalid type %x for field %s:%s\n", type->type, mono_type_get_full_name (field->parent), field->name);
+				g_error ("compute_class_bitmap: Invalid type %x for field %s:%s\n", type->type, mono_type_get_full_name (m_field_get_parent (field)), field->name);
 				break;
 			}
 		}
@@ -2245,7 +2245,7 @@ mono_class_field_is_special_static (MonoClassField *field)
 	if (mono_field_is_deleted (field))
 		return FALSE;
 	if (!(field->type->attrs & FIELD_ATTRIBUTE_LITERAL)) {
-		if (field_is_special_static (field->parent, field) != SPECIAL_STATIC_NONE)
+		if (field_is_special_static (m_field_get_parent (field), field) != SPECIAL_STATIC_NONE)
 			return TRUE;
 	}
 	return FALSE;
@@ -2267,7 +2267,7 @@ mono_class_field_get_special_static_type (MonoClassField *field)
 	if (mono_field_is_deleted (field))
 		return SPECIAL_STATIC_NONE;
 	if (!(field->type->attrs & FIELD_ATTRIBUTE_LITERAL))
-		return field_is_special_static (field->parent, field);
+		return field_is_special_static (m_field_get_parent (field), field);
 	return SPECIAL_STATIC_NONE;
 }
 
@@ -2285,7 +2285,7 @@ mono_class_has_special_static_fields (MonoClass *klass)
 
 	iter = NULL;
 	while ((field = mono_class_get_fields_internal (klass, &iter))) {
-		g_assert (field->parent == klass);
+		g_assert (m_field_get_parent (field) == klass);
 		if (mono_class_field_is_special_static (field))
 			return TRUE;
 	}
@@ -2793,7 +2793,7 @@ mono_field_static_set_value_internal (MonoVTable *vt, MonoClassField *field, voi
 gpointer
 mono_special_static_field_get_offset (MonoClassField *field, MonoError *error)
 {
-	MonoMemoryManager *mem_manager = m_class_get_mem_manager (field->parent);
+	MonoMemoryManager *mem_manager = m_class_get_mem_manager (m_field_get_parent (field));
 	gpointer addr = NULL;
 
 	mono_mem_manager_lock (mem_manager);
@@ -3020,7 +3020,7 @@ mono_field_get_value_object_checked (MonoClassField *field, MonoObject *obj, Mon
 		is_static = TRUE;
 
 		if (!is_literal) {
-			vtable = mono_class_vtable_checked (field->parent, error);
+			vtable = mono_class_vtable_checked (m_field_get_parent (field), error);
 			goto_if_nok (error, return_null);
 
 			if (!vtable->initialized) {

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -746,7 +746,7 @@ MonoReflectionFieldHandle
 mono_field_get_object_handle (MonoClass *klass, MonoClassField *field, MonoError *error)
 {
 	error_init (error);
-	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionField, m_class_get_mem_manager (field->parent), field, klass, field_object_construct, NULL);
+	return CHECK_OR_CONSTRUCT_HANDLE (MonoReflectionField, m_class_get_mem_manager (m_field_get_parent (field)), field, klass, field_object_construct, NULL);
 }
 
 /*

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -2989,7 +2989,7 @@ arch_emit_unbox_arbitrary_trampoline (MonoAotCompile *acfg, int offset, int *tra
 static guint32
 mono_get_field_token (MonoClassField *field)
 {
-	MonoClass *klass = field->parent;
+	MonoClass *klass = m_field_get_parent (field);
 	int i;
 
 	int fcount = mono_class_get_field_count (klass);
@@ -3484,7 +3484,7 @@ encode_field_info (MonoAotCompile *cfg, MonoClassField *field, guint8 *buf, guin
 	guint32 token = mono_get_field_token (field);
 	guint8 *p = buf;
 
-	encode_klass_ref (cfg, field->parent, p, &p);
+	encode_klass_ref (cfg, m_field_get_parent (field), p, &p);
 	g_assert (mono_metadata_token_code (token) == MONO_TOKEN_FIELD_DEF);
 	encode_value (token - MONO_TOKEN_FIELD_DEF, p, &p);
 	*endbuf = p;
@@ -8077,14 +8077,15 @@ mono_aot_readonly_field_override (MonoClassField *field)
 	for (rdv = readonly_values; rdv; rdv = rdv->next) {
 		char *p = rdv->name;
 		int len;
-		len = strlen (m_class_get_name_space (field->parent));
-		if (strncmp (p, m_class_get_name_space (field->parent), len))
+		MonoClass *field_parent = m_field_get_parent (field);
+		len = strlen (m_class_get_name_space (field_parent));
+		if (strncmp (p, m_class_get_name_space (field_parent), len))
 			continue;
 		p += len;
 		if (*p++ != '.')
 			continue;
-		len = strlen (m_class_get_name (field->parent));
-		if (strncmp (p, m_class_get_name (field->parent), len))
+		len = strlen (m_class_get_name (field_parent));
+		if (strncmp (p, m_class_get_name (field_parent), len))
 			continue;
 		p += len;
 		if (*p++ != '.')
@@ -9121,7 +9122,7 @@ compile_method (MonoAotCompile *acfg, MonoMethod *method)
 				break;
 			}
 			case MONO_PATCH_INFO_SFLDA: {
-				MonoClass *klass = patch_info->data.field->parent;
+				MonoClass *klass = m_field_get_parent (patch_info->data.field);
 
 				/* The .cctor needs to run at runtime. */
 				if (mono_class_is_ginst (klass) && !mono_generic_context_is_sharable_full (&mono_class_get_generic_class (klass)->context, FALSE, FALSE) && mono_class_get_cctor (klass))

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3556,9 +3556,9 @@ interp_field_from_token (MonoMethod *method, guint32 token, MonoClass **klass, M
 	MonoClassField *field = NULL;
 	if (method->wrapper_type != MONO_WRAPPER_NONE) {
 		field = (MonoClassField *) mono_method_get_wrapper_data (method, token);
-		*klass = field->parent;
+		*klass = m_field_get_parent (field);
 
-		mono_class_setup_fields (field->parent);
+		mono_class_setup_fields (m_field_get_parent (field));
 	} else {
 		field = mono_field_from_token_checked (m_class_get_image (method->klass), token, klass, generic_context, error);
 		return_val_if_nok (error, NULL);
@@ -4091,7 +4091,7 @@ static void
 interp_emit_ldsflda (TransformData *td, MonoClassField *field, MonoError *error)
 {
 	// Initialize the offset for the field
-	MonoVTable *vtable = mono_class_vtable_checked (field->parent, error);
+	MonoVTable *vtable = mono_class_vtable_checked (m_field_get_parent (field), error);
 	return_if_nok (error);
 
 	push_simple_type (td, STACK_TYPE_MP);
@@ -4164,7 +4164,7 @@ static void
 interp_emit_sfld_access (TransformData *td, MonoClassField *field, MonoClass *field_class, int mt, gboolean is_load, MonoError *error)
 {
 	// Initialize the offset for the field
-	MonoVTable *vtable = mono_class_vtable_checked (field->parent, error);
+	MonoVTable *vtable = mono_class_vtable_checked (m_field_get_parent (field), error);
 	return_if_nok (error);
 
 	if (mono_class_field_is_special_static (field)) {
@@ -6146,11 +6146,11 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			MonoType *ftype = mono_field_get_type_internal (field);
 			mt = mint_type (ftype);
 			klass = mono_class_from_mono_type_internal (ftype);
-			gboolean in_corlib = m_class_get_image (field->parent) == mono_defaults.corlib;
+			gboolean in_corlib = m_class_get_image (m_field_get_parent (field)) == mono_defaults.corlib;
 
 			if (in_corlib && !strcmp (field->name, "IsLittleEndian") &&
-				!strcmp (m_class_get_name (field->parent), "BitConverter") &&
-				!strcmp (m_class_get_name_space (field->parent), "System"))
+				!strcmp (m_class_get_name (m_field_get_parent (field)), "BitConverter") &&
+				!strcmp (m_class_get_name_space (m_field_get_parent (field)), "System"))
 			{
 				interp_add_ins (td, (TARGET_BYTE_ORDER == G_LITTLE_ENDIAN) ? MINT_LDC_I4_1 : MINT_LDC_I4_0);
 				push_simple_type (td, STACK_TYPE_I4);

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -2262,7 +2262,7 @@ emit_array_unsafe_mov (MonoCompile *cfg, MonoMethodSignature *fsig, MonoInst **a
 MonoInst*
 mini_emit_inst_for_field_load (MonoCompile *cfg, MonoClassField *field)
 {
-	MonoClass *klass = field->parent;
+	MonoClass *klass = m_field_get_parent (field);
 	const char *klass_name_space = m_class_get_name_space (klass);
 	const char *klass_name = m_class_get_name (klass);
 	MonoImage *klass_image = m_class_get_image (klass);

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -865,9 +865,9 @@ mono_class_static_field_address (MonoClassField *field)
 
 	//printf ("SFLDA0 %s.%s::%s %d\n", field->parent->name_space, field->parent->name, field->name, field->offset, field->parent->inited);
 
-	mono_class_init_internal (field->parent);
+	mono_class_init_internal (m_field_get_parent (field));
 
-	vtable = mono_class_vtable_checked (field->parent, error);
+	vtable = mono_class_vtable_checked (m_field_get_parent (field), error);
 	if (!is_ok (error)) {
 		mono_error_set_pending_exception (error);
 		return NULL;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -9566,7 +9566,7 @@ calli_end:
 
 			if (method->wrapper_type != MONO_WRAPPER_NONE) {
 				field = (MonoClassField *)mono_method_get_wrapper_data (method, token);
-				klass = field->parent;
+				klass = m_field_get_parent (field);
 			}
 			else {
 				klass = NULL;
@@ -9748,7 +9748,7 @@ calli_end:
 			context_used = mini_class_check_context_used (cfg, klass);
 
 			if (ftype->attrs & FIELD_ATTRIBUTE_LITERAL) {
-				mono_error_set_field_missing (cfg->error, field->parent, field->name, NULL, "Using static instructions with literal field");
+				mono_error_set_field_missing (cfg->error, m_field_get_parent (field), field->name, NULL, "Using static instructions with literal field");
 				CHECK_CFG_ERROR;
 			}
 
@@ -9823,7 +9823,7 @@ calli_end:
 					(context_used && is_special_static)) {
 				MonoInst *iargs [1];
 
-				g_assert (field->parent);
+				g_assert (m_field_get_parent (field));
 				if (context_used) {
 					iargs [0] = emit_get_rgctx_field (cfg, context_used,
 						field, MONO_RGCTX_INFO_CLASS_FIELD);
@@ -9868,7 +9868,7 @@ calli_end:
 			} else if (cfg->compile_aot && addr) {
 				MonoInst *iargs [1];
 
-				g_assert (field->parent);
+				g_assert (m_field_get_parent (field));
 				EMIT_NEW_FIELDCONST (cfg, iargs [0], field);
 				ins = mono_emit_jit_icall (cfg, mono_class_static_field_address, iargs);
 			} else {
@@ -10404,7 +10404,7 @@ field_access_end:
 				} else if (handle_class == mono_defaults.typehandle_class) {
 					context_used = mini_class_check_context_used (cfg, mono_class_from_mono_type_internal ((MonoType *)handle));
 				} else if (handle_class == mono_defaults.fieldhandle_class)
-					context_used = mini_class_check_context_used (cfg, ((MonoClassField*)handle)->parent);
+					context_used = mini_class_check_context_used (cfg, m_field_get_parent (((MonoClassField*)handle)));
 				else if (handle_class == mono_defaults.methodhandle_class)
 					context_used = mini_method_check_context_used (cfg, (MonoMethod *)handle);
 				else

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -672,11 +672,11 @@ inflate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoTempl
 	case MONO_RGCTX_INFO_FIELD_OFFSET: {
 		ERROR_DECL (error);
 		MonoClassField *field = (MonoClassField *)data;
-		MonoType *inflated_type = mono_class_inflate_generic_type_checked (m_class_get_byval_arg (field->parent), context, error);
+		MonoType *inflated_type = mono_class_inflate_generic_type_checked (m_class_get_byval_arg (m_field_get_parent (field)), context, error);
 		mono_error_assert_ok (error); /* FIXME don't swallow the error */
 
 		MonoClass *inflated_class = mono_class_from_mono_type_internal (inflated_type);
-		int i = field - m_class_get_fields (field->parent);
+		int i = field - m_class_get_fields (m_field_get_parent (field));
 		gpointer dummy = NULL;
 
 		mono_metadata_free_type (inflated_type);
@@ -2316,7 +2316,7 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 		if (mono_class_field_is_special_static (field)) {
 			gpointer addr;
 
-			mono_class_vtable_checked (field->parent, error);
+			mono_class_vtable_checked (m_field_get_parent (field), error);
 			mono_error_assert_ok (error);
 
 			/* Return the TLS offset */
@@ -2326,7 +2326,7 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 		}
 
 		/* The value is offset by 1 */
-		if (m_class_is_valuetype (field->parent) && !(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
+		if (m_class_is_valuetype (m_field_get_parent (field)) && !(field->type->attrs & FIELD_ATTRIBUTE_STATIC))
 			return GUINT_TO_POINTER (field->offset - MONO_ABI_SIZEOF (MonoObject) + 1);
 		else
 			return GUINT_TO_POINTER (field->offset + 1);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1506,7 +1506,7 @@ mono_resolve_patch_target_ext (MonoMemoryManager *mem_manager, MonoMethod *metho
 		break;
 	}
 	case MONO_PATCH_INFO_SFLDA: {
-		MonoVTable *vtable = mono_class_vtable_checked (patch_info->data.field->parent, error);
+		MonoVTable *vtable = mono_class_vtable_checked (m_field_get_parent (patch_info->data.field), error);
 		mono_error_assert_ok (error);
 
 		if (mono_class_field_is_special_static (patch_info->data.field)) {


### PR DESCRIPTION
Rename it to `parent_` and add `m_field_get_parent` / `m_field_set_parent` accessors.

(The intention is to borrow the bottom bit of the pointer for an EnC metadata update flag)

No functional change in this PR