### PR TITLE
Improve SuperPMI error message for JIT asserts

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi/icorjitinfo.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/icorjitinfo.cpp
@@ -1782,7 +1782,7 @@ int MyICJI::doAssert(const char* szFile, int iLine, const char* szExpr)
     char buff[16 * 1024];
     sprintf_s(buff, sizeof(buff), "%s (%d) - %s", szFile, iLine, szExpr);
 
-    LogIssue(ISSUE_ASSERT, "%s", buff);
+    LogIssue(ISSUE_ASSERT, "#%d %s", jitInstance->mc->index, buff);
     jitInstance->mc->cr->recMessageLog(buff);
 
     // Under "/boa", ask the user if they want to attach a debugger. If they do, the debugger will be attached,


### PR DESCRIPTION
Currently, the method context numbers are output for each failure,
but the assert message is output separately, so if there are multiple
asserts that fire, and you want to investigate a particular one,
it's hard to figure out which method context number to use.

Add the method context number to the assert message, so the relationship
between the method context number and the assert is obvious.

E.g., you always get messages like the following (both before this change
and after):
```
ERROR: Exception thrown: DebugBreak or AV Exception 123
ERROR: main method 16501 of size 286 failed to load and compile correctly.
```

Before you might see an assert like:
```
ISSUE: <ASSERT> C:\gh\runtime6\src\coreclr\jit\fgbasic.cpp (4699) - Assertion failed '!"unexpected case 1"' in 'CancellationTokenSource:ExecuteCallbackHandlers(bool):this' during 'Update flow graph opt pass' (IL size 286)
```

Now, it will look like:
```
ISSUE: <ASSERT> #16501 C:\gh\runtime6\src\coreclr\jit\fgbasic.cpp (4699) - Assertion failed '!"unexpected case 1"' in 'CancellationTokenSource:ExecuteCallbackHandlers(bool):this' during 'Update flow graph opt pass' (IL size 286)
```