### PR TITLE
Support Single-file executable in Windows 7

### DIFF
--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -107,6 +107,9 @@ if(CLR_CMAKE_TARGET_WIN32)
     # Incremental linking results in the linker inserting extra padding and routing function calls via thunks that can break the
     # invariants (e.g. size of region between Jit_PatchedCodeLast-Jit_PatchCodeStart needs to fit in a page).
     add_linker_flag("/INCREMENTAL:NO")
+
+    # Delay load libraries required for WinRT as that is not supported on all platforms
+    add_linker_flag("/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll")
 endif()
 
 if(CLR_CMAKE_TARGET_WIN32)
@@ -127,6 +130,7 @@ if(CLR_CMAKE_TARGET_WIN32)
         shell32.lib
         bcrypt.lib
         RuntimeObject.lib
+        delayimp.lib
     )
 
     set(RUNTIMEINFO_LIB runtimeinfo)


### PR DESCRIPTION
Windows 7 doesn't have WinRT API set, making it delay loaded allows running single file executable in Windows 7.
https://github.com/dotnet/sdk/pull/23177

.NET code already performs late binding in [utils.cpp](https://github.com/dotnet/runtime/blame/4da6b9a8d55913c0ea560d63590d35dc942425be/src/coreclr/utilcode/util.cpp#L70) and in mscoree [CMakeLists.txt](https://github.com/dotnet/runtime/blame/main/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt#L25) .
But not for singlefilehost.exe

The final change should be backported since .NET 6 is the latest LTS version.  