### PR TITLE
Cleanup in NativeAOT from x86 attempt

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -298,7 +298,7 @@ namespace System.Runtime
         internal static extern void RhpReleaseCastCacheLock();
 
         [DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern ulong PalGetTickCount64();
+        internal static extern ulong RhpGetTickCount64();
 
         [DllImport(Redhawk.BaseName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void RhpAcquireThunkPoolLock();

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -997,7 +997,7 @@ assigningNull:
             //
             private static Entry[] s_cache = new Entry[InitialCacheSize];   // Initialize the cache eagerly to avoid null checks.
             private static UnsafeGCHandle s_previousCache;
-            private static ulong s_tickCountOfLastOverflow = InternalCalls.PalGetTickCount64();
+            private static ulong s_tickCountOfLastOverflow = InternalCalls.RhpGetTickCount64();
             private static int s_entries;
             private static bool s_roundRobinFlushing;
 
@@ -1195,7 +1195,7 @@ assigningNull:
                 s_entries = 0;
 
                 // See how long it has been since the last time the cache was overflowing
-                ulong tickCount = InternalCalls.PalGetTickCount64();
+                ulong tickCount = InternalCalls.RhpGetTickCount64();
                 int tickCountSinceLastOverflow = (int)(tickCount - s_tickCountOfLastOverflow);
                 s_tickCountOfLastOverflow = tickCount;
 

--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -382,6 +382,11 @@ EXTERN_C REDHAWK_API void __cdecl RhpReleaseThunkPoolLock()
     g_ThunkPoolLock.Leave();
 }
 
+EXTERN_C REDHAWK_API void __cdecl RhpGetTickCount64()
+{
+    PalGetTickCount64();
+}
+
 EXTERN_C int32_t __cdecl RhpCalculateStackTraceWorker(void* pOutputBuffer, uint32_t outputBufferLength, void* pAddressInCurrentFrame);
 
 EXTERN_C REDHAWK_API int32_t __cdecl RhpGetCurrentThreadStackTrace(void* pOutputBuffer, uint32_t outputBufferLength, void* pAddressInCurrentFrame)

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -1478,7 +1478,7 @@ bool GCToEEInterface::GetBooleanConfigValue(const char* privateKey, const char* 
 #ifdef UNICODE
     size_t keyLength = strlen(privateKey) + 1;
     TCHAR* pKey = (TCHAR*)_alloca(sizeof(TCHAR) * keyLength);
-    for (int i = 0; i < keyLength; i++)
+    for (size_t i = 0; i < keyLength; i++)
         pKey[i] = privateKey[i];
 #else
     const TCHAR* pKey = privateKey;
@@ -1497,7 +1497,7 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
 #ifdef UNICODE
     size_t keyLength = strlen(privateKey) + 1;
     TCHAR* pKey = (TCHAR*)_alloca(sizeof(TCHAR) * keyLength);
-    for (int i = 0; i < keyLength; i++)
+    for (size_t i = 0; i < keyLength; i++)
         pKey[i] = privateKey[i];
 #else
     const TCHAR* pKey = privateKey;

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkCommon.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkCommon.cpp
@@ -172,7 +172,7 @@ REDHAWK_PALEXPORT int32_t PalGetModuleFileName(_Out_ const TCHAR** pModuleNameOu
     return 0;
 }
 
-REDHAWK_PALEXPORT uint64_t __cdecl PalGetTickCount64()
+REDHAWK_PALEXPORT uint64_t REDHAWK_PALAPI PalGetTickCount64()
 {
     return GetTickCount64();
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Environment.CoreRT.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Environment.CoreRT.Unix.cs
@@ -167,6 +167,6 @@ namespace System
         [DoesNotReturn]
         private static void ExitRaw() => Interop.Sys.Exit(s_latchedExitCode);
 
-        public static long TickCount64 => (long)RuntimeImports.PalGetTickCount64();
+        public static long TickCount64 => (long)RuntimeImports.RhpGetTickCount64();
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -28,7 +28,7 @@ namespace System.Runtime
 
         [DllImport(RuntimeLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         [SuppressGCTransition]
-        internal static extern ulong PalGetTickCount64();
+        internal static extern ulong RhpGetTickCount64();
 
         [DllImport(RuntimeLibrary, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr RhpGetCurrentThread();


### PR DESCRIPTION
This is retrofitting parts of https://github.com/dotnet/runtimelab/pull/1531