### PR TITLE
Speed up crossgen2 by a couple percent

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -28,22 +28,7 @@ namespace ILCompiler
         /// </summary>
         public static DefType GetClosestDefType(this TypeDesc type)
         {
-            if (type.IsArray)
-            {
-                if (!type.IsArrayTypeWithoutGenericInterfaces())
-                {
-                    MetadataType arrayShadowType = type.Context.SystemModule.GetType("System", "Array`1", throwIfNotFound: false);
-                    if (arrayShadowType != null)
-                    {
-                        return arrayShadowType.MakeInstantiatedType(((ArrayType)type).ElementType);
-                    }
-                }
-
-                return type.Context.GetWellKnownType(WellKnownType.Array);
-            }
-
-            Debug.Assert(type is DefType);
-            return (DefType)type;
+            return ((CompilerTypeSystemContext)type.Context).GetClosestDefType(type);
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -27,6 +27,7 @@ namespace ILCompiler
 
         private TypeDesc[] _arrayOfTInterfaces;
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;
+        private MetadataType _arrayOfTType;
 
         public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode, DelegateFeature delegateFeatures)
             : base(details)
@@ -167,6 +168,23 @@ namespace ILCompiler
         protected override DelegateInfo CreateDelegateInfo(TypeDesc delegateType)
         {
             return new DelegateInfo(delegateType, _delegateFeatures);
+        }
+
+        internal DefType GetClosestDefType(TypeDesc type)
+        {
+            if (type.IsArray)
+            {
+                if (!type.IsArrayTypeWithoutGenericInterfaces())
+                {
+                    MetadataType arrayShadowType = _arrayOfTType ?? (_arrayOfTType = SystemModule.GetType("System", "Array`1"));
+                    return arrayShadowType.MakeInstantiatedType(((ArrayType)type).ElementType);
+                }
+
+                return GetWellKnownType(WellKnownType.Array);
+            }
+
+            Debug.Assert(type is DefType);
+            return (DefType)type;
         }
 
         private readonly LazyGenericsSupport.GenericCycleDetector _genericCycleDetector = new LazyGenericsSupport.GenericCycleDetector();

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -17,6 +17,17 @@ namespace ILCompiler
         {
             _genericsMode = genericsMode;
         }
+
+        internal DefType GetClosestDefType(TypeDesc type)
+        {
+            if (type.IsArray)
+            {
+                return GetWellKnownType(WellKnownType.Array);
+            }
+
+            Debug.Assert(type is DefType);
+            return (DefType)type;
+        }
     }
 
     public partial class ReadyToRunCompilerContext : CompilerTypeSystemContext


### PR DESCRIPTION
I ran crossgen2 compiling a Release CoreLib under a profiler and this stood out quite a bit. The JIT-based CoreLib doesn't have the `Array<T>` type so `GetType` was walking all types in CoreLib.

![image](https://user-images.githubusercontent.com/13110571/147810850-1c85958e-9e40-4d18-a4d1-4d5d9a22f288.png)

I split this logic out to an ILC-specific file. I don't remember this showing up in the profiles for ILC, but I added a cache nevertheless.