### PR TITLE
Fixing a crash bug

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -585,7 +585,7 @@ namespace Internal.TypeSystem.Ecma
             an.CultureName = _metadataReader.GetString(assemblyReference.Culture);
             an.ContentType = GetContentTypeFromAssemblyFlags(assemblyReference.Flags);
 
-            var assembly = _moduleResolver.ResolveAssembly(an, throwIfNotFound: false);
+            var assembly = _moduleResolver.ResolveAssembly(an);
             if (assembly == null)
                 return ResolutionFailure.GetAssemblyResolutionFailure(an.Name);
             else

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -585,7 +585,7 @@ namespace Internal.TypeSystem.Ecma
             an.CultureName = _metadataReader.GetString(assemblyReference.Culture);
             an.ContentType = GetContentTypeFromAssemblyFlags(assemblyReference.Flags);
 
-            var assembly = _moduleResolver.ResolveAssembly(an);
+            var assembly = _moduleResolver.ResolveAssembly(an, throwIfNotFound: false);
             if (assembly == null)
                 return ResolutionFailure.GetAssemblyResolutionFailure(an.Name);
             else

--- a/src/coreclr/tools/ILVerification/ILVerifyTypeSystemContext.cs
+++ b/src/coreclr/tools/ILVerification/ILVerifyTypeSystemContext.cs
@@ -53,9 +53,11 @@ namespace ILVerify
         private EcmaModule ResolveAssemblyOrNetmodule(string simpleName, string verificationName, IAssemblyDesc containingAssembly, bool throwIfNotFound)
         {
             PEReader peReader = _resolver.Resolve(simpleName);
-            if (peReader == null && throwIfNotFound)
+            if (peReader == null)
             {
-                throw new VerifierException("Assembly or module not found: " + simpleName);
+                if (throwIfNotFound)
+                    throw new VerifierException("Assembly or module not found: " + simpleName);
+                return null;
             }
             var module = GetModule(peReader, containingAssembly);
             VerifyModuleName(verificationName, module);


### PR DESCRIPTION
ILVerify will currently crash with a `NullReferenceException` if parsing a type signature referring to an assembly that was not specified as a `-r` parameter.

Fixes #63221.