### PR TITLE
First try at implementing newly suggested ctor for providing tighter control over charset

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -439,8 +439,8 @@ namespace System.Net.Http
         public StringContent(string content) : base (default(byte[])) { }
         public StringContent(string content, System.Net.Http.Headers.MediaTypeHeaderValue mediaType) : base (default(byte[])) { }
         public StringContent(string content, System.Text.Encoding? encoding) : base (default(byte[])) { }
-        public StringContent(string content, System.Text.Encoding? encoding, string? mediaType) : base (default(byte[])) { }
         public StringContent(string content, System.Text.Encoding? encoding, System.Net.Http.Headers.MediaTypeHeaderValue mediaTypeHeaderValue) : base (default(byte[])) { }
+        public StringContent(string content, System.Text.Encoding? encoding, string mediaType) : base (default(byte[])) { }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -439,7 +439,7 @@ namespace System.Net.Http
         public StringContent(string content) : base (default(byte[])) { }
         public StringContent(string content, System.Net.Http.Headers.MediaTypeHeaderValue mediaType) : base (default(byte[])) { }
         public StringContent(string content, System.Text.Encoding? encoding) : base (default(byte[])) { }
-        public StringContent(string content, System.Text.Encoding? encoding, System.Net.Http.Headers.MediaTypeHeaderValue mediaTypeHeaderValue) : base (default(byte[])) { }
+        public StringContent(string content, System.Text.Encoding? encoding, System.Net.Http.Headers.MediaTypeHeaderValue mediaType) : base (default(byte[])) { }
         public StringContent(string content, System.Text.Encoding? encoding, string mediaType) : base (default(byte[])) { }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
     }

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -437,8 +437,10 @@ namespace System.Net.Http
     public partial class StringContent : System.Net.Http.ByteArrayContent
     {
         public StringContent(string content) : base (default(byte[])) { }
+        public StringContent(string content, System.Net.Http.Headers.MediaTypeHeaderValue mediaType) : base (default(byte[])) { }
         public StringContent(string content, System.Text.Encoding? encoding) : base (default(byte[])) { }
         public StringContent(string content, System.Text.Encoding? encoding, string? mediaType) : base (default(byte[])) { }
+        public StringContent(string content, System.Text.Encoding? encoding, System.Net.Http.Headers.MediaTypeHeaderValue mediaTypeHeaderValue) : base (default(byte[])) { }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 }
@@ -692,6 +694,7 @@ namespace System.Net.Http.Headers
     {
         protected MediaTypeHeaderValue(System.Net.Http.Headers.MediaTypeHeaderValue source) { }
         public MediaTypeHeaderValue(string mediaType) { }
+        public MediaTypeHeaderValue(string mediaType, string? charSet) { }
         public string? CharSet { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]
         public string? MediaType { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -80,9 +80,19 @@ namespace System.Net.Http.Headers
         }
 
         public MediaTypeHeaderValue(string mediaType)
+            : this(mediaType, null)
+        {
+        }
+
+        public MediaTypeHeaderValue(string mediaType, string? charSet)
         {
             CheckMediaTypeFormat(mediaType, nameof(mediaType));
             _mediaType = mediaType;
+
+            if (!string.IsNullOrEmpty(charSet))
+            {
+                CharSet = charSet;
+            }
         }
 
         public override string ToString()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -80,7 +80,7 @@ namespace System.Net.Http.Headers
         }
 
         public MediaTypeHeaderValue(string mediaType)
-            : this(mediaType, null)
+            : this(mediaType, charSet: null)
         {
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
@@ -29,14 +29,14 @@ namespace System.Net.Http
         }
 
         public StringContent(string content, Encoding? encoding, string mediaType)
-            : this(content, encoding, new MediaTypeHeaderValue(mediaType, (encoding == null) ? DefaultStringEncoding.WebName : encoding.WebName))
+            : this(content, encoding, new MediaTypeHeaderValue(mediaType, (encoding ?? DefaultStringEncoding).WebName))
         {
         }
 
-        public StringContent(string content, Encoding? encoding, MediaTypeHeaderValue mediaTypeHeaderValue)
+        public StringContent(string content, Encoding? encoding, MediaTypeHeaderValue mediaType)
             : base(GetContentByteArray(content, encoding))
         {
-            Headers.ContentType = mediaTypeHeaderValue;
+            Headers.ContentType = mediaType;
         }
 
         // A StringContent is essentially a ByteArrayContent. We serialize the string into a byte-array in the

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StringContent.cs
@@ -14,23 +14,29 @@ namespace System.Net.Http
         private const string DefaultMediaType = "text/plain";
 
         public StringContent(string content)
