### PR TITLE
avoid ArgumentOutOfRangeException while processing invalid or incomplete TLS frame

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -460,11 +460,6 @@ namespace System.Net.Security
                  where TIOAdapter : IReadWriteAdapter
         {
             int readBytes = await FillHandshakeBufferAsync(adapter, SecureChannel.ReadHeaderSize).ConfigureAwait(false);
-            if (readBytes == 0)
-            {
-                throw new IOException(SR.net_io_eof);
-            }
-
             if (_framing == Framing.Unified || _framing == Framing.Unknown)
             {
                 _framing = DetectFraming(_handshakeBuffer.ActiveReadOnlySpan);
@@ -1083,7 +1078,7 @@ namespace System.Net.Security
                 int bytesRead = t.Result;
                 if (bytesRead == 0)
                 {
-                    return new ValueTask<int>(0);
+                    throw new IOException(SR.net_io_eof);
                 }
 
                 _handshakeBuffer.Commit(bytesRead);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -459,7 +459,7 @@ namespace System.Net.Security
         private async ValueTask<ProtocolToken> ReceiveBlobAsync<TIOAdapter>(TIOAdapter adapter)
                  where TIOAdapter : IReadWriteAdapter
         {
-            int readBytes = await FillHandshakeBufferAsync(adapter, SecureChannel.ReadHeaderSize).ConfigureAwait(false);
+            await FillHandshakeBufferAsync(adapter, SecureChannel.ReadHeaderSize).ConfigureAwait(false);
             if (_framing == Framing.Unified || _framing == Framing.Unknown)
             {
                 _framing = DetectFraming(_handshakeBuffer.ActiveReadOnlySpan);
@@ -1056,13 +1056,13 @@ namespace System.Net.Security
 
         // This function tries to make sure buffer has at least minSize bytes available.
         // If we have enough data, it returns synchronously. If not, it will try to read
-        // remaining bytes from given stream.
-        private ValueTask<int> FillHandshakeBufferAsync<TIOAdapter>(TIOAdapter adapter, int minSize)
+        // remaining bytes from given stream. It will throw if unable to fulfill minSize.
+        private ValueTask FillHandshakeBufferAsync<TIOAdapter>(TIOAdapter adapter, int minSize)
              where TIOAdapter : IReadWriteAdapter
         {
             if (_handshakeBuffer.ActiveLength >= minSize)
             {
-                return new ValueTask<int>(minSize);
+                return ValueTask.CompletedTask;
             }
 
             int bytesNeeded = minSize - _handshakeBuffer.ActiveLength;
@@ -1084,9 +1084,9 @@ namespace System.Net.Security
                 _handshakeBuffer.Commit(bytesRead);
             }
 
-            return new ValueTask<int>(minSize);
+            return ValueTask.CompletedTask;
 
-            async ValueTask<int> InternalFillHandshakeBufferAsync(TIOAdapter adap,  ValueTask<int> task, int minSize)
+            async ValueTask InternalFillHandshakeBufferAsync(TIOAdapter adap,  ValueTask<int> task, int minSize)
             {
                 while (true)
                 {
@@ -1099,29 +1099,11 @@ namespace System.Net.Security
                     _handshakeBuffer.Commit(bytesRead);
                     if (_handshakeBuffer.ActiveLength >= minSize)
                     {
-                        return minSize;
+                        return;
                     }
 
                     task = adap.ReadAsync(_handshakeBuffer.AvailableMemory);
                 }
-            }
-        }
-
-        private async ValueTask FillBufferAsync<TIOAdapter>(TIOAdapter adapter, int numBytesRequired)
-            where TIOAdapter : IReadWriteAdapter
-        {
-            Debug.Assert(_internalBufferCount > 0);
-            Debug.Assert(_internalBufferCount < numBytesRequired);
-
-            while (_internalBufferCount < numBytesRequired)
-            {
-                int bytesRead = await adapter.ReadAsync(_internalBuffer.AsMemory(_internalBufferCount)).ConfigureAwait(false);
-                if (bytesRead == 0)
-                {
-                    throw new IOException(SR.net_io_eof);
-                }
-
-                _internalBufferCount += bytesRead;
             }
         }
 


### PR DESCRIPTION
This change fixes issue reported in #62109. The issue has long summary describing what is going on - based on dump provided by the reporter. 

In essence, `FillHandshakeBufferAsync` can "silently fail" on EOF and we can create ArrayBuffer with negative length. Added test would throw `ArgumentOutOfRangeException` on release builds or hit `Assert` with debug builds. 

I modified the `FillHandshakeBufferAsync` to consistently throw if EOF is reached before request bytes are accumulated. This was already there in few places but we missed the case when read would finish synchronously. 

fixes #62109