### PR TITLE
Allow managed type system tests on Alpine

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -245,7 +245,7 @@
 
     <ProjectToBuild Condition="'$(TargetArchitecture)' != 'x64' and '$(BuildArchitecture)' == 'x64'" Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2_crossarch.csproj" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.TypeSystem.ReadyToRun.Tests\ILCompiler.TypeSystem.ReadyToRun.Tests.csproj"
-      Test="true" Category="clr" Condition="'$(__DistroRid)' != 'linux-musl-x64' and '$(DotNetBuildFromSource)' != 'true'"/>
+      Test="true" Category="clr" Condition="'$(DotNetBuildFromSource)' != 'true'"/>
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+clr.nativecorelib+'))">


### PR DESCRIPTION
This was disabled in https://github.com/dotnet/runtime/pull/38128/commits/d98d9a2f52f16a87fdc8a28a252e94eca796abb2. I don't think those problems exist anymore - targets are written differently, and we would likely see musl-arm64 failures if this was still a problem.