-            : this(content, null, null)
+            : this(content, DefaultStringEncoding, DefaultMediaType)
+        {
+        }
+
+        public StringContent(string content, MediaTypeHeaderValue mediaType)
+            : this(content, DefaultStringEncoding, mediaType)
         {
         }
 
         public StringContent(string content, Encoding? encoding)
-            : this(content, encoding, null)
+            : this(content, encoding, DefaultMediaType)
         {
         }
 
-        public StringContent(string content, Encoding? encoding, string? mediaType)
+        public StringContent(string content, Encoding? encoding, string mediaType)
+            : this(content, encoding, new MediaTypeHeaderValue(mediaType, (encoding == null) ? DefaultStringEncoding.WebName : encoding.WebName))
+        {
+        }
+
+        public StringContent(string content, Encoding? encoding, MediaTypeHeaderValue mediaTypeHeaderValue)
             : base(GetContentByteArray(content, encoding))
         {
-            // Initialize the 'Content-Type' header with information provided by parameters.
-            MediaTypeHeaderValue headerValue = new MediaTypeHeaderValue((mediaType == null) ? DefaultMediaType : mediaType);
-            headerValue.CharSet = (encoding == null) ? HttpContent.DefaultStringEncoding.WebName : encoding.WebName;
-
-            Headers.ContentType = headerValue;
+            Headers.ContentType = mediaTypeHeaderValue;
         }
 
         // A StringContent is essentially a ByteArrayContent. We serialize the string into a byte-array in the

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
@@ -70,5 +70,67 @@ namespace System.Net.Http.Functional.Tests
             string roundTrip = new StreamReader(destination, defaultStringEncoding).ReadToEnd();
             Assert.Equal(sourceString, roundTrip);
         }
+
+        [Fact]
+        public async Task Ctor_UseCustomMediaTypeHeaderValue_SpecificEncoding()
+        {
+            // Use UTF-8 encoding to serialize a chinese string.
+            string sourceString = "\u4f1a\u5458\u670d\u52a1";
+
+            var mediaTypeHeaderValue = new Headers.MediaTypeHeaderValue("application/custom", Encoding.UTF8.WebName);
+
+            var content = new StringContent(sourceString, Encoding.UTF8, mediaTypeHeaderValue);
+
+            Assert.Equal("application/custom", content.Headers.ContentType.MediaType);
+            Assert.Equal("utf-8", content.Headers.ContentType.CharSet);
+
+            var destination = new MemoryStream(12);
+            await content.CopyToAsync(destination);
+
+            string destinationString = Encoding.UTF8.GetString(destination.ToArray(), 0, (int)destination.Length);
+
+            Assert.Equal(sourceString, destinationString);
+        }
+
+        [Fact]
+        public async Task Ctor_UseCustomMediaTypeHeaderValue()
+        {
+            // Use UTF-8 encoding to serialize a chinese string.
+            string sourceString = "\u4f1a\u5458\u670d\u52a1";
+
+            var mediaTypeHeaderValue = new Headers.MediaTypeHeaderValue("application/custom", Encoding.UTF8.WebName);
+
+            var content = new StringContent(sourceString, mediaTypeHeaderValue);
+
+            Assert.Equal("application/custom", content.Headers.ContentType.MediaType);
+            Assert.Equal("utf-8", content.Headers.ContentType.CharSet);
+
+            var destination = new MemoryStream(12);
+            await content.CopyToAsync(destination);
+
+            string destinationString = Encoding.UTF8.GetString(destination.ToArray(), 0, (int)destination.Length);
+
+            Assert.Equal(sourceString, destinationString);
+        }
+
+        [Fact]
+        public async Task Ctor_UseSpecificEncodingAndContentType()
+        {
+            // Use UTF-8 encoding to serialize a chinese string.
+            string sourceString = "\u4f1a\u5458\u670d\u52a1";
+            string contentType = "application/custom";
+
+            var content = new StringContent(sourceString, Encoding.UTF8, contentType);
+
+            Assert.Equal("application/custom", content.Headers.ContentType.MediaType);
+            Assert.Equal("utf-8", content.Headers.ContentType.CharSet);
+
+            var destination = new MemoryStream(12);
+            await content.CopyToAsync(destination);
+
+            string destinationString = Encoding.UTF8.GetString(destination.ToArray(), 0, (int)destination.Length);
+
+            Assert.Equal(sourceString, destinationString);
+        }
     }
 }


### PR DESCRIPTION
There are three new ctor implementations.

All are from issue #17036.

```c#
public StringContent(string content, MediaTypeHeaderValue mediaType)
public StringContent(string content, Encoding encoding, MediaTypeHeaderValue mediaType)
public MediaTypeHeaderValue(string mediaType, string charSet)
```

Also, there are tests for the new APIs.