### PR TITLE
[mono][wasm] Remove unused targets from wasm/Makefile.

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -12,24 +12,15 @@ JSVU=$(HOME)/.jsvu
 CHROMEDRIVER?=$(HOME)/.chromedriver
 GECKODRIVER?=$(HOME)/.geckodriver
 
-#
-# These variables are set by wasm.proj
-#
 EMSDK_PATH?=$(TOP)/src/mono/wasm/emsdk
 CONFIG?=Release
 BINDIR?=$(TOP)/artifacts/bin
 OBJDIR?=$(TOP)/artifacts/obj
-PINVOKE_TABLE?=$(TOP)/artifacts/obj/wasm/pinvoke-table.h
-MONO_BIN_DIR?=$(BINDIR)/mono/Browser.wasm.$(CONFIG)
-NATIVE_BIN_DIR?=$(BINDIR)/native/net7.0-Browser-$(CONFIG)-wasm
-ICU_LIBDIR?=
-SYSTEM_NATIVE_LIBDIR?=$(TOP)/src/native/libs/System.Native
 _MSBUILD_WASM_BUILD_ARGS=/p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG)
 XHARNESS_BROWSER?=chrome
-EMCC_DEFAULT_RSP=$(NATIVE_BIN_DIR)/src/emcc-default.rsp
 HELIX_TARGET_QUEUE?=Ubuntu.1804.Amd64.Open
 
-all: build-native icu-files source-files header-files
+all: build-all
 
 #
 # EMSCRIPTEN SETUP
@@ -53,78 +44,16 @@ provision-wasm: .stamp-wasm-install-and-select-$(EMSCRIPTEN_VERSION)
 	@echo "----------------------------------------------------------"
 	@echo "Installed emsdk into EMSDK_PATH=$(TOP)/src/mono/wasm/emsdk"
 
-# FIXME: When https://github.com/dotnet/runtime/issues/54565 is fixed, and the WasmApp targets are updated to use mono runtime components, remove this
-MONO_COMPONENT_LIBS= \
-	$(MONO_BIN_DIR)/libmono-component-hot_reload-static.a \
-	$(MONO_BIN_DIR)/libmono-component-debugger-static.a \
-	$(MONO_BIN_DIR)/libmono-component-diagnostics_tracing-stub-static.a
-
 MONO_OBJ_DIR=$(OBJDIR)/mono/Browser.wasm.$(CONFIG)
-MONO_INCLUDE_DIR=$(MONO_BIN_DIR)/include/mono-2.0
 BUILDS_OBJ_DIR=$(MONO_OBJ_DIR)/wasm
-# libmonosgen-2.0 is in MONO_LIBS twice because the components and the runtime are depend on each other
-MONO_LIBS = \
-	$(MONO_BIN_DIR)/libmono-ee-interp.a \
-	$(MONO_BIN_DIR)/libmonosgen-2.0.a \
-	$(MONO_COMPONENT_LIBS) \
-	$(MONO_BIN_DIR)/libmonosgen-2.0.a \
-	$(MONO_BIN_DIR)/libmono-ilgen.a \
-	$(MONO_BIN_DIR)/libmono-icall-table.a \
-	$(MONO_BIN_DIR)/libmono-profiler-aot.a \
-	${NATIVE_BIN_DIR}/libSystem.Native.a \
-	${NATIVE_BIN_DIR}/libSystem.IO.Compression.Native.a \
-	$(ICU_LIBDIR)/libicuuc.a \
-	$(ICU_LIBDIR)/libicui18n.a
-
-ifeq ($(NOSTRIP),)
-STRIP_CMD=&& $(EMSDK_PATH)/upstream/bin/wasm-opt --strip-dwarf $(NATIVE_BIN_DIR)/dotnet.wasm -o $(NATIVE_BIN_DIR)/dotnet.wasm
-else
-STRIP_CMD=
-endif
-
-#
-# Wasm builds
-#
-
-$(NATIVE_BIN_DIR):
-	mkdir -p $$@
-
-$(NATIVE_BIN_DIR)/src:
-	mkdir -p $$@
-
-$(NATIVE_BIN_DIR)/include/wasm:
-	mkdir -p $$@
-
-$(BUILDS_OBJ_DIR):
-	mkdir -p $$@
-
-$(NATIVE_BIN_DIR)/dotnet.js: runtime/driver.c runtime/pinvoke.c runtime/pinvoke.h runtime/corebindings.c $(NATIVE_BIN_DIR)/src/cjs/runtime.cjs.iffe.js runtime/cjs/dotnet.cjs.lib.js $(SYSTEM_NATIVE_LIBDIR)/pal_random.lib.js $(MONO_LIBS) $(EMCC_DEFAULT_RSP) | $(NATIVE_BIN_DIR)
-	$(DOTNET) build $(CURDIR)/wasm.proj $(_MSBUILD_WASM_BUILD_ARGS) /t:BuildWasmRuntimes $(MSBUILD_ARGS)
-
-$(EMCC_DEFAULT_RSP): $(CURDIR)/wasm.proj | $(NATIVE_BIN_DIR)/src Makefile
-	$(DOTNET) build $(CURDIR)/wasm.proj /p:Configuration=$(CONFIG) /t:GenerateEmccPropsAndRspFiles
-
-$(NATIVE_BIN_DIR)/src/emcc-props.json: $(EMSDK_PATH)/upstream/.emsdk_version | $(NATIVE_BIN_DIR)/src
-	$(DOTNET) build $(CURDIR)/wasm.proj /p:Configuration=$(CONFIG) /t:GenerateEmccPropsAndRspFiles
-
-build-native: $(NATIVE_BIN_DIR)/dotnet.js $(NATIVE_BIN_DIR)/src/emcc-default.rsp $(NATIVE_BIN_DIR)/src/emcc-props.json
 
 clean-emsdk:
 	$(RM) -rf $(EMSDK_LOCAL_PATH)
 
-clean:
-	$(RM) -rf $(BUILDS_OBJ_DIR)
-
-icu-files: $(wildcard $(ICU_LIBDIR)/*.dat) $(ICU_LIBDIR)/libicuuc.a $(ICU_LIBDIR)/libicui18n.a | $(NATIVE_BIN_DIR)
-	cp $^ $(NATIVE_BIN_DIR)
-
-source-files: runtime/driver.c runtime/pinvoke.c runtime/corebindings.c runtime/cjs/dotnet.cjs.lib.js $(SYSTEM_NATIVE_LIBDIR)/pal_random.lib.js | $(NATIVE_BIN_DIR)/src
-	cp $^ $(NATIVE_BIN_DIR)/src
-
-header-files: runtime/pinvoke.h | $(NATIVE_BIN_DIR)/include/wasm
-	cp $^ $(NATIVE_BIN_DIR)/include/wasm
-
+#
 # Helper targets
+#
+
 .PHONY: runtime
 .PHONY: build
 
@@ -152,6 +81,9 @@ app-builder:
 
 build-tasks:
 	$(DOTNET) build $(TOP)/src/tasks/WasmBuildTasks $(MSBUILD_ARGS)
+
+clean:
+	$(RM) -rf $(BUILDS_OBJ_DIR)
 
 run-tests-v8-%:
 	EMSDK_PATH=$(EMSDK_PATH) PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test $(_MSBUILD_WASM_BUILD_ARGS) /p:JSEngine=V8 $(MSBUILD_ARGS)


### PR DESCRIPTION
The real build now happens in runtime/CMakeLists.txt, the Makefile
contains only helper targets now.