### PR TITLE
Add some diagnostics for EFS tests

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.Windows.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.XUnitExtensions;
+using System.Diagnostics;
+using System.Diagnostics.Eventing.Reader;
+using System.Security;
+using System.ServiceProcess;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.IO.Tests
+{
+    public partial class EncryptDecrypt
+    {
+        partial void LogEFSDiagnostics()
+        {
+            try
+            {
+                using var sc = new ServiceController("EFS");
+                _output.WriteLine($"EFS service is: {sc.Status}");
+                if (sc.Status != ServiceControllerStatus.Running)
+                {
+                    _output.WriteLine("Trying to start EFS service");
+                    sc.Start();
+                    _output.WriteLine($"EFS service is now: {sc.Status}");
+                }
+            }
+            catch(Exception e)
+            {
+                _output.WriteLine(e.ToString());
+            }
+
+            var hours = 1; // how many hours to look backwards
+            var query = @$"
+                        <QueryList>
+                          <Query Id='0' Path='System'>
+                            <Select Path='System'>
+                                *[System[Provider/@Name='Server']]
+                            </Select>
+                            <Select Path='System'>
+                                *[System[Provider/@Name='Service Control Manager']]
+                            </Select>
+                            <Select Path='System'>
+                                *[System[Provider/@Name='Microsoft-Windows-EFS']]
+                            </Select>
+                            <Suppress Path='System'>
+                                *[System[TimeCreated[timediff(@SystemTime) &gt;= {hours * 60 * 60 * 1000L}]]]
+                            </Suppress>
+                          </Query>
+                        </QueryList> ";
+
+            var eventQuery = new EventLogQuery("System", PathType.LogName, query);
+
+            var eventReader = new EventLogReader(eventQuery);
+
+            EventRecord record = eventReader.ReadEvent();
+            var garbage = new string[] { "Background Intelligent", "Intel", "Defender", "Intune", "BITS", "NetBT"};
+
+            _output.WriteLine("=====  Dumping recent relevant events: =====");
+            while (record != null)
+            {
+                string description = "";
+                try
+                {
+                    description = record.FormatDescription();
+                }
+                catch (EventLogException) { }
+
+                foreach (string term in garbage)
+                {
+                    if (description.Contains(term, StringComparison.OrdinalIgnoreCase))
+                        goto next;
+                }
+
+                _output.WriteLine($"{record.TimeCreated} {record.ProviderName} [{record.LevelDisplayName} {record.Id}] {description.Replace("\r\n", "  ")}");
+
+            next:
+                record = eventReader.ReadEvent();
+            }
+
+            _output.WriteLine("==== Finished dumping =====");
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.Windows.cs
@@ -35,8 +35,8 @@ namespace System.IO.Tests
 
         partial void LogEFSDiagnostics()
         {
-            var hours = 1; // how many hours to look backwards
-            var query = @$"
+            int hours = 1; // how many hours to look backwards
+            string query = @$"
                         <QueryList>
                           <Query Id='0' Path='System'>
                             <Select Path='System'>
@@ -56,7 +56,7 @@ namespace System.IO.Tests
 
             var eventQuery = new EventLogQuery("System", PathType.LogName, query);
 
-            var eventReader = new EventLogReader(eventQuery);
+            using var eventReader = new EventLogReader(eventQuery);
 
             EventRecord record = eventReader.ReadEvent();
             var garbage = new string[] { "Background Intelligent", "Intel", "Defender", "Intune", "BITS", "NetBT"};

--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.Windows.cs
@@ -26,7 +26,7 @@ namespace System.IO.Tests
                     _output.WriteLine($"EFS service is now: {sc.Status}");
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 _output.WriteLine(e.ToString());
             }

--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -40,6 +40,7 @@ namespace System.IO.Tests
         // because EFS (Encrypted File System), its underlying technology, is not available on these operating systems.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection.IsNotWindowsHomeEdition))]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [OuterLoop] // Occasional failures: https://github.com/dotnet/runtime/issues/12339
         public void EncryptDecrypt_Read()
         {
             string tmpFileName = Path.GetTempFileName();

--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -51,6 +51,8 @@ namespace System.IO.Tests
                 string fileContentRead = File.ReadAllText(tmpFileName);
                 Assert.Equal(textContentToEncrypt, fileContentRead);
 
+                EnsureEFSServiceStarted();
+
                 try
                 {
                     File.Encrypt(tmpFileName);
@@ -81,6 +83,8 @@ namespace System.IO.Tests
                 File.Delete(tmpFileName);
             }
         }
+
+        partial void EnsureEFSServiceStarted(); // no-op on Unix
 
         partial void LogEFSDiagnostics(); // no-op on Unix currently
     }

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="Directory\Delete.Windows.cs" />
+    <Compile Include="File\EncryptDecrypt.Windows.cs" />
     <Compile Include="FileSystemTest.Windows.cs" />
     <Compile Include="FileStream\ctor_options.Windows.cs" />
     <Compile Include="FileStream\FileStreamConformanceTests.Windows.cs" />


### PR DESCRIPTION
Relates to https://github.com/dotnet/runtime/issues/12339

Dump relevant recent events and service status.
Make outerloop to minimise noise.