### PR TITLE
Fixup some formatting in shared code

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/Helpers/VariableLengthIntegerHelper.cs
@@ -109,7 +109,7 @@ namespace System.Net.Http
                             InitialTwoByteLengthMask => 2,
                             InitialFourByteLengthMask => 4,
                             _ => 8 // LengthEightByte
-                    };
+                        };
 
                     Span<byte> temp = (stackalloc byte[8])[..length];
                     if (reader.TryCopyTo(temp))

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HPackDecoderTest.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Linq;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using System.Net.Http.HPack;
+using System.Text;
 using Xunit;
 #if KESTREL
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.HPack;
+using System.Net.Http.QPack;
 using System.Text;
 using Xunit;
-using System.Net.Http.QPack;
-using System.Net.Http.HPack;
 using HeaderField = System.Net.Http.QPack.HeaderField;
 #if KESTREL
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
@@ -236,7 +236,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             else
             {
                 int chunkSize = bytesAtATime.Value;
-                
+
                 // Parse data in chunks, separated by empty chunks
                 for (int i = 0; i < encoded.Length; i += chunkSize)
                 {

--- a/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/VariableLengthIntegerHelperTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/VariableLengthIntegerHelperTests.cs
@@ -276,7 +276,7 @@ namespace Common.Tests.Tests.System.Net.aspnetcore.Http3
         [Theory]
         [InlineData(64, new byte[] { 64, 64 })]
         [InlineData(66, new byte[] { 64, 66 })]
-        [InlineData(16383, new byte[] { 127, 255})]
+        [InlineData(16383, new byte[] { 127, 255 })]
         public void TryWrite_BufferNotEmpty_TwoByteLimit(long longToEncode,
             byte[] expected)
         {
@@ -302,7 +302,7 @@ namespace Common.Tests.Tests.System.Net.aspnetcore.Http3
         }
 
         [Theory]
-        [InlineData(16384, new byte[] {128, 0, 64, 0})]
+        [InlineData(16384, new byte[] {128, 0, 64, 0 })]
         [InlineData(16386, new byte[] { 128, 0, 64, 2 })]
         [InlineData(1073741823, new byte[] { 191, 255, 255, 255 })]
         public void TryWrite_BufferNotEmpty_FourByteLimit(long longToEncode,


### PR DESCRIPTION
These were discovered because we'd cleaned them up as part of running dotnet-format on the aspnetcore repo and the [sync PR](https://github.com/dotnet/aspnetcore/pull/39166/files) is attempting to undo it