### PR TITLE
Robustify a name resolution test

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -155,7 +155,18 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(aliases);
             Assert.NotNull(addresses);
 
-            string name = NameResolutionPal.TryGetNameInfo(addresses[0], out error, out nativeErrorCode);
+            // Not all addresses returned by TryGetAddInfo can be resolved to host names, depending on network configuration.
+            // However at least one should be.
+            string name = null;
+            foreach(IPAddress address in addresses)
+            {
+                name = NameResolutionPal.TryGetNameInfo(address, out error, out nativeErrorCode);
+                if (error != SocketError.HostNotFound)
+                {
+                    break;
+                }
+            }
+
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(name);
         }

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -181,12 +181,22 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(aliases);
             Assert.NotNull(addresses);
 
-            string name = NameResolutionPal.TryGetNameInfo(addresses[0], out error, out nativeErrorCode);
-            if (error == SocketError.HostNotFound)
+            // Not all addresses returned by TryGetAddInfo can be resolved to host names, depending on network configuration.
+            // However at least one should be.
+            string name = null;
+            foreach(IPAddress address in addresses)
+            {
+                name = NameResolutionPal.TryGetNameInfo(address, out error, out nativeErrorCode);
+                if (error != SocketError.HostNotFound)
+                {
+                    break;
+                }
+            }
+
+            if (error == SocketError.HostNotFound && Environment.OSVersion.Platform == PlatformID.Unix)
             {
                 // On Unix, getaddrinfo returns private ipv4 address for hostname. If the OS doesn't have the
                 // reverse dns lookup entry for this address, getnameinfo returns host not found.
-                Assert.Equal(PlatformID.Unix, Environment.OSVersion.Platform);
                 return;
             }
 


### PR DESCRIPTION
These tests get all IP addresses configured for the local machine and arbitrarily try to resolve the first one to a name. On my machine at least, not all these addresses are resolvable. By the comments, it seems this is a configuration issue on some Unix machines as well. Changed the tests to verify that at least one of the addresses are resolved.

On this machine I still have failures in tests that try to resolve ipv6 addresses. This is because [GetNameInfoW here](https://github.com/danmoseley/runtime/blob/bd3c9aa442b2ebda6dad164be0be9157c62121ba/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs#L98) is returning HostNotFound for `::1` or similar addresses. `ping ::1` and `tracert ::1` work fine, so ipv6 is enabled in some sense. There is no relevant entry in `hosts`. @wfurt any idea why this might be happening? If there was an independent way to verify that a machine is in this configuration, I could use that to make the test skip for such machines.
