### PR TITLE
Move `System.Drawing.Common` to `SafeHandle`s et. al.

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.Gdi32)]
         public static partial bool DeleteObject(IntPtr ho);
 
+        public static bool DeleteObject(IntPtr ho, SafeHandle owningHandle)
+        {
+            bool releaseOwner = false;
+            try
+            {
+                owningHandle.DangerousAddRef(ref releaseOwner);
+                return DeleteObject(ho);
+            }
+            finally
+            {
+                if (releaseOwner)
+                {
+                    owningHandle.DangerousRelease();
+                }
+            }
+        }
+
         public static bool DeleteObject(HandleRef ho)
         {
             bool result = DeleteObject(ho.Handle);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DeleteObject.cs
@@ -16,7 +16,10 @@ internal static partial class Interop
             bool releaseOwner = false;
             try
             {
-                owningHandle.DangerousAddRef(ref releaseOwner);
+                if (!owningHandle.IsClosed)
+                {
+                    owningHandle.DangerousAddRef(ref releaseOwner);
+                }
                 return DeleteObject(ho);
             }
             finally

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -166,7 +166,26 @@ namespace System
             return Throws(typeof(TNetCoreExceptionType), typeof(TNetFxExceptionType), action);
         }
 
+        public static Exception Throws<TNetCoreExceptionType, TNetFxExceptionType>(Func<object> action)
+            where TNetCoreExceptionType : Exception
+            where TNetFxExceptionType : Exception
+        {
+            return Throws(typeof(TNetCoreExceptionType), typeof(TNetFxExceptionType), action);
+        }
+
         public static Exception Throws(Type netCoreExceptionType, Type netFxExceptionType, Action action)
+        {
+            if (IsNetFramework)
+            {
+                return Assert.Throws(netFxExceptionType, action);
+            }
+            else
+            {
+                return Assert.Throws(netCoreExceptionType, action);
+            }
+        }
+
+        public static Exception Throws(Type netCoreExceptionType, Type netFxExceptionType, Func<object> action)
         {
             if (IsNetFramework)
             {

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeBrushHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeBrushHandle.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Gdip = System.Drawing.SafeNativeMethods.Gdip;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal class SafeBrushHandle : SafeGdiPlusHandle
+    {
+        public SafeBrushHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        protected override int ReleaseHandleImpl() => Gdip.GdipDeleteBrush(handle);
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeBrushHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeBrushHandle.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Win32.SafeHandles
             SetHandle(preexistingHandle);
         }
 
+        public SafeBrushHandle() : base(true)
+        {
+        }
+
         protected override int ReleaseHandleImpl() => Gdip.GdipDeleteBrush(handle);
     }
 }

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeGdiPlusHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeGdiPlusHandle.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using Gdip = System.Drawing.SafeNativeMethods.Gdip;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal abstract class SafeGdiPlusHandle : SafeHandle
+    {
+        public SafeGdiPlusHandle(bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        protected abstract int ReleaseHandleImpl();
+
+        protected override bool ReleaseHandle()
+        {
+            int releaseResult = Gdip.Ok;
+            try
+            {
+                if (!Gdip.Initialized)
+                {
+                    releaseResult = ReleaseHandleImpl();
+                }
+                Debug.Assert(releaseResult == Gdip.Ok, $"GDI+ returned an error status: {releaseResult}");
+            }
+            catch (Exception ex) when (!ClientUtils.IsSecurityOrCriticalException(ex))
+            {
+                // Catch all non fatal exceptions. This includes exceptions like EntryPointNotFoundException, that is thrown
+                // on Windows Nano.
+            }
+            return releaseResult == Gdip.Ok;
+        }
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeGraphicsPathHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeGraphicsPathHandle.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Gdip = System.Drawing.SafeNativeMethods.Gdip;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal class SafeGraphicsPathHandle : SafeGdiPlusHandle
+    {
+        public SafeGraphicsPathHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        public SafeGraphicsPathHandle() : base(true)
+        {
+        }
+
+        protected override int ReleaseHandleImpl() => Gdip.GdipDeletePath(handle);
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeMatrixHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeMatrixHandle.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Gdip = System.Drawing.SafeNativeMethods.Gdip;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal class SafeMatrixHandle : SafeGdiPlusHandle
+    {
+        public SafeMatrixHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        public SafeMatrixHandle() : base(true)
+        {
+        }
+
+        protected override int ReleaseHandleImpl() => Gdip.GdipDeleteMatrix(handle);
+
+        internal bool HasEqualHandle(SafeMatrixHandle other) =>
+            DangerousGetHandle() == other.DangerousGetHandle();
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeMatrixHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeMatrixHandle.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Win32.SafeHandles
 
         protected override int ReleaseHandleImpl() => Gdip.GdipDeleteMatrix(handle);
 
-        internal bool HasEqualHandle(SafeMatrixHandle other) =>
-            DangerousGetHandle() == other.DangerousGetHandle();
+        internal bool HasEqualHandle(SafeMatrixHandle other) => handle == other.handle;
     }
 }

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafePenHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafePenHandle.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Gdip = System.Drawing.SafeNativeMethods.Gdip;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal class SafePenHandle : SafeGdiPlusHandle
+    {
+        public SafePenHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        protected override int ReleaseHandleImpl() => Gdip.GdipDeletePen(handle);
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafePenHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafePenHandle.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Win32.SafeHandles
             SetHandle(preexistingHandle);
         }
 
+        public SafePenHandle() : base(true)
+        {
+        }
+
         protected override int ReleaseHandleImpl() => Gdip.GdipDeletePen(handle);
     }
 }

--- a/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeRegionHandle.cs
+++ b/src/libraries/System.Drawing.Common/src/Microsoft/Win32/SafeHandles/SafeRegionHandle.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Gdip = System.Drawing.SafeNativeMethods.Gdip;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    internal class SafeRegionHandle : SafeGdiPlusHandle
+    {
+        public SafeRegionHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
+        public SafeRegionHandle() : base(true)
+        {
+        }
+
+        protected override int ReleaseHandleImpl() => Gdip.GdipDeleteRegion(handle);
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -33,8 +33,10 @@ Unix support is disabled by default. See https://aka.ms/systemdrawingnonwindows 
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeBrushHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeGdiPlusHandle.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafeGraphicsPathHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeMatrixHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafePenHandle.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafeRegionHandle.cs" />
     <Compile Include="System\Drawing\Bitmap.cs" />
     <Compile Include="System\Drawing\BitmapSuffixInSameAssemblyAttribute.cs" />
     <Compile Include="System\Drawing\BitmapSuffixInSatelliteAssemblyAttribute.cs" />
@@ -84,6 +86,7 @@ Unix support is disabled by default. See https://aka.ms/systemdrawingnonwindows 
     <Compile Include="System\Drawing\Drawing2D\FillMode.cs" />
     <Compile Include="System\Drawing\Drawing2D\FlushIntention.cs" />
     <Compile Include="System\Drawing\Drawing2D\GraphicsContainer.cs" />
+    <Compile Include="System\Drawing\Drawing2D\GraphicsPath.cs" />
     <Compile Include="System\Drawing\Drawing2D\HatchBrush.cs" />
     <Compile Include="System\Drawing\Drawing2D\HatchStyle.cs" />
     <Compile Include="System\Drawing\Drawing2D\InterpolationMode.cs" />

--- a/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);DRAWING_NAMESPACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -31,6 +31,8 @@ Unix support is disabled by default. See https://aka.ms/systemdrawingnonwindows 
     <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
+    <Compile Include="Microsoft\Win32\SafeHandles\SafeBrushHandle.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafeGdiPlusHandle.cs" />
     <Compile Include="System\Drawing\Bitmap.cs" />
     <Compile Include="System\Drawing\BitmapSuffixInSameAssemblyAttribute.cs" />
     <Compile Include="System\Drawing\BitmapSuffixInSatelliteAssemblyAttribute.cs" />

--- a/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -33,6 +33,7 @@ Unix support is disabled by default. See https://aka.ms/systemdrawingnonwindows 
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeBrushHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeGdiPlusHandle.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafeMatrixHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafePenHandle.cs" />
     <Compile Include="System\Drawing\Bitmap.cs" />
     <Compile Include="System\Drawing\BitmapSuffixInSameAssemblyAttribute.cs" />

--- a/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/libraries/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -33,6 +33,7 @@ Unix support is disabled by default. See https://aka.ms/systemdrawingnonwindows 
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeBrushHandle.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeGdiPlusHandle.cs" />
+    <Compile Include="Microsoft\Win32\SafeHandles\SafePenHandle.cs" />
     <Compile Include="System\Drawing\Bitmap.cs" />
     <Compile Include="System\Drawing\BitmapSuffixInSameAssemblyAttribute.cs" />
     <Compile Include="System\Drawing\BitmapSuffixInSatelliteAssemblyAttribute.cs" />
@@ -43,6 +44,7 @@ Unix support is disabled by default. See https://aka.ms/systemdrawingnonwindows 
     <Compile Include="System\Drawing\ContentAlignment.cs" />
     <Compile Include="System\Drawing\IDeviceContext.cs" />
     <Compile Include="System\Drawing\GdiplusNative.cs" />
+    <Compile Include="System\Drawing\GdiplusNative.ManualMarshalling.cs" />
     <Compile Include="System\Drawing\Graphics.cs" />
     <Compile Include="System\Drawing\GraphicsUnit.cs" />
     <Compile Include="System\Drawing\IconConverter.cs" />

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Brush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Brush.cs
@@ -1,16 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading;
 using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
+using System.Threading;
 
 namespace System.Drawing
 {
     public abstract class Brush : MarshalByRefObject, ICloneable, IDisposable
     {
-#if FINALIZATION_WATCH
-        private string allocationSite = Graphics.GetAllocationStack();
-#endif
         // Handle to native GDI+ brush object to be used on demand.
         private SafeBrushHandle _nativeBrush = null!;
 
@@ -23,7 +21,8 @@ namespace System.Drawing
             Interlocked.Exchange(ref _nativeBrush, brush)?.SetHandleAsInvalid();
         }
 
-        internal SafeBrushHandle SafeNativeBrush => _nativeBrush;
+        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        internal SafeBrushHandle SafeBrushHandle => _nativeBrush;
 
         protected Brush()
         {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Brush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Brush.cs
@@ -1,11 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Globalization;
-using System.Runtime.InteropServices;
-using Gdip = System.Drawing.SafeNativeMethods.Gdip;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Drawing
 {
@@ -15,53 +12,39 @@ namespace System.Drawing
         private string allocationSite = Graphics.GetAllocationStack();
 #endif
         // Handle to native GDI+ brush object to be used on demand.
-        private IntPtr _nativeBrush;
+        private SafeBrushHandle _nativeBrush = null!;
 
         public abstract object Clone();
 
-        protected internal void SetNativeBrush(IntPtr brush) => SetNativeBrushInternal(brush);
-        internal void SetNativeBrushInternal(IntPtr brush) => _nativeBrush = brush;
+        protected internal void SetNativeBrush(IntPtr brush) => SetNativeBrushInternal(new(brush, true));
 
-        [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-        internal IntPtr NativeBrush => _nativeBrush;
+        internal void SetNativeBrushInternal(SafeBrushHandle brush)
+        {
+            Interlocked.Exchange(ref _nativeBrush, brush)?.SetHandleAsInvalid();
+        }
+
+        internal SafeBrushHandle SafeNativeBrush => _nativeBrush;
+
+        protected Brush()
+        {
+        }
+
+        private protected Brush(SafeBrushHandle nativeBrush)
+        {
+            _nativeBrush = nativeBrush;
+        }
 
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)
         {
-#if FINALIZATION_WATCH
-            if (!disposing && nativeBrush != IntPtr.Zero )
-                Debug.WriteLine("**********************\nDisposed through finalization:\n" + allocationSite);
-#endif
-
-            if (_nativeBrush != IntPtr.Zero)
+            if (disposing && _nativeBrush != null)
             {
-                try
-                {
-#if DEBUG
-                    int status = !Gdip.Initialized ? Gdip.Ok :
-#endif
-                    Gdip.GdipDeleteBrush(new HandleRef(this, _nativeBrush));
-#if DEBUG
-                    Debug.Assert(status == Gdip.Ok, $"GDI+ returned an error status: {status.ToString(CultureInfo.InvariantCulture)}");
-#endif
-                }
-                catch (Exception ex) when (!ClientUtils.IsSecurityOrCriticalException(ex))
-                {
-                    // Catch all non fatal exceptions. This includes exceptions like EntryPointNotFoundException, that is thrown
-                    // on Windows Nano.
-                }
-                finally
-                {
-                    _nativeBrush = IntPtr.Zero;
-                }
+                _nativeBrush.Dispose();
             }
         }
-
-        ~Brush() => Dispose(false);
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/CustomLineCap.cs
@@ -28,8 +28,8 @@ namespace System.Drawing.Drawing2D
         {
             IntPtr nativeLineCap;
             int status = Gdip.GdipCreateCustomLineCap(
-                                new HandleRef(fillPath, (fillPath == null) ? IntPtr.Zero : fillPath._nativePath),
-                                new HandleRef(strokePath, (strokePath == null) ? IntPtr.Zero : strokePath._nativePath),
+                                fillPath?.SafeGraphicsPathHandle,
+                                strokePath?.SafeGraphicsPathHandle,
                                 baseCap, baseInset, out nativeLineCap);
 
             if (status != Gdip.Ok)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
@@ -620,7 +620,7 @@ namespace System.Drawing.Drawing2D
             if (matrix == null)
                 throw new ArgumentNullException(nameof(matrix));
 
-            int status = Gdip.GdipTransformPath(_nativePath, matrix.NativeMatrix);
+            int status = Gdip.GdipTransformPath(_nativePath, matrix.SafeMatrixHandle);
             Gdip.CheckStatus(status);
         }
 
@@ -695,8 +695,7 @@ namespace System.Drawing.Drawing2D
 
         public void Flatten(Matrix? matrix, float flatness)
         {
-            IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.NativeMatrix;
-            int status = Gdip.GdipFlattenPath(_nativePath, m, flatness);
+            int status = Gdip.GdipFlattenPath(new HandleRef(this, _nativePath), matrix?.SafeMatrixHandle, flatness);
 
             Gdip.CheckStatus(status);
         }
@@ -718,7 +717,7 @@ namespace System.Drawing.Drawing2D
             int s = Gdip.GdipGetPathWorldBounds(
                 new HandleRef(this, _nativePath),
                 out retval,
-                new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
+                matrix?.SafeMatrixHandle,
                 pen?.SafePenHandle);
 
             Gdip.CheckStatus(s);
@@ -874,10 +873,13 @@ namespace System.Drawing.Drawing2D
             if (destPoints == null)
                 throw new ArgumentNullException(nameof(destPoints));
 
-            IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.NativeMatrix;
-
-            int s = Gdip.GdipWarpPath(_nativePath, m, destPoints, destPoints.Length,
-                            srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height, warpMode, flatness);
+            int s = Gdip.GdipWarpPath(
+                new HandleRef(this, _nativePath),
+                matrix?.SafeMatrixHandle,
+                destPoints,
+                destPoints.Length,
+                srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
+                warpMode, flatness);
 
             Gdip.CheckStatus(s);
         }
@@ -898,9 +900,8 @@ namespace System.Drawing.Drawing2D
                 throw new ArgumentNullException(nameof(pen));
             if (PointCount == 0)
                 return;
-            IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.NativeMatrix;
 
-            int s = Gdip.GdipWidenPath(_nativePath, pen.SafePenHandle, m, flatness);
+            int s = Gdip.GdipWidenPath(new HandleRef(this, _nativePath), pen.SafePenHandle, matrix?.SafeMatrixHandle, flatness);
             Gdip.CheckStatus(s);
         }
     }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
@@ -714,10 +714,12 @@ namespace System.Drawing.Drawing2D
         public RectangleF GetBounds(Matrix? matrix, Pen? pen)
         {
             RectangleF retval;
-            IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.NativeMatrix;
-            IntPtr p = (pen == null) ? IntPtr.Zero : pen.NativePen;
 
-            int s = Gdip.GdipGetPathWorldBounds(_nativePath, out retval, m, p);
+            int s = Gdip.GdipGetPathWorldBounds(
+                new HandleRef(this, _nativePath),
+                out retval,
+                new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
+                pen?.SafePenHandle);
 
             Gdip.CheckStatus(s);
 
@@ -762,7 +764,7 @@ namespace System.Drawing.Drawing2D
             bool result;
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.NativeGraphics;
 
-            int s = Gdip.GdipIsOutlineVisiblePathPointI(_nativePath, x, y, pen.NativePen, g, out result);
+            int s = Gdip.GdipIsOutlineVisiblePathPointI(_nativePath, x, y, pen.SafePenHandle, g, out result);
             Gdip.CheckStatus(s);
 
             return result;
@@ -776,7 +778,7 @@ namespace System.Drawing.Drawing2D
             bool result;
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.NativeGraphics;
 
-            int s = Gdip.GdipIsOutlineVisiblePathPoint(_nativePath, x, y, pen.NativePen, g, out result);
+            int s = Gdip.GdipIsOutlineVisiblePathPoint(_nativePath, x, y, pen.SafePenHandle, g, out result);
             Gdip.CheckStatus(s);
 
             return result;
@@ -898,7 +900,7 @@ namespace System.Drawing.Drawing2D
                 return;
             IntPtr m = (matrix == null) ? IntPtr.Zero : matrix.NativeMatrix;
 
-            int s = Gdip.GdipWidenPath(_nativePath, pen.NativePen, m, flatness);
+            int s = Gdip.GdipWidenPath(_nativePath, pen.SafePenHandle, m, flatness);
             Gdip.CheckStatus(s);
         }
     }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Unix.cs
@@ -34,23 +34,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
-using System.Runtime.InteropServices;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
 namespace System.Drawing.Drawing2D
 {
-    public sealed class GraphicsPath : MarshalByRefObject, ICloneable, IDisposable
+    public sealed partial class GraphicsPath : MarshalByRefObject, ICloneable, IDisposable
     {
         // 1/4 is the FlatnessDefault as defined in GdiPlusEnums.h
         private const float FlatnessDefault = 1.0f / 4.0f;
-
-        internal IntPtr _nativePath = IntPtr.Zero;
-
-        private GraphicsPath(IntPtr ptr)
-        {
-            _nativePath = ptr;
-        }
 
         public GraphicsPath()
         {
@@ -98,7 +91,7 @@ namespace System.Drawing.Drawing2D
 
         public object Clone()
         {
-            IntPtr clone;
+            SafeGraphicsPathHandle clone;
 
             int status = Gdip.GdipClonePath(_nativePath, out clone);
             Gdip.CheckStatus(status);
@@ -106,35 +99,12 @@ namespace System.Drawing.Drawing2D
             return new GraphicsPath(clone);
         }
 
-        public void Dispose()
-        {
-            Dispose(true);
-            System.GC.SuppressFinalize(this);
-        }
-
-        ~GraphicsPath()
-        {
-            Dispose(false);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            int status;
-            if (_nativePath != IntPtr.Zero)
-            {
-                status = Gdip.GdipDeletePath(new HandleRef(this, _nativePath));
-                Gdip.CheckStatus(status);
-
-                _nativePath = IntPtr.Zero;
-            }
-        }
-
         public FillMode FillMode
         {
             get
             {
                 FillMode mode;
-                int status = Gdip.GdipGetPathFillMode(_nativePath, out mode);
+                int status = Gdip.GdipGetPathFillMode(SafeGraphicsPathHandle, out mode);
                 Gdip.CheckStatus(status);
 
                 return mode;
@@ -144,7 +114,7 @@ namespace System.Drawing.Drawing2D
                 if ((value < FillMode.Alternate) || (value > FillMode.Winding))
                     throw new InvalidEnumArgumentException(nameof(FillMode), (int)value, typeof(FillMode));
 
-                int status = Gdip.GdipSetPathFillMode(_nativePath, value);
+                int status = Gdip.GdipSetPathFillMode(SafeGraphicsPathHandle, value);
                 Gdip.CheckStatus(status);
             }
         }
@@ -154,7 +124,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = Gdip.GdipGetPointCount(_nativePath, out count);
+                int status = Gdip.GdipGetPointCount(SafeGraphicsPathHandle, out count);
                 Gdip.CheckStatus(status);
 
                 PointF[] points = new PointF[count];
@@ -164,10 +134,10 @@ namespace System.Drawing.Drawing2D
                 // anyway that would only mean two unrequired unmanaged calls
                 if (count > 0)
                 {
-                    status = Gdip.GdipGetPathPoints(_nativePath, points, count);
+                    status = Gdip.GdipGetPathPoints(SafeGraphicsPathHandle, points, count);
                     Gdip.CheckStatus(status);
 
-                    status = Gdip.GdipGetPathTypes(_nativePath, types, count);
+                    status = Gdip.GdipGetPathTypes(SafeGraphicsPathHandle, types, count);
                     Gdip.CheckStatus(status);
                 }
 
@@ -183,13 +153,13 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = Gdip.GdipGetPointCount(_nativePath, out count);
+                int status = Gdip.GdipGetPointCount(SafeGraphicsPathHandle, out count);
                 Gdip.CheckStatus(status);
                 if (count == 0)
                     throw new ArgumentException("PathPoints");
 
                 PointF[] points = new PointF[count];
-                status = Gdip.GdipGetPathPoints(_nativePath, points, count);
+                status = Gdip.GdipGetPathPoints(SafeGraphicsPathHandle, points, count);
                 Gdip.CheckStatus(status);
 
                 return points;
@@ -201,13 +171,13 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = Gdip.GdipGetPointCount(_nativePath, out count);
+                int status = Gdip.GdipGetPointCount(SafeGraphicsPathHandle, out count);
                 Gdip.CheckStatus(status);
                 if (count == 0)
                     throw new ArgumentException("PathTypes");
 
                 byte[] types = new byte[count];
-                status = Gdip.GdipGetPathTypes(_nativePath, types, count);
+                status = Gdip.GdipGetPathTypes(SafeGraphicsPathHandle, types, count);
                 Gdip.CheckStatus(status);
 
                 return types;
@@ -219,22 +189,10 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int count;
-                int status = Gdip.GdipGetPointCount(_nativePath, out count);
+                int status = Gdip.GdipGetPointCount(SafeGraphicsPathHandle, out count);
                 Gdip.CheckStatus(status);
 
                 return count;
-            }
-        }
-
-        internal IntPtr NativeObject
-        {
-            get
-            {
-                return _nativePath;
-            }
-            set
-            {
-                _nativePath = value;
             }
         }
 
@@ -243,25 +201,25 @@ namespace System.Drawing.Drawing2D
         //
         public void AddArc(Rectangle rect, float startAngle, float sweepAngle)
         {
-            int status = Gdip.GdipAddPathArcI(_nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
+            int status = Gdip.GdipAddPathArcI(SafeGraphicsPathHandle, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
             Gdip.CheckStatus(status);
         }
 
         public void AddArc(RectangleF rect, float startAngle, float sweepAngle)
         {
-            int status = Gdip.GdipAddPathArc(_nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
+            int status = Gdip.GdipAddPathArc(SafeGraphicsPathHandle, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
             Gdip.CheckStatus(status);
         }
 
         public void AddArc(int x, int y, int width, int height, float startAngle, float sweepAngle)
         {
-            int status = Gdip.GdipAddPathArcI(_nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = Gdip.GdipAddPathArcI(SafeGraphicsPathHandle, x, y, width, height, startAngle, sweepAngle);
             Gdip.CheckStatus(status);
         }
 
         public void AddArc(float x, float y, float width, float height, float startAngle, float sweepAngle)
         {
-            int status = Gdip.GdipAddPathArc(_nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = Gdip.GdipAddPathArc(SafeGraphicsPathHandle, x, y, width, height, startAngle, sweepAngle);
             Gdip.CheckStatus(status);
         }
 
@@ -270,7 +228,7 @@ namespace System.Drawing.Drawing2D
         //
         public void AddBezier(Point pt1, Point pt2, Point pt3, Point pt4)
         {
-            int status = Gdip.GdipAddPathBezierI(_nativePath, pt1.X, pt1.Y,
+            int status = Gdip.GdipAddPathBezierI(SafeGraphicsPathHandle, pt1.X, pt1.Y,
                             pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
 
             Gdip.CheckStatus(status);
@@ -278,7 +236,7 @@ namespace System.Drawing.Drawing2D
 
         public void AddBezier(PointF pt1, PointF pt2, PointF pt3, PointF pt4)
         {
-            int status = Gdip.GdipAddPathBezier(_nativePath, pt1.X, pt1.Y,
+            int status = Gdip.GdipAddPathBezier(SafeGraphicsPathHandle, pt1.X, pt1.Y,
                             pt2.X, pt2.Y, pt3.X, pt3.Y, pt4.X, pt4.Y);
 
             Gdip.CheckStatus(status);
@@ -286,13 +244,13 @@ namespace System.Drawing.Drawing2D
 
         public void AddBezier(int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4)
         {
-            int status = Gdip.GdipAddPathBezierI(_nativePath, x1, y1, x2, y2, x3, y3, x4, y4);
+            int status = Gdip.GdipAddPathBezierI(SafeGraphicsPathHandle, x1, y1, x2, y2, x3, y3, x4, y4);
             Gdip.CheckStatus(status);
         }
 
         public void AddBezier(float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4)
         {
-            int status = Gdip.GdipAddPathBezier(_nativePath, x1, y1, x2, y2, x3, y3, x4, y4);
+            int status = Gdip.GdipAddPathBezier(SafeGraphicsPathHandle, x1, y1, x2, y2, x3, y3, x4, y4);
             Gdip.CheckStatus(status);
         }
 
@@ -303,7 +261,7 @@ namespace System.Drawing.Drawing2D
         {
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
-            int status = Gdip.GdipAddPathBeziersI(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathBeziersI(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -311,7 +269,7 @@ namespace System.Drawing.Drawing2D
         {
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
-            int status = Gdip.GdipAddPathBeziers(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathBeziers(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -320,25 +278,25 @@ namespace System.Drawing.Drawing2D
         //
         public void AddEllipse(RectangleF rect)
         {
-            int status = Gdip.GdipAddPathEllipse(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = Gdip.GdipAddPathEllipse(SafeGraphicsPathHandle, rect.X, rect.Y, rect.Width, rect.Height);
             Gdip.CheckStatus(status);
         }
 
         public void AddEllipse(float x, float y, float width, float height)
         {
-            int status = Gdip.GdipAddPathEllipse(_nativePath, x, y, width, height);
+            int status = Gdip.GdipAddPathEllipse(SafeGraphicsPathHandle, x, y, width, height);
             Gdip.CheckStatus(status);
         }
 
         public void AddEllipse(Rectangle rect)
         {
-            int status = Gdip.GdipAddPathEllipseI(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = Gdip.GdipAddPathEllipseI(SafeGraphicsPathHandle, rect.X, rect.Y, rect.Width, rect.Height);
             Gdip.CheckStatus(status);
         }
 
         public void AddEllipse(int x, int y, int width, int height)
         {
-            int status = Gdip.GdipAddPathEllipseI(_nativePath, x, y, width, height);
+            int status = Gdip.GdipAddPathEllipseI(SafeGraphicsPathHandle, x, y, width, height);
             Gdip.CheckStatus(status);
         }
 
@@ -348,13 +306,13 @@ namespace System.Drawing.Drawing2D
         //
         public void AddLine(Point pt1, Point pt2)
         {
-            int status = Gdip.GdipAddPathLineI(_nativePath, pt1.X, pt1.Y, pt2.X, pt2.Y);
+            int status = Gdip.GdipAddPathLineI(SafeGraphicsPathHandle, pt1.X, pt1.Y, pt2.X, pt2.Y);
             Gdip.CheckStatus(status);
         }
 
         public void AddLine(PointF pt1, PointF pt2)
         {
-            int status = Gdip.GdipAddPathLine(_nativePath, pt1.X, pt1.Y, pt2.X,
+            int status = Gdip.GdipAddPathLine(SafeGraphicsPathHandle, pt1.X, pt1.Y, pt2.X,
                             pt2.Y);
 
             Gdip.CheckStatus(status);
@@ -362,13 +320,13 @@ namespace System.Drawing.Drawing2D
 
         public void AddLine(int x1, int y1, int x2, int y2)
         {
-            int status = Gdip.GdipAddPathLineI(_nativePath, x1, y1, x2, y2);
+            int status = Gdip.GdipAddPathLineI(SafeGraphicsPathHandle, x1, y1, x2, y2);
             Gdip.CheckStatus(status);
         }
 
         public void AddLine(float x1, float y1, float x2, float y2)
         {
-            int status = Gdip.GdipAddPathLine(_nativePath, x1, y1, x2,
+            int status = Gdip.GdipAddPathLine(SafeGraphicsPathHandle, x1, y1, x2,
                             y2);
 
             Gdip.CheckStatus(status);
@@ -384,7 +342,7 @@ namespace System.Drawing.Drawing2D
             if (points.Length == 0)
                 throw new ArgumentException(null, nameof(points));
 
-            int status = Gdip.GdipAddPathLine2I(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathLine2I(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -395,7 +353,7 @@ namespace System.Drawing.Drawing2D
             if (points.Length == 0)
                 throw new ArgumentException(null, nameof(points));
 
-            int status = Gdip.GdipAddPathLine2(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathLine2(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -405,19 +363,19 @@ namespace System.Drawing.Drawing2D
         public void AddPie(Rectangle rect, float startAngle, float sweepAngle)
         {
             int status = Gdip.GdipAddPathPie(
-                    _nativePath, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
+                    SafeGraphicsPathHandle, rect.X, rect.Y, rect.Width, rect.Height, startAngle, sweepAngle);
             Gdip.CheckStatus(status);
         }
 
         public void AddPie(int x, int y, int width, int height, float startAngle, float sweepAngle)
         {
-            int status = Gdip.GdipAddPathPieI(_nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = Gdip.GdipAddPathPieI(SafeGraphicsPathHandle, x, y, width, height, startAngle, sweepAngle);
             Gdip.CheckStatus(status);
         }
 
         public void AddPie(float x, float y, float width, float height, float startAngle, float sweepAngle)
         {
-            int status = Gdip.GdipAddPathPie(_nativePath, x, y, width, height, startAngle, sweepAngle);
+            int status = Gdip.GdipAddPathPie(SafeGraphicsPathHandle, x, y, width, height, startAngle, sweepAngle);
             Gdip.CheckStatus(status);
         }
 
@@ -429,7 +387,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathPolygonI(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathPolygonI(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -438,7 +396,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathPolygon(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathPolygon(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -447,13 +405,13 @@ namespace System.Drawing.Drawing2D
         //
         public void AddRectangle(Rectangle rect)
         {
-            int status = Gdip.GdipAddPathRectangleI(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = Gdip.GdipAddPathRectangleI(SafeGraphicsPathHandle, rect.X, rect.Y, rect.Width, rect.Height);
             Gdip.CheckStatus(status);
         }
 
         public void AddRectangle(RectangleF rect)
         {
-            int status = Gdip.GdipAddPathRectangle(_nativePath, rect.X, rect.Y, rect.Width, rect.Height);
+            int status = Gdip.GdipAddPathRectangle(SafeGraphicsPathHandle, rect.X, rect.Y, rect.Width, rect.Height);
             Gdip.CheckStatus(status);
         }
 
@@ -467,7 +425,7 @@ namespace System.Drawing.Drawing2D
             if (rects.Length == 0)
                 throw new ArgumentException(null, nameof(rects));
 
-            int status = Gdip.GdipAddPathRectanglesI(_nativePath, rects, rects.Length);
+            int status = Gdip.GdipAddPathRectanglesI(SafeGraphicsPathHandle, rects, rects.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -478,7 +436,7 @@ namespace System.Drawing.Drawing2D
             if (rects.Length == 0)
                 throw new ArgumentException(null, nameof(rects));
 
-            int status = Gdip.GdipAddPathRectangles(_nativePath, rects, rects.Length);
+            int status = Gdip.GdipAddPathRectangles(SafeGraphicsPathHandle, rects, rects.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -490,14 +448,14 @@ namespace System.Drawing.Drawing2D
             if (addingPath == null)
                 throw new ArgumentNullException(nameof(addingPath));
 
-            int status = Gdip.GdipAddPathPath(_nativePath, addingPath._nativePath, connect);
+            int status = Gdip.GdipAddPathPath(SafeGraphicsPathHandle, addingPath.SafeGraphicsPathHandle, connect);
             Gdip.CheckStatus(status);
         }
 
         public PointF GetLastPoint()
         {
             PointF pt;
-            int status = Gdip.GdipGetPathLastPoint(_nativePath, out pt);
+            int status = Gdip.GdipGetPathLastPoint(SafeGraphicsPathHandle, out pt);
             Gdip.CheckStatus(status);
 
             return pt;
@@ -511,7 +469,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathClosedCurveI(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathClosedCurveI(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -520,7 +478,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathClosedCurve(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathClosedCurve(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -529,7 +487,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathClosedCurve2I(_nativePath, points, points.Length, tension);
+            int status = Gdip.GdipAddPathClosedCurve2I(SafeGraphicsPathHandle, points, points.Length, tension);
             Gdip.CheckStatus(status);
         }
 
@@ -538,7 +496,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathClosedCurve2(_nativePath, points, points.Length, tension);
+            int status = Gdip.GdipAddPathClosedCurve2(SafeGraphicsPathHandle, points, points.Length, tension);
             Gdip.CheckStatus(status);
         }
 
@@ -550,7 +508,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathCurveI(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathCurveI(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -559,7 +517,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathCurve(_nativePath, points, points.Length);
+            int status = Gdip.GdipAddPathCurve(SafeGraphicsPathHandle, points, points.Length);
             Gdip.CheckStatus(status);
         }
 
@@ -568,7 +526,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathCurve2I(_nativePath, points, points.Length, tension);
+            int status = Gdip.GdipAddPathCurve2I(SafeGraphicsPathHandle, points, points.Length, tension);
             Gdip.CheckStatus(status);
         }
 
@@ -577,7 +535,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathCurve2(_nativePath, points, points.Length, tension);
+            int status = Gdip.GdipAddPathCurve2(SafeGraphicsPathHandle, points, points.Length, tension);
             Gdip.CheckStatus(status);
         }
 
@@ -586,7 +544,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathCurve3I(_nativePath, points, points.Length,
+            int status = Gdip.GdipAddPathCurve3I(SafeGraphicsPathHandle, points, points.Length,
                             offset, numberOfSegments, tension);
 
             Gdip.CheckStatus(status);
@@ -597,7 +555,7 @@ namespace System.Drawing.Drawing2D
             if (points == null)
                 throw new ArgumentNullException(nameof(points));
 
-            int status = Gdip.GdipAddPathCurve3(_nativePath, points, points.Length,
+            int status = Gdip.GdipAddPathCurve3(SafeGraphicsPathHandle, points, points.Length,
                             offset, numberOfSegments, tension);
 
             Gdip.CheckStatus(status);
@@ -605,13 +563,13 @@ namespace System.Drawing.Drawing2D
 
         public void Reset()
         {
-            int status = Gdip.GdipResetPath(_nativePath);
+            int status = Gdip.GdipResetPath(SafeGraphicsPathHandle);
             Gdip.CheckStatus(status);
         }
 
         public void Reverse()
         {
-            int status = Gdip.GdipReversePath(_nativePath);
+            int status = Gdip.GdipReversePath(SafeGraphicsPathHandle);
             Gdip.CheckStatus(status);
         }
 
@@ -620,7 +578,7 @@ namespace System.Drawing.Drawing2D
             if (matrix == null)
                 throw new ArgumentNullException(nameof(matrix));
 
-            int status = Gdip.GdipTransformPath(_nativePath, matrix.SafeMatrixHandle);
+            int status = Gdip.GdipTransformPath(SafeGraphicsPathHandle, matrix.SafeMatrixHandle);
             Gdip.CheckStatus(status);
         }
 
@@ -647,7 +605,7 @@ namespace System.Drawing.Drawing2D
 
             IntPtr sformat = (format == null) ? IntPtr.Zero : format.nativeFormat;
             // note: the NullReferenceException on s.Length is the expected (MS) exception
-            int status = Gdip.GdipAddPathStringI(_nativePath, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
+            int status = Gdip.GdipAddPathStringI(SafeGraphicsPathHandle, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
             Gdip.CheckStatus(status);
         }
 
@@ -658,27 +616,27 @@ namespace System.Drawing.Drawing2D
 
             IntPtr sformat = (format == null) ? IntPtr.Zero : format.nativeFormat;
             // note: the NullReferenceException on s.Length is the expected (MS) exception
-            int status = Gdip.GdipAddPathString(_nativePath, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
+            int status = Gdip.GdipAddPathString(SafeGraphicsPathHandle, s, s.Length, family.NativeFamily, style, emSize, ref layoutRect, sformat);
             Gdip.CheckStatus(status);
         }
 
         public void ClearMarkers()
         {
-            int s = Gdip.GdipClearPathMarkers(_nativePath);
+            int s = Gdip.GdipClearPathMarkers(SafeGraphicsPathHandle);
 
             Gdip.CheckStatus(s);
         }
 
         public void CloseAllFigures()
         {
-            int s = Gdip.GdipClosePathFigures(_nativePath);
+            int s = Gdip.GdipClosePathFigures(SafeGraphicsPathHandle);
 
             Gdip.CheckStatus(s);
         }
 
         public void CloseFigure()
         {
-            int s = Gdip.GdipClosePathFigure(_nativePath);
+            int s = Gdip.GdipClosePathFigure(SafeGraphicsPathHandle);
 
             Gdip.CheckStatus(s);
         }
@@ -695,7 +653,7 @@ namespace System.Drawing.Drawing2D
 
         public void Flatten(Matrix? matrix, float flatness)
         {
-            int status = Gdip.GdipFlattenPath(new HandleRef(this, _nativePath), matrix?.SafeMatrixHandle, flatness);
+            int status = Gdip.GdipFlattenPath(SafeGraphicsPathHandle, matrix?.SafeMatrixHandle, flatness);
 
             Gdip.CheckStatus(status);
         }
@@ -715,7 +673,7 @@ namespace System.Drawing.Drawing2D
             RectangleF retval;
 
             int s = Gdip.GdipGetPathWorldBounds(
-                new HandleRef(this, _nativePath),
+                SafeGraphicsPathHandle,
                 out retval,
                 matrix?.SafeMatrixHandle,
                 pen?.SafePenHandle);
@@ -763,7 +721,7 @@ namespace System.Drawing.Drawing2D
             bool result;
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.NativeGraphics;
 
-            int s = Gdip.GdipIsOutlineVisiblePathPointI(_nativePath, x, y, pen.SafePenHandle, g, out result);
+            int s = Gdip.GdipIsOutlineVisiblePathPointI(SafeGraphicsPathHandle, x, y, pen.SafePenHandle, g, out result);
             Gdip.CheckStatus(s);
 
             return result;
@@ -777,7 +735,7 @@ namespace System.Drawing.Drawing2D
             bool result;
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.NativeGraphics;
 
-            int s = Gdip.GdipIsOutlineVisiblePathPoint(_nativePath, x, y, pen.SafePenHandle, g, out result);
+            int s = Gdip.GdipIsOutlineVisiblePathPoint(SafeGraphicsPathHandle, x, y, pen.SafePenHandle, g, out result);
             Gdip.CheckStatus(s);
 
             return result;
@@ -819,7 +777,7 @@ namespace System.Drawing.Drawing2D
 
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.NativeGraphics;
 
-            int s = Gdip.GdipIsVisiblePathPointI(_nativePath, x, y, g, out retval);
+            int s = Gdip.GdipIsVisiblePathPointI(SafeGraphicsPathHandle, x, y, g, out retval);
 
             Gdip.CheckStatus(s);
 
@@ -832,7 +790,7 @@ namespace System.Drawing.Drawing2D
 
             IntPtr g = (graphics == null) ? IntPtr.Zero : graphics.NativeGraphics;
 
-            int s = Gdip.GdipIsVisiblePathPoint(_nativePath, x, y, g, out retval);
+            int s = Gdip.GdipIsVisiblePathPoint(SafeGraphicsPathHandle, x, y, g, out retval);
 
             Gdip.CheckStatus(s);
 
@@ -841,14 +799,14 @@ namespace System.Drawing.Drawing2D
 
         public void SetMarkers()
         {
-            int s = Gdip.GdipSetPathMarker(_nativePath);
+            int s = Gdip.GdipSetPathMarker(SafeGraphicsPathHandle);
 
             Gdip.CheckStatus(s);
         }
 
         public void StartFigure()
         {
-            int s = Gdip.GdipStartPathFigure(_nativePath);
+            int s = Gdip.GdipStartPathFigure(SafeGraphicsPathHandle);
 
             Gdip.CheckStatus(s);
         }
@@ -874,7 +832,7 @@ namespace System.Drawing.Drawing2D
                 throw new ArgumentNullException(nameof(destPoints));
 
             int s = Gdip.GdipWarpPath(
-                new HandleRef(this, _nativePath),
+                SafeGraphicsPathHandle,
                 matrix?.SafeMatrixHandle,
                 destPoints,
                 destPoints.Length,
@@ -901,7 +859,7 @@ namespace System.Drawing.Drawing2D
             if (PointCount == 0)
                 return;
 
-            int s = Gdip.GdipWidenPath(new HandleRef(this, _nativePath), pen.SafePenHandle, matrix?.SafeMatrixHandle, flatness);
+            int s = Gdip.GdipWidenPath(SafeGraphicsPathHandle, pen.SafePenHandle, matrix?.SafeMatrixHandle, flatness);
             Gdip.CheckStatus(s);
         }
     }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Windows.cs
@@ -254,7 +254,7 @@ namespace System.Drawing.Drawing2D
             Gdip.CheckStatus(Gdip.GdipIsOutlineVisiblePathPoint(
                 new HandleRef(this, _nativePath),
                 pt.X, pt.Y,
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 new HandleRef(graphics, graphics?.NativeGraphics ?? IntPtr.Zero),
                 out bool isVisible));
 
@@ -275,7 +275,7 @@ namespace System.Drawing.Drawing2D
             Gdip.CheckStatus(Gdip.GdipIsOutlineVisiblePathPointI(
                 new HandleRef(this, _nativePath),
                 pt.X, pt.Y,
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 new HandleRef(graphics, graphics?.NativeGraphics ?? IntPtr.Zero),
                 out bool isVisible));
 
@@ -688,7 +688,7 @@ namespace System.Drawing.Drawing2D
                 new HandleRef(matrix, matrix.NativeMatrix)));
         }
 
-        public RectangleF GetBounds() => GetBounds(null);
+        public RectangleF GetBounds() => GetBounds(null, null);
 
         public RectangleF GetBounds(Matrix? matrix) => GetBounds(matrix, null);
 
@@ -698,7 +698,7 @@ namespace System.Drawing.Drawing2D
                 new HandleRef(this, _nativePath),
                 out RectangleF bounds,
                 new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
-                new HandleRef(pen, pen?.NativePen ?? IntPtr.Zero)));
+                pen?.SafePenHandle));
 
             return bounds;
         }
@@ -731,7 +731,7 @@ namespace System.Drawing.Drawing2D
 
             Gdip.CheckStatus(Gdip.GdipWidenPath(
                 new HandleRef(this, _nativePath),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
                 flatness));
         }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.Windows.cs
@@ -680,12 +680,12 @@ namespace System.Drawing.Drawing2D
         {
             if (matrix == null)
                 throw new ArgumentNullException(nameof(matrix));
-            if (matrix.NativeMatrix == IntPtr.Zero)
+            if (matrix.SafeMatrixHandle.IsClosed)
                 return;
 
             Gdip.CheckStatus(Gdip.GdipTransformPath(
                 new HandleRef(this, _nativePath),
-                new HandleRef(matrix, matrix.NativeMatrix)));
+                matrix.SafeMatrixHandle));
         }
 
         public RectangleF GetBounds() => GetBounds(null, null);
@@ -697,7 +697,7 @@ namespace System.Drawing.Drawing2D
             Gdip.CheckStatus(Gdip.GdipGetPathWorldBounds(
                 new HandleRef(this, _nativePath),
                 out RectangleF bounds,
-                new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
+                matrix?.SafeMatrixHandle,
                 pen?.SafePenHandle));
 
             return bounds;
@@ -711,7 +711,7 @@ namespace System.Drawing.Drawing2D
         {
             Gdip.CheckStatus(Gdip.GdipFlattenPath(
                 new HandleRef(this, _nativePath),
-                new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
+                matrix?.SafeMatrixHandle,
                 flatness));
         }
 
@@ -732,7 +732,7 @@ namespace System.Drawing.Drawing2D
             Gdip.CheckStatus(Gdip.GdipWidenPath(
                 new HandleRef(this, _nativePath),
                 pen.SafePenHandle,
-                new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
+                matrix?.SafeMatrixHandle,
                 flatness));
         }
 
@@ -745,22 +745,19 @@ namespace System.Drawing.Drawing2D
             Warp(destPoints, srcRect, matrix, warpMode, 0.25f);
         }
 
-        public unsafe void Warp(PointF[] destPoints, RectangleF srcRect, Matrix? matrix, WarpMode warpMode, float flatness)
+        public void Warp(PointF[] destPoints, RectangleF srcRect, Matrix? matrix, WarpMode warpMode, float flatness)
         {
             if (destPoints == null)
                 throw new ArgumentNullException(nameof(destPoints));
 
-            fixed (PointF* p = destPoints)
-            {
-                Gdip.CheckStatus(Gdip.GdipWarpPath(
-                    new HandleRef(this, _nativePath),
-                    new HandleRef(matrix, matrix?.NativeMatrix ?? IntPtr.Zero),
-                    p,
-                    destPoints.Length,
-                    srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
-                    warpMode,
-                    flatness));
-            }
+            Gdip.CheckStatus(Gdip.GdipWarpPath(
+                new HandleRef(this, _nativePath),
+                matrix?.SafeMatrixHandle,
+                destPoints,
+                destPoints.Length,
+                srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
+                warpMode,
+                flatness));
         }
 
         public int PointCount

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Drawing.Drawing2D
+{
+    public partial class GraphicsPath
+    {
+        private readonly SafeGraphicsPathHandle _nativePath;
+
+        internal SafeGraphicsPathHandle SafeGraphicsPathHandle => _nativePath;
+
+        private GraphicsPath(SafeGraphicsPathHandle nativePath)
+        {
+            _nativePath = nativePath;
+        }
+
+        public void Dispose()
+        {
+            _nativePath.Dispose();
+        }
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPathIterator.cs
@@ -13,7 +13,7 @@ namespace System.Drawing.Drawing2D
         public GraphicsPathIterator(GraphicsPath? path)
         {
             IntPtr nativeIter = IntPtr.Zero;
-            int status = Gdip.GdipCreatePathIter(out nativeIter, new HandleRef(path, (path == null) ? IntPtr.Zero : path._nativePath));
+            int status = Gdip.GdipCreatePathIter(out nativeIter, path?.SafeGraphicsPathHandle);
 
             if (status != Gdip.Ok)
                 throw Gdip.StatusException(status);
@@ -78,7 +78,7 @@ namespace System.Drawing.Drawing2D
         public int NextSubpath(GraphicsPath path, out bool isClosed)
         {
             int status = Gdip.GdipPathIterNextSubpathPath(new HandleRef(this, nativeIter), out int resultCount,
-                        new HandleRef(path, (path == null) ? IntPtr.Zero : path._nativePath), out isClosed);
+                        path?.SafeGraphicsPathHandle, out isClosed);
 
             if (status != Gdip.Ok)
                 throw Gdip.StatusException(status);
@@ -111,7 +111,7 @@ namespace System.Drawing.Drawing2D
         public int NextMarker(GraphicsPath path)
         {
             int status = Gdip.GdipPathIterNextMarkerPath(new HandleRef(this, nativeIter), out int resultCount,
-                        new HandleRef(path, (path == null) ? IntPtr.Zero : path._nativePath));
+                        path?.SafeGraphicsPathHandle);
 
             if (status != Gdip.Ok)
                 throw Gdip.StatusException(status);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/HatchBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/HatchBrush.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
-using System.Diagnostics;
+using Microsoft.Win32.SafeHandles;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
 namespace System.Drawing.Drawing2D
@@ -20,23 +19,21 @@ namespace System.Drawing.Drawing2D
                 throw new ArgumentException(SR.Format(SR.InvalidEnumArgument, nameof(hatchstyle), hatchstyle, nameof(HatchStyle)), nameof(hatchstyle));
             }
 
-            IntPtr nativeBrush;
+            SafeBrushHandle nativeBrush;
             int status = Gdip.GdipCreateHatchBrush(unchecked((int)hatchstyle), foreColor.ToArgb(), backColor.ToArgb(), out nativeBrush);
             Gdip.CheckStatus(status);
 
             SetNativeBrushInternal(nativeBrush);
         }
 
-        internal HatchBrush(IntPtr nativeBrush)
+        internal HatchBrush(SafeBrushHandle nativeBrush) : base(nativeBrush)
         {
-            Debug.Assert(nativeBrush != IntPtr.Zero, "Initializing native brush with null.");
-            SetNativeBrushInternal(nativeBrush);
         }
 
         public override object Clone()
         {
-            IntPtr clonedBrush = IntPtr.Zero;
-            int status = Gdip.GdipCloneBrush(new HandleRef(this, NativeBrush), out clonedBrush);
+            SafeBrushHandle clonedBrush;
+            int status = Gdip.GdipCloneBrush(SafeNativeBrush, out clonedBrush);
             Gdip.CheckStatus(status);
 
             return new HatchBrush(clonedBrush);
@@ -47,7 +44,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int hatchStyle;
-                int status = Gdip.GdipGetHatchStyle(new HandleRef(this, NativeBrush), out hatchStyle);
+                int status = Gdip.GdipGetHatchStyle(SafeNativeBrush, out hatchStyle);
                 Gdip.CheckStatus(status);
 
                 return (HatchStyle)hatchStyle;
@@ -59,7 +56,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int foregroundArgb;
-                int status = Gdip.GdipGetHatchForegroundColor(new HandleRef(this, NativeBrush), out foregroundArgb);
+                int status = Gdip.GdipGetHatchForegroundColor(SafeNativeBrush, out foregroundArgb);
                 Gdip.CheckStatus(status);
 
                 return Color.FromArgb(foregroundArgb);
@@ -71,7 +68,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int backgroundArgb;
-                int status = Gdip.GdipGetHatchBackgroundColor(new HandleRef(this, NativeBrush), out backgroundArgb);
+                int status = Gdip.GdipGetHatchBackgroundColor(SafeNativeBrush, out backgroundArgb);
                 Gdip.CheckStatus(status);
 
                 return Color.FromArgb(backgroundArgb);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/HatchBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/HatchBrush.cs
@@ -33,7 +33,7 @@ namespace System.Drawing.Drawing2D
         public override object Clone()
         {
             SafeBrushHandle clonedBrush;
-            int status = Gdip.GdipCloneBrush(SafeNativeBrush, out clonedBrush);
+            int status = Gdip.GdipCloneBrush(SafeBrushHandle, out clonedBrush);
             Gdip.CheckStatus(status);
 
             return new HatchBrush(clonedBrush);
@@ -44,7 +44,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int hatchStyle;
-                int status = Gdip.GdipGetHatchStyle(SafeNativeBrush, out hatchStyle);
+                int status = Gdip.GdipGetHatchStyle(SafeBrushHandle, out hatchStyle);
                 Gdip.CheckStatus(status);
 
                 return (HatchStyle)hatchStyle;
@@ -56,7 +56,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int foregroundArgb;
-                int status = Gdip.GdipGetHatchForegroundColor(SafeNativeBrush, out foregroundArgb);
+                int status = Gdip.GdipGetHatchForegroundColor(SafeBrushHandle, out foregroundArgb);
                 Gdip.CheckStatus(status);
 
                 return Color.FromArgb(foregroundArgb);
@@ -68,7 +68,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int backgroundArgb;
-                int status = Gdip.GdipGetHatchBackgroundColor(SafeNativeBrush, out backgroundArgb);
+                int status = Gdip.GdipGetHatchBackgroundColor(SafeBrushHandle, out backgroundArgb);
                 Gdip.CheckStatus(status);
 
                 return Color.FromArgb(backgroundArgb);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
@@ -119,7 +119,7 @@ namespace System.Drawing.Drawing2D
 
         public override object Clone()
         {
-            Gdip.CheckStatus(Gdip.GdipCloneBrush(SafeNativeBrush, out SafeBrushHandle clonedBrush));
+            Gdip.CheckStatus(Gdip.GdipCloneBrush(SafeBrushHandle, out SafeBrushHandle clonedBrush));
             return new LinearGradientBrush(clonedBrush);
         }
 
@@ -128,7 +128,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int[] colors = new int[] { 0, 0 };
-                Gdip.CheckStatus(Gdip.GdipGetLineColors(SafeNativeBrush, colors));
+                Gdip.CheckStatus(Gdip.GdipGetLineColors(SafeBrushHandle, colors));
 
                 return new Color[]
                 {
@@ -139,7 +139,7 @@ namespace System.Drawing.Drawing2D
             set
             {
                 Gdip.CheckStatus(Gdip.GdipSetLineColors(
-                    SafeNativeBrush,
+                    SafeBrushHandle,
                     value[0].ToArgb(),
                     value[1].ToArgb()));
             }
@@ -149,7 +149,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetLineRect(SafeNativeBrush, out RectangleF rect));
+                Gdip.CheckStatus(Gdip.GdipGetLineRect(SafeBrushHandle, out RectangleF rect));
                 return rect;
             }
         }
@@ -159,14 +159,14 @@ namespace System.Drawing.Drawing2D
             get
             {
                 Gdip.CheckStatus(Gdip.GdipGetLineGammaCorrection(
-                    SafeNativeBrush,
+                    SafeBrushHandle,
                     out bool useGammaCorrection));
 
                 return useGammaCorrection;
             }
             set
             {
-                Gdip.CheckStatus(Gdip.GdipSetLineGammaCorrection(SafeNativeBrush, value));
+                Gdip.CheckStatus(Gdip.GdipSetLineGammaCorrection(SafeBrushHandle, value));
             }
         }
 
@@ -181,7 +181,7 @@ namespace System.Drawing.Drawing2D
                     return null;
 
                 // Figure out the size of blend factor array.
-                Gdip.CheckStatus(Gdip.GdipGetLineBlendCount(SafeNativeBrush, out int retval));
+                Gdip.CheckStatus(Gdip.GdipGetLineBlendCount(SafeBrushHandle, out int retval));
 
                 if (retval <= 0)
                     return null;
@@ -198,7 +198,7 @@ namespace System.Drawing.Drawing2D
                     positions = Marshal.AllocHGlobal(size);
 
                     // Retrieve horizontal blend factors.
-                    Gdip.CheckStatus(Gdip.GdipGetLineBlend(SafeNativeBrush, factors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipGetLineBlend(SafeBrushHandle, factors, positions, count));
 
                     // Return the result in a managed array.
                     var blend = new Blend(count);
@@ -256,7 +256,7 @@ namespace System.Drawing.Drawing2D
                     Marshal.Copy(value.Positions, 0, positions, count);
 
                     // Set blend factors.
-                    Gdip.CheckStatus(Gdip.GdipSetLineBlend(SafeNativeBrush, factors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipSetLineBlend(SafeBrushHandle, factors, positions, count));
                 }
                 finally
                 {
@@ -281,7 +281,7 @@ namespace System.Drawing.Drawing2D
             if (scale < 0 || scale > 1)
                 throw new ArgumentException(SR.GdiplusInvalidParameter, nameof(scale));
 
-            Gdip.CheckStatus(Gdip.GdipSetLineSigmaBlend(SafeNativeBrush, focus, scale));
+            Gdip.CheckStatus(Gdip.GdipSetLineSigmaBlend(SafeBrushHandle, focus, scale));
         }
 
         public void SetBlendTriangularShape(float focus) => SetBlendTriangularShape(focus, (float)1.0);
@@ -293,7 +293,7 @@ namespace System.Drawing.Drawing2D
             if (scale < 0 || scale > 1)
                 throw new ArgumentException(SR.GdiplusInvalidParameter, nameof(scale));
 
-            Gdip.CheckStatus(Gdip.GdipSetLineLinearBlend(SafeNativeBrush, focus, scale));
+            Gdip.CheckStatus(Gdip.GdipSetLineLinearBlend(SafeBrushHandle, focus, scale));
 
             // Setting a triangular shape overrides the explicitly set interpolation colors. libgdiplus correctly clears
             // the interpolation colors (https://github.com/mono/libgdiplus/blob/master/src/lineargradientbrush.c#L959) but
@@ -312,7 +312,7 @@ namespace System.Drawing.Drawing2D
                                                 SR.InterpolationColorsColorBlendNotSet, string.Empty));
 
                 // Figure out the size of blend factor array.
-                Gdip.CheckStatus(Gdip.GdipGetLinePresetBlendCount(SafeNativeBrush, out int retval));
+                Gdip.CheckStatus(Gdip.GdipGetLinePresetBlendCount(SafeBrushHandle, out int retval));
 
                 // Allocate temporary native memory buffer.
                 int count = retval;
@@ -327,7 +327,7 @@ namespace System.Drawing.Drawing2D
                     positions = Marshal.AllocHGlobal(size);
 
                     // Retrieve horizontal blend factors.
-                    Gdip.CheckStatus(Gdip.GdipGetLinePresetBlend(SafeNativeBrush, colors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipGetLinePresetBlend(SafeBrushHandle, colors, positions, count));
 
                     // Return the result in a managed array.
                     var blend = new ColorBlend(count);
@@ -414,7 +414,7 @@ namespace System.Drawing.Drawing2D
                     Marshal.Copy(value.Positions, 0, positions, count);
 
                     // Set blend factors.
-                    Gdip.CheckStatus(Gdip.GdipSetLinePresetBlend(SafeNativeBrush, colors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipSetLinePresetBlend(SafeBrushHandle, colors, positions, count));
                 }
                 finally
                 {
@@ -434,7 +434,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetLineWrapMode(SafeNativeBrush, out int mode));
+                Gdip.CheckStatus(Gdip.GdipGetLineWrapMode(SafeBrushHandle, out int mode));
                 return (WrapMode)mode;
             }
             set
@@ -442,7 +442,7 @@ namespace System.Drawing.Drawing2D
                 if (value < WrapMode.Tile || value > WrapMode.Clamp)
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(WrapMode));
 
-                Gdip.CheckStatus(Gdip.GdipSetLineWrapMode(SafeNativeBrush, unchecked((int)value)));
+                Gdip.CheckStatus(Gdip.GdipSetLineWrapMode(SafeBrushHandle, unchecked((int)value)));
             }
         }
 
@@ -451,7 +451,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 var matrix = new Matrix();
-                Gdip.CheckStatus(Gdip.GdipGetLineTransform(SafeNativeBrush, new HandleRef(matrix, matrix.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipGetLineTransform(SafeBrushHandle, new HandleRef(matrix, matrix.NativeMatrix)));
                 return matrix;
             }
             set
@@ -459,13 +459,13 @@ namespace System.Drawing.Drawing2D
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                Gdip.CheckStatus(Gdip.GdipSetLineTransform(SafeNativeBrush, new HandleRef(value, value.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipSetLineTransform(SafeBrushHandle, new HandleRef(value, value.NativeMatrix)));
             }
         }
 
         public void ResetTransform()
         {
-            Gdip.CheckStatus(Gdip.GdipResetLineTransform(SafeNativeBrush));
+            Gdip.CheckStatus(Gdip.GdipResetLineTransform(SafeBrushHandle));
         }
 
         public void MultiplyTransform(Matrix matrix) => MultiplyTransform(matrix, MatrixOrder.Prepend);
@@ -481,7 +481,7 @@ namespace System.Drawing.Drawing2D
                 return;
 
             Gdip.CheckStatus(Gdip.GdipMultiplyLineTransform(
-                SafeNativeBrush,
+                SafeBrushHandle,
                 new HandleRef(matrix, matrix.NativeMatrix),
                 order));
         }
@@ -490,21 +490,21 @@ namespace System.Drawing.Drawing2D
 
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipTranslateLineTransform(SafeNativeBrush, dx, dy, order));
+            Gdip.CheckStatus(Gdip.GdipTranslateLineTransform(SafeBrushHandle, dx, dy, order));
         }
 
         public void ScaleTransform(float sx, float sy) => ScaleTransform(sx, sy, MatrixOrder.Prepend);
 
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipScaleLineTransform(SafeNativeBrush, sx, sy, order));
+            Gdip.CheckStatus(Gdip.GdipScaleLineTransform(SafeBrushHandle, sx, sy, order));
         }
 
         public void RotateTransform(float angle) => RotateTransform(angle, MatrixOrder.Prepend);
 
         public void RotateTransform(float angle, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipRotateLineTransform(SafeNativeBrush, angle, order));
+            Gdip.CheckStatus(Gdip.GdipRotateLineTransform(SafeBrushHandle, angle, order));
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
@@ -18,7 +18,7 @@ namespace System.Drawing.Drawing2D
                 ref point1, ref point2,
                 color1.ToArgb(), color2.ToArgb(),
                 WrapMode.Tile,
-                out IntPtr nativeBrush));
+                out SafeBrushHandle nativeBrush));
 
             SetNativeBrushInternal(nativeBrush);
         }
@@ -29,7 +29,7 @@ namespace System.Drawing.Drawing2D
                 ref point1, ref point2,
                 color1.ToArgb(), color2.ToArgb(),
                 WrapMode.Tile,
-                out IntPtr nativeBrush));
+                out SafeBrushHandle nativeBrush));
 
             SetNativeBrushInternal(nativeBrush);
         }
@@ -48,7 +48,7 @@ namespace System.Drawing.Drawing2D
                 color2.ToArgb(),
                 linearGradientMode,
                 WrapMode.Tile,
-                out IntPtr nativeBrush));
+                out SafeBrushHandle nativeBrush));
 
             SetNativeBrushInternal(nativeBrush);
         }
@@ -66,7 +66,7 @@ namespace System.Drawing.Drawing2D
                 color2.ToArgb(),
                 linearGradientMode,
                 WrapMode.Tile,
-                out IntPtr nativeBrush));
+                out SafeBrushHandle nativeBrush));
 
             SetNativeBrushInternal(nativeBrush);
         }
@@ -87,7 +87,7 @@ namespace System.Drawing.Drawing2D
                 angle,
                 isAngleScaleable,
                 (int)WrapMode.Tile,
-                out IntPtr nativeBrush));
+                out SafeBrushHandle nativeBrush));
 
             SetNativeBrushInternal(nativeBrush);
         }
@@ -108,20 +108,18 @@ namespace System.Drawing.Drawing2D
                 angle,
                 isAngleScaleable,
                 WrapMode.Tile,
-                out IntPtr nativeBrush));
+                out SafeBrushHandle nativeBrush));
 
             SetNativeBrushInternal(nativeBrush);
         }
 
-        internal LinearGradientBrush(IntPtr nativeBrush)
+        internal LinearGradientBrush(SafeBrushHandle nativeBrush) : base(nativeBrush)
         {
-            Debug.Assert(nativeBrush != IntPtr.Zero, "Initializing native brush with null.");
-            SetNativeBrushInternal(nativeBrush);
         }
 
         public override object Clone()
         {
-            Gdip.CheckStatus(Gdip.GdipCloneBrush(new HandleRef(this, NativeBrush), out IntPtr clonedBrush));
+            Gdip.CheckStatus(Gdip.GdipCloneBrush(SafeNativeBrush, out SafeBrushHandle clonedBrush));
             return new LinearGradientBrush(clonedBrush);
         }
 
@@ -130,7 +128,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 int[] colors = new int[] { 0, 0 };
-                Gdip.CheckStatus(Gdip.GdipGetLineColors(new HandleRef(this, NativeBrush), colors));
+                Gdip.CheckStatus(Gdip.GdipGetLineColors(SafeNativeBrush, colors));
 
                 return new Color[]
                 {
@@ -141,7 +139,7 @@ namespace System.Drawing.Drawing2D
             set
             {
                 Gdip.CheckStatus(Gdip.GdipSetLineColors(
-                    new HandleRef(this, NativeBrush),
+                    SafeNativeBrush,
                     value[0].ToArgb(),
                     value[1].ToArgb()));
             }
@@ -151,7 +149,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetLineRect(new HandleRef(this, NativeBrush), out RectangleF rect));
+                Gdip.CheckStatus(Gdip.GdipGetLineRect(SafeNativeBrush, out RectangleF rect));
                 return rect;
             }
         }
@@ -161,14 +159,14 @@ namespace System.Drawing.Drawing2D
             get
             {
                 Gdip.CheckStatus(Gdip.GdipGetLineGammaCorrection(
-                    new HandleRef(this, NativeBrush),
+                    SafeNativeBrush,
                     out bool useGammaCorrection));
 
                 return useGammaCorrection;
             }
             set
             {
-                Gdip.CheckStatus(Gdip.GdipSetLineGammaCorrection(new HandleRef(this, NativeBrush), value));
+                Gdip.CheckStatus(Gdip.GdipSetLineGammaCorrection(SafeNativeBrush, value));
             }
         }
 
@@ -183,7 +181,7 @@ namespace System.Drawing.Drawing2D
                     return null;
 
                 // Figure out the size of blend factor array.
-                Gdip.CheckStatus(Gdip.GdipGetLineBlendCount(new HandleRef(this, NativeBrush), out int retval));
+                Gdip.CheckStatus(Gdip.GdipGetLineBlendCount(SafeNativeBrush, out int retval));
 
                 if (retval <= 0)
                     return null;
@@ -200,7 +198,7 @@ namespace System.Drawing.Drawing2D
                     positions = Marshal.AllocHGlobal(size);
 
                     // Retrieve horizontal blend factors.
-                    Gdip.CheckStatus(Gdip.GdipGetLineBlend(new HandleRef(this, NativeBrush), factors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipGetLineBlend(SafeNativeBrush, factors, positions, count));
 
                     // Return the result in a managed array.
                     var blend = new Blend(count);
@@ -258,11 +256,7 @@ namespace System.Drawing.Drawing2D
                     Marshal.Copy(value.Positions, 0, positions, count);
 
                     // Set blend factors.
-                    Gdip.CheckStatus(Gdip.GdipSetLineBlend(
-                        new HandleRef(this, NativeBrush),
-                        factors,
-                        positions,
-                        count));
+                    Gdip.CheckStatus(Gdip.GdipSetLineBlend(SafeNativeBrush, factors, positions, count));
                 }
                 finally
                 {
@@ -287,7 +281,7 @@ namespace System.Drawing.Drawing2D
             if (scale < 0 || scale > 1)
                 throw new ArgumentException(SR.GdiplusInvalidParameter, nameof(scale));
 
-            Gdip.CheckStatus(Gdip.GdipSetLineSigmaBlend(new HandleRef(this, NativeBrush), focus, scale));
+            Gdip.CheckStatus(Gdip.GdipSetLineSigmaBlend(SafeNativeBrush, focus, scale));
         }
 
         public void SetBlendTriangularShape(float focus) => SetBlendTriangularShape(focus, (float)1.0);
@@ -299,7 +293,7 @@ namespace System.Drawing.Drawing2D
             if (scale < 0 || scale > 1)
                 throw new ArgumentException(SR.GdiplusInvalidParameter, nameof(scale));
 
-            Gdip.CheckStatus(Gdip.GdipSetLineLinearBlend(new HandleRef(this, NativeBrush), focus, scale));
+            Gdip.CheckStatus(Gdip.GdipSetLineLinearBlend(SafeNativeBrush, focus, scale));
 
             // Setting a triangular shape overrides the explicitly set interpolation colors. libgdiplus correctly clears
             // the interpolation colors (https://github.com/mono/libgdiplus/blob/master/src/lineargradientbrush.c#L959) but
@@ -318,7 +312,7 @@ namespace System.Drawing.Drawing2D
                                                 SR.InterpolationColorsColorBlendNotSet, string.Empty));
 
                 // Figure out the size of blend factor array.
-                Gdip.CheckStatus(Gdip.GdipGetLinePresetBlendCount(new HandleRef(this, NativeBrush), out int retval));
+                Gdip.CheckStatus(Gdip.GdipGetLinePresetBlendCount(SafeNativeBrush, out int retval));
 
                 // Allocate temporary native memory buffer.
                 int count = retval;
@@ -333,7 +327,7 @@ namespace System.Drawing.Drawing2D
                     positions = Marshal.AllocHGlobal(size);
 
                     // Retrieve horizontal blend factors.
-                    Gdip.CheckStatus(Gdip.GdipGetLinePresetBlend(new HandleRef(this, NativeBrush), colors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipGetLinePresetBlend(SafeNativeBrush, colors, positions, count));
 
                     // Return the result in a managed array.
                     var blend = new ColorBlend(count);
@@ -420,7 +414,7 @@ namespace System.Drawing.Drawing2D
                     Marshal.Copy(value.Positions, 0, positions, count);
 
                     // Set blend factors.
-                    Gdip.CheckStatus(Gdip.GdipSetLinePresetBlend(new HandleRef(this, NativeBrush), colors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipSetLinePresetBlend(SafeNativeBrush, colors, positions, count));
                 }
                 finally
                 {
@@ -440,7 +434,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetLineWrapMode(new HandleRef(this, NativeBrush), out int mode));
+                Gdip.CheckStatus(Gdip.GdipGetLineWrapMode(SafeNativeBrush, out int mode));
                 return (WrapMode)mode;
             }
             set
@@ -448,7 +442,7 @@ namespace System.Drawing.Drawing2D
                 if (value < WrapMode.Tile || value > WrapMode.Clamp)
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(WrapMode));
 
-                Gdip.CheckStatus(Gdip.GdipSetLineWrapMode(new HandleRef(this, NativeBrush), unchecked((int)value)));
+                Gdip.CheckStatus(Gdip.GdipSetLineWrapMode(SafeNativeBrush, unchecked((int)value)));
             }
         }
 
@@ -457,7 +451,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 var matrix = new Matrix();
-                Gdip.CheckStatus(Gdip.GdipGetLineTransform(new HandleRef(this, NativeBrush), new HandleRef(matrix, matrix.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipGetLineTransform(SafeNativeBrush, new HandleRef(matrix, matrix.NativeMatrix)));
                 return matrix;
             }
             set
@@ -465,13 +459,13 @@ namespace System.Drawing.Drawing2D
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                Gdip.CheckStatus(Gdip.GdipSetLineTransform(new HandleRef(this, NativeBrush), new HandleRef(value, value.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipSetLineTransform(SafeNativeBrush, new HandleRef(value, value.NativeMatrix)));
             }
         }
 
         public void ResetTransform()
         {
-            Gdip.CheckStatus(Gdip.GdipResetLineTransform(new HandleRef(this, NativeBrush)));
+            Gdip.CheckStatus(Gdip.GdipResetLineTransform(SafeNativeBrush));
         }
 
         public void MultiplyTransform(Matrix matrix) => MultiplyTransform(matrix, MatrixOrder.Prepend);
@@ -487,7 +481,7 @@ namespace System.Drawing.Drawing2D
                 return;
 
             Gdip.CheckStatus(Gdip.GdipMultiplyLineTransform(
-                new HandleRef(this, NativeBrush),
+                SafeNativeBrush,
                 new HandleRef(matrix, matrix.NativeMatrix),
                 order));
         }
@@ -496,24 +490,21 @@ namespace System.Drawing.Drawing2D
 
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipTranslateLineTransform(
-                new HandleRef(this, NativeBrush), dx, dy, order));
+            Gdip.CheckStatus(Gdip.GdipTranslateLineTransform(SafeNativeBrush, dx, dy, order));
         }
 
         public void ScaleTransform(float sx, float sy) => ScaleTransform(sx, sy, MatrixOrder.Prepend);
 
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipScaleLineTransform(
-                new HandleRef(this, NativeBrush), sx, sy, order));
+            Gdip.CheckStatus(Gdip.GdipScaleLineTransform(SafeNativeBrush, sx, sy, order));
         }
 
         public void RotateTransform(float angle) => RotateTransform(angle, MatrixOrder.Prepend);
 
         public void RotateTransform(float angle, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipRotateLineTransform(
-                new HandleRef(this, NativeBrush), angle, order));
+            Gdip.CheckStatus(Gdip.GdipRotateLineTransform(SafeNativeBrush, angle, order));
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
@@ -451,7 +451,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 var matrix = new Matrix();
-                Gdip.CheckStatus(Gdip.GdipGetLineTransform(SafeBrushHandle, new HandleRef(matrix, matrix.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipGetLineTransform(SafeBrushHandle, matrix.SafeMatrixHandle));
                 return matrix;
             }
             set
@@ -459,7 +459,7 @@ namespace System.Drawing.Drawing2D
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                Gdip.CheckStatus(Gdip.GdipSetLineTransform(SafeBrushHandle, new HandleRef(value, value.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipSetLineTransform(SafeBrushHandle, value.SafeMatrixHandle));
             }
         }
 
@@ -477,12 +477,12 @@ namespace System.Drawing.Drawing2D
 
             // Multiplying the transform by a disposed matrix is a nop in GDI+, but throws
             // with the libgdiplus backend. Simulate a nop for compatability with GDI+.
-            if (matrix.NativeMatrix == IntPtr.Zero)
+            if (matrix.SafeMatrixHandle.IsClosed)
                 return;
 
             Gdip.CheckStatus(Gdip.GdipMultiplyLineTransform(
                 SafeBrushHandle,
-                new HandleRef(matrix, matrix.NativeMatrix),
+                matrix.SafeMatrixHandle,
                 order));
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -63,7 +63,7 @@ namespace System.Drawing.Drawing2D
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            Gdip.CheckStatus(Gdip.GdipCreatePathGradientFromPath(new HandleRef(path, path._nativePath), out SafeBrushHandle nativeBrush));
+            Gdip.CheckStatus(Gdip.GdipCreatePathGradientFromPath(path.SafeGraphicsPathHandle, out SafeBrushHandle nativeBrush));
             SetNativeBrushInternal(nativeBrush);
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -73,7 +73,7 @@ namespace System.Drawing.Drawing2D
 
         public override object Clone()
         {
-            Gdip.CheckStatus(Gdip.GdipCloneBrush(SafeNativeBrush, out SafeBrushHandle clonedBrush));
+            Gdip.CheckStatus(Gdip.GdipCloneBrush(SafeBrushHandle, out SafeBrushHandle clonedBrush));
             return new PathGradientBrush(clonedBrush);
         }
 
@@ -81,12 +81,12 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientCenterColor(SafeNativeBrush, out int argb));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientCenterColor(SafeBrushHandle, out int argb));
                 return Color.FromArgb(argb);
             }
             set
             {
-                Gdip.CheckStatus(Gdip.GdipSetPathGradientCenterColor(SafeNativeBrush, value.ToArgb()));
+                Gdip.CheckStatus(Gdip.GdipSetPathGradientCenterColor(SafeBrushHandle, value.ToArgb()));
             }
         }
 
@@ -95,13 +95,13 @@ namespace System.Drawing.Drawing2D
             get
             {
                 Gdip.CheckStatus(Gdip.GdipGetPathGradientSurroundColorCount(
-                    SafeNativeBrush,
+                    SafeBrushHandle,
                     out int count));
 
                 int[] argbs = new int[count];
 
                 Gdip.CheckStatus(Gdip.GdipGetPathGradientSurroundColorsWithCount(
-                    SafeNativeBrush,
+                    SafeBrushHandle,
                     argbs,
                     ref count));
 
@@ -119,7 +119,7 @@ namespace System.Drawing.Drawing2D
                     argbs[i] = value[i].ToArgb();
 
                 Gdip.CheckStatus(Gdip.GdipSetPathGradientSurroundColorsWithCount(
-                    SafeNativeBrush,
+                    SafeBrushHandle,
                     argbs,
                     ref count));
             }
@@ -129,12 +129,12 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientCenterPoint(SafeNativeBrush, out PointF point));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientCenterPoint(SafeBrushHandle, out PointF point));
                 return point;
             }
             set
             {
-                Gdip.CheckStatus(Gdip.GdipSetPathGradientCenterPoint(SafeNativeBrush, ref value));
+                Gdip.CheckStatus(Gdip.GdipSetPathGradientCenterPoint(SafeBrushHandle, ref value));
             }
         }
 
@@ -142,7 +142,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientRect(SafeNativeBrush, out RectangleF rect));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientRect(SafeBrushHandle, out RectangleF rect));
                 return rect;
             }
         }
@@ -152,7 +152,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 // Figure out the size of blend factor array
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientBlendCount(SafeNativeBrush, out int retval));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientBlendCount(SafeBrushHandle, out int retval));
 
                 // Allocate temporary native memory buffer
 
@@ -163,7 +163,7 @@ namespace System.Drawing.Drawing2D
 
                 // Retrieve horizontal blend factors
 
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientBlend(SafeNativeBrush, factors, positions, count));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientBlend(SafeBrushHandle, factors, positions, count));
 
                 // Return the result in a managed array
 
@@ -212,7 +212,7 @@ namespace System.Drawing.Drawing2D
 
                     // Set blend factors
 
-                    Gdip.CheckStatus(Gdip.GdipSetPathGradientBlend(SafeNativeBrush, factors, positions, count));
+                    Gdip.CheckStatus(Gdip.GdipSetPathGradientBlend(SafeBrushHandle, factors, positions, count));
                 }
                 finally
                 {
@@ -237,7 +237,7 @@ namespace System.Drawing.Drawing2D
             if (scale < 0 || scale > 1)
                 throw new ArgumentException(SR.GdiplusInvalidParameter, nameof(scale));
 
-            Gdip.CheckStatus(Gdip.GdipSetPathGradientSigmaBlend(SafeNativeBrush, focus, scale));
+            Gdip.CheckStatus(Gdip.GdipSetPathGradientSigmaBlend(SafeBrushHandle, focus, scale));
         }
 
         public void SetBlendTriangularShape(float focus) => SetBlendTriangularShape(focus, (float)1.0);
@@ -249,7 +249,7 @@ namespace System.Drawing.Drawing2D
             if (scale < 0 || scale > 1)
                 throw new ArgumentException(SR.GdiplusInvalidParameter, nameof(scale));
 
-            Gdip.CheckStatus(Gdip.GdipSetPathGradientLinearBlend(SafeNativeBrush, focus, scale));
+            Gdip.CheckStatus(Gdip.GdipSetPathGradientLinearBlend(SafeBrushHandle, focus, scale));
         }
 
         public ColorBlend InterpolationColors
@@ -257,7 +257,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 // Figure out the size of blend factor array
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientPresetBlendCount(SafeNativeBrush, out int count));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientPresetBlendCount(SafeBrushHandle, out int count));
 
                 // If count is 0, then there is nothing to marshal.
                 // In this case, we'll return an empty ColorBlend...
@@ -274,7 +274,7 @@ namespace System.Drawing.Drawing2D
                     return blend;
 
                 // Retrieve horizontal blend factors
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientPresetBlend(SafeNativeBrush, colors, positions, count));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientPresetBlend(SafeBrushHandle, colors, positions, count));
 
                 // Return the result in a managed array
 
@@ -307,7 +307,7 @@ namespace System.Drawing.Drawing2D
                 }
 
                 // Set blend factors
-                Gdip.CheckStatus(Gdip.GdipSetPathGradientPresetBlend(SafeNativeBrush, argbs, positions, count));
+                Gdip.CheckStatus(Gdip.GdipSetPathGradientPresetBlend(SafeBrushHandle, argbs, positions, count));
             }
         }
 
@@ -316,7 +316,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 Matrix matrix = new Matrix();
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientTransform(SafeNativeBrush, new HandleRef(matrix, matrix.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientTransform(SafeBrushHandle, new HandleRef(matrix, matrix.NativeMatrix)));
                 return matrix;
             }
             set
@@ -324,13 +324,13 @@ namespace System.Drawing.Drawing2D
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                Gdip.CheckStatus(Gdip.GdipSetPathGradientTransform(SafeNativeBrush, new HandleRef(value, value.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipSetPathGradientTransform(SafeBrushHandle, new HandleRef(value, value.NativeMatrix)));
             }
         }
 
         public void ResetTransform()
         {
-            Gdip.CheckStatus(Gdip.GdipResetPathGradientTransform(SafeNativeBrush));
+            Gdip.CheckStatus(Gdip.GdipResetPathGradientTransform(SafeBrushHandle));
         }
 
         public void MultiplyTransform(Matrix matrix) => MultiplyTransform(matrix, MatrixOrder.Prepend);
@@ -346,7 +346,7 @@ namespace System.Drawing.Drawing2D
                 return;
 
             Gdip.CheckStatus(Gdip.GdipMultiplyPathGradientTransform(
-                SafeNativeBrush,
+                SafeBrushHandle,
                 new HandleRef(matrix, matrix.NativeMatrix),
                 order));
         }
@@ -355,21 +355,21 @@ namespace System.Drawing.Drawing2D
 
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipTranslatePathGradientTransform(SafeNativeBrush, dx, dy, order));
+            Gdip.CheckStatus(Gdip.GdipTranslatePathGradientTransform(SafeBrushHandle, dx, dy, order));
         }
 
         public void ScaleTransform(float sx, float sy) => ScaleTransform(sx, sy, MatrixOrder.Prepend);
 
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipScalePathGradientTransform(SafeNativeBrush, sx, sy, order));
+            Gdip.CheckStatus(Gdip.GdipScalePathGradientTransform(SafeBrushHandle, sx, sy, order));
         }
 
         public void RotateTransform(float angle) => RotateTransform(angle, MatrixOrder.Prepend);
 
         public void RotateTransform(float angle, MatrixOrder order)
         {
-            Gdip.CheckStatus(Gdip.GdipRotatePathGradientTransform(SafeNativeBrush, angle, order));
+            Gdip.CheckStatus(Gdip.GdipRotatePathGradientTransform(SafeBrushHandle, angle, order));
         }
 
         public PointF FocusScales
@@ -379,12 +379,12 @@ namespace System.Drawing.Drawing2D
                 float[] scaleX = new float[] { 0.0f };
                 float[] scaleY = new float[] { 0.0f };
 
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientFocusScales(SafeNativeBrush, scaleX, scaleY));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientFocusScales(SafeBrushHandle, scaleX, scaleY));
                 return new PointF(scaleX[0], scaleY[0]);
             }
             set
             {
-                Gdip.CheckStatus(Gdip.GdipSetPathGradientFocusScales(SafeNativeBrush, value.X, value.Y));
+                Gdip.CheckStatus(Gdip.GdipSetPathGradientFocusScales(SafeBrushHandle, value.X, value.Y));
             }
         }
 
@@ -392,7 +392,7 @@ namespace System.Drawing.Drawing2D
         {
             get
             {
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientWrapMode(SafeNativeBrush, out int mode));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientWrapMode(SafeBrushHandle, out int mode));
                 return (WrapMode)mode;
             }
             set
@@ -400,7 +400,7 @@ namespace System.Drawing.Drawing2D
                 if (value < WrapMode.Tile || value > WrapMode.Clamp)
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(WrapMode));
 
-                Gdip.CheckStatus(Gdip.GdipSetPathGradientWrapMode(SafeNativeBrush, unchecked((int)value)));
+                Gdip.CheckStatus(Gdip.GdipSetPathGradientWrapMode(SafeBrushHandle, unchecked((int)value)));
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -316,7 +316,7 @@ namespace System.Drawing.Drawing2D
             get
             {
                 Matrix matrix = new Matrix();
-                Gdip.CheckStatus(Gdip.GdipGetPathGradientTransform(SafeBrushHandle, new HandleRef(matrix, matrix.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipGetPathGradientTransform(SafeBrushHandle, matrix.SafeMatrixHandle));
                 return matrix;
             }
             set
@@ -324,7 +324,7 @@ namespace System.Drawing.Drawing2D
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                Gdip.CheckStatus(Gdip.GdipSetPathGradientTransform(SafeBrushHandle, new HandleRef(value, value.NativeMatrix)));
+                Gdip.CheckStatus(Gdip.GdipSetPathGradientTransform(SafeBrushHandle, value.SafeMatrixHandle));
             }
         }
 
@@ -342,12 +342,12 @@ namespace System.Drawing.Drawing2D
 
             // Multiplying the transform by a disposed matrix is a nop in GDI+, but throws
             // with the libgdiplus backend. Simulate a nop for compatability with GDI+.
-            if (matrix.NativeMatrix == IntPtr.Zero)
+            if (matrix.SafeMatrixHandle.IsClosed)
                 return;
 
             Gdip.CheckStatus(Gdip.GdipMultiplyPathGradientTransform(
                 SafeBrushHandle,
-                new HandleRef(matrix, matrix.NativeMatrix),
+                matrix.SafeMatrixHandle,
                 order));
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Gdiplus.cs
@@ -18,7 +18,9 @@ namespace System.Drawing
         internal static partial class Gdip
         {
             private static readonly IntPtr s_initToken;
-            private const string ThreadDataSlotName = "system.drawing.threaddata";
+
+            [ThreadStatic]
+            private static IDictionary? s_threadData;
 
             static Gdip()
             {
@@ -44,21 +46,7 @@ namespace System.Drawing
             /// a per-thread basis. This way we can avoid 'object in use' crashes when different threads are
             /// referencing the same drawing object.
             /// </summary>
-            internal static IDictionary ThreadData
-            {
-                get
-                {
-                    LocalDataStoreSlot slot = Thread.GetNamedDataSlot(ThreadDataSlotName);
-                    IDictionary? threadData = (IDictionary?)Thread.GetData(slot);
-                    if (threadData == null)
-                    {
-                        threadData = new Hashtable();
-                        Thread.SetData(slot, threadData);
-                    }
-
-                    return threadData;
-                }
-            }
+            internal static IDictionary ThreadData => s_threadData ??= new Hashtable();
 
             // Used to ensure static constructor has run.
             internal static void DummyFunction()

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.ManualMarshalling.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.ManualMarshalling.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing.Drawing2D;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -10,15 +11,21 @@ namespace System.Drawing
     {
         internal static unsafe partial class Gdip
         {
-            [DllImport(LibraryName, EntryPoint = nameof(GdipGetPathWorldBounds))]
-            private static extern int GdipGetPathWorldBounds_impl(HandleRef path, out RectangleF gprectf, HandleRef matrix, IntPtr penOptional);
-
             // Passing null SafeHandles in P/Invokes is not supported so we will do it the manual way.
-            internal static int GdipGetPathWorldBounds(HandleRef path, out RectangleF gprectf, HandleRef matrix, SafePenHandle? penOptional)
+            // TODO: Revisit this file when custom marshallers are available.
+            internal static int GdipGetPathWorldBounds(HandleRef path, out RectangleF gprectf, SafeMatrixHandle? matrixOptional, SafePenHandle? penOptional)
             {
+                bool releaseMatrix = false;
                 bool releasePen = false;
                 try
                 {
+                    IntPtr nativeMatrix = IntPtr.Zero;
+                    if (matrixOptional != null)
+                    {
+                        matrixOptional.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                    }
+
                     IntPtr nativePen = IntPtr.Zero;
                     if (penOptional != null)
                     {
@@ -26,16 +33,103 @@ namespace System.Drawing
                         nativePen = penOptional.DangerousGetHandle();
                     }
 
-                    return GdipGetPathWorldBounds_impl(path, out gprectf, matrix, nativePen);
+                    return __PInvoke__(path, out gprectf, nativeMatrix, nativePen);
                 }
                 finally
                 {
+                    if (releaseMatrix)
+                    {
+                        matrixOptional!.DangerousRelease();
+                    }
+
                     if (releasePen)
                     {
                         penOptional!.DangerousRelease();
                     }
                 }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipGetPathWorldBounds))]
+                static extern int __PInvoke__(HandleRef path, out RectangleF gprectf, IntPtr nativeMatrix, IntPtr penOptional);
             }
+
+            internal static int GdipFlattenPath(HandleRef path, SafeMatrixHandle? matrixOptional, float flatness)
+            {
+                bool releaseMatrix = false;
+                try
+                {
+                    IntPtr nativeMatrix = IntPtr.Zero;
+                    if (matrixOptional != null)
+                    {
+                        matrixOptional.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                    }
+
+                    return __PInvoke__(path, nativeMatrix, flatness);
+                }
+                finally
+                {
+                    if (releaseMatrix)
+                    {
+                        matrixOptional!.DangerousRelease();
+                    }
+                }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipFlattenPath))]
+                static extern int __PInvoke__(HandleRef path, IntPtr nativeMatrix, float flatness);
+            }
+
+            internal static int GdipWidenPath(HandleRef path, SafePenHandle pen, SafeMatrixHandle? matrixOptional, float flatness)
+            {
+                bool releaseMatrix = false;
+                try
+                {
+                    IntPtr nativeMatrix = IntPtr.Zero;
+                    if (matrixOptional != null)
+                    {
+                        matrixOptional.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                    }
+
+                    return __PInvoke__(path, pen, nativeMatrix, flatness);
+                }
+                finally
+                {
+                    if (releaseMatrix)
+                    {
+                        matrixOptional!.DangerousRelease();
+                    }
+                }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipWidenPath))]
+                static extern int __PInvoke__(HandleRef path, SafePenHandle pen, IntPtr nativeMatrix, float flatness);
+            }
+
+            internal static int GdipWarpPath(HandleRef path, SafeMatrixHandle? matrixOptional, PointF[] points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness)
+            {
+                bool releaseMatrix = false;
+                try
+                {
+                    IntPtr nativeMatrix = IntPtr.Zero;
+                    if (matrixOptional != null)
+                    {
+                        matrixOptional.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                    }
+
+                    return __PInvoke__(path, nativeMatrix, points, count, srcX, srcY, srcWidth, srcHeight, warpMode, flatness);
+                }
+                finally
+                {
+                    if (releaseMatrix)
+                    {
+                        matrixOptional!.DangerousRelease();
+                    }
+                }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipWarpPath))]
+                static extern int __PInvoke__(HandleRef path, IntPtr nativeMatrix, PointF[] points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness);
+            }
+
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.ManualMarshalling.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.ManualMarshalling.cs
@@ -13,24 +13,24 @@ namespace System.Drawing
         {
             // Passing null SafeHandles in P/Invokes is not supported so we will do it the manual way.
             // TODO: Revisit this file when custom marshallers are available.
-            internal static int GdipGetPathWorldBounds(HandleRef path, out RectangleF gprectf, SafeMatrixHandle? matrixOptional, SafePenHandle? penOptional)
+            internal static int GdipGetPathWorldBounds(SafeGraphicsPathHandle path, out RectangleF gprectf, SafeMatrixHandle? matrix, SafePenHandle? pen)
             {
                 bool releaseMatrix = false;
                 bool releasePen = false;
                 try
                 {
                     IntPtr nativeMatrix = IntPtr.Zero;
-                    if (matrixOptional != null)
+                    if (matrix != null)
                     {
-                        matrixOptional.DangerousAddRef(ref releaseMatrix);
-                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                        matrix.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrix.DangerousGetHandle();
                     }
 
                     IntPtr nativePen = IntPtr.Zero;
-                    if (penOptional != null)
+                    if (pen != null)
                     {
-                        penOptional.DangerousAddRef(ref releasePen);
-                        nativePen = penOptional.DangerousGetHandle();
+                        pen.DangerousAddRef(ref releasePen);
+                        nativePen = pen.DangerousGetHandle();
                     }
 
                     return __PInvoke__(path, out gprectf, nativeMatrix, nativePen);
@@ -39,29 +39,29 @@ namespace System.Drawing
                 {
                     if (releaseMatrix)
                     {
-                        matrixOptional!.DangerousRelease();
+                        matrix!.DangerousRelease();
                     }
 
                     if (releasePen)
                     {
-                        penOptional!.DangerousRelease();
+                        pen!.DangerousRelease();
                     }
                 }
 
                 [DllImport(LibraryName, EntryPoint = nameof(GdipGetPathWorldBounds))]
-                static extern int __PInvoke__(HandleRef path, out RectangleF gprectf, IntPtr nativeMatrix, IntPtr penOptional);
+                static extern int __PInvoke__(SafeGraphicsPathHandle path, out RectangleF gprectf, IntPtr matrix, IntPtr pen);
             }
 
-            internal static int GdipFlattenPath(HandleRef path, SafeMatrixHandle? matrixOptional, float flatness)
+            internal static int GdipFlattenPath(SafeGraphicsPathHandle path, SafeMatrixHandle? matrix, float flatness)
             {
                 bool releaseMatrix = false;
                 try
                 {
                     IntPtr nativeMatrix = IntPtr.Zero;
-                    if (matrixOptional != null)
+                    if (matrix != null)
                     {
-                        matrixOptional.DangerousAddRef(ref releaseMatrix);
-                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                        matrix.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrix.DangerousGetHandle();
                     }
 
                     return __PInvoke__(path, nativeMatrix, flatness);
@@ -70,24 +70,24 @@ namespace System.Drawing
                 {
                     if (releaseMatrix)
                     {
-                        matrixOptional!.DangerousRelease();
+                        matrix!.DangerousRelease();
                     }
                 }
 
                 [DllImport(LibraryName, EntryPoint = nameof(GdipFlattenPath))]
-                static extern int __PInvoke__(HandleRef path, IntPtr nativeMatrix, float flatness);
+                static extern int __PInvoke__(SafeGraphicsPathHandle path, IntPtr matrix, float flatness);
             }
 
-            internal static int GdipWidenPath(HandleRef path, SafePenHandle pen, SafeMatrixHandle? matrixOptional, float flatness)
+            internal static int GdipWidenPath(SafeGraphicsPathHandle path, SafePenHandle pen, SafeMatrixHandle? matrix, float flatness)
             {
                 bool releaseMatrix = false;
                 try
                 {
                     IntPtr nativeMatrix = IntPtr.Zero;
-                    if (matrixOptional != null)
+                    if (matrix != null)
                     {
-                        matrixOptional.DangerousAddRef(ref releaseMatrix);
-                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                        matrix.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrix.DangerousGetHandle();
                     }
 
                     return __PInvoke__(path, pen, nativeMatrix, flatness);
@@ -96,24 +96,24 @@ namespace System.Drawing
                 {
                     if (releaseMatrix)
                     {
-                        matrixOptional!.DangerousRelease();
+                        matrix!.DangerousRelease();
                     }
                 }
 
                 [DllImport(LibraryName, EntryPoint = nameof(GdipWidenPath))]
-                static extern int __PInvoke__(HandleRef path, SafePenHandle pen, IntPtr nativeMatrix, float flatness);
+                static extern int __PInvoke__(SafeGraphicsPathHandle path, SafePenHandle pen, IntPtr matrix, float flatness);
             }
 
-            internal static int GdipWarpPath(HandleRef path, SafeMatrixHandle? matrixOptional, PointF[] points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness)
+            internal static int GdipWarpPath(SafeGraphicsPathHandle path, SafeMatrixHandle? matrix, PointF[] points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness)
             {
                 bool releaseMatrix = false;
                 try
                 {
                     IntPtr nativeMatrix = IntPtr.Zero;
-                    if (matrixOptional != null)
+                    if (matrix != null)
                     {
-                        matrixOptional.DangerousAddRef(ref releaseMatrix);
-                        nativeMatrix = matrixOptional.DangerousGetHandle();
+                        matrix.DangerousAddRef(ref releaseMatrix);
+                        nativeMatrix = matrix.DangerousGetHandle();
                     }
 
                     return __PInvoke__(path, nativeMatrix, points, count, srcX, srcY, srcWidth, srcHeight, warpMode, flatness);
@@ -122,14 +122,130 @@ namespace System.Drawing
                 {
                     if (releaseMatrix)
                     {
-                        matrixOptional!.DangerousRelease();
+                        matrix!.DangerousRelease();
                     }
                 }
 
                 [DllImport(LibraryName, EntryPoint = nameof(GdipWarpPath))]
-                static extern int __PInvoke__(HandleRef path, IntPtr nativeMatrix, PointF[] points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness);
+                static extern int __PInvoke__(SafeGraphicsPathHandle path, IntPtr matrix, PointF[] points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness);
             }
 
+            internal static int GdipCreateCustomLineCap(SafeGraphicsPathHandle? fillPath, SafeGraphicsPathHandle? strokePath, LineCap baseCap, float baseInset, out IntPtr customCap)
+            {
+                bool releaseFillPath = false;
+                bool releaseStrokePath = false;
+                try
+                {
+                    IntPtr nativeFillPath = IntPtr.Zero;
+                    if (fillPath != null)
+                    {
+                        fillPath.DangerousAddRef(ref releaseFillPath);
+                        nativeFillPath = fillPath.DangerousGetHandle();
+                    }
+
+                    IntPtr nativeStrokePath = IntPtr.Zero;
+                    if (strokePath != null)
+                    {
+                        strokePath.DangerousAddRef(ref releaseStrokePath);
+                        nativeStrokePath = strokePath.DangerousGetHandle();
+                    }
+
+                    return __PInvoke__(nativeFillPath, nativeStrokePath, baseCap, baseInset, out customCap);
+                }
+                finally
+                {
+                    if (releaseFillPath)
+                    {
+                        fillPath!.DangerousRelease();
+                    }
+
+                    if (releaseStrokePath)
+                    {
+                        strokePath!.DangerousRelease();
+                    }
+                }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipCreateCustomLineCap))]
+                static extern int __PInvoke__(IntPtr fillpath, IntPtr strokepath, LineCap baseCap, float baseInset, out IntPtr customCap);
+            }
+
+            internal static int GdipCreatePathIter(out IntPtr pathIter, SafeGraphicsPathHandle? path)
+            {
+                bool releasePath = false;
+                try
+                {
+                    IntPtr nativePath = IntPtr.Zero;
+                    if (path != null)
+                    {
+                        path.DangerousAddRef(ref releasePath);
+                        nativePath = path.DangerousGetHandle();
+                    }
+
+                    return __PInvoke__(out pathIter, nativePath);
+                }
+                finally
+                {
+                    if (releasePath)
+                    {
+                        path!.DangerousRelease();
+                    }
+                }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipCreatePathIter))]
+                static extern int __PInvoke__(out IntPtr pathIter, IntPtr path);
+            }
+
+            internal static int GdipPathIterNextSubpathPath(HandleRef pathIter, out int resultCount, SafeGraphicsPathHandle? path, out bool isClosed)
+            {
+                bool releasePath = false;
+                try
+                {
+                    IntPtr nativePath = IntPtr.Zero;
+                    if (path != null)
+                    {
+                        path.DangerousAddRef(ref releasePath);
+                        nativePath = path.DangerousGetHandle();
+                    }
+
+                    return __PInvoke__(pathIter, out resultCount, nativePath, out isClosed);
+                }
+                finally
+                {
+                    if (releasePath)
+                    {
+                        path!.DangerousRelease();
+                    }
+                }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipPathIterNextSubpathPath))]
+                static extern int __PInvoke__(HandleRef pathIter, out int resultCount, IntPtr path, out bool isClosed);
+            }
+
+            internal static int GdipPathIterNextMarkerPath(HandleRef pathIter, out int resultCount, SafeGraphicsPathHandle? path)
+            {
+                bool releasePath = false;
+                try
+                {
+                    IntPtr nativePath = IntPtr.Zero;
+                    if (path != null)
+                    {
+                        path.DangerousAddRef(ref releasePath);
+                        nativePath = path.DangerousGetHandle();
+                    }
+
+                    return __PInvoke__(pathIter, out resultCount, nativePath);
+                }
+                finally
+                {
+                    if (releasePath)
+                    {
+                        path!.DangerousRelease();
+                    }
+                }
+
+                [DllImport(LibraryName, EntryPoint = nameof(GdipPathIterNextMarkerPath))]
+                static extern int __PInvoke__(HandleRef pathIter, out int resultCount, IntPtr path);
+            }
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.ManualMarshalling.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.ManualMarshalling.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Drawing
+{
+    internal static partial class SafeNativeMethods
+    {
+        internal static unsafe partial class Gdip
+        {
+            [DllImport(LibraryName, EntryPoint = nameof(GdipGetPathWorldBounds))]
+            private static extern int GdipGetPathWorldBounds_impl(HandleRef path, out RectangleF gprectf, HandleRef matrix, IntPtr penOptional);
+
+            // Passing null SafeHandles in P/Invokes is not supported so we will do it the manual way.
+            internal static int GdipGetPathWorldBounds(HandleRef path, out RectangleF gprectf, HandleRef matrix, SafePenHandle? penOptional)
+            {
+                bool releasePen = false;
+                try
+                {
+                    IntPtr nativePen = IntPtr.Zero;
+                    if (penOptional != null)
+                    {
+                        penOptional.DangerousAddRef(ref releasePen);
+                        nativePen = penOptional.DangerousGetHandle();
+                    }
+
+                    return GdipGetPathWorldBounds_impl(path, out gprectf, matrix, nativePen);
+                }
+                finally
+                {
+                    if (releasePen)
+                    {
+                        penOptional!.DangerousRelease();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -1,13 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+using Microsoft.Win32.SafeHandles;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
-using System.Drawing.Printing;
-using System.Drawing.Text;
-using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace System.Drawing
@@ -84,12 +80,6 @@ namespace System.Drawing
             internal static partial void GdipFree(IntPtr ptr);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipDeleteBrush(HandleRef brush);
-
-            [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipGetBrushType(IntPtr brush, out BrushType type);
-
-            [DllImport(LibraryName)]
             internal static extern int GdipDeleteGraphics(HandleRef graphics);
 
             [GeneratedDllImport(LibraryName)]
@@ -99,7 +89,7 @@ namespace System.Drawing
             internal static extern int GdipReleaseDC(HandleRef graphics, HandleRef hdc);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipFillPath(IntPtr graphics, IntPtr brush, IntPtr path);
+            internal static partial int GdipFillPath(IntPtr graphics, SafeBrushHandle brush, IntPtr path);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetNearestColor(IntPtr graphics, out int argb);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -19,7 +19,7 @@ namespace System.Drawing
             // When set to false, where Carbon Drawing is used instead.
             // macOS users can force X11 by setting the SYSTEM_DRAWING_COMMON_FORCE_X11 flag.
             public static bool UseX11Drawable { get; } =
-                !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+                !OperatingSystem.IsMacOS() ||
                 Environment.GetEnvironmentVariable("SYSTEM_DRAWING_COMMON_FORCE_X11") != null;
 
             internal static IntPtr LoadNativeLibrary()
@@ -27,7 +27,7 @@ namespace System.Drawing
                 var assembly = System.Reflection.Assembly.GetExecutingAssembly();
 
                 IntPtr lib = IntPtr.Zero;
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                if (OperatingSystem.IsMacOS())
                 {
                     if (!NativeLibrary.TryLoad("libgdiplus.dylib", assembly, default, out lib))
                     {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -332,16 +332,7 @@ namespace System.Drawing
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipWidenPath(IntPtr path, IntPtr pen, IntPtr matrix, float flatness);
-
-#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName)]
-            internal static extern int GdipGetPathWorldBounds(IntPtr path, out RectangleF bounds, IntPtr matrix, IntPtr pen);
-
-            [DllImport(LibraryName)]
-            internal static extern int GdipGetPathWorldBoundsI(IntPtr path, out Rectangle bounds, IntPtr matrix, IntPtr pen);
-#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+            internal static partial int GdipWidenPath(IntPtr path, SafePenHandle pen, IntPtr matrix, float flatness);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, out bool result);
@@ -350,10 +341,10 @@ namespace System.Drawing
             internal static partial int GdipIsVisiblePathPointI(IntPtr path, int x, int y, IntPtr graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, IntPtr pen, IntPtr graphics, out bool result);
+            internal static partial int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, SafePenHandle pen, IntPtr graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, IntPtr pen, IntPtr graphics, out bool result);
+            internal static partial int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, SafePenHandle pen, IntPtr graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFontFromLogfont(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr ptr);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -320,19 +320,7 @@ namespace System.Drawing
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipFlattenPath(IntPtr path, IntPtr matrix, float floatness);
-
-            [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipTransformPath(IntPtr path, IntPtr matrix);
-
-#pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-            // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
-            [DllImport(LibraryName)]
-            internal static extern int GdipWarpPath(IntPtr path, IntPtr matrix, PointF[] points, int count, float srcx, float srcy, float srcwidth, float srcheight, WarpMode mode, float flatness);
-#pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-
-            [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipWidenPath(IntPtr path, SafePenHandle pen, IntPtr matrix, float flatness);
+            internal static partial int GdipTransformPath(IntPtr path, SafeMatrixHandle matrix);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, out bool result);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -89,7 +89,7 @@ namespace System.Drawing
             internal static extern int GdipReleaseDC(HandleRef graphics, HandleRef hdc);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipFillPath(IntPtr graphics, SafeBrushHandle brush, IntPtr path);
+            internal static partial int GdipFillPath(IntPtr graphics, SafeBrushHandle brush, SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetNearestColor(IntPtr graphics, out int argb);
@@ -97,10 +97,10 @@ namespace System.Drawing
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
-            internal static extern int GdipAddPathString(IntPtr path, string s, int lenght, IntPtr family, int style, float emSize, ref RectangleF layoutRect, IntPtr format);
+            internal static extern int GdipAddPathString(SafeGraphicsPathHandle path, string s, int lenght, IntPtr family, int style, float emSize, ref RectangleF layoutRect, IntPtr format);
 
             [DllImport(LibraryName, CharSet = CharSet.Unicode, ExactSpelling = true)]
-            internal static extern int GdipAddPathStringI(IntPtr path, string s, int lenght, IntPtr family, int style, float emSize, ref Rectangle layoutRect, IntPtr format);
+            internal static extern int GdipAddPathStringI(SafeGraphicsPathHandle path, string s, int lenght, IntPtr family, int style, float emSize, ref Rectangle layoutRect, IntPtr format);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
@@ -143,196 +143,196 @@ namespace System.Drawing
             internal static partial int GdipGetImageGraphicsContext(IntPtr image, out IntPtr graphics);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreatePath(FillMode brushMode, out IntPtr path);
+            internal static partial int GdipCreatePath(FillMode brushMode, out SafeGraphicsPathHandle path);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipCreatePath2(PointF[] points, byte[] types, int count, FillMode brushMode, out IntPtr path);
+            internal static extern int GdipCreatePath2(PointF[] points, byte[] types, int count, FillMode brushMode, out SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreatePath2I(Point[] points, byte[] types, int count, FillMode brushMode, out IntPtr path);
+            internal static extern int GdipCreatePath2I(Point[] points, byte[] types, int count, FillMode brushMode, out SafeGraphicsPathHandle path);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipClonePath(IntPtr path, out IntPtr clonePath);
+            internal static partial int GdipClonePath(SafeGraphicsPathHandle path, out SafeGraphicsPathHandle clonedPath);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipDeletePath(HandleRef path);
+            internal static extern int GdipDeletePath(IntPtr path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipResetPath(IntPtr path);
+            internal static partial int GdipResetPath(SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipGetPointCount(IntPtr path, out int count);
+            internal static partial int GdipGetPointCount(SafeGraphicsPathHandle path, out int count);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipGetPathTypes(IntPtr path, byte[] types, int count);
+            internal static partial int GdipGetPathTypes(SafeGraphicsPathHandle path, byte[] types, int count);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathPoints(IntPtr path, [Out] PointF[] points, int count);
+            internal static extern int GdipGetPathPoints(SafeGraphicsPathHandle path, [Out] PointF[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathPointsI(IntPtr path, [Out] Point[] points, int count);
+            internal static extern int GdipGetPathPointsI(SafeGraphicsPathHandle path, [Out] Point[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipGetPathFillMode(IntPtr path, out FillMode fillMode);
+            internal static partial int GdipGetPathFillMode(SafeGraphicsPathHandle path, out FillMode fillMode);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipSetPathFillMode(IntPtr path, FillMode fillMode);
+            internal static partial int GdipSetPathFillMode(SafeGraphicsPathHandle path, FillMode fillMode);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipStartPathFigure(IntPtr path);
+            internal static partial int GdipStartPathFigure(SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipClosePathFigure(IntPtr path);
+            internal static partial int GdipClosePathFigure(SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipClosePathFigures(IntPtr path);
+            internal static partial int GdipClosePathFigures(SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipSetPathMarker(IntPtr path);
+            internal static partial int GdipSetPathMarker(SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipClearPathMarkers(IntPtr path);
+            internal static partial int GdipClearPathMarkers(SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipReversePath(IntPtr path);
+            internal static partial int GdipReversePath(SafeGraphicsPathHandle path);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathLastPoint(IntPtr path, out PointF lastPoint);
+            internal static extern int GdipGetPathLastPoint(SafeGraphicsPathHandle path, out PointF lastPoint);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathLine(IntPtr path, float x1, float y1, float x2, float y2);
+            internal static partial int GdipAddPathLine(SafeGraphicsPathHandle path, float x1, float y1, float x2, float y2);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathLine2(IntPtr path, PointF[] points, int count);
+            internal static extern int GdipAddPathLine2(SafeGraphicsPathHandle path, PointF[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathLine2I(IntPtr path, Point[] points, int count);
+            internal static extern int GdipAddPathLine2I(SafeGraphicsPathHandle path, Point[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathArc(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            internal static partial int GdipAddPathArc(SafeGraphicsPathHandle path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathBezier(IntPtr path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
+            internal static partial int GdipAddPathBezier(SafeGraphicsPathHandle path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathBeziers(IntPtr path, PointF[] points, int count);
+            internal static extern int GdipAddPathBeziers(SafeGraphicsPathHandle path, PointF[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve(IntPtr path, PointF[] points, int count);
+            internal static extern int GdipAddPathCurve(SafeGraphicsPathHandle path, PointF[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurveI(IntPtr path, Point[] points, int count);
+            internal static extern int GdipAddPathCurveI(SafeGraphicsPathHandle path, Point[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve2(IntPtr path, PointF[] points, int count, float tension);
+            internal static extern int GdipAddPathCurve2(SafeGraphicsPathHandle path, PointF[] points, int count, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve2I(IntPtr path, Point[] points, int count, float tension);
+            internal static extern int GdipAddPathCurve2I(SafeGraphicsPathHandle path, Point[] points, int count, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve3(IntPtr path, PointF[] points, int count, int offset, int numberOfSegments, float tension);
+            internal static extern int GdipAddPathCurve3(SafeGraphicsPathHandle path, PointF[] points, int count, int offset, int numberOfSegments, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve3I(IntPtr path, Point[] points, int count, int offset, int numberOfSegments, float tension);
+            internal static extern int GdipAddPathCurve3I(SafeGraphicsPathHandle path, Point[] points, int count, int offset, int numberOfSegments, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurve(IntPtr path, PointF[] points, int count);
+            internal static extern int GdipAddPathClosedCurve(SafeGraphicsPathHandle path, PointF[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurveI(IntPtr path, Point[] points, int count);
+            internal static extern int GdipAddPathClosedCurveI(SafeGraphicsPathHandle path, Point[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurve2(IntPtr path, PointF[] points, int count, float tension);
+            internal static extern int GdipAddPathClosedCurve2(SafeGraphicsPathHandle path, PointF[] points, int count, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurve2I(IntPtr path, Point[] points, int count, float tension);
+            internal static extern int GdipAddPathClosedCurve2I(SafeGraphicsPathHandle path, Point[] points, int count, float tension);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathRectangle(IntPtr path, float x, float y, float width, float height);
+            internal static partial int GdipAddPathRectangle(SafeGraphicsPathHandle path, float x, float y, float width, float height);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathRectangles(IntPtr path, RectangleF[] rects, int count);
+            internal static extern int GdipAddPathRectangles(SafeGraphicsPathHandle path, RectangleF[] rects, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathEllipse(IntPtr path, float x, float y, float width, float height);
+            internal static partial int GdipAddPathEllipse(SafeGraphicsPathHandle path, float x, float y, float width, float height);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathEllipseI(IntPtr path, int x, int y, int width, int height);
+            internal static partial int GdipAddPathEllipseI(SafeGraphicsPathHandle path, int x, int y, int width, int height);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathPie(IntPtr path, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            internal static partial int GdipAddPathPie(SafeGraphicsPathHandle path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathPieI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            internal static partial int GdipAddPathPieI(SafeGraphicsPathHandle path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathPolygon(IntPtr path, PointF[] points, int count);
+            internal static extern int GdipAddPathPolygon(SafeGraphicsPathHandle path, PointF[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathPath(IntPtr path, IntPtr addingPath, bool connect);
+            internal static partial int GdipAddPathPath(SafeGraphicsPathHandle path, SafeGraphicsPathHandle addingPath, bool connect);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathLineI(IntPtr path, int x1, int y1, int x2, int y2);
+            internal static partial int GdipAddPathLineI(SafeGraphicsPathHandle path, int x1, int y1, int x2, int y2);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathArcI(IntPtr path, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            internal static partial int GdipAddPathArcI(SafeGraphicsPathHandle path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathBezierI(IntPtr path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
+            internal static partial int GdipAddPathBezierI(SafeGraphicsPathHandle path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathBeziersI(IntPtr path, Point[] points, int count);
+            internal static extern int GdipAddPathBeziersI(SafeGraphicsPathHandle path, Point[] points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathPolygonI(IntPtr path, Point[] points, int count);
+            internal static extern int GdipAddPathPolygonI(SafeGraphicsPathHandle path, Point[] points, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipAddPathRectangleI(IntPtr path, int x, int y, int width, int height);
+            internal static partial int GdipAddPathRectangleI(SafeGraphicsPathHandle path, int x, int y, int width, int height);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathRectanglesI(IntPtr path, Rectangle[] rects, int count);
+            internal static extern int GdipAddPathRectanglesI(SafeGraphicsPathHandle path, Rectangle[] rects, int count);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipTransformPath(IntPtr path, SafeMatrixHandle matrix);
+            internal static partial int GdipTransformPath(SafeGraphicsPathHandle path, SafeMatrixHandle matrix);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsVisiblePathPoint(IntPtr path, float x, float y, IntPtr graphics, out bool result);
+            internal static partial int GdipIsVisiblePathPoint(SafeGraphicsPathHandle path, float x, float y, IntPtr graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsVisiblePathPointI(IntPtr path, int x, int y, IntPtr graphics, out bool result);
+            internal static partial int GdipIsVisiblePathPointI(SafeGraphicsPathHandle path, int x, int y, IntPtr graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsOutlineVisiblePathPoint(IntPtr path, float x, float y, SafePenHandle pen, IntPtr graphics, out bool result);
+            internal static partial int GdipIsOutlineVisiblePathPoint(SafeGraphicsPathHandle path, float x, float y, SafePenHandle pen, IntPtr graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipIsOutlineVisiblePathPointI(IntPtr path, int x, int y, SafePenHandle pen, IntPtr graphics, out bool result);
+            internal static partial int GdipIsOutlineVisiblePathPointI(SafeGraphicsPathHandle path, int x, int y, SafePenHandle pen, IntPtr graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFontFromLogfont(IntPtr hdc, ref Interop.User32.LOGFONT lf, out IntPtr ptr);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -28,175 +28,175 @@ namespace System.Drawing
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreatePath(int brushMode, out IntPtr path);
+            internal static partial int GdipCreatePath(int brushMode, out SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreatePath2(PointF* points, byte* types, int count, int brushMode, out IntPtr path);
+            internal static partial int GdipCreatePath2(PointF* points, byte* types, int count, int brushMode, out SafeGraphicsPathHandle path);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreatePath2I(Point* points, byte* types, int count, int brushMode, out IntPtr path);
+            internal static partial int GdipCreatePath2I(Point* points, byte* types, int count, int brushMode, out SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipClonePath(HandleRef path, out IntPtr clonepath);
+            internal static extern int GdipClonePath(SafeGraphicsPathHandle path, out SafeGraphicsPathHandle clonepath);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipDeletePath(HandleRef path);
+            internal static extern int GdipDeletePath(IntPtr path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipResetPath(HandleRef path);
+            internal static extern int GdipResetPath(SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPointCount(HandleRef path, out int count);
+            internal static extern int GdipGetPointCount(SafeGraphicsPathHandle path, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathTypes(HandleRef path, byte[] types, int count);
+            internal static extern int GdipGetPathTypes(SafeGraphicsPathHandle path, byte[] types, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathPoints(HandleRef path, PointF* points, int count);
+            internal static extern int GdipGetPathPoints(SafeGraphicsPathHandle path, PointF* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathFillMode(HandleRef path, out FillMode fillmode);
+            internal static extern int GdipGetPathFillMode(SafeGraphicsPathHandle path, out FillMode fillmode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathFillMode(HandleRef path, FillMode fillmode);
+            internal static extern int GdipSetPathFillMode(SafeGraphicsPathHandle path, FillMode fillmode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathData(HandleRef path, GpPathData* pathData);
+            internal static extern int GdipGetPathData(SafeGraphicsPathHandle path, GpPathData* pathData);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipStartPathFigure(HandleRef path);
+            internal static extern int GdipStartPathFigure(SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipClosePathFigure(HandleRef path);
+            internal static extern int GdipClosePathFigure(SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipClosePathFigures(HandleRef path);
+            internal static extern int GdipClosePathFigures(SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathMarker(HandleRef path);
+            internal static extern int GdipSetPathMarker(SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipClearPathMarkers(HandleRef path);
+            internal static extern int GdipClearPathMarkers(SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipReversePath(HandleRef path);
+            internal static extern int GdipReversePath(SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathLastPoint(HandleRef path, out PointF lastPoint);
+            internal static extern int GdipGetPathLastPoint(SafeGraphicsPathHandle path, out PointF lastPoint);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathLine(HandleRef path, float x1, float y1, float x2, float y2);
+            internal static extern int GdipAddPathLine(SafeGraphicsPathHandle path, float x1, float y1, float x2, float y2);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathLine2(HandleRef path, PointF* points, int count);
+            internal static extern int GdipAddPathLine2(SafeGraphicsPathHandle path, PointF* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathArc(HandleRef path, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            internal static extern int GdipAddPathArc(SafeGraphicsPathHandle path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathBezier(HandleRef path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
+            internal static extern int GdipAddPathBezier(SafeGraphicsPathHandle path, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathBeziers(HandleRef path, PointF* points, int count);
+            internal static extern int GdipAddPathBeziers(SafeGraphicsPathHandle path, PointF* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve(HandleRef path, PointF* points, int count);
+            internal static extern int GdipAddPathCurve(SafeGraphicsPathHandle path, PointF* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve2(HandleRef path, PointF* points, int count, float tension);
+            internal static extern int GdipAddPathCurve2(SafeGraphicsPathHandle path, PointF* points, int count, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve3(HandleRef path, PointF* points, int count, int offset, int numberOfSegments, float tension);
+            internal static extern int GdipAddPathCurve3(SafeGraphicsPathHandle path, PointF* points, int count, int offset, int numberOfSegments, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurve(HandleRef path, PointF* points, int count);
+            internal static extern int GdipAddPathClosedCurve(SafeGraphicsPathHandle path, PointF* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurve2(HandleRef path, PointF* points, int count, float tension);
+            internal static extern int GdipAddPathClosedCurve2(SafeGraphicsPathHandle path, PointF* points, int count, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathRectangle(HandleRef path, float x, float y, float width, float height);
+            internal static extern int GdipAddPathRectangle(SafeGraphicsPathHandle path, float x, float y, float width, float height);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathRectangles(HandleRef path, RectangleF* rects, int count);
+            internal static extern int GdipAddPathRectangles(SafeGraphicsPathHandle path, RectangleF* rects, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathEllipse(HandleRef path, float x, float y, float width, float height);
+            internal static extern int GdipAddPathEllipse(SafeGraphicsPathHandle path, float x, float y, float width, float height);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathPie(HandleRef path, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            internal static extern int GdipAddPathPie(SafeGraphicsPathHandle path, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathPolygon(HandleRef path, PointF* points, int count);
+            internal static extern int GdipAddPathPolygon(SafeGraphicsPathHandle path, PointF* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathPath(HandleRef path, HandleRef addingPath, bool connect);
+            internal static extern int GdipAddPathPath(SafeGraphicsPathHandle path, SafeGraphicsPathHandle addingPath, bool connect);
 
             [DllImport(LibraryName, CharSet = CharSet.Unicode)]
-            internal static extern int GdipAddPathString(HandleRef path, string s, int length, HandleRef fontFamily, int style, float emSize, ref RectangleF layoutRect, HandleRef format);
+            internal static extern int GdipAddPathString(SafeGraphicsPathHandle path, string s, int length, HandleRef fontFamily, int style, float emSize, ref RectangleF layoutRect, HandleRef format);
 
             [DllImport(LibraryName, CharSet = CharSet.Unicode)]
-            internal static extern int GdipAddPathStringI(HandleRef path, string s, int length, HandleRef fontFamily, int style, float emSize, ref Rectangle layoutRect, HandleRef format);
+            internal static extern int GdipAddPathStringI(SafeGraphicsPathHandle path, string s, int length, HandleRef fontFamily, int style, float emSize, ref Rectangle layoutRect, HandleRef format);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathLineI(HandleRef path, int x1, int y1, int x2, int y2);
+            internal static extern int GdipAddPathLineI(SafeGraphicsPathHandle path, int x1, int y1, int x2, int y2);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathLine2I(HandleRef path, Point* points, int count);
+            internal static extern int GdipAddPathLine2I(SafeGraphicsPathHandle path, Point* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathArcI(HandleRef path, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            internal static extern int GdipAddPathArcI(SafeGraphicsPathHandle path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathBezierI(HandleRef path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
+            internal static extern int GdipAddPathBezierI(SafeGraphicsPathHandle path, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathBeziersI(HandleRef path, Point* points, int count);
+            internal static extern int GdipAddPathBeziersI(SafeGraphicsPathHandle path, Point* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurveI(HandleRef path, Point* points, int count);
+            internal static extern int GdipAddPathCurveI(SafeGraphicsPathHandle path, Point* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve2I(HandleRef path, Point* points, int count, float tension);
+            internal static extern int GdipAddPathCurve2I(SafeGraphicsPathHandle path, Point* points, int count, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathCurve3I(HandleRef path, Point* points, int count, int offset, int numberOfSegments, float tension);
+            internal static extern int GdipAddPathCurve3I(SafeGraphicsPathHandle path, Point* points, int count, int offset, int numberOfSegments, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurveI(HandleRef path, Point* points, int count);
+            internal static extern int GdipAddPathClosedCurveI(SafeGraphicsPathHandle path, Point* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathClosedCurve2I(HandleRef path, Point* points, int count, float tension);
+            internal static extern int GdipAddPathClosedCurve2I(SafeGraphicsPathHandle path, Point* points, int count, float tension);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathRectangleI(HandleRef path, int x, int y, int width, int height);
+            internal static extern int GdipAddPathRectangleI(SafeGraphicsPathHandle path, int x, int y, int width, int height);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathRectanglesI(HandleRef path, Rectangle* rects, int count);
+            internal static extern int GdipAddPathRectanglesI(SafeGraphicsPathHandle path, Rectangle* rects, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathEllipseI(HandleRef path, int x, int y, int width, int height);
+            internal static extern int GdipAddPathEllipseI(SafeGraphicsPathHandle path, int x, int y, int width, int height);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathPieI(HandleRef path, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            internal static extern int GdipAddPathPieI(SafeGraphicsPathHandle path, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipAddPathPolygonI(HandleRef path, Point* points, int count);
+            internal static extern int GdipAddPathPolygonI(SafeGraphicsPathHandle path, Point* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTransformPath(HandleRef path, SafeMatrixHandle matrix);
+            internal static extern int GdipTransformPath(SafeGraphicsPathHandle path, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsVisiblePathPoint(HandleRef path, float x, float y, HandleRef graphics, out bool result);
+            internal static extern int GdipIsVisiblePathPoint(SafeGraphicsPathHandle path, float x, float y, HandleRef graphics, out bool result);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsVisiblePathPointI(HandleRef path, int x, int y, HandleRef graphics, out bool result);
+            internal static extern int GdipIsVisiblePathPointI(SafeGraphicsPathHandle path, int x, int y, HandleRef graphics, out bool result);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsOutlineVisiblePathPoint(HandleRef path, float x, float y, SafePenHandle pen, HandleRef graphics, out bool result);
+            internal static extern int GdipIsOutlineVisiblePathPoint(SafeGraphicsPathHandle path, float x, float y, SafePenHandle pen, HandleRef graphics, out bool result);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsOutlineVisiblePathPointI(HandleRef path, int x, int y, SafePenHandle pen, HandleRef graphics, out bool result);
+            internal static extern int GdipIsOutlineVisiblePathPointI(SafeGraphicsPathHandle path, int x, int y, SafePenHandle pen, HandleRef graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipLoadImageFromStream(IntPtr stream, IntPtr* image);
@@ -265,7 +265,7 @@ namespace System.Drawing
             internal static extern int GdipDrawBeziersI(HandleRef graphics, SafePenHandle pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillPath(HandleRef graphics, SafeBrushHandle brush, HandleRef path);
+            internal static extern int GdipFillPath(HandleRef graphics, SafeBrushHandle brush, SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestPoint(HandleRef graphics, HandleRef metafile, ref PointF destPoint, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -184,16 +184,7 @@ namespace System.Drawing
             internal static extern int GdipAddPathPolygonI(HandleRef path, Point* points, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipFlattenPath(HandleRef path, HandleRef matrixfloat, float flatness);
-
-            [DllImport(LibraryName)]
-            internal static extern int GdipWidenPath(HandleRef path, SafePenHandle pen, HandleRef matrix, float flatness);
-
-            [DllImport(LibraryName)]
-            internal static extern int GdipWarpPath(HandleRef path, HandleRef matrix, PointF* points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness);
-
-            [DllImport(LibraryName)]
-            internal static extern int GdipTransformPath(HandleRef path, HandleRef matrix);
+            internal static extern int GdipTransformPath(HandleRef path, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipIsVisiblePathPoint(HandleRef path, float x, float y, HandleRef graphics, out bool result);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Win32.SafeHandles;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Internal;
@@ -209,9 +210,6 @@ namespace System.Drawing
             [DllImport(LibraryName)]
             internal static extern int GdipIsOutlineVisiblePathPointI(HandleRef path, int x, int y, HandleRef pen, HandleRef graphics, out bool result);
 
-            [DllImport(LibraryName)]
-            internal static extern int GdipDeleteBrush(HandleRef brush);
-
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipLoadImageFromStream(IntPtr stream, IntPtr* image);
 
@@ -279,7 +277,7 @@ namespace System.Drawing
             internal static extern int GdipDrawBeziersI(HandleRef graphics, HandleRef pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillPath(HandleRef graphics, HandleRef brush, HandleRef path);
+            internal static extern int GdipFillPath(HandleRef graphics, SafeBrushHandle brush, HandleRef path);
 
             [DllImport(LibraryName)]
             internal static extern int GdipEnumerateMetafileDestPoint(HandleRef graphics, HandleRef metafile, ref PointF destPoint, Graphics.EnumerateMetafileProc callback, IntPtr callbackdata, HandleRef imageattributes);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -187,7 +187,7 @@ namespace System.Drawing
             internal static extern int GdipFlattenPath(HandleRef path, HandleRef matrixfloat, float flatness);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipWidenPath(HandleRef path, HandleRef pen, HandleRef matrix, float flatness);
+            internal static extern int GdipWidenPath(HandleRef path, SafePenHandle pen, HandleRef matrix, float flatness);
 
             [DllImport(LibraryName)]
             internal static extern int GdipWarpPath(HandleRef path, HandleRef matrix, PointF* points, int count, float srcX, float srcY, float srcWidth, float srcHeight, WarpMode warpMode, float flatness);
@@ -196,19 +196,16 @@ namespace System.Drawing
             internal static extern int GdipTransformPath(HandleRef path, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathWorldBounds(HandleRef path, out RectangleF gprectf, HandleRef matrix, HandleRef pen);
-
-            [DllImport(LibraryName)]
             internal static extern int GdipIsVisiblePathPoint(HandleRef path, float x, float y, HandleRef graphics, out bool result);
 
             [DllImport(LibraryName)]
             internal static extern int GdipIsVisiblePathPointI(HandleRef path, int x, int y, HandleRef graphics, out bool result);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsOutlineVisiblePathPoint(HandleRef path, float x, float y, HandleRef pen, HandleRef graphics, out bool result);
+            internal static extern int GdipIsOutlineVisiblePathPoint(HandleRef path, float x, float y, SafePenHandle pen, HandleRef graphics, out bool result);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsOutlineVisiblePathPointI(HandleRef path, int x, int y, HandleRef pen, HandleRef graphics, out bool result);
+            internal static extern int GdipIsOutlineVisiblePathPointI(HandleRef path, int x, int y, SafePenHandle pen, HandleRef graphics, out bool result);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipLoadImageFromStream(IntPtr stream, IntPtr* image);
@@ -271,10 +268,10 @@ namespace System.Drawing
             internal static partial IntPtr GdipCreateHalftonePalette();
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawBeziers(HandleRef graphics, HandleRef pen, PointF* points, int count);
+            internal static extern int GdipDrawBeziers(HandleRef graphics, SafePenHandle pen, PointF* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawBeziersI(HandleRef graphics, HandleRef pen, Point* points, int count);
+            internal static extern int GdipDrawBeziersI(HandleRef graphics, SafePenHandle pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillPath(HandleRef graphics, SafeBrushHandle brush, HandleRef path);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Win32.SafeHandles;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
@@ -139,199 +140,202 @@ namespace System.Drawing
             internal static extern int GdipPathIterCopyData(HandleRef pathIter, out int resultCount, PointF* points, byte* types, int startIndex, int endIndex);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateHatchBrush(int hatchstyle, int forecol, int backcol, out IntPtr brush);
+            internal static partial int GdipCreateHatchBrush(int hatchstyle, int forecol, int backcol, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetHatchStyle(HandleRef brush, out int hatchstyle);
+            internal static extern int GdipGetHatchStyle(SafeBrushHandle brush, out int hatchstyle);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetHatchForegroundColor(HandleRef brush, out int forecol);
+            internal static extern int GdipGetHatchForegroundColor(SafeBrushHandle brush, out int forecol);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetHatchBackgroundColor(HandleRef brush, out int backcol);
+            internal static extern int GdipGetHatchBackgroundColor(SafeBrushHandle brush, out int backcol);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCloneBrush(HandleRef brush, out IntPtr clonebrush);
+            internal static extern int GdipCloneBrush(SafeBrushHandle brush, out SafeBrushHandle clonebrush);
+
+            [DllImport(LibraryName)]
+            internal static extern int GdipDeleteBrush(IntPtr brush);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateLineBrush(ref PointF point1, ref PointF point2, int color1, int color2, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static extern int GdipCreateLineBrush(ref PointF point1, ref PointF point2, int color1, int color2, WrapMode wrapMode, out SafeBrushHandle lineGradient);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateLineBrushI(ref Point point1, ref Point point2, int color1, int color2, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static extern int GdipCreateLineBrushI(ref Point point1, ref Point point2, int color1, int color2, WrapMode wrapMode, out SafeBrushHandle lineGradient);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateLineBrushFromRect(ref RectangleF rect, int color1, int color2, LinearGradientMode lineGradientMode, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static extern int GdipCreateLineBrushFromRect(ref RectangleF rect, int color1, int color2, LinearGradientMode lineGradientMode, WrapMode wrapMode, out SafeBrushHandle lineGradient);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateLineBrushFromRectI(ref Rectangle rect, int color1, int color2, LinearGradientMode lineGradientMode, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static extern int GdipCreateLineBrushFromRectI(ref Rectangle rect, int color1, int color2, LinearGradientMode lineGradientMode, WrapMode wrapMode, out SafeBrushHandle lineGradient);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateLineBrushFromRectWithAngle(ref RectangleF rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static extern int GdipCreateLineBrushFromRectWithAngle(ref RectangleF rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out SafeBrushHandle lineGradient);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateLineBrushFromRectWithAngleI(ref Rectangle rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out IntPtr lineGradient);
+            internal static extern int GdipCreateLineBrushFromRectWithAngleI(ref Rectangle rect, int color1, int color2, float angle, bool isAngleScaleable, WrapMode wrapMode, out SafeBrushHandle lineGradient);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineColors(HandleRef brush, int color1, int color2);
+            internal static extern int GdipSetLineColors(SafeBrushHandle brush, int color1, int color2);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineColors(HandleRef brush, int[] colors);
+            internal static extern int GdipGetLineColors(SafeBrushHandle brush, int[] colors);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineRect(HandleRef brush, out RectangleF gprectf);
+            internal static extern int GdipGetLineRect(SafeBrushHandle brush, out RectangleF gprectf);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineGammaCorrection(HandleRef brush, out bool useGammaCorrection);
+            internal static extern int GdipGetLineGammaCorrection(SafeBrushHandle brush, out bool useGammaCorrection);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineGammaCorrection(HandleRef brush, bool useGammaCorrection);
+            internal static extern int GdipSetLineGammaCorrection(SafeBrushHandle brush, bool useGammaCorrection);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineSigmaBlend(HandleRef brush, float focus, float scale);
+            internal static extern int GdipSetLineSigmaBlend(SafeBrushHandle brush, float focus, float scale);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineLinearBlend(HandleRef brush, float focus, float scale);
+            internal static extern int GdipSetLineLinearBlend(SafeBrushHandle brush, float focus, float scale);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineBlendCount(HandleRef brush, out int count);
+            internal static extern int GdipGetLineBlendCount(SafeBrushHandle brush, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
+            internal static extern int GdipGetLineBlend(SafeBrushHandle brush, IntPtr blend, IntPtr positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
+            internal static extern int GdipSetLineBlend(SafeBrushHandle brush, IntPtr blend, IntPtr positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLinePresetBlendCount(HandleRef brush, out int count);
+            internal static extern int GdipGetLinePresetBlendCount(SafeBrushHandle brush, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLinePresetBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
+            internal static extern int GdipGetLinePresetBlend(SafeBrushHandle brush, IntPtr blend, IntPtr positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLinePresetBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
+            internal static extern int GdipSetLinePresetBlend(SafeBrushHandle brush, IntPtr blend, IntPtr positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineWrapMode(HandleRef brush, int wrapMode);
+            internal static extern int GdipSetLineWrapMode(SafeBrushHandle brush, int wrapMode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineWrapMode(HandleRef brush, out int wrapMode);
+            internal static extern int GdipGetLineWrapMode(SafeBrushHandle brush, out int wrapMode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipResetLineTransform(HandleRef brush);
+            internal static extern int GdipResetLineTransform(SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyLineTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyLineTransform(SafeBrushHandle brush, HandleRef matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineTransform(HandleRef brush, HandleRef matrix);
+            internal static extern int GdipGetLineTransform(SafeBrushHandle brush, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineTransform(HandleRef brush, HandleRef matrix);
+            internal static extern int GdipSetLineTransform(SafeBrushHandle brush, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslateLineTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
+            internal static extern int GdipTranslateLineTransform(SafeBrushHandle brush, float dx, float dy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipScaleLineTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
+            internal static extern int GdipScaleLineTransform(SafeBrushHandle brush, float sx, float sy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipRotateLineTransform(HandleRef brush, float angle, MatrixOrder order);
+            internal static extern int GdipRotateLineTransform(SafeBrushHandle brush, float angle, MatrixOrder order);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreatePathGradient(PointF* points, int count, WrapMode wrapMode, out IntPtr brush);
+            internal static partial int GdipCreatePathGradient(PointF* points, int count, WrapMode wrapMode, out SafeBrushHandle brush);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreatePathGradientI(Point* points, int count, WrapMode wrapMode, out IntPtr brush);
+            internal static partial int GdipCreatePathGradientI(Point* points, int count, WrapMode wrapMode, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreatePathGradientFromPath(HandleRef path, out IntPtr brush);
+            internal static extern int GdipCreatePathGradientFromPath(HandleRef path, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientCenterColor(HandleRef brush, out int color);
+            internal static extern int GdipGetPathGradientCenterColor(SafeBrushHandle brush, out int color);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientCenterColor(HandleRef brush, int color);
+            internal static extern int GdipSetPathGradientCenterColor(SafeBrushHandle brush, int color);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientSurroundColorsWithCount(HandleRef brush, int[] color, ref int count);
+            internal static extern int GdipGetPathGradientSurroundColorsWithCount(SafeBrushHandle brush, int[] color, ref int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientSurroundColorsWithCount(HandleRef brush, int[] argb, ref int count);
+            internal static extern int GdipSetPathGradientSurroundColorsWithCount(SafeBrushHandle brush, int[] argb, ref int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientCenterPoint(HandleRef brush, out PointF point);
+            internal static extern int GdipGetPathGradientCenterPoint(SafeBrushHandle brush, out PointF point);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientCenterPoint(HandleRef brush, ref PointF point);
+            internal static extern int GdipSetPathGradientCenterPoint(SafeBrushHandle brush, ref PointF point);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientRect(HandleRef brush, out RectangleF gprectf);
+            internal static extern int GdipGetPathGradientRect(SafeBrushHandle brush, out RectangleF gprectf);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientPointCount(HandleRef brush, out int count);
+            internal static extern int GdipGetPathGradientPointCount(SafeBrushHandle brush, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientSurroundColorCount(HandleRef brush, out int count);
+            internal static extern int GdipGetPathGradientSurroundColorCount(SafeBrushHandle brush, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientBlendCount(HandleRef brush, out int count);
+            internal static extern int GdipGetPathGradientBlendCount(SafeBrushHandle brush, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientBlend(HandleRef brush, float[] blend, float[] positions, int count);
+            internal static extern int GdipGetPathGradientBlend(SafeBrushHandle brush, float[] blend, float[] positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientBlend(HandleRef brush, IntPtr blend, IntPtr positions, int count);
+            internal static extern int GdipSetPathGradientBlend(SafeBrushHandle brush, IntPtr blend, IntPtr positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientPresetBlendCount(HandleRef brush, out int count);
+            internal static extern int GdipGetPathGradientPresetBlendCount(SafeBrushHandle brush, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientPresetBlend(HandleRef brush, int[] blend, float[] positions, int count);
+            internal static extern int GdipGetPathGradientPresetBlend(SafeBrushHandle brush, int[] blend, float[] positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientPresetBlend(HandleRef brush, int[] blend, float[] positions, int count);
+            internal static extern int GdipSetPathGradientPresetBlend(SafeBrushHandle brush, int[] blend, float[] positions, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientSigmaBlend(HandleRef brush, float focus, float scale);
+            internal static extern int GdipSetPathGradientSigmaBlend(SafeBrushHandle brush, float focus, float scale);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientLinearBlend(HandleRef brush, float focus, float scale);
+            internal static extern int GdipSetPathGradientLinearBlend(SafeBrushHandle brush, float focus, float scale);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientWrapMode(HandleRef brush, int wrapmode);
+            internal static extern int GdipSetPathGradientWrapMode(SafeBrushHandle brush, int wrapmode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientWrapMode(HandleRef brush, out int wrapmode);
+            internal static extern int GdipGetPathGradientWrapMode(SafeBrushHandle brush, out int wrapmode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientTransform(HandleRef brush, HandleRef matrix);
+            internal static extern int GdipSetPathGradientTransform(SafeBrushHandle brush, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientTransform(HandleRef brush, HandleRef matrix);
+            internal static extern int GdipGetPathGradientTransform(SafeBrushHandle brush, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipResetPathGradientTransform(HandleRef brush);
+            internal static extern int GdipResetPathGradientTransform(SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyPathGradientTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyPathGradientTransform(SafeBrushHandle brush, HandleRef matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslatePathGradientTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
+            internal static extern int GdipTranslatePathGradientTransform(SafeBrushHandle brush, float dx, float dy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipScalePathGradientTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
+            internal static extern int GdipScalePathGradientTransform(SafeBrushHandle brush, float sx, float sy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipRotatePathGradientTransform(HandleRef brush, float angle, MatrixOrder order);
+            internal static extern int GdipRotatePathGradientTransform(SafeBrushHandle brush, float angle, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientFocusScales(HandleRef brush, float[] xScale, float[] yScale);
+            internal static extern int GdipGetPathGradientFocusScales(SafeBrushHandle brush, float[] xScale, float[] yScale);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientFocusScales(HandleRef brush, float xScale, float yScale);
+            internal static extern int GdipSetPathGradientFocusScales(SafeBrushHandle brush, float xScale, float yScale);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateImageAttributes(out IntPtr imageattr);
@@ -385,59 +389,59 @@ namespace System.Drawing
             internal static partial int GdipGetImageEncoders(int numEncoders, int size, IntPtr encoders);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateSolidFill(int color, out IntPtr brush);
+            internal static partial int GdipCreateSolidFill(int color, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetSolidFillColor(HandleRef brush, int color);
+            internal static extern int GdipSetSolidFillColor(SafeBrushHandle brush, int color);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetSolidFillColor(HandleRef brush, out int color);
+            internal static extern int GdipGetSolidFillColor(SafeBrushHandle brush, out int color);
 
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateTexture(HandleRef bitmap, int wrapmode, out IntPtr texture);
+            internal static extern int GdipCreateTexture(HandleRef bitmap, int wrapmode, out SafeBrushHandle texture);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateTexture2(HandleRef bitmap, int wrapmode, float x, float y, float width, float height, out IntPtr texture);
+            internal static extern int GdipCreateTexture2(HandleRef bitmap, int wrapmode, float x, float y, float width, float height, out SafeBrushHandle texture);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateTextureIA(HandleRef bitmap, HandleRef imageAttrib, float x, float y, float width, float height, out IntPtr texture);
+            internal static extern int GdipCreateTextureIA(HandleRef bitmap, HandleRef imageAttrib, float x, float y, float width, float height, out SafeBrushHandle texture);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateTexture2I(HandleRef bitmap, int wrapmode, int x, int y, int width, int height, out IntPtr texture);
+            internal static extern int GdipCreateTexture2I(HandleRef bitmap, int wrapmode, int x, int y, int width, int height, out SafeBrushHandle texture);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateTextureIAI(HandleRef bitmap, HandleRef imageAttrib, int x, int y, int width, int height, out IntPtr texture);
+            internal static extern int GdipCreateTextureIAI(HandleRef bitmap, HandleRef imageAttrib, int x, int y, int width, int height, out SafeBrushHandle texture);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetTextureTransform(HandleRef brush, HandleRef matrix);
+            internal static extern int GdipSetTextureTransform(SafeBrushHandle brush, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetTextureTransform(HandleRef brush, HandleRef matrix);
+            internal static extern int GdipGetTextureTransform(SafeBrushHandle brush, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipResetTextureTransform(HandleRef brush);
+            internal static extern int GdipResetTextureTransform(SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyTextureTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyTextureTransform(SafeBrushHandle brush, HandleRef matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslateTextureTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
+            internal static extern int GdipTranslateTextureTransform(SafeBrushHandle brush, float dx, float dy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipScaleTextureTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
+            internal static extern int GdipScaleTextureTransform(SafeBrushHandle brush, float sx, float sy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipRotateTextureTransform(HandleRef brush, float angle, MatrixOrder order);
+            internal static extern int GdipRotateTextureTransform(SafeBrushHandle brush, float angle, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetTextureWrapMode(HandleRef brush, int wrapMode);
+            internal static extern int GdipSetTextureWrapMode(SafeBrushHandle brush, int wrapMode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetTextureWrapMode(HandleRef brush, out int wrapMode);
+            internal static extern int GdipGetTextureWrapMode(SafeBrushHandle brush, out int wrapMode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetTextureImage(HandleRef brush, out IntPtr image);
+            internal static extern int GdipGetTextureImage(SafeBrushHandle brush, out IntPtr image);
 
             [DllImport(LibraryName)]
             internal static extern int GdipGetFontCollectionFamilyCount(HandleRef fontCollection, out int numFound);
@@ -533,7 +537,7 @@ namespace System.Drawing
             internal static partial int GdipCreatePen1(int argb, float width, int unit, out IntPtr pen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreatePen2(HandleRef brush, float width, int unit, out IntPtr pen);
+            internal static extern int GdipCreatePen2(SafeBrushHandle brush, float width, int unit, out IntPtr pen);
 
             [DllImport(LibraryName)]
             internal static extern int GdipClonePen(HandleRef pen, out IntPtr clonepen);
@@ -605,19 +609,19 @@ namespace System.Drawing
             internal static extern int GdipGetPenTransform(HandleRef pen, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipResetPenTransform(HandleRef brush);
+            internal static extern int GdipResetPenTransform(HandleRef pen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyPenTransform(HandleRef brush, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyPenTransform(HandleRef pen, HandleRef matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslatePenTransform(HandleRef brush, float dx, float dy, MatrixOrder order);
+            internal static extern int GdipTranslatePenTransform(HandleRef pen, float dx, float dy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipScalePenTransform(HandleRef brush, float sx, float sy, MatrixOrder order);
+            internal static extern int GdipScalePenTransform(HandleRef pen, float sx, float sy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipRotatePenTransform(HandleRef brush, float angle, MatrixOrder order);
+            internal static extern int GdipRotatePenTransform(HandleRef pen, float angle, MatrixOrder order);
 
             [DllImport(LibraryName)]
             internal static extern int GdipSetPenColor(HandleRef pen, int argb);
@@ -626,10 +630,10 @@ namespace System.Drawing
             internal static extern int GdipGetPenColor(HandleRef pen, out int argb);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenBrushFill(HandleRef pen, HandleRef brush);
+            internal static extern int GdipSetPenBrushFill(HandleRef pen, SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenBrushFill(HandleRef pen, out IntPtr brush);
+            internal static extern int GdipGetPenBrushFill(HandleRef pen, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
             internal static extern int GdipGetPenFillType(HandleRef pen, out int pentype);
@@ -845,7 +849,7 @@ namespace System.Drawing
             internal static extern int GdipDeleteRegion(HandleRef region);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillRegion(HandleRef graphics, HandleRef brush, HandleRef region);
+            internal static extern int GdipFillRegion(HandleRef graphics, SafeBrushHandle brush, HandleRef region);
 
             [DllImport(LibraryName)]
             internal static extern int GdipSetInfinite(HandleRef region);
@@ -1244,31 +1248,31 @@ namespace System.Drawing
             internal static extern int GdipDrawPolygonI(HandleRef graphics, HandleRef pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillEllipse(HandleRef graphics, HandleRef brush, float x, float y, float width, float height);
+            internal static extern int GdipFillEllipse(HandleRef graphics, SafeBrushHandle brush, float x, float y, float width, float height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillEllipseI(HandleRef graphics, HandleRef brush, int x, int y, int width, int height);
+            internal static extern int GdipFillEllipseI(HandleRef graphics, SafeBrushHandle brush, int x, int y, int width, int height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillPolygon(HandleRef graphics, HandleRef brush, PointF* points, int count, FillMode brushMode);
+            internal static extern int GdipFillPolygon(HandleRef graphics, SafeBrushHandle brush, PointF* points, int count, FillMode brushMode);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillPolygonI(HandleRef graphics, HandleRef brush, Point* points, int count, FillMode brushMode);
+            internal static extern int GdipFillPolygonI(HandleRef graphics, SafeBrushHandle brush, Point* points, int count, FillMode brushMode);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillRectangle(HandleRef graphics, HandleRef brush, float x, float y, float width, float height);
+            internal static extern int GdipFillRectangle(HandleRef graphics, SafeBrushHandle brush, float x, float y, float width, float height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillRectangleI(HandleRef graphics, HandleRef brush, int x, int y, int width, int height);
+            internal static extern int GdipFillRectangleI(HandleRef graphics, SafeBrushHandle brush, int x, int y, int width, int height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillRectangles(HandleRef graphics, HandleRef brush, RectangleF* rects, int count);
+            internal static extern int GdipFillRectangles(HandleRef graphics, SafeBrushHandle brush, RectangleF* rects, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillRectanglesI(HandleRef graphics, HandleRef brush, Rectangle* rects, int count);
+            internal static extern int GdipFillRectanglesI(HandleRef graphics, SafeBrushHandle brush, Rectangle* rects, int count);
 
             [DllImport(LibraryName, CharSet = CharSet.Unicode, SetLastError = true)]
-            internal static extern int GdipDrawString(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, HandleRef brush);
+            internal static extern int GdipDrawString(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, SafeBrushHandle brush);
 
             [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImageRectI(HandleRef graphics, HandleRef image, int x, int y, int width, int height);
@@ -1307,22 +1311,22 @@ namespace System.Drawing
             internal static extern int GdipDrawCurve3I(HandleRef graphics, HandleRef pen, Point* points, int count, int offset, int numberOfSegments, float tension);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillClosedCurve(HandleRef graphics, HandleRef brush, PointF* points, int count);
+            internal static extern int GdipFillClosedCurve(HandleRef graphics, SafeBrushHandle brush, PointF* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillClosedCurveI(HandleRef graphics, HandleRef brush, Point* points, int count);
+            internal static extern int GdipFillClosedCurveI(HandleRef graphics, SafeBrushHandle brush, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillClosedCurve2(HandleRef graphics, HandleRef brush, PointF* points, int count, float tension, FillMode mode);
+            internal static extern int GdipFillClosedCurve2(HandleRef graphics, SafeBrushHandle brush, PointF* points, int count, float tension, FillMode mode);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillClosedCurve2I(HandleRef graphics, HandleRef brush, Point* points, int count, float tension, FillMode mode);
+            internal static extern int GdipFillClosedCurve2I(HandleRef graphics, SafeBrushHandle brush, Point* points, int count, float tension, FillMode mode);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillPie(HandleRef graphics, HandleRef brush, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            internal static extern int GdipFillPie(HandleRef graphics, SafeBrushHandle brush, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillPieI(HandleRef graphics, HandleRef brush, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            internal static extern int GdipFillPieI(HandleRef graphics, SafeBrushHandle brush, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName, CharSet = CharSet.Unicode)]
             internal static extern int GdipMeasureString(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, ref RectangleF boundingBox, out int codepointsFitted, out int linesFilled);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -534,139 +534,139 @@ namespace System.Drawing
             internal static extern int GdipGetLogFontW(HandleRef font, HandleRef graphics, ref Interop.User32.LOGFONT lf);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreatePen1(int argb, float width, int unit, out IntPtr pen);
+            internal static partial int GdipCreatePen1(int argb, float width, int unit, out SafePenHandle pen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreatePen2(SafeBrushHandle brush, float width, int unit, out IntPtr pen);
+            internal static extern int GdipCreatePen2(SafeBrushHandle brush, float width, int unit, out SafePenHandle pen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipClonePen(HandleRef pen, out IntPtr clonepen);
+            internal static extern int GdipClonePen(SafePenHandle pen, out SafePenHandle clonedPen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipDeletePen(HandleRef Pen);
+            internal static extern int GdipDeletePen(IntPtr Pen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenMode(HandleRef pen, PenAlignment penAlign);
+            internal static extern int GdipSetPenMode(SafePenHandle pen, PenAlignment penAlign);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenMode(HandleRef pen, out PenAlignment penAlign);
+            internal static extern int GdipGetPenMode(SafePenHandle pen, out PenAlignment penAlign);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenWidth(HandleRef pen, float width);
+            internal static extern int GdipSetPenWidth(SafePenHandle pen, float width);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenWidth(HandleRef pen, float[] width);
+            internal static extern int GdipGetPenWidth(SafePenHandle pen, float[] width);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenLineCap197819(HandleRef pen, int startCap, int endCap, int dashCap);
+            internal static extern int GdipSetPenLineCap197819(SafePenHandle pen, int startCap, int endCap, int dashCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenStartCap(HandleRef pen, int startCap);
+            internal static extern int GdipSetPenStartCap(SafePenHandle pen, int startCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenEndCap(HandleRef pen, int endCap);
+            internal static extern int GdipSetPenEndCap(SafePenHandle pen, int endCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenStartCap(HandleRef pen, out int startCap);
+            internal static extern int GdipGetPenStartCap(SafePenHandle pen, out int startCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenEndCap(HandleRef pen, out int endCap);
+            internal static extern int GdipGetPenEndCap(SafePenHandle pen, out int endCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenDashCap197819(HandleRef pen, out int dashCap);
+            internal static extern int GdipGetPenDashCap197819(SafePenHandle pen, out int dashCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenDashCap197819(HandleRef pen, int dashCap);
+            internal static extern int GdipSetPenDashCap197819(SafePenHandle pen, int dashCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenLineJoin(HandleRef pen, int lineJoin);
+            internal static extern int GdipSetPenLineJoin(SafePenHandle pen, int lineJoin);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenLineJoin(HandleRef pen, out int lineJoin);
+            internal static extern int GdipGetPenLineJoin(SafePenHandle pen, out int lineJoin);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenCustomStartCap(HandleRef pen, HandleRef customCap);
+            internal static extern int GdipSetPenCustomStartCap(SafePenHandle pen, HandleRef customCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenCustomStartCap(HandleRef pen, out IntPtr customCap);
+            internal static extern int GdipGetPenCustomStartCap(SafePenHandle pen, out IntPtr customCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenCustomEndCap(HandleRef pen, HandleRef customCap);
+            internal static extern int GdipSetPenCustomEndCap(SafePenHandle pen, HandleRef customCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenCustomEndCap(HandleRef pen, out IntPtr customCap);
+            internal static extern int GdipGetPenCustomEndCap(SafePenHandle pen, out IntPtr customCap);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenMiterLimit(HandleRef pen, float miterLimit);
+            internal static extern int GdipSetPenMiterLimit(SafePenHandle pen, float miterLimit);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenMiterLimit(HandleRef pen, float[] miterLimit);
+            internal static extern int GdipGetPenMiterLimit(SafePenHandle pen, float[] miterLimit);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenTransform(HandleRef pen, HandleRef matrix);
+            internal static extern int GdipSetPenTransform(SafePenHandle pen, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenTransform(HandleRef pen, HandleRef matrix);
+            internal static extern int GdipGetPenTransform(SafePenHandle pen, HandleRef matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipResetPenTransform(HandleRef pen);
+            internal static extern int GdipResetPenTransform(SafePenHandle pen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyPenTransform(HandleRef pen, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyPenTransform(SafePenHandle pen, HandleRef matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslatePenTransform(HandleRef pen, float dx, float dy, MatrixOrder order);
+            internal static extern int GdipTranslatePenTransform(SafePenHandle pen, float dx, float dy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipScalePenTransform(HandleRef pen, float sx, float sy, MatrixOrder order);
+            internal static extern int GdipScalePenTransform(SafePenHandle pen, float sx, float sy, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipRotatePenTransform(HandleRef pen, float angle, MatrixOrder order);
+            internal static extern int GdipRotatePenTransform(SafePenHandle pen, float angle, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenColor(HandleRef pen, int argb);
+            internal static extern int GdipSetPenColor(SafePenHandle pen, int argb);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenColor(HandleRef pen, out int argb);
+            internal static extern int GdipGetPenColor(SafePenHandle pen, out int argb);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenBrushFill(HandleRef pen, SafeBrushHandle brush);
+            internal static extern int GdipSetPenBrushFill(SafePenHandle pen, SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenBrushFill(HandleRef pen, out SafeBrushHandle brush);
+            internal static extern int GdipGetPenBrushFill(SafePenHandle pen, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenFillType(HandleRef pen, out int pentype);
+            internal static extern int GdipGetPenFillType(SafePenHandle pen, out int pentype);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenDashStyle(HandleRef pen, out int dashstyle);
+            internal static extern int GdipGetPenDashStyle(SafePenHandle pen, out int dashstyle);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenDashStyle(HandleRef pen, int dashstyle);
+            internal static extern int GdipSetPenDashStyle(SafePenHandle pen, int dashstyle);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenDashArray(HandleRef pen, HandleRef memorydash, int count);
+            internal static extern int GdipSetPenDashArray(SafePenHandle pen, HandleRef memorydash, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenDashOffset(HandleRef pen, float[] dashoffset);
+            internal static extern int GdipGetPenDashOffset(SafePenHandle pen, float[] dashoffset);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenDashOffset(HandleRef pen, float dashoffset);
+            internal static extern int GdipSetPenDashOffset(SafePenHandle pen, float dashoffset);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenDashCount(HandleRef pen, out int dashcount);
+            internal static extern int GdipGetPenDashCount(SafePenHandle pen, out int dashcount);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenDashArray(HandleRef pen, float[] memorydash, int count);
+            internal static extern int GdipGetPenDashArray(SafePenHandle pen, float[] memorydash, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenCompoundCount(HandleRef pen, out int count);
+            internal static extern int GdipGetPenCompoundCount(SafePenHandle pen, out int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenCompoundArray(HandleRef pen, float[] array, int count);
+            internal static extern int GdipSetPenCompoundArray(SafePenHandle pen, float[] array, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenCompoundArray(HandleRef pen, float[] array, int count);
+            internal static extern int GdipGetPenCompoundArray(SafePenHandle pen, float[] array, int count);
 
             [DllImport(LibraryName)]
             internal static extern int GdipSetWorldTransform(HandleRef graphics, HandleRef matrix);
@@ -1206,46 +1206,46 @@ namespace System.Drawing
             internal static extern int GdipSaveGraphics(HandleRef graphics, out int state);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawArc(HandleRef graphics, HandleRef pen, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            internal static extern int GdipDrawArc(HandleRef graphics, SafePenHandle pen, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawArcI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            internal static extern int GdipDrawArcI(HandleRef graphics, SafePenHandle pen, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawLinesI(HandleRef graphics, HandleRef pen, Point* points, int count);
+            internal static extern int GdipDrawLinesI(HandleRef graphics, SafePenHandle pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawBezier(HandleRef graphics, HandleRef pen, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
+            internal static extern int GdipDrawBezier(HandleRef graphics, SafePenHandle pen, float x1, float y1, float x2, float y2, float x3, float y3, float x4, float y4);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawEllipse(HandleRef graphics, HandleRef pen, float x, float y, float width, float height);
+            internal static extern int GdipDrawEllipse(HandleRef graphics, SafePenHandle pen, float x, float y, float width, float height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawEllipseI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height);
+            internal static extern int GdipDrawEllipseI(HandleRef graphics, SafePenHandle pen, int x, int y, int width, int height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawLine(HandleRef graphics, HandleRef pen, float x1, float y1, float x2, float y2);
+            internal static extern int GdipDrawLine(HandleRef graphics, SafePenHandle pen, float x1, float y1, float x2, float y2);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawLineI(HandleRef graphics, HandleRef pen, int x1, int y1, int x2, int y2);
+            internal static extern int GdipDrawLineI(HandleRef graphics, SafePenHandle pen, int x1, int y1, int x2, int y2);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawLines(HandleRef graphics, HandleRef pen, PointF* points, int count);
+            internal static extern int GdipDrawLines(HandleRef graphics, SafePenHandle pen, PointF* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawPath(HandleRef graphics, HandleRef pen, HandleRef path);
+            internal static extern int GdipDrawPath(HandleRef graphics, SafePenHandle pen, HandleRef path);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawPie(HandleRef graphics, HandleRef pen, float x, float y, float width, float height, float startAngle, float sweepAngle);
+            internal static extern int GdipDrawPie(HandleRef graphics, SafePenHandle pen, float x, float y, float width, float height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawPieI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height, float startAngle, float sweepAngle);
+            internal static extern int GdipDrawPieI(HandleRef graphics, SafePenHandle pen, int x, int y, int width, int height, float startAngle, float sweepAngle);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawPolygon(HandleRef graphics, HandleRef pen, PointF* points, int count);
+            internal static extern int GdipDrawPolygon(HandleRef graphics, SafePenHandle pen, PointF* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawPolygonI(HandleRef graphics, HandleRef pen, Point* points, int count);
+            internal static extern int GdipDrawPolygonI(HandleRef graphics, SafePenHandle pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillEllipse(HandleRef graphics, SafeBrushHandle brush, float x, float y, float width, float height);
@@ -1281,34 +1281,34 @@ namespace System.Drawing
             internal static extern int GdipGraphicsClear(HandleRef graphics, int argb);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawClosedCurve(HandleRef graphics, HandleRef pen, PointF* points, int count);
+            internal static extern int GdipDrawClosedCurve(HandleRef graphics, SafePenHandle pen, PointF* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawClosedCurveI(HandleRef graphics, HandleRef pen, Point* points, int count);
+            internal static extern int GdipDrawClosedCurveI(HandleRef graphics, SafePenHandle pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawClosedCurve2(HandleRef graphics, HandleRef pen, PointF* points, int count, float tension);
+            internal static extern int GdipDrawClosedCurve2(HandleRef graphics, SafePenHandle pen, PointF* points, int count, float tension);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawClosedCurve2I(HandleRef graphics, HandleRef pen, Point* points, int count, float tension);
+            internal static extern int GdipDrawClosedCurve2I(HandleRef graphics, SafePenHandle pen, Point* points, int count, float tension);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawCurve(HandleRef graphics, HandleRef pen, PointF* points, int count);
+            internal static extern int GdipDrawCurve(HandleRef graphics, SafePenHandle pen, PointF* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawCurveI(HandleRef graphics, HandleRef pen, Point* points, int count);
+            internal static extern int GdipDrawCurveI(HandleRef graphics, SafePenHandle pen, Point* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawCurve2(HandleRef graphics, HandleRef pen, PointF* points, int count, float tension);
+            internal static extern int GdipDrawCurve2(HandleRef graphics, SafePenHandle pen, PointF* points, int count, float tension);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawCurve2I(HandleRef graphics, HandleRef pen, Point* points, int count, float tension);
+            internal static extern int GdipDrawCurve2I(HandleRef graphics, SafePenHandle pen, Point* points, int count, float tension);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawCurve3(HandleRef graphics, HandleRef pen, PointF* points, int count, int offset, int numberOfSegments, float tension);
+            internal static extern int GdipDrawCurve3(HandleRef graphics, SafePenHandle pen, PointF* points, int count, int offset, int numberOfSegments, float tension);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawCurve3I(HandleRef graphics, HandleRef pen, Point* points, int count, int offset, int numberOfSegments, float tension);
+            internal static extern int GdipDrawCurve3I(HandleRef graphics, SafePenHandle pen, Point* points, int count, int offset, int numberOfSegments, float tension);
 
             [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipFillClosedCurve(HandleRef graphics, SafeBrushHandle brush, PointF* points, int count);
@@ -1368,16 +1368,16 @@ namespace System.Drawing
             internal static extern int GdipDrawImagePointRectI(HandleRef graphics, HandleRef image, int x, int y, int srcx, int srcy, int srcwidth, int srcheight, int srcunit);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawRectangle(HandleRef graphics, HandleRef pen, float x, float y, float width, float height);
+            internal static extern int GdipDrawRectangle(HandleRef graphics, SafePenHandle pen, float x, float y, float width, float height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawRectangleI(HandleRef graphics, HandleRef pen, int x, int y, int width, int height);
+            internal static extern int GdipDrawRectangleI(HandleRef graphics, SafePenHandle pen, int x, int y, int width, int height);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawRectangles(HandleRef graphics, HandleRef pen, RectangleF* rects, int count);
+            internal static extern int GdipDrawRectangles(HandleRef graphics, SafePenHandle pen, RectangleF* rects, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawRectanglesI(HandleRef graphics, HandleRef pen, Rectangle* rects, int count);
+            internal static extern int GdipDrawRectanglesI(HandleRef graphics, SafePenHandle pen, Rectangle* rects, int count);
 
             [DllImport(LibraryName)]
             internal static extern int GdipTransformPoints(HandleRef graphics, int destSpace, int srcSpace, PointF* points, int count);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -58,9 +58,6 @@ namespace System.Drawing
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipGetCustomLineCapType(IntPtr customCap, out CustomLineCapType capType);
 
-            [DllImport(LibraryName)]
-            internal static extern int GdipCreateCustomLineCap(HandleRef fillpath, HandleRef strokepath, LineCap baseCap, float baseInset, out IntPtr customCap);
-
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipDeleteCustomLineCap(IntPtr customCap);
 
@@ -101,25 +98,16 @@ namespace System.Drawing
             internal static extern int GdipGetCustomLineCapWidthScale(HandleRef customCap, out float widthScale);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreatePathIter(out IntPtr pathIter, HandleRef path);
-
-            [DllImport(LibraryName)]
             internal static extern int GdipDeletePathIter(HandleRef pathIter);
 
             [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextSubpath(HandleRef pathIter, out int resultCount, out int startIndex, out int endIndex, out bool isClosed);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipPathIterNextSubpathPath(HandleRef pathIter, out int resultCount, HandleRef path, out bool isClosed);
-
-            [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextPathType(HandleRef pathIter, out int resultCount, out byte pathType, out int startIndex, out int endIndex);
 
             [DllImport(LibraryName)]
             internal static extern int GdipPathIterNextMarker(HandleRef pathIter, out int resultCount, out int startIndex, out int endIndex);
-
-            [DllImport(LibraryName)]
-            internal static extern int GdipPathIterNextMarkerPath(HandleRef pathIter, out int resultCount, HandleRef path);
 
             [DllImport(LibraryName)]
             internal static extern int GdipPathIterGetCount(HandleRef pathIter, out int count);
@@ -251,7 +239,7 @@ namespace System.Drawing
             internal static partial int GdipCreatePathGradientI(Point* points, int count, WrapMode wrapMode, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreatePathGradientFromPath(HandleRef path, out SafeBrushHandle brush);
+            internal static extern int GdipCreatePathGradientFromPath(SafeGraphicsPathHandle path, out SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
             internal static extern int GdipGetPathGradientCenterColor(SafeBrushHandle brush, out int color);
@@ -834,7 +822,7 @@ namespace System.Drawing
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateRegionPath(HandleRef path, out SafeRegionHandle region);
+            internal static extern int GdipCreateRegionPath(SafeGraphicsPathHandle path, out SafeRegionHandle region);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateRegionRgnData(byte[] rgndata, int size, out SafeRegionHandle region);
@@ -864,7 +852,7 @@ namespace System.Drawing
             internal static extern int GdipCombineRegionRectI(SafeRegionHandle region, ref Rectangle gprect, CombineMode mode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCombineRegionPath(SafeRegionHandle region, HandleRef path, CombineMode mode);
+            internal static extern int GdipCombineRegionPath(SafeRegionHandle region, SafeGraphicsPathHandle path, CombineMode mode);
 
             [DllImport(LibraryName)]
             internal static extern int GdipCombineRegionRegion(SafeRegionHandle region, SafeRegionHandle region2, CombineMode mode);
@@ -930,7 +918,7 @@ namespace System.Drawing
             internal static extern int GdipSetClipRectI(HandleRef graphics, int x, int y, int width, int height, CombineMode mode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetClipPath(HandleRef graphics, HandleRef path, CombineMode mode);
+            internal static extern int GdipSetClipPath(HandleRef graphics, SafeGraphicsPathHandle path, CombineMode mode);
 
             [DllImport(LibraryName)]
             internal static extern int GdipSetClipRegion(HandleRef graphics, SafeRegionHandle region, CombineMode mode);
@@ -1233,7 +1221,7 @@ namespace System.Drawing
             internal static extern int GdipDrawLines(HandleRef graphics, SafePenHandle pen, PointF* points, int count);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipDrawPath(HandleRef graphics, SafePenHandle pen, HandleRef path);
+            internal static extern int GdipDrawPath(HandleRef graphics, SafePenHandle pen, SafeGraphicsPathHandle path);
 
             [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawPie(HandleRef graphics, SafePenHandle pen, float x, float y, float width, float height, float startAngle, float sweepAngle);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -822,100 +822,100 @@ namespace System.Drawing
             internal static extern int GdipIsMatrixEqual(SafeMatrixHandle matrix, SafeMatrixHandle matrix2, out int boolean);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateRegion(out IntPtr region);
+            internal static partial int GdipCreateRegion(out SafeRegionHandle region);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateRegionRect(ref RectangleF gprectf, out IntPtr region);
+            internal static extern int GdipCreateRegionRect(ref RectangleF gprectf, out SafeRegionHandle region);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateRegionRectI(ref Rectangle gprect, out IntPtr region);
+            internal static extern int GdipCreateRegionRectI(ref Rectangle gprect, out SafeRegionHandle region);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateRegionPath(HandleRef path, out IntPtr region);
+            internal static extern int GdipCreateRegionPath(HandleRef path, out SafeRegionHandle region);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateRegionRgnData(byte[] rgndata, int size, out IntPtr region);
+            internal static partial int GdipCreateRegionRgnData(byte[] rgndata, int size, out SafeRegionHandle region);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateRegionHrgn(IntPtr hRgn, out IntPtr region);
+            internal static partial int GdipCreateRegionHrgn(IntPtr hRgn, out SafeRegionHandle region);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCloneRegion(HandleRef region, out IntPtr cloneregion);
+            internal static extern int GdipCloneRegion(SafeRegionHandle region, out SafeRegionHandle clonedRegion);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipDeleteRegion(HandleRef region);
+            internal static extern int GdipDeleteRegion(IntPtr region);
 
             [DllImport(LibraryName, SetLastError = true)]
-            internal static extern int GdipFillRegion(HandleRef graphics, SafeBrushHandle brush, HandleRef region);
+            internal static extern int GdipFillRegion(HandleRef graphics, SafeBrushHandle brush, SafeRegionHandle region);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetInfinite(HandleRef region);
+            internal static extern int GdipSetInfinite(SafeRegionHandle region);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetEmpty(HandleRef region);
+            internal static extern int GdipSetEmpty(SafeRegionHandle region);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCombineRegionRect(HandleRef region, ref RectangleF gprectf, CombineMode mode);
+            internal static extern int GdipCombineRegionRect(SafeRegionHandle region, ref RectangleF gprectf, CombineMode mode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCombineRegionRectI(HandleRef region, ref Rectangle gprect, CombineMode mode);
+            internal static extern int GdipCombineRegionRectI(SafeRegionHandle region, ref Rectangle gprect, CombineMode mode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCombineRegionPath(HandleRef region, HandleRef path, CombineMode mode);
+            internal static extern int GdipCombineRegionPath(SafeRegionHandle region, HandleRef path, CombineMode mode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCombineRegionRegion(HandleRef region, HandleRef region2, CombineMode mode);
+            internal static extern int GdipCombineRegionRegion(SafeRegionHandle region, SafeRegionHandle region2, CombineMode mode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslateRegion(HandleRef region, float dx, float dy);
+            internal static extern int GdipTranslateRegion(SafeRegionHandle region, float dx, float dy);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslateRegionI(HandleRef region, int dx, int dy);
+            internal static extern int GdipTranslateRegionI(SafeRegionHandle region, int dx, int dy);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTransformRegion(HandleRef region, SafeMatrixHandle matrix);
+            internal static extern int GdipTransformRegion(SafeRegionHandle region, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionBounds(HandleRef region, HandleRef graphics, out RectangleF gprectf);
+            internal static extern int GdipGetRegionBounds(SafeRegionHandle region, HandleRef graphics, out RectangleF gprectf);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionHRgn(HandleRef region, HandleRef graphics, out IntPtr hrgn);
+            internal static extern int GdipGetRegionHRgn(SafeRegionHandle region, HandleRef graphics, out IntPtr hrgn);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsEmptyRegion(HandleRef region, HandleRef graphics, out int boolean);
+            internal static extern int GdipIsEmptyRegion(SafeRegionHandle region, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsInfiniteRegion(HandleRef region, HandleRef graphics, out int boolean);
+            internal static extern int GdipIsInfiniteRegion(SafeRegionHandle region, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsEqualRegion(HandleRef region, HandleRef region2, HandleRef graphics, out int boolean);
+            internal static extern int GdipIsEqualRegion(SafeRegionHandle region, SafeRegionHandle region2, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionDataSize(HandleRef region, out int bufferSize);
+            internal static extern int GdipGetRegionDataSize(SafeRegionHandle region, out int bufferSize);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionData(HandleRef region, byte[] regionData, int bufferSize, out int sizeFilled);
+            internal static extern int GdipGetRegionData(SafeRegionHandle region, byte[] regionData, int bufferSize, out int sizeFilled);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsVisibleRegionPoint(HandleRef region, float X, float Y, HandleRef graphics, out int boolean);
+            internal static extern int GdipIsVisibleRegionPoint(SafeRegionHandle region, float X, float Y, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsVisibleRegionPointI(HandleRef region, int X, int Y, HandleRef graphics, out int boolean);
+            internal static extern int GdipIsVisibleRegionPointI(SafeRegionHandle region, int X, int Y, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsVisibleRegionRect(HandleRef region, float X, float Y, float width, float height, HandleRef graphics, out int boolean);
+            internal static extern int GdipIsVisibleRegionRect(SafeRegionHandle region, float X, float Y, float width, float height, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsVisibleRegionRectI(HandleRef region, int X, int Y, int width, int height, HandleRef graphics, out int boolean);
+            internal static extern int GdipIsVisibleRegionRectI(SafeRegionHandle region, int X, int Y, int width, int height, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionScansCount(HandleRef region, out int count, SafeMatrixHandle matrix);
+            internal static extern int GdipGetRegionScansCount(SafeRegionHandle region, out int count, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionScans(HandleRef region, RectangleF* rects, out int count, SafeMatrixHandle matrix);
+            internal static extern int GdipGetRegionScans(SafeRegionHandle region, RectangleF* rects, out int count, SafeMatrixHandle matrix);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromHDC(IntPtr hdc, out IntPtr graphics);
@@ -933,7 +933,7 @@ namespace System.Drawing
             internal static extern int GdipSetClipPath(HandleRef graphics, HandleRef path, CombineMode mode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetClipRegion(HandleRef graphics, HandleRef region, CombineMode mode);
+            internal static extern int GdipSetClipRegion(HandleRef graphics, SafeRegionHandle region, CombineMode mode);
 
             [DllImport(LibraryName)]
             internal static extern int GdipResetClip(HandleRef graphics);
@@ -942,7 +942,7 @@ namespace System.Drawing
             internal static extern int GdipTranslateClip(HandleRef graphics, float dx, float dy);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetClip(HandleRef graphics, HandleRef region);
+            internal static extern int GdipGetClip(HandleRef graphics, SafeRegionHandle region);
 
             [DllImport(LibraryName)]
             internal static extern int GdipGetClipBounds(HandleRef graphics, out RectangleF rect);
@@ -1332,7 +1332,7 @@ namespace System.Drawing
             internal static extern int GdipMeasureString(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, ref RectangleF boundingBox, out int codepointsFitted, out int linesFilled);
 
             [DllImport(LibraryName, CharSet = CharSet.Unicode)]
-            internal static extern int GdipMeasureCharacterRanges(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, int characterCount, [In] [Out] IntPtr[] region);
+            internal static extern int GdipMeasureCharacterRanges(HandleRef graphics, string textString, int length, HandleRef font, ref RectangleF layoutRect, HandleRef stringFormat, int characterCount, [In] [Out] IntPtr[] regions);
 
             [DllImport(LibraryName, SetLastError = true)]
             internal static extern int GdipDrawImageI(HandleRef graphics, HandleRef image, int x, int y);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -227,13 +227,13 @@ namespace System.Drawing
             internal static extern int GdipResetLineTransform(SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyLineTransform(SafeBrushHandle brush, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyLineTransform(SafeBrushHandle brush, SafeMatrixHandle matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetLineTransform(SafeBrushHandle brush, HandleRef matrix);
+            internal static extern int GdipGetLineTransform(SafeBrushHandle brush, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetLineTransform(SafeBrushHandle brush, HandleRef matrix);
+            internal static extern int GdipSetLineTransform(SafeBrushHandle brush, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipTranslateLineTransform(SafeBrushHandle brush, float dx, float dy, MatrixOrder order);
@@ -311,16 +311,16 @@ namespace System.Drawing
             internal static extern int GdipGetPathGradientWrapMode(SafeBrushHandle brush, out int wrapmode);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPathGradientTransform(SafeBrushHandle brush, HandleRef matrix);
+            internal static extern int GdipSetPathGradientTransform(SafeBrushHandle brush, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPathGradientTransform(SafeBrushHandle brush, HandleRef matrix);
+            internal static extern int GdipGetPathGradientTransform(SafeBrushHandle brush, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipResetPathGradientTransform(SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyPathGradientTransform(SafeBrushHandle brush, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyPathGradientTransform(SafeBrushHandle brush, SafeMatrixHandle matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
             internal static extern int GdipTranslatePathGradientTransform(SafeBrushHandle brush, float dx, float dy, MatrixOrder order);
@@ -414,16 +414,16 @@ namespace System.Drawing
             internal static extern int GdipCreateTextureIAI(HandleRef bitmap, HandleRef imageAttrib, int x, int y, int width, int height, out SafeBrushHandle texture);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetTextureTransform(SafeBrushHandle brush, HandleRef matrix);
+            internal static extern int GdipSetTextureTransform(SafeBrushHandle brush, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetTextureTransform(SafeBrushHandle brush, HandleRef matrix);
+            internal static extern int GdipGetTextureTransform(SafeBrushHandle brush, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipResetTextureTransform(SafeBrushHandle brush);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyTextureTransform(SafeBrushHandle brush, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyTextureTransform(SafeBrushHandle brush, SafeMatrixHandle matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
             internal static extern int GdipTranslateTextureTransform(SafeBrushHandle brush, float dx, float dy, MatrixOrder order);
@@ -603,16 +603,16 @@ namespace System.Drawing
             internal static extern int GdipGetPenMiterLimit(SafePenHandle pen, float[] miterLimit);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetPenTransform(SafePenHandle pen, HandleRef matrix);
+            internal static extern int GdipSetPenTransform(SafePenHandle pen, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetPenTransform(SafePenHandle pen, HandleRef matrix);
+            internal static extern int GdipGetPenTransform(SafePenHandle pen, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipResetPenTransform(SafePenHandle pen);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyPenTransform(SafePenHandle pen, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyPenTransform(SafePenHandle pen, SafeMatrixHandle matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
             internal static extern int GdipTranslatePenTransform(SafePenHandle pen, float dx, float dy, MatrixOrder order);
@@ -669,13 +669,13 @@ namespace System.Drawing
             internal static extern int GdipGetPenCompoundArray(SafePenHandle pen, float[] array, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetWorldTransform(HandleRef graphics, HandleRef matrix);
+            internal static extern int GdipSetWorldTransform(HandleRef graphics, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipResetWorldTransform(HandleRef graphics);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyWorldTransform(HandleRef graphics, HandleRef matrix, MatrixOrder order);
+            internal static extern int GdipMultiplyWorldTransform(HandleRef graphics, SafeMatrixHandle matrix, MatrixOrder order);
 
             [DllImport(LibraryName)]
             internal static extern int GdipTranslateWorldTransform(HandleRef graphics, float dx, float dy, MatrixOrder order);
@@ -687,7 +687,7 @@ namespace System.Drawing
             internal static extern int GdipRotateWorldTransform(HandleRef graphics, float angle, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetWorldTransform(HandleRef graphics, HandleRef matrix);
+            internal static extern int GdipGetWorldTransform(HandleRef graphics, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipSetCompositingMode(HandleRef graphics, CompositingMode compositingMode);
@@ -756,70 +756,70 @@ namespace System.Drawing
             internal static extern int GdipGetDpiY(HandleRef graphics, out float dpi);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateMatrix(out IntPtr matrix);
+            internal static partial int GdipCreateMatrix(out SafeMatrixHandle matrix);
 
             [GeneratedDllImport(LibraryName)]
-            internal static partial int GdipCreateMatrix2(float m11, float m12, float m21, float m22, float dx, float dy, out IntPtr matrix);
+            internal static partial int GdipCreateMatrix2(float m11, float m12, float m21, float m22, float dx, float dy, out SafeMatrixHandle matrix);
 
 #pragma warning disable DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
             // TODO: [DllImportGenerator] Switch to use GeneratedDllImport once we support blittable structs defined in other assemblies.
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateMatrix3(ref RectangleF rect, PointF* dstplg, out IntPtr matrix);
+            internal static extern int GdipCreateMatrix3(ref RectangleF rect, PointF* dstplg, out SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCreateMatrix3I(ref Rectangle rect, Point* dstplg, out IntPtr matrix);
+            internal static extern int GdipCreateMatrix3I(ref Rectangle rect, Point* dstplg, out SafeMatrixHandle matrix);
 #pragma warning restore DLLIMPORTGENANALYZER015 // Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
 
             [DllImport(LibraryName)]
-            internal static extern int GdipCloneMatrix(HandleRef matrix, out IntPtr cloneMatrix);
+            internal static extern int GdipCloneMatrix(SafeMatrixHandle matrix, out SafeMatrixHandle clonedMatrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipDeleteMatrix(HandleRef matrix);
+            internal static extern int GdipDeleteMatrix(IntPtr matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipSetMatrixElements(HandleRef matrix, float m11, float m12, float m21, float m22, float dx, float dy);
+            internal static extern int GdipSetMatrixElements(SafeMatrixHandle matrix, float m11, float m12, float m21, float m22, float dx, float dy);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipMultiplyMatrix(HandleRef matrix, HandleRef matrix2, MatrixOrder order);
+            internal static extern int GdipMultiplyMatrix(SafeMatrixHandle matrix, SafeMatrixHandle matrix2, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTranslateMatrix(HandleRef matrix, float offsetX, float offsetY, MatrixOrder order);
+            internal static extern int GdipTranslateMatrix(SafeMatrixHandle matrix, float offsetX, float offsetY, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipScaleMatrix(HandleRef matrix, float scaleX, float scaleY, MatrixOrder order);
+            internal static extern int GdipScaleMatrix(SafeMatrixHandle matrix, float scaleX, float scaleY, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipRotateMatrix(HandleRef matrix, float angle, MatrixOrder order);
+            internal static extern int GdipRotateMatrix(SafeMatrixHandle matrix, float angle, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipShearMatrix(HandleRef matrix, float shearX, float shearY, MatrixOrder order);
+            internal static extern int GdipShearMatrix(SafeMatrixHandle matrix, float shearX, float shearY, MatrixOrder order);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipInvertMatrix(HandleRef matrix);
+            internal static extern int GdipInvertMatrix(SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTransformMatrixPoints(HandleRef matrix, PointF* pts, int count);
+            internal static extern int GdipTransformMatrixPoints(SafeMatrixHandle matrix, PointF* pts, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTransformMatrixPointsI(HandleRef matrix, Point* pts, int count);
+            internal static extern int GdipTransformMatrixPointsI(SafeMatrixHandle matrix, Point* pts, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipVectorTransformMatrixPoints(HandleRef matrix, PointF* pts, int count);
+            internal static extern int GdipVectorTransformMatrixPoints(SafeMatrixHandle matrix, PointF* pts, int count);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipVectorTransformMatrixPointsI(HandleRef matrix, Point* pts, int count);
+            internal static extern int GdipVectorTransformMatrixPointsI(SafeMatrixHandle matrix, Point* pts, int count);
 
             [DllImport(LibraryName)]
-            internal static extern unsafe int GdipGetMatrixElements(HandleRef matrix, float* m);
+            internal static extern unsafe int GdipGetMatrixElements(SafeMatrixHandle matrix, float* m);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsMatrixInvertible(HandleRef matrix, out int boolean);
+            internal static extern int GdipIsMatrixInvertible(SafeMatrixHandle matrix, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsMatrixIdentity(HandleRef matrix, out int boolean);
+            internal static extern int GdipIsMatrixIdentity(SafeMatrixHandle matrix, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipIsMatrixEqual(HandleRef matrix, HandleRef matrix2, out int boolean);
+            internal static extern int GdipIsMatrixEqual(SafeMatrixHandle matrix, SafeMatrixHandle matrix2, out int boolean);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateRegion(out IntPtr region);
@@ -876,7 +876,7 @@ namespace System.Drawing
             internal static extern int GdipTranslateRegionI(HandleRef region, int dx, int dy);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipTransformRegion(HandleRef region, HandleRef matrix);
+            internal static extern int GdipTransformRegion(HandleRef region, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
             internal static extern int GdipGetRegionBounds(HandleRef region, HandleRef graphics, out RectangleF gprectf);
@@ -912,10 +912,10 @@ namespace System.Drawing
             internal static extern int GdipIsVisibleRegionRectI(HandleRef region, int X, int Y, int width, int height, HandleRef graphics, out int boolean);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionScansCount(HandleRef region, out int count, HandleRef matrix);
+            internal static extern int GdipGetRegionScansCount(HandleRef region, out int count, SafeMatrixHandle matrix);
 
             [DllImport(LibraryName)]
-            internal static extern int GdipGetRegionScans(HandleRef region, RectangleF* rects, out int count, HandleRef matrix);
+            internal static extern int GdipGetRegionScans(HandleRef region, RectangleF* rects, out int count, SafeMatrixHandle matrix);
 
             [GeneratedDllImport(LibraryName)]
             internal static partial int GdipCreateFromHDC(IntPtr hdc, out IntPtr graphics);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -417,7 +417,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            int status = Gdip.GdipFillPath(NativeGraphics, brush.NativeBrush, path._nativePath);
+            int status = Gdip.GdipFillPath(NativeGraphics, brush.SafeNativeBrush, path._nativePath);
             Gdip.CheckStatus(status);
         }
 
@@ -428,7 +428,7 @@ namespace System.Drawing
             if (region == null)
                 throw new ArgumentNullException(nameof(region));
 
-            int status = (int)Gdip.GdipFillRegion(new HandleRef(this, NativeGraphics), new HandleRef(brush, brush.NativeBrush), new HandleRef(region, region.NativeRegion));
+            int status = Gdip.GdipFillRegion(new HandleRef(this, NativeGraphics), brush.SafeNativeBrush, new HandleRef(region, region.NativeRegion));
             Gdip.CheckStatus(status);
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -417,7 +417,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            int status = Gdip.GdipFillPath(NativeGraphics, brush.SafeNativeBrush, path._nativePath);
+            int status = Gdip.GdipFillPath(NativeGraphics, brush.SafeBrushHandle, path._nativePath);
             Gdip.CheckStatus(status);
         }
 
@@ -428,7 +428,7 @@ namespace System.Drawing
             if (region == null)
                 throw new ArgumentNullException(nameof(region));
 
-            int status = Gdip.GdipFillRegion(new HandleRef(this, NativeGraphics), brush.SafeNativeBrush, new HandleRef(region, region.NativeRegion));
+            int status = Gdip.GdipFillRegion(new HandleRef(this, NativeGraphics), brush.SafeBrushHandle, new HandleRef(region, region.NativeRegion));
             Gdip.CheckStatus(status);
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -583,7 +583,6 @@ namespace System.Drawing
             throw new NotImplementedException();
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [EditorBrowsable(EditorBrowsableState.Never)]
         [SupportedOSPlatform("windows")]
         public void GetContextInfo(out PointF offset)
@@ -597,7 +596,6 @@ namespace System.Drawing
         {
             throw new PlatformNotSupportedException();
         }
-#endif
 
         private void CheckErrorStatus(int status)
         {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -428,7 +428,7 @@ namespace System.Drawing
             if (region == null)
                 throw new ArgumentNullException(nameof(region));
 
-            int status = Gdip.GdipFillRegion(new HandleRef(this, NativeGraphics), brush.SafeBrushHandle, new HandleRef(region, region.NativeRegion));
+            int status = Gdip.GdipFillRegion(new HandleRef(this, NativeGraphics), brush.SafeBrushHandle, region.SafeRegionHandle);
             Gdip.CheckStatus(status);
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -271,7 +271,7 @@ namespace System.Drawing
                 Point p4 = points[i + 3];
 
                 status = Gdip.GdipDrawBezier(
-                                        new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                                        new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                                         p1.X, p1.Y, p2.X, p2.Y,
                                         p3.X, p3.Y, p4.X, p4.Y);
                 Gdip.CheckStatus(status);
@@ -299,7 +299,7 @@ namespace System.Drawing
                 PointF p4 = points[i + 3];
 
                 status = Gdip.GdipDrawBezier(
-                                        new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                                        new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                                         p1.X, p1.Y, p2.X, p2.Y,
                                         p3.X, p3.Y, p4.X, p4.Y);
                 Gdip.CheckStatus(status);
@@ -337,7 +337,7 @@ namespace System.Drawing
             if (!float.IsNaN(x1) && !float.IsNaN(y1) &&
                 !float.IsNaN(x2) && !float.IsNaN(y2))
             {
-                int status = Gdip.GdipDrawLine(new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen), x1, y1, x2, y2);
+                int status = Gdip.GdipDrawLine(new HandleRef(this, NativeGraphics), pen.SafePenHandle, x1, y1, x2, y2);
                 Gdip.CheckStatus(status);
             }
         }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Unix.cs
@@ -417,7 +417,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            int status = Gdip.GdipFillPath(NativeGraphics, brush.SafeBrushHandle, path._nativePath);
+            int status = Gdip.GdipFillPath(NativeGraphics, brush.SafeBrushHandle, path.SafeGraphicsPathHandle);
             Gdip.CheckStatus(status);
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -288,7 +288,7 @@ namespace System.Drawing
             if (pen == null)
                 throw new ArgumentNullException(nameof(pen));
 
-            CheckErrorStatus(Gdip.GdipDrawLine(new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen), x1, y1, x2, y2));
+            CheckErrorStatus(Gdip.GdipDrawLine(new HandleRef(this, NativeGraphics), pen.SafePenHandle, x1, y1, x2, y2));
         }
 
         /// <summary>
@@ -305,7 +305,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawBeziers(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -324,7 +324,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawBeziersI(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p,
                     points.Length));
             }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -342,7 +342,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillPath(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 new HandleRef(path, path._nativePath)));
         }
 
@@ -358,7 +358,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillRegion(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 new HandleRef(region, region.NativeRegion)));
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -343,7 +343,7 @@ namespace System.Drawing
             CheckErrorStatus(Gdip.GdipFillPath(
                 new HandleRef(this, NativeGraphics),
                 brush.SafeBrushHandle,
-                new HandleRef(path, path._nativePath)));
+                path.SafeGraphicsPathHandle));
         }
 
         /// <summary>

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -342,7 +342,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillPath(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 new HandleRef(path, path._nativePath)));
         }
 
@@ -358,7 +358,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillRegion(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 new HandleRef(region, region.NativeRegion)));
         }
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -359,7 +359,7 @@ namespace System.Drawing
             CheckErrorStatus(Gdip.GdipFillRegion(
                 new HandleRef(this, NativeGraphics),
                 brush.SafeBrushHandle,
-                new HandleRef(region, region.NativeRegion)));
+                region.SafeRegionHandle));
         }
 
         public void DrawIcon(Icon icon, int x, int y)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.Windows.cs
@@ -765,7 +765,6 @@ namespace System.Drawing
             }
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         /// <summary>
         ///  Gets the cumulative offset.
         /// </summary>
@@ -792,7 +791,6 @@ namespace System.Drawing
             Vector2 translation = cumulativeTransform.Translation;
             offset = new PointF(translation.X, translation.Y);
         }
-#endif
 
         public RectangleF VisibleClipBounds
         {

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -1153,7 +1153,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillRectangle(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 x, y, width, height));
         }
 
@@ -1175,7 +1175,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillRectangleI(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 x, y, width, height));
         }
 
@@ -1193,7 +1193,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillRectangles(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     r, rects.Length));
             }
         }
@@ -1212,7 +1212,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillRectanglesI(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     r, rects.Length));
             }
         }
@@ -1239,7 +1239,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillPolygon(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     p, points.Length,
                     fillMode));
             }
@@ -1267,7 +1267,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillPolygonI(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     p, points.Length,
                     fillMode));
             }
@@ -1291,7 +1291,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillEllipse(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 x, y, width, height));
         }
 
@@ -1313,7 +1313,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillEllipseI(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 x, y, width, height));
         }
 
@@ -1335,7 +1335,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillPie(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -1351,7 +1351,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillPieI(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(brush, brush.NativeBrush),
+                brush.SafeNativeBrush,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -1371,7 +1371,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurve(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     p, points.Length));
             }
         }
@@ -1395,7 +1395,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurve2(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     p, points.Length,
                     tension,
                     fillmode));
@@ -1416,7 +1416,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurveI(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     p, points.Length));
             }
         }
@@ -1437,7 +1437,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurve2I(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(brush, brush.NativeBrush),
+                    brush.SafeNativeBrush,
                     p, points.Length,
                     tension,
                     fillmode));
@@ -1488,7 +1488,7 @@ namespace System.Drawing
                 new HandleRef(font, font.NativeFont),
                 ref layoutRectangle,
                 new HandleRef(format, format?.nativeFormat ?? IntPtr.Zero),
-                new HandleRef(brush, brush.NativeBrush)));
+                brush.SafeNativeBrush));
         }
 
         public SizeF MeasureString(

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -1153,7 +1153,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillRectangle(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 x, y, width, height));
         }
 
@@ -1175,7 +1175,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillRectangleI(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 x, y, width, height));
         }
 
@@ -1193,7 +1193,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillRectangles(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     r, rects.Length));
             }
         }
@@ -1212,7 +1212,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillRectanglesI(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     r, rects.Length));
             }
         }
@@ -1239,7 +1239,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillPolygon(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     p, points.Length,
                     fillMode));
             }
@@ -1267,7 +1267,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillPolygonI(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     p, points.Length,
                     fillMode));
             }
@@ -1291,7 +1291,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillEllipse(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 x, y, width, height));
         }
 
@@ -1313,7 +1313,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillEllipseI(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 x, y, width, height));
         }
 
@@ -1335,7 +1335,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillPie(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -1351,7 +1351,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipFillPieI(
                 new HandleRef(this, NativeGraphics),
-                brush.SafeNativeBrush,
+                brush.SafeBrushHandle,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -1371,7 +1371,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurve(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     p, points.Length));
             }
         }
@@ -1395,7 +1395,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurve2(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     p, points.Length,
                     tension,
                     fillmode));
@@ -1416,7 +1416,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurveI(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     p, points.Length));
             }
         }
@@ -1437,7 +1437,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipFillClosedCurve2I(
                     new HandleRef(this, NativeGraphics),
-                    brush.SafeNativeBrush,
+                    brush.SafeBrushHandle,
                     p, points.Length,
                     tension,
                     fillmode));
@@ -1488,7 +1488,7 @@ namespace System.Drawing
                 new HandleRef(font, font.NativeFont),
                 ref layoutRectangle,
                 new HandleRef(format, format?.nativeFormat ?? IntPtr.Zero),
-                brush.SafeNativeBrush));
+                brush.SafeBrushHandle));
         }
 
         public SizeF MeasureString(

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -641,7 +641,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipDrawArc(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -665,7 +665,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipDrawArcI(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -688,7 +688,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(pen));
 
             CheckErrorStatus(Gdip.GdipDrawBezier(
-                new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                 x1, y1, x2, y2, x3, y3, x4, y4));
         }
 
@@ -725,7 +725,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(pen));
 
             CheckErrorStatus(Gdip.GdipDrawRectangle(
-                new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                 x, y, width, height));
         }
 
@@ -738,7 +738,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(pen));
 
             CheckErrorStatus(Gdip.GdipDrawRectangleI(
-                new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                 x, y, width, height));
         }
 
@@ -755,7 +755,7 @@ namespace System.Drawing
             fixed (RectangleF* r = rects)
             {
                 CheckErrorStatus(Gdip.GdipDrawRectangles(
-                    new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                    new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                     r, rects.Length));
             }
         }
@@ -773,7 +773,7 @@ namespace System.Drawing
             fixed (Rectangle* r = rects)
             {
                 CheckErrorStatus(Gdip.GdipDrawRectanglesI(
-                    new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                    new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                     r, rects.Length));
             }
         }
@@ -796,7 +796,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipDrawEllipse(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 x, y, width, height));
         }
 
@@ -818,7 +818,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipDrawEllipseI(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 x, y, width, height));
         }
 
@@ -840,7 +840,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipDrawPie(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -864,7 +864,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipDrawPieI(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 x, y, width, height,
                 startAngle,
                 sweepAngle));
@@ -883,7 +883,7 @@ namespace System.Drawing
             fixed (PointF* p = points)
             {
                 CheckErrorStatus(Gdip.GdipDrawPolygon(
-                    new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                    new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -901,7 +901,7 @@ namespace System.Drawing
             fixed (Point* p = points)
             {
                 CheckErrorStatus(Gdip.GdipDrawPolygonI(
-                    new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen),
+                    new HandleRef(this, NativeGraphics), pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -918,7 +918,7 @@ namespace System.Drawing
 
             CheckErrorStatus(Gdip.GdipDrawPath(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(pen, pen.NativePen),
+                pen.SafePenHandle,
                 new HandleRef(path, path._nativePath)));
         }
 
@@ -936,7 +936,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawCurve(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -955,7 +955,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawCurve2(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length,
                     tension));
             }
@@ -980,7 +980,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawCurve3(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length,
                     offset,
                     numberOfSegments,
@@ -1002,7 +1002,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawCurveI(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -1021,7 +1021,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawCurve2I(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length,
                     tension));
             }
@@ -1041,7 +1041,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawCurve3I(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length,
                     offset,
                     numberOfSegments,
@@ -1063,7 +1063,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawClosedCurve(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -1082,7 +1082,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawClosedCurve2(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length,
                     tension));
             }
@@ -1102,7 +1102,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawClosedCurveI(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -1121,7 +1121,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawClosedCurve2I(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length,
                     tension));
             }
@@ -2161,7 +2161,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawLines(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p, points.Length));
             }
         }
@@ -2175,7 +2175,7 @@ namespace System.Drawing
             if (pen == null)
                 throw new ArgumentNullException(nameof(pen));
 
-            CheckErrorStatus(Gdip.GdipDrawLineI(new HandleRef(this, NativeGraphics), new HandleRef(pen, pen.NativePen), x1, y1, x2, y2));
+            CheckErrorStatus(Gdip.GdipDrawLineI(new HandleRef(this, NativeGraphics), pen.SafePenHandle, x1, y1, x2, y2));
         }
 
         /// <summary>
@@ -2200,7 +2200,7 @@ namespace System.Drawing
             {
                 CheckErrorStatus(Gdip.GdipDrawLinesI(
                     new HandleRef(this, NativeGraphics),
-                    new HandleRef(pen, pen.NativePen),
+                    pen.SafePenHandle,
                     p,
                     points.Length));
             }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -438,7 +438,7 @@ namespace System.Drawing
 
             Gdip.CheckStatus(Gdip.GdipSetClipPath(
                 new HandleRef(this, NativeGraphics),
-                new HandleRef(path, path._nativePath),
+                path.SafeGraphicsPathHandle,
                 combineMode));
         }
 
@@ -907,7 +907,7 @@ namespace System.Drawing
             CheckErrorStatus(Gdip.GdipDrawPath(
                 new HandleRef(this, NativeGraphics),
                 pen.SafePenHandle,
-                new HandleRef(path, path._nativePath)));
+                path.SafeGraphicsPathHandle));
         }
 
         /// <summary>

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Internal/SystemColorTracker.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Internal/SystemColorTracker.cs
@@ -39,7 +39,7 @@ namespace System.Drawing.Internal
 
                 if (!addedTracker)
                 {
-                    Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+                    Debug.Assert(OperatingSystem.IsWindows());
                     addedTracker = true;
                     SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(OnUserPreferenceChanged);
                 }
@@ -132,7 +132,7 @@ namespace System.Drawing.Internal
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
-            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+            Debug.Assert(OperatingSystem.IsWindows());
 
             // Update pens and brushes
             if (e.Category == UserPreferenceCategory.Color)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.Unix.cs
@@ -22,7 +22,7 @@ namespace System.Drawing
             get
             {
                 IntPtr lineCap = IntPtr.Zero;
-                int status = Gdip.GdipGetPenCustomStartCap(new HandleRef(this, NativePen), out lineCap);
+                int status = Gdip.GdipGetPenCustomStartCap(SafePenHandle, out lineCap);
                 Gdip.CheckStatus(status);
                 if (lineCap == IntPtr.Zero)
                 {
@@ -38,7 +38,7 @@ namespace System.Drawing
                     throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
                 }
 
-                int status = Gdip.GdipSetPenCustomStartCap(new HandleRef(this, NativePen),
+                int status = Gdip.GdipSetPenCustomStartCap(SafePenHandle,
                                                               new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
                 Gdip.CheckStatus(status);
             }
@@ -70,7 +70,7 @@ namespace System.Drawing
                 CustomLineCap? clone = value == null ? null : (CustomLineCap)value.Clone();
 
                 int status = Gdip.GdipSetPenCustomEndCap(
-                    new HandleRef(this, NativePen),
+                    SafePenHandle,
                     new HandleRef(clone, (clone == null) ? IntPtr.Zero : clone.nativeCap));
                 Gdip.CheckStatus(status);
                 _cachedEndCap = clone;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.Windows.cs
@@ -17,7 +17,7 @@ namespace System.Drawing
             get
             {
                 IntPtr lineCap = IntPtr.Zero;
-                int status = Gdip.GdipGetPenCustomStartCap(new HandleRef(this, NativePen), out lineCap);
+                int status = Gdip.GdipGetPenCustomStartCap(SafePenHandle, out lineCap);
                 Gdip.CheckStatus(status);
 
                 return CustomLineCap.CreateCustomLineCapObject(lineCap);
@@ -29,7 +29,7 @@ namespace System.Drawing
                     throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
                 }
 
-                int status = Gdip.GdipSetPenCustomStartCap(new HandleRef(this, NativePen),
+                int status = Gdip.GdipSetPenCustomStartCap(SafePenHandle,
                                                               new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
                 Gdip.CheckStatus(status);
             }
@@ -43,7 +43,7 @@ namespace System.Drawing
             get
             {
                 IntPtr lineCap = IntPtr.Zero;
-                int status = Gdip.GdipGetPenCustomEndCap(new HandleRef(this, NativePen), out lineCap);
+                int status = Gdip.GdipGetPenCustomEndCap(SafePenHandle, out lineCap);
                 Gdip.CheckStatus(status);
                 return CustomLineCap.CreateCustomLineCapObject(lineCap);
             }
@@ -55,7 +55,7 @@ namespace System.Drawing
                 }
 
                 int status = Gdip.GdipSetPenCustomEndCap(
-                    new HandleRef(this, NativePen),
+                    SafePenHandle,
                     new HandleRef(value, (value == null) ? IntPtr.Zero : value.nativeCap));
                 Gdip.CheckStatus(status);
             }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -378,7 +378,7 @@ namespace System.Drawing
             get
             {
                 var matrix = new Matrix();
-                int status = Gdip.GdipGetPenTransform(SafePenHandle, new HandleRef(matrix, matrix.NativeMatrix));
+                int status = Gdip.GdipGetPenTransform(SafePenHandle, matrix.SafeMatrixHandle);
                 Gdip.CheckStatus(status);
 
                 return matrix;
@@ -396,7 +396,7 @@ namespace System.Drawing
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                int status = Gdip.GdipSetPenTransform(SafePenHandle, new HandleRef(value, value.NativeMatrix));
+                int status = Gdip.GdipSetPenTransform(SafePenHandle, value.SafeMatrixHandle);
                 Gdip.CheckStatus(status);
             }
         }
@@ -420,14 +420,14 @@ namespace System.Drawing
         /// </summary>
         public void MultiplyTransform(Matrix matrix, MatrixOrder order)
         {
-            if (matrix.NativeMatrix == IntPtr.Zero)
+            if (matrix.SafeMatrixHandle.IsClosed)
             {
                 // Disposed matrices should result in a no-op.
                 return;
             }
 
             int status = Gdip.GdipMultiplyPenTransform(SafePenHandle,
-                                                          new HandleRef(matrix, matrix.NativeMatrix),
+                                                          matrix.SafeMatrixHandle,
                                                           order);
             Gdip.CheckStatus(status);
         }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing.Drawing2D;
-using System.Drawing.Internal;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
@@ -92,7 +92,7 @@ namespace System.Drawing
             }
 
             IntPtr pen = IntPtr.Zero;
-            int status = Gdip.GdipCreatePen2(new HandleRef(brush, brush.NativeBrush),
+            int status = Gdip.GdipCreatePen2(brush.SafeNativeBrush,
                 width,
                 (int)GraphicsUnit.World,
                 out pen);
@@ -651,15 +651,14 @@ namespace System.Drawing
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                int status = Gdip.GdipSetPenBrushFill(new HandleRef(this, NativePen),
-                    new HandleRef(value, value.NativeBrush));
+                int status = Gdip.GdipSetPenBrushFill(new HandleRef(this, NativePen), value.SafeNativeBrush);
                 Gdip.CheckStatus(status);
             }
         }
 
-        private IntPtr GetNativeBrush()
+        private SafeBrushHandle GetNativeBrush()
         {
-            IntPtr nativeBrush = IntPtr.Zero;
+            SafeBrushHandle nativeBrush;
             int status = Gdip.GdipGetPenBrushFill(new HandleRef(this, NativePen), out nativeBrush);
             Gdip.CheckStatus(status);
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -86,7 +86,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(brush));
             }
 
-            int status = Gdip.GdipCreatePen2(brush.SafeNativeBrush,
+            int status = Gdip.GdipCreatePen2(brush.SafeBrushHandle,
                 width,
                 (int)GraphicsUnit.World,
                 out _nativePen);
@@ -602,7 +602,7 @@ namespace System.Drawing
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                int status = Gdip.GdipSetPenBrushFill(SafePenHandle, value.SafeNativeBrush);
+                int status = Gdip.GdipSetPenBrushFill(SafePenHandle, value.SafeBrushHandle);
                 Gdip.CheckStatus(status);
             }
         }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -113,21 +113,12 @@ namespace System.Drawing
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        private void Dispose(bool disposing)
-        {
             if (_immutable)
             {
                 throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
             }
 
-            if (disposing)
-            {
-                _nativePen.Dispose();
-            }
+            _nativePen.Dispose();
         }
 
         /// <summary>

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Region.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Region.Unix.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Drawing.Drawing2D;
-using System.Drawing.Internal;
-using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
 namespace System.Drawing
@@ -18,8 +16,21 @@ namespace System.Drawing
             }
 
             // for libgdiplus HRGN == GpRegion*, and we check the return code
-            int status = Gdip.GdipDeleteRegion(new HandleRef(this, regionHandle));
-            Gdip.CheckStatus(status);
+            SafeRegionHandle nativeRegion = SafeRegionHandle;
+            bool releaseThisRegion = false;
+            try
+            {
+                nativeRegion.DangerousAddRef(ref releaseThisRegion);
+                int status = Gdip.GdipDeleteRegion(nativeRegion.DangerousGetHandle());
+                Gdip.CheckStatus(status);
+            }
+            finally
+            {
+                if (releaseThisRegion)
+                {
+                    nativeRegion.DangerousRelease();
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Region.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Region.Windows.cs
@@ -16,7 +16,7 @@ namespace System.Drawing
                 throw new ArgumentNullException(nameof(regionHandle));
             }
 
-            Interop.Gdi32.DeleteObject(new HandleRef(this, regionHandle));
+            Interop.Gdi32.DeleteObject(regionHandle, this.SafeRegionHandle);
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -279,7 +279,7 @@ namespace System.Drawing
 
             Gdip.CheckStatus(Gdip.GdipTransformRegion(
                 new HandleRef(this, NativeRegion),
-                new HandleRef(matrix, matrix.NativeMatrix)));
+                matrix.SafeMatrixHandle));
         }
 
         public RectangleF GetBounds(Graphics g)
@@ -415,7 +415,7 @@ namespace System.Drawing
             Gdip.CheckStatus(Gdip.GdipGetRegionScansCount(
                 new HandleRef(this, NativeRegion),
                 out int count,
-                new HandleRef(matrix, matrix.NativeMatrix)));
+                matrix.SafeMatrixHandle));
 
             RectangleF[] rectangles = new RectangleF[count];
 
@@ -430,7 +430,7 @@ namespace System.Drawing
                     (new HandleRef(this, NativeRegion),
                     r,
                     out count,
-                    new HandleRef(matrix, matrix.NativeMatrix)));
+                    matrix.SafeMatrixHandle));
             }
 
             return rectangles;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -34,7 +34,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            Gdip.CheckStatus(Gdip.GdipCreateRegionPath(new HandleRef(path, path._nativePath), out _nativeRegion));
+            Gdip.CheckStatus(Gdip.GdipCreateRegionPath(path.SafeGraphicsPathHandle, out _nativeRegion));
         }
 
         public Region(RegionData rgnData)
@@ -92,7 +92,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, new HandleRef(path, path._nativePath), CombineMode.Intersect));
+            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, path.SafeGraphicsPathHandle, CombineMode.Intersect));
         }
 
         public void Intersect(Region region)
@@ -118,7 +118,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, new HandleRef(path, path._nativePath), CombineMode.Union));
+            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, path.SafeGraphicsPathHandle, CombineMode.Union));
         }
 
         public void Union(Region region)
@@ -144,7 +144,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, new HandleRef(path, path._nativePath), CombineMode.Xor));
+            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, path.SafeGraphicsPathHandle, CombineMode.Xor));
         }
 
         public void Xor(Region region)
@@ -172,7 +172,7 @@ namespace System.Drawing
 
             Gdip.CheckStatus(Gdip.GdipCombineRegionPath(
                 SafeRegionHandle,
-                new HandleRef(path, path._nativePath),
+                path.SafeGraphicsPathHandle,
                 CombineMode.Exclude));
         }
 
@@ -202,7 +202,7 @@ namespace System.Drawing
             if (path == null)
                 throw new ArgumentNullException(nameof(path));
 
-            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, new HandleRef(path, path._nativePath), CombineMode.Complement));
+            Gdip.CheckStatus(Gdip.GdipCombineRegionPath(SafeRegionHandle, path.SafeGraphicsPathHandle, CombineMode.Complement));
         }
 
         public void Complement(Region region)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/SolidBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/SolidBrush.cs
@@ -127,7 +127,7 @@ namespace System.Drawing
 #if FEATURE_SYSTEM_EVENTS
         void ISystemColorTracker.OnSystemColorChanged()
         {
-            if (NativeBrush != IntPtr.Zero)
+            if (!SafeNativeBrush.IsClosed)
             {
                 InternalSetColor(_color);
             }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/SolidBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/SolidBrush.cs
@@ -51,7 +51,7 @@ namespace System.Drawing
         public override object Clone()
         {
             SafeBrushHandle clonedBrush;
-            int status = Gdip.GdipCloneBrush(SafeNativeBrush, out clonedBrush);
+            int status = Gdip.GdipCloneBrush(SafeBrushHandle, out clonedBrush);
             Gdip.CheckStatus(status);
 
             // Clones of immutable brushes are not immutable.
@@ -79,7 +79,7 @@ namespace System.Drawing
                 if (_color == Color.Empty)
                 {
                     int colorARGB;
-                    int status = Gdip.GdipGetSolidFillColor(SafeNativeBrush, out colorARGB);
+                    int status = Gdip.GdipGetSolidFillColor(SafeBrushHandle, out colorARGB);
                     Gdip.CheckStatus(status);
 
                     _color = Color.FromArgb(colorARGB);
@@ -118,7 +118,7 @@ namespace System.Drawing
         // Sets the color even if the brush is considered immutable.
         private void InternalSetColor(Color value)
         {
-            int status = Gdip.GdipSetSolidFillColor(SafeNativeBrush, value.ToArgb());
+            int status = Gdip.GdipSetSolidFillColor(SafeBrushHandle, value.ToArgb());
             Gdip.CheckStatus(status);
 
             _color = value;
@@ -127,7 +127,7 @@ namespace System.Drawing
 #if FEATURE_SYSTEM_EVENTS
         void ISystemColorTracker.OnSystemColorChanged()
         {
-            if (!SafeNativeBrush.IsClosed)
+            if (!SafeBrushHandle.IsClosed)
             {
                 InternalSetColor(_color);
             }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/SolidBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/SolidBrush.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
 namespace System.Drawing
@@ -26,7 +25,7 @@ namespace System.Drawing
         {
             _color = color;
 
-            IntPtr nativeBrush = IntPtr.Zero;
+            SafeBrushHandle nativeBrush;
             int status = Gdip.GdipCreateSolidFill(_color.ToArgb(), out nativeBrush);
             Gdip.CheckStatus(status);
 
@@ -45,16 +44,14 @@ namespace System.Drawing
             _immutable = immutable;
         }
 
-        internal SolidBrush(IntPtr nativeBrush)
+        internal SolidBrush(SafeBrushHandle nativeBrush) : base(nativeBrush)
         {
-            Debug.Assert(nativeBrush != IntPtr.Zero, "Initializing native brush with null.");
-            SetNativeBrushInternal(nativeBrush);
         }
 
         public override object Clone()
         {
-            IntPtr clonedBrush = IntPtr.Zero;
-            int status = Gdip.GdipCloneBrush(new HandleRef(this, NativeBrush), out clonedBrush);
+            SafeBrushHandle clonedBrush;
+            int status = Gdip.GdipCloneBrush(SafeNativeBrush, out clonedBrush);
             Gdip.CheckStatus(status);
 
             // Clones of immutable brushes are not immutable.
@@ -82,7 +79,7 @@ namespace System.Drawing
                 if (_color == Color.Empty)
                 {
                     int colorARGB;
-                    int status = Gdip.GdipGetSolidFillColor(new HandleRef(this, NativeBrush), out colorARGB);
+                    int status = Gdip.GdipGetSolidFillColor(SafeNativeBrush, out colorARGB);
                     Gdip.CheckStatus(status);
 
                     _color = Color.FromArgb(colorARGB);
@@ -121,7 +118,7 @@ namespace System.Drawing
         // Sets the color even if the brush is considered immutable.
         private void InternalSetColor(Color value)
         {
-            int status = Gdip.GdipSetSolidFillColor(new HandleRef(this, NativeBrush), value.ToArgb());
+            int status = Gdip.GdipSetSolidFillColor(SafeNativeBrush, value.ToArgb());
             Gdip.CheckStatus(status);
 
             _color = value;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
@@ -147,7 +147,7 @@ namespace System.Drawing
         public override object Clone()
         {
             SafeBrushHandle clonedBrush;
-            int status = Gdip.GdipCloneBrush(SafeNativeBrush, out clonedBrush);
+            int status = Gdip.GdipCloneBrush(SafeBrushHandle, out clonedBrush);
             Gdip.CheckStatus(status);
 
             return new TextureBrush(clonedBrush);
@@ -158,7 +158,7 @@ namespace System.Drawing
             get
             {
                 var matrix = new Matrix();
-                int status = Gdip.GdipGetTextureTransform(SafeNativeBrush, new HandleRef(matrix, matrix.NativeMatrix));
+                int status = Gdip.GdipGetTextureTransform(SafeBrushHandle, new HandleRef(matrix, matrix.NativeMatrix));
                 Gdip.CheckStatus(status);
 
                 return matrix;
@@ -170,7 +170,7 @@ namespace System.Drawing
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                int status = Gdip.GdipSetTextureTransform(SafeNativeBrush, new HandleRef(value, value.NativeMatrix));
+                int status = Gdip.GdipSetTextureTransform(SafeBrushHandle, new HandleRef(value, value.NativeMatrix));
                 Gdip.CheckStatus(status);
             }
         }
@@ -180,7 +180,7 @@ namespace System.Drawing
             get
             {
                 int mode = 0;
-                int status = Gdip.GdipGetTextureWrapMode(SafeNativeBrush, out mode);
+                int status = Gdip.GdipGetTextureWrapMode(SafeBrushHandle, out mode);
                 Gdip.CheckStatus(status);
 
                 return (WrapMode)mode;
@@ -192,7 +192,7 @@ namespace System.Drawing
                     throw new InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(WrapMode));
                 }
 
-                int status = Gdip.GdipSetTextureWrapMode(SafeNativeBrush, unchecked((int)value));
+                int status = Gdip.GdipSetTextureWrapMode(SafeBrushHandle, unchecked((int)value));
                 Gdip.CheckStatus(status);
             }
         }
@@ -202,7 +202,7 @@ namespace System.Drawing
             get
             {
                 IntPtr image;
-                int status = Gdip.GdipGetTextureImage(SafeNativeBrush, out image);
+                int status = Gdip.GdipGetTextureImage(SafeBrushHandle, out image);
                 Gdip.CheckStatus(status);
 
                 return Image.CreateImageObject(image);
@@ -211,7 +211,7 @@ namespace System.Drawing
 
         public void ResetTransform()
         {
-            int status = Gdip.GdipResetTextureTransform(SafeNativeBrush);
+            int status = Gdip.GdipResetTextureTransform(SafeBrushHandle);
             Gdip.CheckStatus(status);
         }
 
@@ -231,7 +231,7 @@ namespace System.Drawing
                 return;
             }
 
-            int status = Gdip.GdipMultiplyTextureTransform(SafeNativeBrush,
+            int status = Gdip.GdipMultiplyTextureTransform(SafeBrushHandle,
                                                               new HandleRef(matrix, matrix.NativeMatrix),
                                                               order);
             Gdip.CheckStatus(status);
@@ -241,7 +241,7 @@ namespace System.Drawing
 
         public void TranslateTransform(float dx, float dy, MatrixOrder order)
         {
-            int status = Gdip.GdipTranslateTextureTransform(SafeNativeBrush,
+            int status = Gdip.GdipTranslateTextureTransform(SafeBrushHandle,
                                                                dx,
                                                                dy,
                                                                order);
@@ -252,7 +252,7 @@ namespace System.Drawing
 
         public void ScaleTransform(float sx, float sy, MatrixOrder order)
         {
-            int status = Gdip.GdipScaleTextureTransform(SafeNativeBrush,
+            int status = Gdip.GdipScaleTextureTransform(SafeBrushHandle,
                                                            sx,
                                                            sy,
                                                            order);
@@ -263,7 +263,7 @@ namespace System.Drawing
 
         public void RotateTransform(float angle, MatrixOrder order)
         {
-            int status = Gdip.GdipRotateTextureTransform(SafeNativeBrush,
+            int status = Gdip.GdipRotateTextureTransform(SafeBrushHandle,
                                                             angle,
                                                             order);
             Gdip.CheckStatus(status);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
@@ -158,7 +158,7 @@ namespace System.Drawing
             get
             {
                 var matrix = new Matrix();
-                int status = Gdip.GdipGetTextureTransform(SafeBrushHandle, new HandleRef(matrix, matrix.NativeMatrix));
+                int status = Gdip.GdipGetTextureTransform(SafeBrushHandle, matrix.SafeMatrixHandle);
                 Gdip.CheckStatus(status);
 
                 return matrix;
@@ -170,7 +170,7 @@ namespace System.Drawing
                     throw new ArgumentNullException(nameof(value));
                 }
 
-                int status = Gdip.GdipSetTextureTransform(SafeBrushHandle, new HandleRef(value, value.NativeMatrix));
+                int status = Gdip.GdipSetTextureTransform(SafeBrushHandle, value.SafeMatrixHandle);
                 Gdip.CheckStatus(status);
             }
         }
@@ -226,13 +226,13 @@ namespace System.Drawing
 
             // Multiplying the transform by a disposed matrix is a nop in GDI+, but throws
             // with the libgdiplus backend. Simulate a nop for compatability with GDI+.
-            if (matrix.NativeMatrix == IntPtr.Zero)
+            if (matrix.SafeMatrixHandle.IsClosed)
             {
                 return;
             }
 
             int status = Gdip.GdipMultiplyTextureTransform(SafeBrushHandle,
-                                                              new HandleRef(matrix, matrix.NativeMatrix),
+                                                              matrix.SafeMatrixHandle,
                                                               order);
             Gdip.CheckStatus(status);
         }

--- a/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
@@ -397,14 +397,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Ctor_DisposedImage_ThrowsArgumentException()
+        public void Ctor_DisposedImage_ThrowsObjectDisposedException()
         {
             var image = new Bitmap(1, 1);
             image.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => new Bitmap(image));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Bitmap(image, 1, 1));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Bitmap(image, new Size(1, 1)));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Bitmap(image));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Bitmap(image, 1, 1));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Bitmap(image, new Size(1, 1)));
         }
 
         public static IEnumerable<object[]> Clone_TestData()
@@ -549,14 +549,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Clone());
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Clone(new Rectangle(0, 0, 1, 1), PixelFormat.Format32bppArgb));
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Clone(new RectangleF(0, 0, 1, 1), PixelFormat.Format32bppArgb));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Clone(new Rectangle(0, 0, 1, 1), PixelFormat.Format32bppArgb));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Clone(new RectangleF(0, 0, 1, 1), PixelFormat.Format32bppArgb));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -573,12 +573,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetFrameCount_Disposed_ThrowsArgumentException()
+        public void GetFrameCount_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetFrameCount(FrameDimension.Page));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetFrameCount(FrameDimension.Page));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -598,12 +598,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SelectActiveFrame_Disposed_ThrowsArgumentException()
+        public void SelectActiveFrame_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.SelectActiveFrame(FrameDimension.Page, 0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.SelectActiveFrame(FrameDimension.Page, 0));
         }
 
         public static IEnumerable<object[]> GetPixel_TestData()
@@ -662,12 +662,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetPixel_Disposed_ThrowsArgumentException()
+        public void GetPixel_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPixel(0, 0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetPixel(0, 0));
         }
 
         public static IEnumerable<object[]> GetHbitmap_TestData()
@@ -733,12 +733,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetHbitmap_Disposed_ThrowsArgumentException()
+        public void GetHbitmap_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetHbitmap());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetHbitmap());
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -814,12 +814,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetHicon_Disposed_ThrowsArgumentException()
+        public void GetHicon_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetHicon());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetHicon());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -994,13 +994,13 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MakeTransparent_Disposed_ThrowsArgumentException()
+        public void MakeTransparent_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.MakeTransparent());
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.MakeTransparent(Color.Red));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.MakeTransparent());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.MakeTransparent(Color.Red));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1084,12 +1084,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetPixel_Disposed_ThrowsArgumentException()
+        public void SetPixel_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.SetPixel(0, 0, Color.Red));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.SetPixel(0, 0, Color.Red));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1132,12 +1132,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetResolution_Disposed_ThrowsArgumentException()
+        public void SetResolution_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.SetResolution(1, 1));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.SetResolution(1, 1));
         }
 
         public static IEnumerable<object[]> LockBits_NotUnix_TestData()
@@ -1336,14 +1336,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void LockBits_Disposed_ThrowsArgumentException()
+        public void LockBits_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb));
 
             var bitmapData = new BitmapData();
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb, bitmapData));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb, bitmapData));
             Assert.Equal(IntPtr.Zero, bitmapData.Scan0);
         }
 
@@ -1436,23 +1436,23 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void UnlockBits_Disposed_ThrowsArgumentException()
+        public void UnlockBits_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.UnlockBits(new BitmapData()));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.UnlockBits(new BitmapData()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Size_Disposed_ThrowsArgumentException()
+        public void Size_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Width);
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Height);
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Size);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Width);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Height);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Size);
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1635,15 +1635,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Palette_Disposed_ThrowsArgumentException()
+        public void Palette_Disposed_ThrowsObjectDisposedException()
         {
             var bitmap = new Bitmap(1, 1);
             ColorPalette palette = bitmap.Palette;
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Palette);
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Palette = palette);
-            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.Size);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Palette);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Palette = palette);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Size);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/28859")]

--- a/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
@@ -402,9 +402,9 @@ namespace System.Drawing.Tests
             var image = new Bitmap(1, 1);
             image.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Bitmap(image));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Bitmap(image, 1, 1));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Bitmap(image, new Size(1, 1)));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Bitmap(image));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Bitmap(image, 1, 1));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Bitmap(image, new Size(1, 1)));
         }
 
         public static IEnumerable<object[]> Clone_TestData()
@@ -554,9 +554,9 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Clone());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Clone(new Rectangle(0, 0, 1, 1), PixelFormat.Format32bppArgb));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Clone(new RectangleF(0, 0, 1, 1), PixelFormat.Format32bppArgb));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Clone(new Rectangle(0, 0, 1, 1), PixelFormat.Format32bppArgb));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Clone(new RectangleF(0, 0, 1, 1), PixelFormat.Format32bppArgb));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -578,7 +578,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetFrameCount(FrameDimension.Page));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.GetFrameCount(FrameDimension.Page));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -603,7 +603,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.SelectActiveFrame(FrameDimension.Page, 0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.SelectActiveFrame(FrameDimension.Page, 0));
         }
 
         public static IEnumerable<object[]> GetPixel_TestData()
@@ -667,7 +667,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetPixel(0, 0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.GetPixel(0, 0));
         }
 
         public static IEnumerable<object[]> GetHbitmap_TestData()
@@ -738,7 +738,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetHbitmap());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.GetHbitmap());
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -819,7 +819,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.GetHicon());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.GetHicon());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -999,8 +999,8 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.MakeTransparent());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.MakeTransparent(Color.Red));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.MakeTransparent());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.MakeTransparent(Color.Red));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1089,7 +1089,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.SetPixel(0, 0, Color.Red));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.SetPixel(0, 0, Color.Red));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1137,7 +1137,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.SetResolution(1, 1));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.SetResolution(1, 1));
         }
 
         public static IEnumerable<object[]> LockBits_NotUnix_TestData()
@@ -1340,10 +1340,10 @@ namespace System.Drawing.Tests
         {
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb));
 
             var bitmapData = new BitmapData();
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb, bitmapData));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.LockBits(new Rectangle(0, 0, 1, 1), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb, bitmapData));
             Assert.Equal(IntPtr.Zero, bitmapData.Scan0);
         }
 
@@ -1441,7 +1441,7 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.UnlockBits(new BitmapData()));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.UnlockBits(new BitmapData()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1450,9 +1450,9 @@ namespace System.Drawing.Tests
             var bitmap = new Bitmap(1, 1);
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Width);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Height);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Size);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Width);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Height);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Size);
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1641,9 +1641,9 @@ namespace System.Drawing.Tests
             ColorPalette palette = bitmap.Palette;
             bitmap.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Palette);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Palette = palette);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => bitmap.Size);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Palette);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Palette = palette);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => bitmap.Size);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsDrawingSupported), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/28859")]

--- a/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BitmapTests.cs
@@ -1815,7 +1815,7 @@ namespace System.Drawing.Tests
                 set => _stream.Position = _canSeek ? value : throw new NotSupportedException();
             }
             public override void Flush() => _stream.Flush();
-            public override int Read(byte[] buffer, int offset, int count) => _canRead ?  _stream.Read(buffer, offset, count) : throw new NotSupportedException();
+            public override int Read(byte[] buffer, int offset, int count) => _canRead ? _stream.Read(buffer, offset, count) : throw new NotSupportedException();
             public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
             public override void SetLength(long value) => _stream.SetLength(value);
             public override void Write(byte[] buffer, int offset, int count) => _stream.Write(buffer, offset, count);

--- a/src/libraries/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -167,7 +167,7 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Allocate_DisposedGraphics_ThrowsArgumentException()
+        public void Allocate_DisposedGraphics_ThrowsObjectDisposedException()
         {
             using (var context = new BufferedGraphicsContext())
             using (var image = new Bitmap(10, 10))
@@ -176,8 +176,8 @@ namespace System.Drawing.Tests
                 graphics.Dispose();
 
                 Rectangle largeRectangle = new Rectangle(0, 0, context.MaximumBuffer.Width + 1, context.MaximumBuffer.Height + 1);
-                AssertExtensions.Throws<ArgumentException>(null, () => context.Allocate(graphics, largeRectangle));
-                AssertExtensions.Throws<ArgumentException>(null, () => context.Allocate(graphics, Rectangle.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => context.Allocate(graphics, largeRectangle));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => context.Allocate(graphics, Rectangle.Empty));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -176,8 +176,8 @@ namespace System.Drawing.Tests
                 graphics.Dispose();
 
                 Rectangle largeRectangle = new Rectangle(0, 0, context.MaximumBuffer.Width + 1, context.MaximumBuffer.Height + 1);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => context.Allocate(graphics, largeRectangle));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => context.Allocate(graphics, Rectangle.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => context.Allocate(graphics, largeRectangle));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => context.Allocate(graphics, Rectangle.Empty));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
@@ -236,13 +236,13 @@ namespace System.Drawing.Drawing2D.Tests
             using (CustomLineCap customLineCap = new CustomLineCap(null, strokePath))
             {
                 customLineCap.Dispose();
-                AssertExtensions.Throws<ArgumentException>(null, () => customLineCap.StrokeJoin);
-                AssertExtensions.Throws<ArgumentException>(null, () => customLineCap.BaseCap);
-                AssertExtensions.Throws<ArgumentException>(null, () => customLineCap.BaseInset);
-                AssertExtensions.Throws<ArgumentException>(null, () => customLineCap.WidthScale);
-                AssertExtensions.Throws<ArgumentException>(null, () => customLineCap.Clone());
-                AssertExtensions.Throws<ArgumentException>(null, () => customLineCap.SetStrokeCaps(LineCap.Flat, LineCap.Flat));
-                AssertExtensions.Throws<ArgumentException>(null, () => customLineCap.GetStrokeCaps(out LineCap startCap, out LineCap endCap));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.StrokeJoin);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.BaseCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.BaseInset);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.WidthScale);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.Clone());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.SetStrokeCaps(LineCap.Flat, LineCap.Flat));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.GetStrokeCaps(out LineCap startCap, out LineCap endCap));
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
@@ -236,13 +236,13 @@ namespace System.Drawing.Drawing2D.Tests
             using (CustomLineCap customLineCap = new CustomLineCap(null, strokePath))
             {
                 customLineCap.Dispose();
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.StrokeJoin);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.BaseCap);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.BaseInset);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.WidthScale);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.Clone());
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.SetStrokeCaps(LineCap.Flat, LineCap.Flat));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => customLineCap.GetStrokeCaps(out LineCap startCap, out LineCap endCap));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => customLineCap.StrokeJoin);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => customLineCap.BaseCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => customLineCap.BaseInset);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => customLineCap.WidthScale);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => customLineCap.Clone());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => customLineCap.SetStrokeCaps(LineCap.Flat, LineCap.Flat));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => customLineCap.GetStrokeCaps(out LineCap startCap, out LineCap endCap));
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
@@ -91,7 +91,7 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -100,7 +100,7 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.HatchStyle);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.HatchStyle);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -109,7 +109,7 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ForegroundColor);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ForegroundColor);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -118,7 +118,7 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.BackgroundColor);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.BackgroundColor);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
@@ -86,39 +86,39 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void HatchStyle_EmptyAndGetDisposed_ThrowsArgumentException()
+        public void HatchStyle_EmptyAndGetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.HatchStyle);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.HatchStyle);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ForegroundColor_EmptyAndGetDisposed_ThrowsArgumentException()
+        public void ForegroundColor_EmptyAndGetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.ForegroundColor);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ForegroundColor);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void BackgroundColor_EmptyAndGetDisposed_ThrowsArgumentException()
+        public void BackgroundColor_EmptyAndGetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new HatchBrush(HatchStyle.DarkHorizontal, Color.PeachPuff, Color.Purple);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.BackgroundColor);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.BackgroundColor);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
@@ -270,12 +270,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
@@ -384,13 +384,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Blend_GetSetDisposed_ThrowsArgumentException()
+        public void Blend_GetSetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Blend);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Blend = new Blend());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Blend);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Blend = new Blend());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -405,13 +405,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GammaCorrection_GetSetDisposed_ThrowsArgumentException()
+        public void GammaCorrection_GetSetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.GammaCorrection = true);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.GammaCorrection);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.GammaCorrection = true);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -522,7 +522,7 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void InterpolationColors_GetSetDisposed_ThrowsArgumentException()
+        public void InterpolationColors_GetSetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true)
             {
@@ -534,8 +534,8 @@ namespace System.Drawing.Drawing2D.Tests
             };
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors = new ColorBlend
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.InterpolationColors);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.InterpolationColors = new ColorBlend
             {
                 Colors = new Color[2],
                 Positions = new float[] { 0f, 1f }
@@ -615,22 +615,22 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void LinearColors_GetSetDisposed_ThrowsArgumentException()
+        public void LinearColors_GetSetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.LinearColors);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.LinearColors = new Color[] { Color.Red, Color.Wheat });
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.LinearColors);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.LinearColors = new Color[] { Color.Red, Color.Wheat });
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
-        public void Rectangle_GetDisposed_ThrowsArgumentException()
+        public void Rectangle_GetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Rectangle);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Rectangle);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -653,13 +653,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_GetSetDisposed_ThrowsArgumentException()
+        public void Transform_GetSetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Transform);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Transform = new Matrix());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform = new Matrix());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -696,13 +696,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void WrapMode_GetSetDisposed_ThrowsArgumentException()
+        public void WrapMode_GetSetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.WrapMode);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.WrapMode = WrapMode.TileFlipX);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode = WrapMode.TileFlipX);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -718,12 +718,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ResetTransform_Disposed_ThrowsArgumentException()
+        public void ResetTransform_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.ResetTransform());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ResetTransform());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -805,13 +805,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MultiplyTransform_Disposed_ThrowsArgumentException()
+        public void MultiplyTransform_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(new Matrix()));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(new Matrix(), MatrixOrder.Prepend));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(new Matrix()));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(new Matrix(), MatrixOrder.Prepend));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -861,13 +861,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TranslateTransform_Disposed_ThrowsArgumentException()
+        public void TranslateTransform_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.TranslateTransform(0, 0));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.TranslateTransform(0, 0, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(0, 0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(0, 0, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -917,13 +917,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ScaleTransform_Disposed_ThrowsArgumentException()
+        public void ScaleTransform_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.ScaleTransform(0, 0));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.ScaleTransform(0, 0, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(0, 0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(0, 0, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -974,13 +974,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void RotateTransform_Disposed_ThrowsArgumentException()
+        public void RotateTransform_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.RotateTransform(0));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.RotateTransform(0, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(0, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1024,13 +1024,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetSigmalBellShape_Disposed_ThrowsArgumentException()
+        public void SetSigmalBellShape_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetSigmaBellShape(0));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetSigmaBellShape(0, 1));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(0, 1));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1092,13 +1092,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetBlendTriangularShape_Disposed_ThrowsArgumentException()
+        public void SetBlendTriangularShape_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetBlendTriangularShape(0));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetBlendTriangularShape(0, 1));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(0, 1));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
@@ -275,7 +275,7 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
@@ -389,8 +389,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Blend);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Blend = new Blend());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Blend);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Blend = new Blend());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -410,8 +410,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.GammaCorrection);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.GammaCorrection = true);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.GammaCorrection);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.GammaCorrection = true);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -534,8 +534,8 @@ namespace System.Drawing.Drawing2D.Tests
             };
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.InterpolationColors);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.InterpolationColors = new ColorBlend
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.InterpolationColors);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.InterpolationColors = new ColorBlend
             {
                 Colors = new Color[2],
                 Positions = new float[] { 0f, 1f }
@@ -620,8 +620,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.LinearColors);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.LinearColors = new Color[] { Color.Red, Color.Wheat });
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.LinearColors);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.LinearColors = new Color[] { Color.Red, Color.Wheat });
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
@@ -630,7 +630,7 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Rectangle);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Rectangle);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -658,8 +658,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform = new Matrix());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Transform);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Transform = new Matrix());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -701,8 +701,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode = WrapMode.TileFlipX);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.WrapMode);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.WrapMode = WrapMode.TileFlipX);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -723,7 +723,7 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ResetTransform());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ResetTransform());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -810,8 +810,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(new Matrix()));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(new Matrix(), MatrixOrder.Prepend));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.MultiplyTransform(new Matrix()));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.MultiplyTransform(new Matrix(), MatrixOrder.Prepend));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -866,8 +866,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(0, 0));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(0, 0, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.TranslateTransform(0, 0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.TranslateTransform(0, 0, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -922,8 +922,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(0, 0));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(0, 0, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ScaleTransform(0, 0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ScaleTransform(0, 0, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -979,8 +979,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(0));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(0, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.RotateTransform(0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.RotateTransform(0, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1029,8 +1029,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(0));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(0, 1));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetSigmaBellShape(0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetSigmaBellShape(0, 1));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1097,8 +1097,8 @@ namespace System.Drawing.Drawing2D.Tests
             var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(0));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(0, 1));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetBlendTriangularShape(0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetBlendTriangularShape(0, 1));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -180,7 +180,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().Clone());
         }
 
         public static IEnumerable<object[]> Equals_TestData()
@@ -226,19 +226,19 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Equals_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Equals(new Matrix()));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().Equals(new Matrix()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Equals_DisposedOther_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Matrix().Equals(CreateDisposedMatrix()));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Matrix().Equals(CreateDisposedMatrix()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Elements_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Elements);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().Elements);
         }
 
         public static IEnumerable<object[]> Invert_TestData()
@@ -284,19 +284,19 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Invert_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Invert());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().Invert());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsIdentity_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().IsIdentity);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().IsIdentity);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsInvertible_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().IsInvertible);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().IsInvertible);
         }
 
         public static IEnumerable<object[]> Multiply_TestData()
@@ -381,8 +381,8 @@ namespace System.Drawing.Drawing2D.Tests
 
             using (var other = new Matrix())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Multiply(other));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Multiply(other, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Multiply(other));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Multiply(other, MatrixOrder.Prepend));
             }
         }
 
@@ -393,8 +393,8 @@ namespace System.Drawing.Drawing2D.Tests
 
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => matrix.Multiply(disposedMatrix));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => matrix.Multiply(disposedMatrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => matrix.Multiply(disposedMatrix));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => matrix.Multiply(disposedMatrix, MatrixOrder.Prepend));
             }
         }
 
@@ -424,7 +424,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Reset_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Reset());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().Reset());
         }
 
         public static IEnumerable<object[]> Rotate_TestData()
@@ -517,7 +517,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Rotate_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Rotate(1, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedMatrix().Rotate(1, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -536,8 +536,8 @@ namespace System.Drawing.Drawing2D.Tests
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.RotateAt(1, PointF.Empty));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -623,8 +623,8 @@ namespace System.Drawing.Drawing2D.Tests
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Scale(1, 2));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Scale(1, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Scale(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Scale(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> Shear_TestData()
@@ -700,8 +700,8 @@ namespace System.Drawing.Drawing2D.Tests
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Shear(1, 2));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Shear(1, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Shear(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Shear(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> Translate_TestData()
@@ -767,8 +767,8 @@ namespace System.Drawing.Drawing2D.Tests
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Translate(1, 2));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Translate(1, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Translate(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.Translate(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> TransformPoints_TestData()
@@ -826,8 +826,8 @@ namespace System.Drawing.Drawing2D.Tests
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformPoints(new PointF[1]));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.TransformPoints(new Point[1]));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.TransformPoints(new PointF[1]));
         }
 
         public static IEnumerable<object[]> TransformVectors_TestData()
@@ -898,9 +898,9 @@ namespace System.Drawing.Drawing2D.Tests
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.VectorTransformPoints(new Point[1]));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformVectors(new PointF[1]));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.VectorTransformPoints(new Point[1]));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.TransformPoints(new Point[1]));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedMatrix.TransformVectors(new PointF[1]));
         }
 
         private static void AssertEqualFloatArray(float[] expected, float[] actual)

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -178,9 +178,9 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Clone());
         }
 
         public static IEnumerable<object[]> Equals_TestData()
@@ -224,21 +224,21 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Equals_Disposed_ThrowsArgumentException()
+        public void Equals_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Equals(new Matrix()));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Equals(new Matrix()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Equals_DisposedOther_ThrowsArgumentException()
+        public void Equals_DisposedOther_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Matrix().Equals(CreateDisposedMatrix()));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Matrix().Equals(CreateDisposedMatrix()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Elements_Disposed_ThrowsArgumentException()
+        public void Elements_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Elements);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Elements);
         }
 
         public static IEnumerable<object[]> Invert_TestData()
@@ -282,21 +282,21 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Invert_Disposed_ThrowsArgumentException()
+        public void Invert_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Invert());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Invert());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void IsIdentity_Disposed_ThrowsArgumentException()
+        public void IsIdentity_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().IsIdentity);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().IsIdentity);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void IsInvertible_Disposed_ThrowsArgumentException()
+        public void IsInvertible_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().IsInvertible);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().IsInvertible);
         }
 
         public static IEnumerable<object[]> Multiply_TestData()
@@ -375,26 +375,26 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Multiply_Disposed_ThrowsArgumentException()
+        public void Multiply_Disposed_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
             using (var other = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Multiply(other));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Multiply(other, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Multiply(other));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Multiply(other, MatrixOrder.Prepend));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Multiply_DisposedMatrix_ThrowsArgumentException()
+        public void Multiply_DisposedMatrix_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => matrix.Multiply(disposedMatrix));
-                AssertExtensions.Throws<ArgumentException>(null, () => matrix.Multiply(disposedMatrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => matrix.Multiply(disposedMatrix));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => matrix.Multiply(disposedMatrix, MatrixOrder.Prepend));
             }
         }
 
@@ -422,9 +422,9 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Reset_Disposed_ThrowsArgumentException()
+        public void Reset_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Reset());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Reset());
         }
 
         public static IEnumerable<object[]> Rotate_TestData()
@@ -515,9 +515,9 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Rotate_Disposed_ThrowsArgumentException()
+        public void Rotate_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Rotate(1, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedMatrix().Rotate(1, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -532,12 +532,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void RotateAt_Disposed_ThrowsArgumentException()
+        public void RotateAt_Disposed_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -619,12 +619,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Scale_Disposed_ThrowsArgumentException()
+        public void Scale_Disposed_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Scale(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Scale(1, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Scale(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Scale(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> Shear_TestData()
@@ -696,12 +696,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Shear_Disposed_ThrowsArgumentException()
+        public void Shear_Disposed_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Shear(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Shear(1, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Shear(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Shear(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> Translate_TestData()
@@ -763,12 +763,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Translate_Disposed_ThrowsArgumentException()
+        public void Translate_Disposed_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Translate(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Translate(1, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Translate(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.Translate(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> TransformPoints_TestData()
@@ -822,12 +822,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TransformPoints_Disposed_ThrowsArgumentException()
+        public void TransformPoints_Disposed_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new PointF[1]));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformPoints(new PointF[1]));
         }
 
         public static IEnumerable<object[]> TransformVectors_TestData()
@@ -894,13 +894,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TransformVectors_Disposed_ThrowsArgumentException()
+        public void TransformVectors_Disposed_ThrowsObjectDisposedException()
         {
             Matrix disposedMatrix = CreateDisposedMatrix();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.VectorTransformPoints(new Point[1]));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformVectors(new PointF[1]));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.VectorTransformPoints(new Point[1]));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedMatrix.TransformVectors(new PointF[1]));
         }
 
         private static void AssertEqualFloatArray(float[] expected, float[] actual)

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -141,12 +141,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -163,12 +163,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CenterColor_Disposed_ThrowsArgumentException()
+        public void CenterColor_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.CenterColor = Color.Blue);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.CenterColor = Color.Blue);
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
@@ -204,13 +204,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SurroundColors_Disposed_ThrowsArgumentException()
+        public void SurroundColors_Disposed_ThrowsObjectDisposedException()
         {
             Color[] colors = new Color[2] { Color.FromArgb(255, 0, 0, 255), Color.FromArgb(255, 255, 0, 0) };
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SurroundColors = colors);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SurroundColors = colors);
         }
 
         public static IEnumerable<object[]> SurroundColors_InvalidColorsLength_TestData()
@@ -259,12 +259,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CenterPoint_Disposed_ThrowsArgumentException()
+        public void CenterPoint_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.CenterPoint);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.CenterPoint);
         }
 
         public static IEnumerable<object[]> Blend_FactorsPositions_TestData()
@@ -316,12 +316,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Blend_Disposed_ThrowsArgumentException()
+        public void Blend_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Blend);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Blend);
         }
 
         public static IEnumerable<object[]> Blend_InvalidFactorsPositions_TestData()
@@ -454,13 +454,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetSigmaBellShape_Disposed_ThrowsArgumentException()
+        public void SetSigmaBellShape_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetSigmaBellShape(1f));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetSigmaBellShape(1f, 1f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(1f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(1f, 1f));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -546,13 +546,13 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetBlendTriangularShape_Disposed_ThrowsArgumentException()
+        public void SetBlendTriangularShape_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetBlendTriangularShape(1f));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.SetBlendTriangularShape(1f, 1f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(1f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(1f, 1f));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -620,12 +620,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void InterpolationColors_Disposed_ThrowsArgumentException()
+        public void InterpolationColors_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.InterpolationColors);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -724,12 +724,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_Disposed_ThrowsArgumentException()
+        public void Transform_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Transform);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -767,12 +767,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ResetTransform_Disposed_ThrowsArgumentException()
+        public void ResetTransform_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.ResetTransform());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ResetTransform());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -804,14 +804,14 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MultiplyTransform_Disposed_ThrowsArgumentException()
+        public void MultiplyTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (Matrix matrix = new Matrix(1, 0, 0, 1, 1, 1))
             {
                 PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Append));
             }
         }
 
@@ -889,12 +889,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TranslateTransform_Disposed_ThrowsArgumentException()
+        public void TranslateTransform_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.TranslateTransform(20f, 30f, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(20f, 30f, MatrixOrder.Append));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -945,12 +945,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ScaleTransform_Disposed_ThrowsArgumentException()
+        public void ScaleTransform_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.ScaleTransform(0.25f, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(0.25f, 2, MatrixOrder.Append));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -992,12 +992,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void RotateTransform_Disposed_ThrowsArgumentException()
+        public void RotateTransform_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.RotateTransform(45, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(45, MatrixOrder.Append));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1022,12 +1022,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void FocusScales_Disposed_ThrowsArgumentException()
+        public void FocusScales_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.FocusScales);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.FocusScales);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1042,12 +1042,12 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void WrapMode_Disposed_ThrowsArgumentException()
+        public void WrapMode_Disposed_ThrowsObjectDisposedException()
         {
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.WrapMode);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -146,7 +146,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -168,7 +168,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.CenterColor = Color.Blue);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.CenterColor = Color.Blue);
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
@@ -210,7 +210,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SurroundColors = colors);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SurroundColors = colors);
         }
 
         public static IEnumerable<object[]> SurroundColors_InvalidColorsLength_TestData()
@@ -264,7 +264,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.CenterPoint);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.CenterPoint);
         }
 
         public static IEnumerable<object[]> Blend_FactorsPositions_TestData()
@@ -321,7 +321,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Blend);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Blend);
         }
 
         public static IEnumerable<object[]> Blend_InvalidFactorsPositions_TestData()
@@ -459,8 +459,8 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(1f));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetSigmaBellShape(1f, 1f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetSigmaBellShape(1f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetSigmaBellShape(1f, 1f));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -551,8 +551,8 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(1f));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.SetBlendTriangularShape(1f, 1f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetBlendTriangularShape(1f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.SetBlendTriangularShape(1f, 1f));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -625,7 +625,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.InterpolationColors);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.InterpolationColors);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -729,7 +729,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Transform);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -772,7 +772,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ResetTransform());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ResetTransform());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -811,7 +811,7 @@ namespace System.Drawing.Drawing2D.Tests
                 PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.MultiplyTransform(matrix, MatrixOrder.Append));
             }
         }
 
@@ -894,7 +894,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(20f, 30f, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.TranslateTransform(20f, 30f, MatrixOrder.Append));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -950,7 +950,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(0.25f, 2, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ScaleTransform(0.25f, 2, MatrixOrder.Append));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -997,7 +997,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(45, MatrixOrder.Append));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.RotateTransform(45, MatrixOrder.Append));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1027,7 +1027,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.FocusScales);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.FocusScales);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1047,7 +1047,7 @@ namespace System.Drawing.Drawing2D.Tests
             PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.WrapMode);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -227,22 +227,22 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void IsStyleAvailable_Disposed_ThrowsArgumentException()
+        public void IsStyleAvailable_Disposed_ThrowsObjectDisposedException()
         {
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.IsStyleAvailable(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.IsStyleAvailable(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetEmHeight_Disposed_ThrowsArgumentException()
+        public void GetEmHeight_Disposed_ThrowsObjectDisposedException()
         {
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetEmHeight(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetEmHeight(FontStyle.Italic));
         }
 
         private const int FrenchLCID = 1036;
@@ -269,42 +269,42 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetName_Disposed_ThrowsArgumentException()
+        public void GetName_Disposed_ThrowsObjectDisposedException()
         {
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetName(0));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetName(0));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetCellAscent_Disposed_ThrowsArgumentException()
+        public void GetCellAscent_Disposed_ThrowsObjectDisposedException()
         {
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetCellAscent(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetCellAscent(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetCellDescent_Disposed_ThrowsArgumentException()
+        public void GetCellDescent_Disposed_ThrowsObjectDisposedException()
         {
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetCellDescent(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetCellDescent(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetLineSpacing_Disposed_ThrowsArgumentException()
+        public void GetLineSpacing_Disposed_ThrowsObjectDisposedException()
         {
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetLineSpacing(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetLineSpacing(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]

--- a/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -232,7 +232,7 @@ namespace System.Drawing.Tests
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.IsStyleAvailable(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontFamily.IsStyleAvailable(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -242,7 +242,7 @@ namespace System.Drawing.Tests
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetEmHeight(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontFamily.GetEmHeight(FontStyle.Italic));
         }
 
         private const int FrenchLCID = 1036;
@@ -274,7 +274,7 @@ namespace System.Drawing.Tests
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetName(0));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontFamily.GetName(0));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -284,7 +284,7 @@ namespace System.Drawing.Tests
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetCellAscent(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontFamily.GetCellAscent(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -294,7 +294,7 @@ namespace System.Drawing.Tests
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetCellDescent(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontFamily.GetCellDescent(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -304,7 +304,7 @@ namespace System.Drawing.Tests
             FontFamily fontFamily = FontFamily.GenericMonospace;
             fontFamily.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontFamily.GetLineSpacing(FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontFamily.GetLineSpacing(FontStyle.Italic));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]

--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -369,17 +369,17 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Ctor_DisposedFamily_ThrowsArgumentException()
+        public void Ctor_DisposedFamily_ThrowsObjectDisposedException()
         {
             FontFamily family = FontFamily.GenericSansSerif;
             family.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10, FontStyle.Italic));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10, GraphicsUnit.Display));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10, gdiVerticalFont: true));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, GraphicsUnit.Display));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10, gdiVerticalFont: true));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -447,14 +447,14 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_DisposedFont_ThrowsArgumentException()
+        public void Clone_DisposedFont_ThrowsObjectDisposedException()
         {
             using (FontFamily family = FontFamily.GenericSansSerif)
             {
                 var font = new Font(family, 10);
                 font.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => font.Clone());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.Clone());
             }
         }
 
@@ -590,7 +590,7 @@ namespace System.Drawing.Tests
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2060")] // causes an AccessViolation in GDI+
-        public void GetHeight_DisposedGraphics_ThrowsArgumentException()
+        public void GetHeight_DisposedGraphics_ThrowsObjectDisposedException()
         {
             using (FontFamily family = FontFamily.GenericMonospace)
             using (var font = new Font(family, 10))
@@ -599,12 +599,12 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => font.GetHeight(graphics));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight(graphics));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetHeight_Disposed_ThrowsArgumentException()
+        public void GetHeight_Disposed_ThrowsObjectDisposedException()
         {
             using (FontFamily family = FontFamily.GenericSansSerif)
             using (var image = new Bitmap(10, 10))
@@ -613,9 +613,9 @@ namespace System.Drawing.Tests
                 var font = new Font(family, 10);
                 font.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => font.GetHeight());
-                AssertExtensions.Throws<ArgumentException>(null, () => font.GetHeight(10));
-                AssertExtensions.Throws<ArgumentException>(null, () => font.GetHeight(graphics));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight(10));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight(graphics));
             }
         }
 
@@ -871,7 +871,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ToLogFont_DisposedGraphics_ThrowsArgumentException()
+        public void ToLogFont_DisposedGraphics_ThrowsObjectDisposedException()
         {
             using (FontFamily family = FontFamily.GenericMonospace)
             using (var font = new Font(family, 10))
@@ -880,7 +880,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                Assert.Throws<ArgumentException>(() => font.ToLogFont(new LOGFONT(), graphics));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.ToLogFont(new LOGFONT(), graphics));
             }
         }
 
@@ -937,7 +937,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
-        public void ToHfont_Disposed_ThrowsArgumentException()
+        public void ToHfont_Disposed_ThrowsObjectDisposedException()
         {
             using (FontFamily family = FontFamily.GenericSansSerif)
             using (var image = new Bitmap(10, 10))
@@ -946,7 +946,7 @@ namespace System.Drawing.Tests
                 var font = new Font(family, 10);
                 font.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => font.ToHfont());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.ToHfont());
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -374,12 +374,12 @@ namespace System.Drawing.Tests
             FontFamily family = FontFamily.GenericSansSerif;
             family.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, GraphicsUnit.Display));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10, gdiVerticalFont: true));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Font(family, 10));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Font(family, 10, FontStyle.Italic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Font(family, 10, GraphicsUnit.Display));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Font(family, 10, FontStyle.Italic, GraphicsUnit.Display, 10, gdiVerticalFont: true));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -454,7 +454,7 @@ namespace System.Drawing.Tests
                 var font = new Font(family, 10);
                 font.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.Clone());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => font.Clone());
             }
         }
 
@@ -599,7 +599,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight(graphics));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => font.GetHeight(graphics));
             }
         }
 
@@ -613,9 +613,9 @@ namespace System.Drawing.Tests
                 var font = new Font(family, 10);
                 font.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight());
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight(10));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.GetHeight(graphics));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => font.GetHeight());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => font.GetHeight(10));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => font.GetHeight(graphics));
             }
         }
 
@@ -880,7 +880,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.ToLogFont(new LOGFONT(), graphics));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => font.ToLogFont(new LOGFONT(), graphics));
             }
         }
 
@@ -946,7 +946,7 @@ namespace System.Drawing.Tests
                 var font = new Font(family, 10);
                 font.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => font.ToHfont());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => font.ToHfont());
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.Core.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.Core.cs
@@ -51,8 +51,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformElements);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformElements = Matrix3x2.Identity);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TransformElements);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TransformElements = Matrix3x2.Identity);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.Core.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.Core.cs
@@ -44,15 +44,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TransformElements_GetSetWhenDisposed_ThrowsArgumentException()
+        public void TransformElements_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformElements);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformElements = Matrix3x2.Identity);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformElements);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformElements = Matrix3x2.Identity);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
@@ -84,7 +84,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(bitmap);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.GetHdc());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.GetHdc());
             }
         }
 
@@ -248,9 +248,9 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(bitmap);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ReleaseHdc());
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ReleaseHdc(IntPtr.Zero));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ReleaseHdcInternal(IntPtr.Zero));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.ReleaseHdc());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.ReleaseHdc(IntPtr.Zero));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.ReleaseHdcInternal(IntPtr.Zero));
             }
         }
 
@@ -341,7 +341,7 @@ namespace System.Drawing.Tests
             var image = new Bitmap(10, 10);
             image.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => Graphics.FromImage(image));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => Graphics.FromImage(image));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -442,8 +442,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingMode);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingMode = CompositingMode.SourceCopy);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CompositingMode);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CompositingMode = CompositingMode.SourceCopy);
             }
         }
 
@@ -536,8 +536,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingQuality);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingQuality = CompositingQuality.AssumeLinear);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CompositingQuality);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CompositingQuality = CompositingQuality.AssumeLinear);
             }
         }
 
@@ -598,7 +598,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DpiX);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DpiX);
             }
         }
 
@@ -629,7 +629,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DpiX);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DpiX);
             }
         }
 
@@ -682,8 +682,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Flush());
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Flush(FlushIntention.Flush));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.Flush());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.Flush(FlushIntention.Flush));
             }
         }
 
@@ -756,8 +756,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.InterpolationMode);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.InterpolationMode = InterpolationMode.HighQualityBilinear);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.InterpolationMode);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.InterpolationMode = InterpolationMode.HighQualityBilinear);
             }
         }
 
@@ -818,8 +818,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageScale);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageScale = 10);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.PageScale);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.PageScale = 10);
             }
         }
 
@@ -890,8 +890,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageUnit);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageUnit = GraphicsUnit.Document);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.PageUnit);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.PageUnit = GraphicsUnit.Document);
             }
         }
 
@@ -961,8 +961,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PixelOffsetMode);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PixelOffsetMode = PixelOffsetMode.Default);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.PixelOffsetMode);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.PixelOffsetMode = PixelOffsetMode.Default);
             }
         }
 
@@ -1051,8 +1051,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RenderingOrigin);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RenderingOrigin = Point.Empty);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.RenderingOrigin);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.RenderingOrigin = Point.Empty);
             }
         }
 
@@ -1122,8 +1122,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.SmoothingMode);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.SmoothingMode = SmoothingMode.AntiAlias);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.SmoothingMode);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.SmoothingMode = SmoothingMode.AntiAlias);
             }
         }
 
@@ -1181,8 +1181,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextContrast);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextContrast = 5);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TextContrast);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TextContrast = 5);
             }
         }
 
@@ -1243,8 +1243,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextRenderingHint);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TextRenderingHint);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit);
             }
         }
 
@@ -1296,7 +1296,7 @@ namespace System.Drawing.Tests
                 var matrix = new Matrix();
                 matrix.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.Transform = matrix);
             }
         }
 
@@ -1341,8 +1341,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Transform);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.Transform);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.Transform = matrix);
             }
         }
 
@@ -1388,7 +1388,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ResetTransform());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.ResetTransform());
             }
         }
 
@@ -1509,8 +1509,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.MultiplyTransform(matrix));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.MultiplyTransform(matrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.MultiplyTransform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.MultiplyTransform(matrix, MatrixOrder.Prepend));
             }
         }
 
@@ -1595,8 +1595,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TranslateTransform(0, 0));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TranslateTransform(0, 0, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TranslateTransform(0, 0));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TranslateTransform(0, 0, MatrixOrder.Append));
             }
         }
 
@@ -1689,8 +1689,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ScaleTransform(0, 0));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ScaleTransform(0, 0, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.ScaleTransform(0, 0));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.ScaleTransform(0, 0, MatrixOrder.Append));
             }
         }
 
@@ -1776,8 +1776,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RotateTransform(0));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RotateTransform(0, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.RotateTransform(0));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.RotateTransform(0, MatrixOrder.Append));
             }
         }
 
@@ -1961,10 +1961,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty, CopyPixelOperation.MergeCopy));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty, CopyPixelOperation.MergeCopy));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty, CopyPixelOperation.MergeCopy));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty, CopyPixelOperation.MergeCopy));
             }
         }
 
@@ -2222,8 +2222,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new Point[] { Point.Empty }));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new PointF[] { PointF.Empty }));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new Point[] { Point.Empty }));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new PointF[] { PointF.Empty }));
             }
         }
 
@@ -2273,7 +2273,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.GetNearestColor(Color.Red));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.GetNearestColor(Color.Red));
             }
         }
 
@@ -2301,10 +2301,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2371,10 +2371,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2400,9 +2400,9 @@ namespace System.Drawing.Tests
                 pen.Dispose();
 
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangle(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2437,9 +2437,9 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangle(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2463,8 +2463,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new Rectangle[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new RectangleF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangles(pen, new Rectangle[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangles(pen, new RectangleF[2]));
             }
         }
 
@@ -2522,8 +2522,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new Rectangle[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new RectangleF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangles(pen, new Rectangle[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawRectangles(pen, new RectangleF[2]));
             }
         }
 
@@ -2550,10 +2550,10 @@ namespace System.Drawing.Tests
                 pen.Dispose();
 
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2589,10 +2589,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2618,10 +2618,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2687,10 +2687,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2714,8 +2714,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPolygon(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPolygon(pen, new PointF[2]));
             }
         }
 
@@ -2775,8 +2775,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPolygon(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPolygon(pen, new PointF[2]));
             }
         }
 
@@ -2801,7 +2801,7 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPath(pen, graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPath(pen, graphicsPath));
             }
         }
 
@@ -2826,7 +2826,7 @@ namespace System.Drawing.Tests
                 var graphicsPath = new GraphicsPath();
                 graphicsPath.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPath(pen, graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPath(pen, graphicsPath));
             }
         }
 
@@ -2861,7 +2861,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPath(pen, graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawPath(pen, graphicsPath));
             }
         }
 
@@ -2890,13 +2890,13 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new Point[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2], 0, 2));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
             }
         }
 
@@ -2990,13 +2990,13 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new Point[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2], 0, 2));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
             }
         }
 
@@ -3022,10 +3022,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Winding));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Winding));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new Point[3]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Winding));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new PointF[3]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Winding));
             }
         }
 
@@ -3092,10 +3092,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Alternate));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Alternate));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new Point[3]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Alternate));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new PointF[3]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Alternate));
             }
         }
 
@@ -3148,7 +3148,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Clear(Color.Red));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.Clear(Color.Red));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
@@ -84,7 +84,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(bitmap);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.GetHdc());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.GetHdc());
             }
         }
 
@@ -248,9 +248,9 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(bitmap);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.ReleaseHdc());
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.ReleaseHdc(IntPtr.Zero));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.ReleaseHdcInternal(IntPtr.Zero));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ReleaseHdc());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ReleaseHdc(IntPtr.Zero));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ReleaseHdcInternal(IntPtr.Zero));
             }
         }
 
@@ -336,12 +336,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void FromImage_DisposedImage_ThrowsArgumentException()
+        public void FromImage_DisposedImage_ThrowsObjectDisposedException()
         {
             var image = new Bitmap(10, 10);
             image.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => Graphics.FromImage(image));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => Graphics.FromImage(image));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -435,15 +435,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CompositingMode_GetSetWhenDisposed_ThrowsArgumentException()
+        public void CompositingMode_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CompositingMode);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CompositingMode = CompositingMode.SourceCopy);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingMode);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingMode = CompositingMode.SourceCopy);
             }
         }
 
@@ -529,15 +529,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CompositingQuality_GetSetWhenDisposed_ThrowsArgumentException()
+        public void CompositingQuality_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CompositingQuality);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CompositingQuality = CompositingQuality.AssumeLinear);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingQuality);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CompositingQuality = CompositingQuality.AssumeLinear);
             }
         }
 
@@ -591,14 +591,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DpiX_GetWhenDisposed_ThrowsArgumentException()
+        public void DpiX_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DpiX);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DpiX);
             }
         }
 
@@ -622,14 +622,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DpiY_GetWhenDisposed_ThrowsArgumentException()
+        public void DpiY_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DpiX);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DpiX);
             }
         }
 
@@ -675,15 +675,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Flush_Disposed_ThrowsArgumentException()
+        public void Flush_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.Flush());
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.Flush(FlushIntention.Flush));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Flush());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Flush(FlushIntention.Flush));
             }
         }
 
@@ -749,15 +749,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void InterpolationMode_GetSetWhenDisposed_ThrowsArgumentException()
+        public void InterpolationMode_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.InterpolationMode);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.InterpolationMode = InterpolationMode.HighQualityBilinear);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.InterpolationMode);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.InterpolationMode = InterpolationMode.HighQualityBilinear);
             }
         }
 
@@ -811,15 +811,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void PageScale_GetSetWhenDisposed_ThrowsArgumentException()
+        public void PageScale_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.PageScale);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.PageScale = 10);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageScale);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageScale = 10);
             }
         }
 
@@ -883,15 +883,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void PageUnit_GetSetWhenDisposed_ThrowsArgumentException()
+        public void PageUnit_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.PageUnit);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.PageUnit = GraphicsUnit.Document);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageUnit);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PageUnit = GraphicsUnit.Document);
             }
         }
 
@@ -954,15 +954,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void PixelOffsetMode_GetSetWhenDisposed_ThrowsArgumentException()
+        public void PixelOffsetMode_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.PixelOffsetMode);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.PixelOffsetMode = PixelOffsetMode.Default);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PixelOffsetMode);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.PixelOffsetMode = PixelOffsetMode.Default);
             }
         }
 
@@ -1044,15 +1044,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void RenderingOrigin_GetSetWhenDisposed_ThrowsArgumentException()
+        public void RenderingOrigin_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.RenderingOrigin);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.RenderingOrigin = Point.Empty);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RenderingOrigin);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RenderingOrigin = Point.Empty);
             }
         }
 
@@ -1115,15 +1115,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SmoothingMode_GetSetWhenDisposed_ThrowsArgumentException()
+        public void SmoothingMode_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.SmoothingMode);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.SmoothingMode = SmoothingMode.AntiAlias);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.SmoothingMode);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.SmoothingMode = SmoothingMode.AntiAlias);
             }
         }
 
@@ -1174,15 +1174,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TextContrast_GetSetWhenDisposed_ThrowsArgumentException()
+        public void TextContrast_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TextContrast);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TextContrast = 5);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextContrast);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextContrast = 5);
             }
         }
 
@@ -1236,15 +1236,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TextRenderingHint_GetSetWhenDisposed_ThrowsArgumentException()
+        public void TextRenderingHint_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TextRenderingHint);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextRenderingHint);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TextRenderingHint = TextRenderingHint.SingleBitPerPixelGridFit);
             }
         }
 
@@ -1288,7 +1288,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_SetDisposedMatrix_ThrowsArgumentException()
+        public void Transform_SetDisposedMatrix_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -1296,7 +1296,7 @@ namespace System.Drawing.Tests
                 var matrix = new Matrix();
                 matrix.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Transform = matrix);
             }
         }
 
@@ -1333,7 +1333,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_GetSetWhenDisposed_ThrowsArgumentException()
+        public void Transform_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var matrix = new Matrix())
@@ -1341,8 +1341,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.Transform);
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Transform);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Transform = matrix);
             }
         }
 
@@ -1381,14 +1381,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ResetTransform_Disposed_ThrowsArgumentException()
+        public void ResetTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.ResetTransform());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ResetTransform());
             }
         }
 
@@ -1501,7 +1501,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MultiplyTransform_Disposed_ThrowsArgumentException()
+        public void MultiplyTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var matrix = new Matrix())
@@ -1509,8 +1509,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.MultiplyTransform(matrix));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.MultiplyTransform(matrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.MultiplyTransform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.MultiplyTransform(matrix, MatrixOrder.Prepend));
             }
         }
 
@@ -1588,15 +1588,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TranslateTransform_Disposed_ThrowsArgumentException()
+        public void TranslateTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TranslateTransform(0, 0));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TranslateTransform(0, 0, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TranslateTransform(0, 0));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TranslateTransform(0, 0, MatrixOrder.Append));
             }
         }
 
@@ -1682,15 +1682,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ScaleTransform_Disposed_ThrowsArgumentException()
+        public void ScaleTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.ScaleTransform(0, 0));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.ScaleTransform(0, 0, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ScaleTransform(0, 0));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.ScaleTransform(0, 0, MatrixOrder.Append));
             }
         }
 
@@ -1769,15 +1769,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void RotateTransform_Disposed_ThrowsArgumentException()
+        public void RotateTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.RotateTransform(0));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.RotateTransform(0, MatrixOrder.Append));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RotateTransform(0));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.RotateTransform(0, MatrixOrder.Append));
             }
         }
 
@@ -1954,17 +1954,17 @@ namespace System.Drawing.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/23375")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CopyFromScreen_Disposed_ThrowsArgumentException()
+        public void CopyFromScreen_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty, CopyPixelOperation.MergeCopy));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty, CopyPixelOperation.MergeCopy));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty, CopyPixelOperation.MergeCopy));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty, CopyPixelOperation.MergeCopy));
             }
         }
 
@@ -2215,15 +2215,15 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TransformPoints_Disposed_ThrowsArgumentException()
+        public void TransformPoints_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new Point[] { Point.Empty }));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new PointF[] { PointF.Empty }));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new Point[] { Point.Empty }));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new PointF[] { PointF.Empty }));
             }
         }
 
@@ -2266,14 +2266,14 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetNearestColor_Disposed_ThrowsArgumentException()
+        public void GetNearestColor_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.GetNearestColor(Color.Red));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.GetNearestColor(Color.Red));
             }
         }
 
@@ -2293,7 +2293,7 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawArc_DisposedPen_ThrowsArgumentException()
+        public void DrawArc_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2301,10 +2301,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2363,7 +2363,7 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawArc_Disposed_ThrowsArgumentException()
+        public void DrawArc_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2371,10 +2371,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2391,7 +2391,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawRectangle_DisposedPen_ThrowsArgumentException()
+        public void DrawRectangle_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2400,9 +2400,9 @@ namespace System.Drawing.Tests
                 pen.Dispose();
 
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangle(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2429,7 +2429,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawRectangle_Disposed_ThrowsArgumentException()
+        public void DrawRectangle_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2437,9 +2437,9 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangle(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangle(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2455,7 +2455,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawRectangles_DisposedPen_ThrowsArgumentException()
+        public void DrawRectangles_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2463,8 +2463,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangles(pen, new Rectangle[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangles(pen, new RectangleF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new Rectangle[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new RectangleF[2]));
             }
         }
 
@@ -2514,7 +2514,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawRectangles_Disposed_ThrowsArgumentException()
+        public void DrawRectangles_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2522,8 +2522,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangles(pen, new Rectangle[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawRectangles(pen, new RectangleF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new Rectangle[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawRectangles(pen, new RectangleF[2]));
             }
         }
 
@@ -2541,7 +2541,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawEllipse_DisposedPen_ThrowsArgumentException()
+        public void DrawEllipse_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2550,10 +2550,10 @@ namespace System.Drawing.Tests
                 pen.Dispose();
 
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2581,7 +2581,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawEllipse_Disposed_ThrowsArgumentException()
+        public void DrawEllipse_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2589,10 +2589,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, 0, 0, 1, 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0, 0, 1, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawEllipse(pen, 0f, 0f, 1f, 1f));
             }
         }
 
@@ -2610,7 +2610,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawPie_DisposedPen_ThrowsArgumentException()
+        public void DrawPie_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2618,10 +2618,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2679,7 +2679,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawPie_Disposed_ThrowsArgumentException()
+        public void DrawPie_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2687,10 +2687,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPie(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -2706,7 +2706,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawPolygon_DisposedPen_ThrowsArgumentException()
+        public void DrawPolygon_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2714,8 +2714,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPolygon(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPolygon(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new PointF[2]));
             }
         }
 
@@ -2767,7 +2767,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawPolygon_Disposed_ThrowsArgumentException()
+        public void DrawPolygon_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2775,8 +2775,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPolygon(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPolygon(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPolygon(pen, new PointF[2]));
             }
         }
 
@@ -2792,7 +2792,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawPath_DisposedPen_ThrowsArgumentException()
+        public void DrawPath_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2801,7 +2801,7 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPath(pen, graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPath(pen, graphicsPath));
             }
         }
 
@@ -2817,7 +2817,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawPath_DisposedPath_ThrowsArgumentException()
+        public void DrawPath_DisposedPath_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2826,7 +2826,7 @@ namespace System.Drawing.Tests
                 var graphicsPath = new GraphicsPath();
                 graphicsPath.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPath(pen, graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPath(pen, graphicsPath));
             }
         }
 
@@ -2852,7 +2852,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawPath_Disposed_ThrowsArgumentException()
+        public void DrawPath_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2861,7 +2861,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawPath(pen, graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawPath(pen, graphicsPath));
             }
         }
 
@@ -2882,7 +2882,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawCurve_DisposedPen_ThrowsArgumentException()
+        public void DrawCurve_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -2890,13 +2890,13 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new Point[2], 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2], 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
             }
         }
 
@@ -2982,7 +2982,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawCurve_Disposed_ThrowsArgumentException()
+        public void DrawCurve_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -2990,13 +2990,13 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new Point[2], 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2], 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new Point[2], 0, 2, 1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawCurve(pen, new PointF[2], 0, 2, 1));
             }
         }
 
@@ -3014,7 +3014,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawClosedCurve_DisposedPen_ThrowsArgumentException()
+        public void DrawClosedCurve_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -3022,10 +3022,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new Point[3]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Winding));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Winding));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Winding));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Winding));
             }
         }
 
@@ -3084,7 +3084,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawClosedCurve_Disposed_ThrowsArgumentException()
+        public void DrawClosedCurve_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -3092,10 +3092,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new Point[3]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Alternate));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Alternate));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new Point[3], 1, FillMode.Alternate));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawClosedCurve(pen, new PointF[3], 1, FillMode.Alternate));
             }
         }
 
@@ -3140,7 +3140,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clear_Disposed_ThrowsArgumentException()
+        public void Clear_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -3148,7 +3148,7 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.Clear(Color.Red));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.Clear(Color.Red));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
@@ -80,7 +80,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawBezier_DisposedPen_ThrowsArgumentException()
+        public void DrawBezier_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -88,9 +88,9 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawBezier(pen, 1, 2, 3, 4, 5, 6, 7, 8));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawBezier(pen, Point.Empty, Point.Empty, Point.Empty, Point.Empty));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawBezier(pen, PointF.Empty, PointF.Empty, PointF.Empty, PointF.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBezier(pen, 1, 2, 3, 4, 5, 6, 7, 8));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBezier(pen, Point.Empty, Point.Empty, Point.Empty, Point.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBezier(pen, PointF.Empty, PointF.Empty, PointF.Empty, PointF.Empty));
             }
         }
 
@@ -116,7 +116,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
-        public void DrawBezier_Disposed_ThrowsArgumentException()
+        public void DrawBezier_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -124,10 +124,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -144,7 +144,7 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawBeziers_DisposedPen_ThrowsArgumentException()
+        public void DrawBeziers_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -152,8 +152,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawBeziers(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawBeziers(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new PointF[2]));
             }
         }
 
@@ -205,7 +205,7 @@ namespace System.Drawing.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawBeziers_Disposed_ThrowsArgumentException()
+        public void DrawBeziers_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -213,8 +213,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawBeziers(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawBeziers(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new PointF[2]));
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
@@ -88,9 +88,9 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBezier(pen, 1, 2, 3, 4, 5, 6, 7, 8));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBezier(pen, Point.Empty, Point.Empty, Point.Empty, Point.Empty));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBezier(pen, PointF.Empty, PointF.Empty, PointF.Empty, PointF.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawBezier(pen, 1, 2, 3, 4, 5, 6, 7, 8));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawBezier(pen, Point.Empty, Point.Empty, Point.Empty, Point.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawBezier(pen, PointF.Empty, PointF.Empty, PointF.Empty, PointF.Empty));
             }
         }
 
@@ -124,10 +124,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, 0, 0, 1, 1, 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, new RectangleF(0, 0, 1, 1), 0, 90));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawArc(pen, 0f, 0f, 1f, 1f, 0, 90));
             }
         }
 
@@ -152,8 +152,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawBeziers(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawBeziers(pen, new PointF[2]));
             }
         }
 
@@ -213,8 +213,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawBeziers(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawBeziers(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawBeziers(pen, new PointF[2]));
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
@@ -61,10 +61,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, Point.Empty, Point.Empty));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0, 0, 0, 0));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, Point.Empty, Point.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, 0, 0, 0, 0));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
             }
         }
 
@@ -100,10 +100,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, Point.Empty, Point.Empty));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0, 0, 0, 0));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, Point.Empty, Point.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, 0, 0, 0, 0));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
             }
         }
 
@@ -127,8 +127,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLines(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLines(pen, new PointF[2]));
             }
         }
 
@@ -188,8 +188,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new Point[2]));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLines(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => graphics.DrawLines(pen, new PointF[2]));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
@@ -53,7 +53,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawLine_DisposedPen_ThrowsArgumentException()
+        public void DrawLine_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -61,10 +61,10 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, Point.Empty, Point.Empty));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, 0, 0, 0, 0));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, Point.Empty, Point.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0, 0, 0, 0));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
             }
         }
 
@@ -92,7 +92,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawLine_Disposed_ThrowsArgumentException()
+        public void DrawLine_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -100,10 +100,10 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, Point.Empty, Point.Empty));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, 0, 0, 0, 0));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, Point.Empty, Point.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0, 0, 0, 0));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, PointF.Empty, PointF.Empty));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLine(pen, 0f, 0f, 0f, 0f));
             }
         }
 
@@ -119,7 +119,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawLines_DisposedPen_ThrowsArgumentException()
+        public void DrawLines_DisposedPen_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -127,8 +127,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(Color.Red);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLines(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLines(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new PointF[2]));
             }
         }
 
@@ -180,7 +180,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DrawLines_Disposed_ThrowsArgumentException()
+        public void DrawLines_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var pen = new Pen(Color.Red))
@@ -188,8 +188,8 @@ namespace System.Drawing.Tests
                 Graphics graphics = Graphics.FromImage(image);
                 graphics.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLines(pen, new Point[2]));
-                AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLines(pen, new PointF[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new Point[2]));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => graphics.DrawLines(pen, new PointF[2]));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -92,7 +92,7 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.Clone());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -235,9 +235,9 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix, ColorMatrixFlag.Default));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix, ColorMatrixFlag.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() =>
                 imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Default));
         }
 
@@ -352,8 +352,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorMatrix());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorMatrix(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearColorMatrix());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearColorMatrix(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -474,9 +474,9 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix, ColorMatrixFlag.Default));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix, ColorMatrixFlag.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() =>
                 imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix, ColorMatrixFlag.Default, ColorAdjustType.Default));
         }
 
@@ -575,7 +575,7 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetThreshold(0.5f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetThreshold(0.5f));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -629,7 +629,7 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearThreshold(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearThreshold(ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -696,8 +696,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetGamma(2.2f));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetGamma(2.2f, ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetGamma(2.2f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetGamma(2.2f, ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -733,7 +733,7 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearGamma(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearGamma(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -788,8 +788,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetNoOp());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetNoOp(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetNoOp());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetNoOp(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -866,8 +866,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearNoOp());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearNoOp(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearNoOp());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearNoOp(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -935,8 +935,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150)));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150)));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() =>
                 imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150), ColorAdjustType.Default));
         }
 
@@ -990,8 +990,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorKey());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorKey(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearColorKey());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearColorKey(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1098,8 +1098,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY, ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY, ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1176,8 +1176,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannel());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannel(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearOutputChannel());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearOutputChannel(ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1214,9 +1214,9 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() =>
                 imageAttr.SetOutputChannelColorProfile(Helpers.GetTestColorProfilePath("RSWOP.icm")));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() =>
                 imageAttr.SetOutputChannelColorProfile(Helpers.GetTestColorProfilePath("RSWOP.icm"), ColorAdjustType.Default));
         }
 
@@ -1319,8 +1319,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannelColorProfile());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannelColorProfile(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearOutputChannelColorProfile());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearOutputChannelColorProfile(ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1384,8 +1384,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetRemapTable(_yellowToRedColorMap));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetRemapTable(_yellowToRedColorMap, ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetRemapTable(_yellowToRedColorMap));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetRemapTable(_yellowToRedColorMap, ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1465,8 +1465,8 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearRemapTable());
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearRemapTable(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearRemapTable());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.ClearRemapTable(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1485,9 +1485,9 @@ namespace System.Drawing.Imaging.Tests
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black, true));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetWrapMode(WrapMode.Clamp));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black, true));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1499,7 +1499,7 @@ namespace System.Drawing.Imaging.Tests
 
             using (var bitmap = new Bitmap(_rectangle.Width, _rectangle.Height))
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.GetAdjustedPalette(bitmap.Palette, ColorAdjustType.Default));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => imageAttr.GetAdjustedPalette(bitmap.Palette, ColorAdjustType.Default));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -87,12 +87,12 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.Clone());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -230,14 +230,14 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetColorMatrix_Disposed_ThrowsArgumentException()
+        public void SetColorMatrix_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix));
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix, ColorMatrixFlag.Default));
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix, ColorMatrixFlag.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
                 imageAttr.SetColorMatrix(_greenComponentToZeroColorMatrix, ColorMatrixFlag.Default, ColorAdjustType.Default));
         }
 
@@ -347,13 +347,13 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearColorMatrix_Disposed_ThrowsArgumentException()
+        public void ClearColorMatrix_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearColorMatrix());
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearColorMatrix(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorMatrix());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorMatrix(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -469,14 +469,14 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetColorMatrices_Disposed_ThrowsArgumentException()
+        public void SetColorMatrices_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix));
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix, ColorMatrixFlag.Default));
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix, ColorMatrixFlag.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
                 imageAttr.SetColorMatrices(_greenComponentToZeroColorMatrix, _grayMatrix, ColorMatrixFlag.Default, ColorAdjustType.Default));
         }
 
@@ -570,12 +570,12 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetThreshold_Disposed_ThrowsArgumentException()
+        public void SetThreshold_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetThreshold(0.5f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetThreshold(0.5f));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -624,12 +624,12 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearThreshold_Disposed_ThrowsArgumentException()
+        public void ClearThreshold_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearThreshold(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearThreshold(ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -691,13 +691,13 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetGamma_Disposed_ThrowsArgumentException()
+        public void SetGamma_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetGamma(2.2f));
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetGamma(2.2f, ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetGamma(2.2f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetGamma(2.2f, ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -728,12 +728,12 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearGamma_Disposed_ThrowsArgumentException()
+        public void ClearGamma_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearGamma(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearGamma(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -783,13 +783,13 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetNoOp_Disposed_ThrowsArgumentException()
+        public void SetNoOp_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetNoOp());
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetNoOp(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetNoOp());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetNoOp(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -861,13 +861,13 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearNoOp_Disposed_ThrowsArgumentException()
+        public void ClearNoOp_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearNoOp());
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearNoOp(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearNoOp());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearNoOp(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -930,13 +930,13 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetColorKey_Disposed_ThrowsArgumentException()
+        public void SetColorKey_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150)));
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150)));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
                 imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150), ColorAdjustType.Default));
         }
 
@@ -985,13 +985,13 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearColorKey_Disposed_ThrowsArgumentException()
+        public void ClearColorKey_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearColorKey());
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearColorKey(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorKey());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearColorKey(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1093,13 +1093,13 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetOutputChannel_Disposed_ThrowsArgumentException()
+        public void SetOutputChannel_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY));
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY, ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetOutputChannel(ColorChannelFlag.ColorChannelY, ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1171,13 +1171,13 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearOutputChannel_Disposed_ThrowsArgumentException()
+        public void ClearOutputChannel_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannel());
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannel(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannel());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannel(ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1209,14 +1209,14 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetOutputChannelColorProfile_Disposed_ThrowsArgumentException()
+        public void SetOutputChannelColorProfile_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
                 imageAttr.SetOutputChannelColorProfile(Helpers.GetTestColorProfilePath("RSWOP.icm")));
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
                 imageAttr.SetOutputChannelColorProfile(Helpers.GetTestColorProfilePath("RSWOP.icm"), ColorAdjustType.Default));
         }
 
@@ -1314,13 +1314,13 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearOutputChannelColorProfile_Disposed_ThrowsArgumentException()
+        public void ClearOutputChannelColorProfile_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannelColorProfile());
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearOutputChannelColorProfile(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannelColorProfile());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearOutputChannelColorProfile(ColorAdjustType.Default));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1379,13 +1379,13 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetRemapTable_Disposed_ThrowsArgumentException()
+        public void SetRemapTable_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetRemapTable(_yellowToRedColorMap));
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetRemapTable(_yellowToRedColorMap, ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetRemapTable(_yellowToRedColorMap));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetRemapTable(_yellowToRedColorMap, ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1460,13 +1460,13 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ClearRemapTable_Disposed_ThrowsArgumentException()
+        public void ClearRemapTable_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearRemapTable());
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.ClearRemapTable(ColorAdjustType.Default));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearRemapTable());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.ClearRemapTable(ColorAdjustType.Default));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1480,26 +1480,26 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetWrapMode_Disposed_ThrowsArgumentException()
+        public void SetWrapMode_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp));
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black));
-            AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black, true));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.SetWrapMode(WrapMode.Clamp, Color.Black, true));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetAdjustedPalette_Disposed_ThrowsArgumentException()
+        public void GetAdjustedPalette_Disposed_ThrowsObjectDisposedException()
         {
             var imageAttr = new ImageAttributes();
             imageAttr.Dispose();
 
             using (var bitmap = new Bitmap(_rectangle.Width, _rectangle.Height))
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => imageAttr.GetAdjustedPalette(bitmap.Palette, ColorAdjustType.Default));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => imageAttr.GetAdjustedPalette(bitmap.Palette, ColorAdjustType.Default));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -995,7 +995,7 @@ namespace System.Drawing.Imaging.Tests
             var metafile = new Metafile(GetPath(WmfFile));
             metafile.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => metafile.GetMetafileHeader());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => metafile.GetMetafileHeader());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1014,7 +1014,7 @@ namespace System.Drawing.Imaging.Tests
             var metafile = new Metafile(GetPath(WmfFile));
             metafile.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => metafile.GetHenhmetafile());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => metafile.GetHenhmetafile());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1023,7 +1023,7 @@ namespace System.Drawing.Imaging.Tests
             var metafile = new Metafile(GetPath(WmfFile));
             metafile.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() =>
                 metafile.PlayRecord(EmfPlusRecordType.BeginContainer, 0, 1, new byte[1]));
         }
 

--- a/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -990,12 +990,12 @@ namespace System.Drawing.Imaging.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetMetafileHeader_Disposed_ThrowsArgumentException()
+        public void GetMetafileHeader_Disposed_ThrowsObjectDisposedException()
         {
             var metafile = new Metafile(GetPath(WmfFile));
             metafile.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => metafile.GetMetafileHeader());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => metafile.GetMetafileHeader());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1009,21 +1009,21 @@ namespace System.Drawing.Imaging.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetHenhmetafile_Disposed_ThrowsArgumentException()
+        public void GetHenhmetafile_Disposed_ThrowsObjectDisposedException()
         {
             var metafile = new Metafile(GetPath(WmfFile));
             metafile.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => metafile.GetHenhmetafile());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => metafile.GetHenhmetafile());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void PlayRecord_Disposed_ThrowsArgumentException()
+        public void PlayRecord_Disposed_ThrowsObjectDisposedException()
         {
             var metafile = new Metafile(GetPath(WmfFile));
             metafile.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ObjectDisposedException>(null, () =>
                 metafile.PlayRecord(EmfPlusRecordType.BeginContainer, 0, 1, new byte[1]));
         }
 

--- a/src/libraries/System.Drawing.Common/tests/PenTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/PenTests.cs
@@ -84,13 +84,13 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Ctor_DisposedBrush_ThrowsArgumentException()
+        public void Ctor_DisposedBrush_ThrowsObjectDisposedException()
         {
             var brush = new SolidBrush(Color.Red);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => new Pen(brush));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Pen(brush, 10));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Pen(brush));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Pen(brush, 10));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -149,15 +149,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Alignment_GetWhenDisposed_ThrowsArgumentException()
+        public void Alignment_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Alignment);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Alignment = PenAlignment.Center);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Alignment);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Alignment = PenAlignment.Center);
             }
         }
 
@@ -198,27 +198,27 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Brush_SetDisposedBrush_ThrowsArgumentException()
+        public void Brush_SetDisposedBrush_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var pen = new Pen(brush))
             {
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Brush = brush);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Brush = brush);
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Brush_GetSetWhenDisposed_ThrowsArgumentException()
+        public void Brush_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Brush);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Brush = brush);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Brush);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Brush = brush);
             }
         }
 
@@ -250,14 +250,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Clone());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Clone());
             }
         }
 
@@ -323,19 +323,19 @@ namespace System.Drawing.Tests
             pen.Color = Color.Red;
             Assert.Equal(Color.Red, pen.Color);
 
-            AssertExtensions.Throws<ArgumentException>(null, () => pen.Color = Color.Black);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Color = Color.Black);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Color_GetSetWhenDisposedWithBrush_ThrowsArgumentException()
+        public void Color_GetSetWhenDisposedWithBrush_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Color);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Color = Color.Red);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Color);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Color = Color.Red);
             }
         }
 
@@ -396,15 +396,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CompoundArray_GetSetWhenDisposed_ThrowsArgumentException()
+        public void CompoundArray_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CompoundArray);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CompoundArray = new float[] { 1 });
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CompoundArray);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CompoundArray = new float[] { 1 });
             }
         }
 
@@ -438,7 +438,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CustomEndCap_SetDisposedLineCap_ThrowsArgumentException()
+        public void CustomEndCap_SetDisposedLineCap_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var pen = new Pen(brush))
@@ -448,12 +448,12 @@ namespace System.Drawing.Tests
                 var lineCap = new CustomLineCap(fillPath, strokePath);
                 lineCap.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CustomEndCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomEndCap = lineCap);
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CustomEndCap_GetSetWhenDisposed_ThrowsArgumentException()
+        public void CustomEndCap_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var fillPath = new GraphicsPath())
@@ -463,8 +463,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CustomEndCap);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CustomEndCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomEndCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomEndCap = lineCap);
             }
         }
 
@@ -498,7 +498,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CustomStartCap_SetDisposedLineCap_ThrowsArgumentException()
+        public void CustomStartCap_SetDisposedLineCap_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var pen = new Pen(brush))
@@ -508,12 +508,12 @@ namespace System.Drawing.Tests
                 var lineCap = new CustomLineCap(fillPath, strokePath);
                 lineCap.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CustomStartCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomStartCap = lineCap);
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void CustomStartCap_GetSetWhenDisposed_ThrowsArgumentException()
+        public void CustomStartCap_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var fillPath = new GraphicsPath())
@@ -523,8 +523,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CustomStartCap);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.CustomStartCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomStartCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomStartCap = lineCap);
             }
         }
 
@@ -556,15 +556,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DashCap_GetWhenDisposed_ThrowsArgumentException()
+        public void DashCap_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashCap);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashCap = DashCap.Triangle);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashCap = DashCap.Triangle);
             }
         }
 
@@ -586,15 +586,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DashOffset_GetSetWhenDisposed_ThrowsArgumentException()
+        public void DashOffset_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashOffset);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashOffset = 10);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashOffset);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashOffset = 10);
             }
         }
 
@@ -653,15 +653,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DashPattern_GetSetWhenDisposed_ThrowsArgumentException()
+        public void DashPattern_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashPattern);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashPattern = new float[] { 1 });
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashPattern);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashPattern = new float[] { 1 });
             }
         }
 
@@ -718,15 +718,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DashStyle_GetWhenDisposed_ThrowsArgumentException()
+        public void DashStyle_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashStyle);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.DashStyle = DashStyle.Dash);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashStyle);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashStyle = DashStyle.Dash);
             }
         }
 
@@ -778,15 +778,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void EndCap_GetSetWhenDisposed_ThrowsArgumentException()
+        public void EndCap_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.EndCap);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.EndCap = LineCap.ArrowAnchor);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.EndCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.EndCap = LineCap.ArrowAnchor);
             }
         }
 
@@ -818,15 +818,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void LineJoin_GetSetWhenDisposed_ThrowsArgumentException()
+        public void LineJoin_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.LineJoin);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.LineJoin = LineJoin.Miter);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.LineJoin);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.LineJoin = LineJoin.Miter);
             }
         }
 
@@ -848,15 +848,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MiterLimit_GetSetWhenDisposed_ThrowsArgumentException()
+        public void MiterLimit_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.MiterLimit);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.MiterLimit = 10);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MiterLimit);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MiterLimit = 10);
             }
         }
 
@@ -959,7 +959,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MultiplyTransform_Disposed_ThrowsArgumentException()
+        public void MultiplyTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var matrix = new Matrix())
@@ -967,8 +967,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.MultiplyTransform(matrix));
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.MultiplyTransform(matrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MultiplyTransform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MultiplyTransform(matrix, MatrixOrder.Prepend));
             }
         }
 
@@ -990,7 +990,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ResetTransform_Disposed_ThrowsArgumentException()
+        public void ResetTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var matrix = new Matrix())
@@ -998,7 +998,7 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.ResetTransform());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.ResetTransform());
             }
         }
         public static IEnumerable<object[]> RotateTransform_TestData()
@@ -1050,7 +1050,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void RotateTransform_Disposed_ThrowsArgumentException()
+        public void RotateTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var matrix = new Matrix())
@@ -1058,8 +1058,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.RotateTransform(1));
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.RotateTransform(1, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.RotateTransform(1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.RotateTransform(1, MatrixOrder.Prepend));
             }
         }
 
@@ -1114,7 +1114,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ScaleTransform_Disposed_ThrowsArgumentException()
+        public void ScaleTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var matrix = new Matrix())
@@ -1122,8 +1122,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.ScaleTransform(1, 2));
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.ScaleTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.ScaleTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.ScaleTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -1150,14 +1150,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetLineCap_Disposed_ThrowsArgumentException()
+        public void SetLineCap_Disposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.SetLineCap(LineCap.AnchorMask, LineCap.ArrowAnchor, DashCap.Flat));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.SetLineCap(LineCap.AnchorMask, LineCap.ArrowAnchor, DashCap.Flat));
             }
         }
 
@@ -1185,15 +1185,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void StartCap_GetSetWhenDisposed_ThrowsArgumentException()
+        public void StartCap_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.StartCap);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.StartCap = LineCap.ArrowAnchor);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.StartCap);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.StartCap = LineCap.ArrowAnchor);
             }
         }
 
@@ -1236,7 +1236,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_SetDisposedLineCap_ThrowsArgumentException()
+        public void Transform_SetDisposedLineCap_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var pen = new Pen(brush))
@@ -1244,12 +1244,12 @@ namespace System.Drawing.Tests
                 var matrix = new Matrix();
                 matrix.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Transform = matrix);
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_GetSetWhenDisposed_ThrowsArgumentException()
+        public void Transform_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var matrix = new Matrix())
@@ -1257,8 +1257,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Transform);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Transform);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Transform = matrix);
             }
         }
 
@@ -1313,7 +1313,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TranslateTransform_Disposed_ThrowsArgumentException()
+        public void TranslateTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             using (var matrix = new Matrix())
@@ -1321,8 +1321,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.TranslateTransform(1, 2));
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.TranslateTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.TranslateTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.TranslateTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -1344,15 +1344,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Width_GetSetWhenDisposed_ThrowsArgumentException()
+        public void Width_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var brush = new SolidBrush(Color.Red))
             {
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Width);
-                AssertExtensions.Throws<ArgumentException>(null, () => pen.Width = 10);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Width);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Width = 10);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/PenTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/PenTests.cs
@@ -89,8 +89,8 @@ namespace System.Drawing.Tests
             var brush = new SolidBrush(Color.Red);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Pen(brush));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Pen(brush, 10));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Pen(brush));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Pen(brush, 10));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -156,8 +156,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Alignment);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Alignment = PenAlignment.Center);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Alignment);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Alignment = PenAlignment.Center);
             }
         }
 
@@ -205,7 +205,7 @@ namespace System.Drawing.Tests
             {
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Brush = brush);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Brush = brush);
             }
         }
 
@@ -217,8 +217,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Brush);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Brush = brush);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Brush);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Brush = brush);
             }
         }
 
@@ -257,7 +257,7 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Clone());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Clone());
             }
         }
 
@@ -323,7 +323,7 @@ namespace System.Drawing.Tests
             pen.Color = Color.Red;
             Assert.Equal(Color.Red, pen.Color);
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Color = Color.Black);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Color = Color.Black);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -334,8 +334,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Color);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Color = Color.Red);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Color);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Color = Color.Red);
             }
         }
 
@@ -403,8 +403,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CompoundArray);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CompoundArray = new float[] { 1 });
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CompoundArray);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CompoundArray = new float[] { 1 });
             }
         }
 
@@ -448,7 +448,7 @@ namespace System.Drawing.Tests
                 var lineCap = new CustomLineCap(fillPath, strokePath);
                 lineCap.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomEndCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CustomEndCap = lineCap);
             }
         }
 
@@ -463,8 +463,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomEndCap);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomEndCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CustomEndCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CustomEndCap = lineCap);
             }
         }
 
@@ -508,7 +508,7 @@ namespace System.Drawing.Tests
                 var lineCap = new CustomLineCap(fillPath, strokePath);
                 lineCap.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomStartCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CustomStartCap = lineCap);
             }
         }
 
@@ -523,8 +523,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomStartCap);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.CustomStartCap = lineCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CustomStartCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.CustomStartCap = lineCap);
             }
         }
 
@@ -563,8 +563,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashCap);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashCap = DashCap.Triangle);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashCap = DashCap.Triangle);
             }
         }
 
@@ -593,8 +593,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashOffset);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashOffset = 10);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashOffset);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashOffset = 10);
             }
         }
 
@@ -660,8 +660,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashPattern);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashPattern = new float[] { 1 });
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashPattern);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashPattern = new float[] { 1 });
             }
         }
 
@@ -725,8 +725,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashStyle);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.DashStyle = DashStyle.Dash);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashStyle);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.DashStyle = DashStyle.Dash);
             }
         }
 
@@ -785,8 +785,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.EndCap);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.EndCap = LineCap.ArrowAnchor);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.EndCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.EndCap = LineCap.ArrowAnchor);
             }
         }
 
@@ -825,8 +825,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.LineJoin);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.LineJoin = LineJoin.Miter);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.LineJoin);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.LineJoin = LineJoin.Miter);
             }
         }
 
@@ -855,8 +855,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MiterLimit);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MiterLimit = 10);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.MiterLimit);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.MiterLimit = 10);
             }
         }
 
@@ -967,8 +967,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MultiplyTransform(matrix));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.MultiplyTransform(matrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.MultiplyTransform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.MultiplyTransform(matrix, MatrixOrder.Prepend));
             }
         }
 
@@ -998,7 +998,7 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.ResetTransform());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.ResetTransform());
             }
         }
         public static IEnumerable<object[]> RotateTransform_TestData()
@@ -1058,8 +1058,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.RotateTransform(1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.RotateTransform(1, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.RotateTransform(1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.RotateTransform(1, MatrixOrder.Prepend));
             }
         }
 
@@ -1122,8 +1122,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.ScaleTransform(1, 2));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.ScaleTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.ScaleTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.ScaleTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -1157,7 +1157,7 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.SetLineCap(LineCap.AnchorMask, LineCap.ArrowAnchor, DashCap.Flat));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.SetLineCap(LineCap.AnchorMask, LineCap.ArrowAnchor, DashCap.Flat));
             }
         }
 
@@ -1192,8 +1192,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.StartCap);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.StartCap = LineCap.ArrowAnchor);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.StartCap);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.StartCap = LineCap.ArrowAnchor);
             }
         }
 
@@ -1244,7 +1244,7 @@ namespace System.Drawing.Tests
                 var matrix = new Matrix();
                 matrix.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Transform = matrix);
             }
         }
 
@@ -1257,8 +1257,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Transform);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Transform);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Transform = matrix);
             }
         }
 
@@ -1321,8 +1321,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.TranslateTransform(1, 2));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.TranslateTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.TranslateTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.TranslateTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -1351,8 +1351,8 @@ namespace System.Drawing.Tests
                 var pen = new Pen(brush);
                 pen.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Width);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => pen.Width = 10);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Width);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => pen.Width = 10);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/RegionTests.cs
@@ -276,12 +276,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Ctor_DisposedGraphicsPath_ThrowsArgumentException()
+        public void Ctor_DisposedGraphicsPath_ThrowsObjectDisposedException()
         {
             var path = new GraphicsPath();
             path.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region(path));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region(path));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -300,9 +300,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().Clone());
         }
 
         public static IEnumerable<object[]> Complement_TestData()
@@ -449,9 +449,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Complement_DisposedRegion_ThrowsArgumentException()
+        public void Complement_DisposedRegion_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Complement(CreateDisposedRegion()));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Complement(CreateDisposedRegion()));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -570,17 +570,17 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Complement_Disposed_ThrowsArgumentException()
+        public void Complement_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(graphicPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(disposedRegion));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(graphicPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(disposedRegion));
             }
         }
 
@@ -667,7 +667,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Equals_DisposedGraphics_ThrowsArgumentException()
+        public void Equals_DisposedGraphics_ThrowsObjectDisposedException()
         {
             using (var region = new Region())
             using (var other = new Region())
@@ -675,17 +675,17 @@ namespace System.Drawing.Tests
             {
                 var graphics = Graphics.FromImage(image);
                 graphics.Dispose();
-                AssertExtensions.Throws<ArgumentException>(null, () => region.Equals(region, graphics));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.Equals(region, graphics));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Equals_Disposed_ThrowsArgumentException()
+        public void Equals_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Equals(new Region(), s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Equals(disposedRegion, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Equals(new Region(), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Equals(disposedRegion, s_graphic));
         }
 
         public static IEnumerable<object[]> Exclude_TestData()
@@ -893,9 +893,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Exclude_DisposedRegion_ThrowsArgumentException()
+        public void Exclude_DisposedRegion_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Exclude(CreateDisposedRegion()));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Exclude(CreateDisposedRegion()));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -990,17 +990,17 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Exclude_Disposed_ThrowsArgumentException()
+        public void Exclude_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(other));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(other));
             }
         }
 
@@ -1070,9 +1070,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetHrgn_Disposed_ThrowsArgumentException()
+        public void GetHrgn_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetHrgn(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetHrgn(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1094,27 +1094,27 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetBounds_DisposedGraphics_ThrowsArgumentException()
+        public void GetBounds_DisposedGraphics_ThrowsObjectDisposedException()
         {
             using (var region = new Region())
             using (var image = new Bitmap(10, 10))
             {
                 var graphics = Graphics.FromImage(image);
                 graphics.Dispose();
-                AssertExtensions.Throws<ArgumentException>(null, () => region.GetBounds(graphics));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.GetBounds(graphics));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetBounds_Disposed_ThrowsArgumentException()
+        public void GetBounds_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetBounds(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetBounds(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetRegionData_Disposed_ThrowsArgumentException()
+        public void GetRegionData_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetRegionData());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetRegionData());
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1143,23 +1143,23 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetRegionScans_Disposed_ThrowsArgumentException()
+        public void GetRegionScans_Disposed_ThrowsObjectDisposedException()
         {
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetRegionScans(matrix));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetRegionScans(matrix));
             }
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetRegionScans_DisposedMatrix_ThrowsArgumentException()
+        public void GetRegionScans_DisposedMatrix_ThrowsObjectDisposedException()
         {
             using (var region = new Region())
             {
                 var matrix = new Matrix();
                 matrix.Dispose();
-                AssertExtensions.Throws<ArgumentException>(null, () => region.GetRegionScans(matrix));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.GetRegionScans(matrix));
             }
         }
 
@@ -1282,9 +1282,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Intersect_DisposedRegion_ThrowsArgumentException()
+        public void Intersect_DisposedRegion_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Intersect(CreateDisposedRegion()));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Intersect(CreateDisposedRegion()));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1405,17 +1405,17 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Intersect_Disposed_ThrowsArgumentException()
+        public void Intersect_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(other));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(other));
             }
         }
 
@@ -1429,9 +1429,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void IsEmpty_Disposed_ThrowsArgumentException()
+        public void IsEmpty_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().IsEmpty(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().IsEmpty(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1444,21 +1444,21 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void IsInfinite_DisposedGraphics_ThrowsArgumentException()
+        public void IsInfinite_DisposedGraphics_ThrowsObjectDisposedException()
         {
             using (var region = new Region())
             using (var image = new Bitmap(10, 10))
             {
                 var graphics = Graphics.FromImage(image);
                 graphics.Dispose();
-                AssertExtensions.Throws<ArgumentException>(null, () => region.IsInfinite(graphics));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.IsInfinite(graphics));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void IsInfinite_Disposed_ThrowsArgumentException()
+        public void IsInfinite_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().IsInfinite(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().IsInfinite(s_graphic));
         }
 
         public static IEnumerable<object[]> IsVisible_Rectangle_TestData()
@@ -1571,29 +1571,29 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void IsVisible_Disposed_ThrowsArgumentException()
+        public void IsVisible_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new PointF(1, 2)));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Point(1, 2)));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new PointF(1, 2)));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Point(1, 2)));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f, s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new PointF(1, 2), s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Point(1, 2), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new PointF(1, 2), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Point(1, 2), s_graphic));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4)));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4)));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4)));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4)));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f, s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4), s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4), s_graphic));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1, 2, s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1, 2, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4, s_graphic));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1618,9 +1618,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MakeEmpty_Disposed_ThrowsArgumentException()
+        public void MakeEmpty_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().MakeEmpty());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().MakeEmpty());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1641,9 +1641,9 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MakeInfinite_Disposed_ThrowsArgumentException()
+        public void MakeInfinite_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().MakeInfinite());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().MakeInfinite());
         }
 
         public static IEnumerable<object[]> Union_TestData()
@@ -1882,11 +1882,11 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Union_DisposedRegion_ThrowsArgumentException()
+        public void Union_DisposedRegion_ThrowsObjectDisposedException()
         {
             using (var region = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => region.Union(CreateDisposedRegion()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.Union(CreateDisposedRegion()));
             }
         }
 
@@ -1979,17 +1979,17 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Union_Disposed_ThrowsArgumentException()
+        public void Union_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(disposedRegion));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(disposedRegion));
             }
         }
 
@@ -2081,11 +2081,11 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_Disposed_ThrowsArgumentException()
+        public void Transform_Disposed_ThrowsObjectDisposedException()
         {
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().Transform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().Transform(matrix));
             }
         }
 
@@ -2179,12 +2179,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Translate_Disposed_ThrowsArgumentException()
+        public void Translate_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Translate(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Translate(1f, 2f));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Translate(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Translate(1f, 2f));
         }
 
         public static IEnumerable<object[]> Xor_TestData()
@@ -2295,11 +2295,11 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Xor_DisposedRegion_ThrowsArgumentException()
+        public void Xor_DisposedRegion_ThrowsObjectDisposedException()
         {
             using (var region = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => region.Xor(CreateDisposedRegion()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.Xor(CreateDisposedRegion()));
             }
         }
 
@@ -2395,17 +2395,17 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Xor_Disposed_ThrowsArgumentException()
+        public void Xor_Disposed_ThrowsObjectDisposedException()
         {
             Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(other));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(other));
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/RegionTests.cs
@@ -281,7 +281,7 @@ namespace System.Drawing.Tests
             var path = new GraphicsPath();
             path.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region(path));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Region(path));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -302,7 +302,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().Clone());
         }
 
         public static IEnumerable<object[]> Complement_TestData()
@@ -451,7 +451,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Complement_DisposedRegion_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Complement(CreateDisposedRegion()));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Region().Complement(CreateDisposedRegion()));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -577,10 +577,10 @@ namespace System.Drawing.Tests
             using (var graphicPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(graphicPath));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(new Rectangle()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(new RectangleF()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Complement(disposedRegion));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Complement(graphicPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Complement(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Complement(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Complement(disposedRegion));
             }
         }
 
@@ -675,7 +675,7 @@ namespace System.Drawing.Tests
             {
                 var graphics = Graphics.FromImage(image);
                 graphics.Dispose();
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.Equals(region, graphics));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => region.Equals(region, graphics));
             }
         }
 
@@ -684,8 +684,8 @@ namespace System.Drawing.Tests
         {
             Region disposedRegion = CreateDisposedRegion();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Equals(new Region(), s_graphic));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Equals(disposedRegion, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Equals(new Region(), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Region().Equals(disposedRegion, s_graphic));
         }
 
         public static IEnumerable<object[]> Exclude_TestData()
@@ -895,7 +895,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Exclude_DisposedRegion_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Exclude(CreateDisposedRegion()));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Region().Exclude(CreateDisposedRegion()));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -997,10 +997,10 @@ namespace System.Drawing.Tests
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(graphicsPath));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(new Rectangle()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(new RectangleF()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Exclude(other));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Exclude(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Exclude(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Exclude(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Exclude(other));
             }
         }
 
@@ -1072,7 +1072,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHrgn_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetHrgn(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().GetHrgn(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1101,20 +1101,20 @@ namespace System.Drawing.Tests
             {
                 var graphics = Graphics.FromImage(image);
                 graphics.Dispose();
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.GetBounds(graphics));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => region.GetBounds(graphics));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetBounds_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetBounds(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().GetBounds(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetRegionData_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetRegionData());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().GetRegionData());
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1147,7 +1147,7 @@ namespace System.Drawing.Tests
         {
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().GetRegionScans(matrix));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().GetRegionScans(matrix));
             }
         }
 
@@ -1159,7 +1159,7 @@ namespace System.Drawing.Tests
             {
                 var matrix = new Matrix();
                 matrix.Dispose();
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.GetRegionScans(matrix));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => region.GetRegionScans(matrix));
             }
         }
 
@@ -1284,7 +1284,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Intersect_DisposedRegion_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new Region().Intersect(CreateDisposedRegion()));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new Region().Intersect(CreateDisposedRegion()));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -1412,10 +1412,10 @@ namespace System.Drawing.Tests
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(graphicsPath));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(new Rectangle()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(new RectangleF()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Intersect(other));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Intersect(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Intersect(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Intersect(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Intersect(other));
             }
         }
 
@@ -1431,7 +1431,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsEmpty_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().IsEmpty(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().IsEmpty(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1451,14 +1451,14 @@ namespace System.Drawing.Tests
             {
                 var graphics = Graphics.FromImage(image);
                 graphics.Dispose();
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.IsInfinite(graphics));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => region.IsInfinite(graphics));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsInfinite_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().IsInfinite(s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().IsInfinite(s_graphic));
         }
 
         public static IEnumerable<object[]> IsVisible_Rectangle_TestData()
@@ -1575,25 +1575,25 @@ namespace System.Drawing.Tests
         {
             Region disposedRegion = CreateDisposedRegion();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new PointF(1, 2)));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Point(1, 2)));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(1f, 2f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new PointF(1, 2)));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new Point(1, 2)));
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f, s_graphic));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new PointF(1, 2), s_graphic));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Point(1, 2), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(1f, 2f, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new PointF(1, 2), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new Point(1, 2), s_graphic));
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4)));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4)));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(1f, 2f, 3f, 4f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4)));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4)));
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f, s_graphic));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4), s_graphic));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(1f, 2f, 3f, 4f, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4), s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4), s_graphic));
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1, 2, s_graphic));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(1, 2, s_graphic));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(1, 2, 3, 4));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.IsVisible(1, 2, 3, 4, s_graphic));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1620,7 +1620,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeEmpty_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().MakeEmpty());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().MakeEmpty());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1643,7 +1643,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeInfinite_Disposed_ThrowsObjectDisposedException()
         {
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().MakeInfinite());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().MakeInfinite());
         }
 
         public static IEnumerable<object[]> Union_TestData()
@@ -1886,7 +1886,7 @@ namespace System.Drawing.Tests
         {
             using (var region = new Region())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.Union(CreateDisposedRegion()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => region.Union(CreateDisposedRegion()));
             }
         }
 
@@ -1986,10 +1986,10 @@ namespace System.Drawing.Tests
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(graphicsPath));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(new Rectangle()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(new RectangleF()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Union(disposedRegion));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Union(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Union(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Union(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Union(disposedRegion));
             }
         }
 
@@ -2085,7 +2085,7 @@ namespace System.Drawing.Tests
         {
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => CreateDisposedRegion().Transform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => CreateDisposedRegion().Transform(matrix));
             }
         }
 
@@ -2183,8 +2183,8 @@ namespace System.Drawing.Tests
         {
             Region disposedRegion = CreateDisposedRegion();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Translate(1, 2));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Translate(1f, 2f));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Translate(1, 2));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Translate(1f, 2f));
         }
 
         public static IEnumerable<object[]> Xor_TestData()
@@ -2299,7 +2299,7 @@ namespace System.Drawing.Tests
         {
             using (var region = new Region())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => region.Xor(CreateDisposedRegion()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => region.Xor(CreateDisposedRegion()));
             }
         }
 
@@ -2402,10 +2402,10 @@ namespace System.Drawing.Tests
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(graphicsPath));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(new Rectangle()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(new RectangleF()));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => disposedRegion.Xor(other));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Xor(graphicsPath));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Xor(new Rectangle()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Xor(new RectangleF()));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => disposedRegion.Xor(other));
             }
         }
     }

--- a/src/libraries/System.Drawing.Common/tests/SolidBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/SolidBrushTests.cs
@@ -51,21 +51,21 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             var brush = new SolidBrush(Color.LavenderBlush);
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
-        public void Color_EmptyAndGetDisposed_ThrowsArgumentException()
+        public void Color_EmptyAndGetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new SolidBrush(new Color());
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Color);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Color);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -85,12 +85,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Color_SetDisposed_ThrowsArgumentException()
+        public void Color_SetDisposed_ThrowsObjectDisposedException()
         {
             var brush = new SolidBrush(new Color());
             brush.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Color = Color.WhiteSmoke);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Color = Color.WhiteSmoke);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/SolidBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/SolidBrushTests.cs
@@ -56,7 +56,7 @@ namespace System.Drawing.Tests
             var brush = new SolidBrush(Color.LavenderBlush);
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Clone());
         }
 
         [ConditionalFact(Helpers.IsWindowsOrAtLeastLibgdiplus6)]
@@ -65,7 +65,7 @@ namespace System.Drawing.Tests
             var brush = new SolidBrush(new Color());
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Color);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Color);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -90,7 +90,7 @@ namespace System.Drawing.Tests
             var brush = new SolidBrush(new Color());
             brush.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Color = Color.WhiteSmoke);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Color = Color.WhiteSmoke);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/StringFormatTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/StringFormatTests.cs
@@ -90,12 +90,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Ctor_DisposedFormat_ThrowsArgumentException()
+        public void Ctor_DisposedFormat_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => new StringFormat(format));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new StringFormat(format));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -127,12 +127,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.Clone());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Clone());
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -152,12 +152,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetDigitSubstitution_Disposed_ThrowsArgumentException()
+        public void SetDigitSubstitution_Disposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.SetDigitSubstitution(0, StringDigitSubstitute.None));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.SetDigitSubstitution(0, StringDigitSubstitute.None));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -202,21 +202,21 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetTabStops_Disposed_ThrowsArgumentException()
+        public void SetTabStops_Disposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.SetTabStops(0, new float[0]));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.SetTabStops(0, new float[0]));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void GetTabStops_Disposed_ThrowsArgumentException()
+        public void GetTabStops_Disposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.GetTabStops(out float firstTabOffset));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.GetTabStops(out float firstTabOffset));
         }
 
         public static IEnumerable<object[]> SetMeasurableCharacterRanges_TestData()
@@ -256,12 +256,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SetMeasurableCharacterRanges_Disposed_ThrowsArgumentException()
+        public void SetMeasurableCharacterRanges_Disposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.SetMeasurableCharacterRanges(new CharacterRange[0]));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.SetMeasurableCharacterRanges(new CharacterRange[0]));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -288,31 +288,31 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Alignment_GetSetWhenDisposed_ThrowsArgumentException()
+        public void Alignment_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.Alignment);
-            AssertExtensions.Throws<ArgumentException>(null, () => format.Alignment = StringAlignment.Center);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Alignment);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Alignment = StringAlignment.Center);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DigitSubstitutionMethod_GetSetWhenDisposed_ThrowsArgumentException()
+        public void DigitSubstitutionMethod_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.DigitSubstitutionMethod);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.DigitSubstitutionMethod);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void DigitSubstitutionLanguage_GetSetWhenDisposed_ThrowsArgumentException()
+        public void DigitSubstitutionLanguage_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.DigitSubstitutionLanguage);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.DigitSubstitutionLanguage);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -328,13 +328,13 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void FormatFlags_GetSetWhenDisposed_ThrowsArgumentException()
+        public void FormatFlags_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.FormatFlags);
-            AssertExtensions.Throws<ArgumentException>(null, () => format.FormatFlags = StringFormatFlags.NoClip);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.FormatFlags);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.FormatFlags = StringFormatFlags.NoClip);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -361,13 +361,13 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void LineAlignment_GetSetWhenDisposed_ThrowsArgumentException()
+        public void LineAlignment_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.LineAlignment);
-            AssertExtensions.Throws<ArgumentException>(null, () => format.LineAlignment = StringAlignment.Center);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.LineAlignment);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.LineAlignment = StringAlignment.Center);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -394,13 +394,13 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void HotkeyPrefix_GetSetWhenDisposed_ThrowsArgumentException()
+        public void HotkeyPrefix_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.HotkeyPrefix);
-            AssertExtensions.Throws<ArgumentException>(null, () => format.HotkeyPrefix = HotkeyPrefix.Hide);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.HotkeyPrefix);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.HotkeyPrefix = HotkeyPrefix.Hide);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -425,14 +425,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Trimming_GetSetWhenDisposed_ThrowsArgumentException()
+        public void Trimming_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat();
             format.Dispose();
 
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.Trimming);
-            AssertExtensions.Throws<ArgumentException>(null, () => format.Trimming = StringTrimming.Word);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Trimming);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Trimming = StringTrimming.Word);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -475,12 +475,12 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ToString_Disposed_ThrowsArgumentException()
+        public void ToString_Disposed_ThrowsObjectDisposedException()
         {
             var format = new StringFormat(StringFormatFlags.DirectionVertical);
             format.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => format.ToString());
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.ToString());
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/tests/StringFormatTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/StringFormatTests.cs
@@ -95,7 +95,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new StringFormat(format));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new StringFormat(format));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -132,7 +132,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Clone());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.Clone());
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -157,7 +157,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.SetDigitSubstitution(0, StringDigitSubstitute.None));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.SetDigitSubstitution(0, StringDigitSubstitute.None));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -207,7 +207,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.SetTabStops(0, new float[0]));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.SetTabStops(0, new float[0]));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -216,7 +216,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.GetTabStops(out float firstTabOffset));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.GetTabStops(out float firstTabOffset));
         }
 
         public static IEnumerable<object[]> SetMeasurableCharacterRanges_TestData()
@@ -261,7 +261,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.SetMeasurableCharacterRanges(new CharacterRange[0]));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.SetMeasurableCharacterRanges(new CharacterRange[0]));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -293,8 +293,8 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Alignment);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Alignment = StringAlignment.Center);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.Alignment);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.Alignment = StringAlignment.Center);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -303,7 +303,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.DigitSubstitutionMethod);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.DigitSubstitutionMethod);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -312,7 +312,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.DigitSubstitutionLanguage);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.DigitSubstitutionLanguage);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -333,8 +333,8 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.FormatFlags);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.FormatFlags = StringFormatFlags.NoClip);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.FormatFlags);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.FormatFlags = StringFormatFlags.NoClip);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -366,8 +366,8 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.LineAlignment);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.LineAlignment = StringAlignment.Center);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.LineAlignment);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.LineAlignment = StringAlignment.Center);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -399,8 +399,8 @@ namespace System.Drawing.Tests
             var format = new StringFormat();
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.HotkeyPrefix);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.HotkeyPrefix = HotkeyPrefix.Hide);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.HotkeyPrefix);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.HotkeyPrefix = HotkeyPrefix.Hide);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -431,8 +431,8 @@ namespace System.Drawing.Tests
             format.Dispose();
 
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Trimming);
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.Trimming = StringTrimming.Word);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.Trimming);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.Trimming = StringTrimming.Word);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -480,7 +480,7 @@ namespace System.Drawing.Tests
             var format = new StringFormat(StringFormatFlags.DirectionVertical);
             format.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => format.ToString());
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => format.ToString());
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -165,7 +165,7 @@ namespace System.Drawing.Text.Tests
             var fontCollection = new PrivateFontCollection();
             fontCollection.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontCollection.AddFontFile("fileName"));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontCollection.AddFontFile("fileName"));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -236,7 +236,7 @@ namespace System.Drawing.Text.Tests
             var fontCollection = new PrivateFontCollection();
             fontCollection.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontCollection.AddMemoryFont((IntPtr)10, 100));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontCollection.AddMemoryFont((IntPtr)10, 100));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -245,7 +245,7 @@ namespace System.Drawing.Text.Tests
             var fontCollection = new PrivateFontCollection();
             fontCollection.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontCollection.Families);
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => fontCollection.Families);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -160,12 +160,12 @@ namespace System.Drawing.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void AddFontFile_Disposed_ThrowsArgumentException()
+        public void AddFontFile_Disposed_ThrowsObjectDisposedException()
         {
             var fontCollection = new PrivateFontCollection();
             fontCollection.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontCollection.AddFontFile("fileName"));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontCollection.AddFontFile("fileName"));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -231,21 +231,21 @@ namespace System.Drawing.Text.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void AddMemoryFont_Disposed_ThrowsArgumentException()
+        public void AddMemoryFont_Disposed_ThrowsObjectDisposedException()
         {
             var fontCollection = new PrivateFontCollection();
             fontCollection.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontCollection.AddMemoryFont((IntPtr)10, 100));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontCollection.AddMemoryFont((IntPtr)10, 100));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Families_GetWhenDisposed_ThrowsArgumentException()
+        public void Families_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             var fontCollection = new PrivateFontCollection();
             fontCollection.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => fontCollection.Families);
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => fontCollection.Families);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/TextureBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/TextureBrushTests.cs
@@ -284,14 +284,14 @@ namespace System.Drawing.Tests
             var image = new Bitmap(10, 10);
             image.Dispose();
 
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, WrapMode.Tile));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, RectangleF.Empty));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, Rectangle.Empty));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, RectangleF.Empty, null));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, Rectangle.Empty, null));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, WrapMode.Tile, RectangleF.Empty));
-            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, WrapMode.Tile, Rectangle.Empty));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image, WrapMode.Tile));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image, RectangleF.Empty));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image, Rectangle.Empty));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image, RectangleF.Empty, null));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image, Rectangle.Empty, null));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image, WrapMode.Tile, RectangleF.Empty));
+            AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => new TextureBrush(image, WrapMode.Tile, Rectangle.Empty));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -352,7 +352,7 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Clone());
             }
         }
 
@@ -364,7 +364,7 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Image);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Image);
             }
         }
 
@@ -476,8 +476,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(matrix));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.MultiplyTransform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.MultiplyTransform(matrix, MatrixOrder.Prepend));
             }
         }
 
@@ -506,7 +506,7 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ResetTransform());
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ResetTransform());
             }
         }
 
@@ -573,8 +573,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(1));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(1, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.RotateTransform(1));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.RotateTransform(1, MatrixOrder.Prepend));
             }
         }
 
@@ -643,8 +643,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(1, 2));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ScaleTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.ScaleTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -679,7 +679,7 @@ namespace System.Drawing.Tests
                 var matrix = new Matrix();
                 matrix.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Transform = matrix);
             }
         }
 
@@ -692,8 +692,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Transform);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.Transform = matrix);
             }
         }
 
@@ -762,8 +762,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(1, 2));
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.TranslateTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.TranslateTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -803,8 +803,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode);
-                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode = WrapMode.Tile);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.WrapMode);
+                AssertExtensions.Throws<ObjectDisposedException, ArgumentException>(() => brush.WrapMode = WrapMode.Tile);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/TextureBrushTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/TextureBrushTests.cs
@@ -279,19 +279,19 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Ctor_DisposedImage_ThrowsArgumentException()
+        public void Ctor_DisposedImage_ThrowsObjectDisposedException()
         {
             var image = new Bitmap(10, 10);
             image.Dispose();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image));
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, WrapMode.Tile));
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, RectangleF.Empty));
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, Rectangle.Empty));
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, RectangleF.Empty, null));
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, Rectangle.Empty, null));
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, WrapMode.Tile, RectangleF.Empty));
-            AssertExtensions.Throws<ArgumentException>(null, () => new TextureBrush(image, WrapMode.Tile, Rectangle.Empty));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, WrapMode.Tile));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, RectangleF.Empty));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, Rectangle.Empty));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, RectangleF.Empty, null));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, Rectangle.Empty, null));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, WrapMode.Tile, RectangleF.Empty));
+            AssertExtensions.Throws<ObjectDisposedException>(null, () => new TextureBrush(image, WrapMode.Tile, Rectangle.Empty));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -345,26 +345,26 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Clone_Disposed_ThrowsArgumentException()
+        public void Clone_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.Clone());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Clone());
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Image_GetWhenDisposed_ThrowsArgumentException()
+        public void Image_GetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.Image);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Image);
             }
         }
 
@@ -468,7 +468,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void MultiplyTransform_Disposed_ThrowsArgumentException()
+        public void MultiplyTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var matrix = new Matrix())
@@ -476,8 +476,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(matrix));
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(matrix));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Prepend));
             }
         }
 
@@ -499,14 +499,14 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ResetTransform_Disposed_ThrowsArgumentException()
+        public void ResetTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.ResetTransform());
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ResetTransform());
             }
         }
 
@@ -565,7 +565,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void RotateTransform_Disposed_ThrowsArgumentException()
+        public void RotateTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var matrix = new Matrix())
@@ -573,8 +573,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.RotateTransform(1));
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.RotateTransform(1, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(1));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.RotateTransform(1, MatrixOrder.Prepend));
             }
         }
 
@@ -635,7 +635,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void ScaleTransform_Disposed_ThrowsArgumentException()
+        public void ScaleTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var matrix = new Matrix())
@@ -643,8 +643,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.ScaleTransform(1, 2));
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.ScaleTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.ScaleTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -671,7 +671,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_SetDisposedMatrix_ThrowsArgumentException()
+        public void Transform_SetDisposedMatrix_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var brush = new TextureBrush(image))
@@ -679,12 +679,12 @@ namespace System.Drawing.Tests
                 var matrix = new Matrix();
                 matrix.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform = matrix);
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void Transform_GetSetWhenDisposed_ThrowsArgumentException()
+        public void Transform_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var matrix = new Matrix())
@@ -692,8 +692,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.Transform);
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.Transform = matrix);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.Transform = matrix);
             }
         }
 
@@ -754,7 +754,7 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void TranslateTransform_Disposed_ThrowsArgumentException()
+        public void TranslateTransform_Disposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             using (var matrix = new Matrix())
@@ -762,8 +762,8 @@ namespace System.Drawing.Tests
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.TranslateTransform(1, 2));
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.TranslateTransform(1, 2, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(1, 2));
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.TranslateTransform(1, 2, MatrixOrder.Prepend));
             }
         }
 
@@ -796,15 +796,15 @@ namespace System.Drawing.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void WrapMode_GetSetWhenDisposed_ThrowsArgumentException()
+        public void WrapMode_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             using (var image = new Bitmap(10, 10))
             {
                 var brush = new TextureBrush(image);
                 brush.Dispose();
 
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.WrapMode);
-                AssertExtensions.Throws<ArgumentException>(null, () => brush.WrapMode = WrapMode.Tile);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode);
+                AssertExtensions.Throws<ObjectDisposedException>(null, () => brush.WrapMode = WrapMode.Tile);
             }
         }
 


### PR DESCRIPTION
The interop code of `System.Drawing.Common` heavily uses the very old `HandleRef` type which predates the widely used and safer `SafeHandle`s that .NET Framework 2.0 brought. Its use of this legacy type has become an issue since the P/Invoke generator doesn't support marshalling `HandleRef`s.

For this reason and to also improve the library's stability (`SafeHandles` are strongly-typed and harder to misuse and I have seen `IntPtr`s in P/Invoke signatures that should have been `HandleRef`s), this PR will replace all usages of `HandleRef` with `SafeHandle`s.

I have created a (currently internal) subclass of `SafeHandle` called `SafeGdiPlusHandle`, which will be inherited by one class per GDI+ handle type (`SafeBrushHandle`, `SafePenHandle` etc). dotnet/winforms#8833 will need to be reconsidered and perhaps superseded by a new proposal that makes the safe handles public.

I will also fix other minor things I might encounter.