### PR TITLE
Fix setting the configuration parameter in the apple test runner

### DIFF
--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -17,7 +17,7 @@ if [ -n "$6" ]; then
     ADDITIONAL_ARGS=${@:6}
 fi
 
-if [[ "$CONFIGURATION" != "Debug" ]]; then $CONFIGURATION="Release"; fi
+if [[ "$CONFIGURATION" != "Debug" ]]; then CONFIGURATION="Release"; fi
 
 if [[ "$TARGET_OS" == "maccatalyst" ]]; then TARGET=maccatalyst; fi
 


### PR DESCRIPTION
This PR fixes a typo which prevented local test run for macatalyst release build due to the following error:
```
  XHarness command issued: apple test --app=/Users/maxim/dev/runtime/artifacts/bin/System.Security.SecureString.Tests/net7.0-Release/maccatalyst-arm64/AppBundle/System.Security.SecureString.Tests/-maccatalyst/System.Security.SecureString.Tests.app --targets=maccatalyst --xcode=/Applications/Xcode.app/Contents/Developer/../.. --output-directory=/Users/maxim/dev/runtime/artifacts/bin/System.Security.SecureString.Tests/net7.0-Release/maccatalyst-arm64/AppBundle/xharness-output
  info: Preparing run for maccatalyst
  info: Getting app bundle information from '/Users/maxim/dev/runtime/artifacts/bin/System.Security.SecureString.Tests/net7.0-Release/maccatalyst-arm64/AppBundle/System.Security.SecureString.Tests/-maccatalyst/System.Security.SecureString.Tests.app'
  fail: Failed to find Info.plist inside the app bundle at: '/Users/maxim/dev/runtime/artifacts/bin/System.Security.SecureString.Tests/net7.0-Release/maccatalyst-arm64/AppBundle/System.Security.SecureString.Tests/-maccatalyst/System.Security.SecureString.Tests.app/Contents/Info.plist'
  XHarness exit code: 79 (FAILED_TO_GET_BUNDLE_INFO)
```
It's because the app bundle path didn't contain config part (`-maccatalyst` instead of `Release-maccatalyst`)