### PR TITLE
Fix stack overflow with X509Certificate FriendlyName

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextPropertyString.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertGetCertificateContextPropertyString.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
         [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertGetCertificateContextProperty", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static unsafe partial bool CertGetCertificateContextPropertyString(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, byte* pvData, ref int pcbData);
+        internal static unsafe partial bool CertGetCertificateContextPropertyString(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, byte* pvData, ref uint pcbData);
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -294,6 +294,12 @@ namespace Internal.Cryptography.Pal
                         return string.Empty;
 
                     int spanLength = (cbData + 1) / 2;
+
+                    if (spanLength < 0)
+                    {
+                        return string.Empty;
+                    }
+
                     Span<char> buffer = spanLength <= 256 ? stackalloc char[spanLength] : new char[spanLength];
                     fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
                     {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -294,7 +294,9 @@ namespace Internal.Cryptography.Pal
                         return string.Empty;
 
                     uint spanLength = (cbData + 1) / 2;
-                    Span<char> buffer = spanLength <= 256 ? stackalloc char[spanLength] : new char[spanLength];
+                    Span<char> buffer = spanLength <= 256 ?
+                        stackalloc char[(int)spanLength] : // Already checked to be a size that won't overflow.
+                        new char[spanLength];
                     fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
                     {
                         if (!Interop.Crypt32.CertGetCertificateContextPropertyString(_certContext, Interop.Crypt32.CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, (byte*)ptr, ref cbData))

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -303,7 +303,7 @@ namespace Internal.Cryptography.Pal
                             return string.Empty;
                     }
 
-                    return new string(buffer.Slice(0, (cbData / 2) - 1));
+                    return new string(buffer.Slice(0, ((int)cbData / 2) - 1));
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/CertificatePal.cs
@@ -289,17 +289,11 @@ namespace Internal.Cryptography.Pal
             {
                 unsafe
                 {
-                    int cbData = 0;
+                    uint cbData = 0;
                     if (!Interop.Crypt32.CertGetCertificateContextPropertyString(_certContext, Interop.Crypt32.CertContextPropId.CERT_FRIENDLY_NAME_PROP_ID, null, ref cbData))
                         return string.Empty;
 
-                    int spanLength = (cbData + 1) / 2;
-
-                    if (spanLength < 0)
-                    {
-                        return string.Empty;
-                    }
-
+                    uint spanLength = (cbData + 1) / 2;
                     Span<char> buffer = spanLength <= 256 ? stackalloc char[spanLength] : new char[spanLength];
                     fixed (char* ptr = &MemoryMarshal.GetReference(buffer))
                     {


### PR DESCRIPTION
A FriendlyName in Windows' length is a DWORD, an unsigned integer. We however marshal it as a signed integer, so a friendly name with a length greater than int.MaxValue would wrap around to negative. This
in turn would be "below" the stackalloc threshold, and attempt to stackalloc a negative value. stackalloc treats this value as unsigned, so it results in allocating too much on the stack.

<details>
<summary>Expand for steps to reproduce</summary>

```c#
// Windows only
using System;
using System.Diagnostics;
using System.Runtime.InteropServices;
using System.Security.Cryptography;
using System.Security.Cryptography.X509Certificates;

unsafe
{
    [DllImport("Crypt32", CharSet = CharSet.Unicode, SetLastError = true)]
    static unsafe extern bool CertSetCertificateContextProperty(IntPtr pCertContext, uint dwPropId, uint dwFlags, DATA_BLOB* pvData);
    const int CERT_FRIENDLY_NAME_PROP_ID = 11;


    using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
    CertificateRequest req = new("CN=potato", key, HashAlgorithmName.SHA256);
    using X509Certificate2 cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now);

    IntPtr certContext = cert.Handle;
    Debug.Assert(certContext != IntPtr.Zero);

    uint cbBigFriendlyName = 5U + int.MaxValue;
    byte* pBigFriendlyName = (byte*)NativeMemory.Alloc(cbBigFriendlyName);

    Span<byte> lo = new(pBigFriendlyName, int.MaxValue - 1);
    Span<byte> hi = new(pBigFriendlyName + int.MaxValue - 1, 6);
    MemoryMarshal.Cast<byte, char>(lo).Fill('A');
    MemoryMarshal.Cast<byte, char>(hi).Fill('A');
    DATA_BLOB blob = new DATA_BLOB(pBigFriendlyName, cbBigFriendlyName);

    bool result = CertSetCertificateContextProperty(certContext, CERT_FRIENDLY_NAME_PROP_ID, 0, &blob);
    Debug.Assert(result);

    // Will stack overflow.
    _ = cert.FriendlyName;
}

[StructLayout(LayoutKind.Sequential)]
internal unsafe struct DATA_BLOB
{
    internal uint cbData;
    internal void* pbData;

    internal DATA_BLOB(void* handle, uint size)
    {
        cbData = size;
        pbData = handle;
    }
}
```
</details>