### PR TITLE
Implement DiagnosticName in NativeAOT code

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/GenericParameterDesc.Diagnostic.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/GenericParameterDesc.Diagnostic.cs
@@ -11,6 +11,12 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the name of the generic parameter as defined in the metadata. This must not throw
         /// </summary>
-        public abstract string DiagnosticName { get; }
+        public virtual string DiagnosticName
+        {
+            get
+            {
+                return string.Concat("T", Index.ToStringInvariant());
+            }
+        }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AssemblyGetExecutingAssemblyMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AssemblyGetExecutingAssemblyMethodThunk.cs
@@ -44,6 +44,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return $"GetExecutingAssembly_{ExecutingAssembly.GetName().Name}";
+            }
+        }
+
         public override TypeDesc OwningType
         {
             get;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.cs
@@ -79,6 +79,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "CalliMarshallingMethodThunk";
+            }
+        }
+
         public override PInvokeMetadata GetPInvokeMethodMetadata()
         {
             // Return PInvokeAttributes.PreserveSig to circumvent marshalling required checks

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -237,6 +237,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return NamePrefix + "__" + DelegateType.DiagnosticName;
+            }
+        }
+
         public override MethodIL EmitIL()
         {
             return PInvokeILEmitter.EmitIL(this, default(PInvokeILEmitterConfiguration), _interopStateManager);

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -90,6 +90,14 @@ namespace Internal.IL.Stubs
                 return SystemDelegateType.GetKnownField("m_functionPointer");
             }
         }
+
+        public sealed override string DiagnosticName
+        {
+            get
+            {
+                return Name;
+            }
+        }
     }
 
     /// <summary>
@@ -773,6 +781,14 @@ namespace Internal.IL.Stubs
         }
 
         public override string Name
+        {
+            get
+            {
+                return "GetThunk";
+            }
+        }
+
+        public override string DiagnosticName
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
@@ -308,6 +308,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return Name;
+            }
+        }
+
         public override MethodIL EmitIL()
         {
             ILEmitter emitter = new ILEmitter();

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/EnumThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/EnumThunks.cs
@@ -64,6 +64,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "GetHashCode";
+            }
+        }
+
         public override bool IsVirtual
         {
             get
@@ -140,6 +148,14 @@ namespace Internal.IL.Stubs
         }
 
         public override string Name
+        {
+            get
+            {
+                return "Equals";
+            }
+        }
+
+        public override string DiagnosticName
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.cs
@@ -75,6 +75,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "ForwardDelegateCreationStub__" + DelegateType.DiagnosticName;
+            }
+        }
+
         /// <summary>
         /// This thunk creates a delegate from a native function pointer
         /// by first creating a PInvokeDelegateWrapper from the function pointer

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
@@ -44,6 +44,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return Method.DiagnosticName;
+            }
+        }
+
         public override TypeDesc OwningType
         {
             get

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
@@ -126,6 +126,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return NamePrefix + "__" + ManagedType.DiagnosticName;
+            }
+        }
+
         private Marshaller[] InitializeMarshallers()
         {
             Debug.Assert(_interopStateManager != null);

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
@@ -41,6 +41,14 @@ namespace Internal.IL.Stubs
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return $"{_helperMethod.DiagnosticName}_{Signature.Length}_{DefaultAssemblyName}";
+            }
+        }
+
         public override TypeDesc OwningType
         {
             get;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.cs
@@ -149,5 +149,13 @@ namespace Internal.IL.Stubs
                 return "__GetFieldHelper";
             }
         }
+
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "__GetFieldHelper";
+            }
+        }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/IL/TypeSystemContext.GeneratedAssembly.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/TypeSystemContext.GeneratedAssembly.cs
@@ -89,7 +89,23 @@ namespace Internal.TypeSystem
                 get;
             }
 
+            public override string DiagnosticName
+            {
+                get
+                {
+                    return Name;
+                }
+            }
+
             public override string Namespace
+            {
+                get
+                {
+                    return "Internal.CompilerGenerated";
+                }
+            }
+
+            public override string DiagnosticNamespace
             {
                 get
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -35,11 +35,27 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "_InlineArray__" + ElementType.DiagnosticName + "__" + Length;
+            }
+        }
+
         public override string Namespace
         {
             get
             {
                 return "Internal.CompilerGenerated";
+            }
+        }
+
+        public override string DiagnosticNamespace
+        {
+            get
+            {
+                return Namespace;
             }
         }
 
@@ -317,6 +333,14 @@ namespace Internal.TypeSystem.Interop
                     {
                         return "set_Item";
                     }
+                }
+            }
+
+            public override string DiagnosticName
+            {
+                get
+                {
+                    return Name;
                 }
             }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -28,7 +28,23 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "__NativeType__" + ManagedStructType.DiagnosticName;
+            }
+        }
+
         public override string Namespace
+        {
+            get
+            {
+                return "Internal.CompilerGenerated";
+            }
+        }
+
+        public override string DiagnosticNamespace
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
@@ -35,7 +35,23 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "PInvokeDelegateWrapper__" + DelegateType.DiagnosticName;
+            }
+        }
+
         public override string Namespace
+        {
+            get
+            {
+                return "Internal.CompilerGenerated";
+            }
+        }
+
+        public override string DiagnosticNamespace
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.cs
@@ -33,6 +33,14 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return ".ctor";
+            }
+        }
+
         private MethodSignature _signature;
         public override MethodSignature Signature
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -259,7 +259,8 @@ namespace ILCompiler
             public override string Name => "Boxed_" + ValueTypeRepresented.Name;
 
             public override string Namespace => ValueTypeRepresented.Namespace;
-
+            public override string DiagnosticName => "Boxed_" + ValueTypeRepresented.DiagnosticName;
+            public override string DiagnosticNamespace => ValueTypeRepresented.DiagnosticNamespace;
             public override Instantiation Instantiation => ValueTypeRepresented.Instantiation;
             public override PInvokeStringFormat PInvokeStringFormat => PInvokeStringFormat.AutoClass;
             public override bool IsExplicitLayout => false;
@@ -411,6 +412,14 @@ namespace ILCompiler
                 }
             }
 
+            public override string DiagnosticName
+            {
+                get
+                {
+                    return _targetMethod.DiagnosticName + "_Unbox";
+                }
+            }
+
             public override MethodIL EmitIL()
             {
                 if (_owningType.ValueTypeRepresented.IsByRefLike)
@@ -484,6 +493,14 @@ namespace ILCompiler
                 get
                 {
                     return _targetMethod.Name + "_Unbox";
+                }
+            }
+
+            public override string DiagnosticName
+            {
+                get
+                {
+                    return _targetMethod.DiagnosticName + "_Unbox";
                 }
             }
 
@@ -574,6 +591,7 @@ namespace ILCompiler
             public override TypeDesc OwningType => _methodRepresented.OwningType;
 
             public override string Name => _methodRepresented.Name;
+            public override string DiagnosticName => _methodRepresented.DiagnosticName;
 
             public override MethodSignature Signature
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.IntefaceThunks.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.IntefaceThunks.cs
@@ -194,6 +194,14 @@ namespace ILCompiler
                 }
             }
 
+            public override string DiagnosticName
+            {
+                get
+                {
+                    return _targetMethod.DiagnosticName;
+                }
+            }
+
             public MethodDesc BaseMethod => _targetMethod;
 
             public string Prefix => $"__InstantiatingStub_{_interfaceIndex}_";
@@ -274,6 +282,7 @@ namespace ILCompiler
             public override TypeDesc OwningType => _owningType;
 
             public override string Name => _methodRepresented.Name;
+            public override string DiagnosticName => _methodRepresented.DiagnosticName;
 
             public override MethodSignature Signature
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/AppContextInitializerMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/AppContextInitializerMethod.cs
@@ -54,6 +54,14 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "SetAppContextSwitches";
+            }
+        }
+
         public override MethodIL EmitIL()
         {
             ILEmitter emitter = new ILEmitter();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
@@ -48,6 +48,14 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "NativeLibraryStartup";
+            }
+        }
+
         public override MethodIL EmitIL()
         {
             ILEmitter emitter = new ILEmitter();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -53,6 +53,14 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
+        public override string DiagnosticName
+        {
+            get
+            {
+                return "StartupCodeMain";
+            }
+        }
+
         public override MethodIL EmitIL()
         {
             ILEmitter emitter = new ILEmitter();
@@ -222,6 +230,14 @@ namespace Internal.IL.Stubs.StartupCode
             }
 
             public override string Name
+            {
+                get
+                {
+                    return "MainMethodWrapper";
+                }
+            }
+
+            public override string DiagnosticName
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -9,6 +9,8 @@
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <EnableDiaSymReaderUse Condition="'$(DotNetBuildFromSource)' != 'true'">true</EnableDiaSymReaderUse>
+    <DefineConstants Condition="'$(EnableDiaSymReaderUse)' != 'true'">$(DefineConstants);DISABLE_UNMANAGED_PDB_SYMBOLS</DefineConstants>
 
     <!-- We're binplacing these into an existing publish layout so that F5 build in VS updates
          the same bits tests expect to see in artifacts/ilc. That way we never need to wonder which
@@ -24,18 +26,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.MemoryMappedFiles">
-      <Version>4.3.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
       <Version>$(SystemReflectionMetadataVersion)</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.DiaSymReader">
+    <PackageReference Condition = "'$(EnableDiaSymReaderUse)' == 'true'" Include="Microsoft.DiaSymReader">
       <Version>1.3.0</Version>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
+    <Compile Include="..\..\Common\TypeSystem\Common\ArrayMethod.Diagnostic.cs">
+      <Link>TypeSystem\Common\ArrayMethod.Diagnostic.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Canon\ArrayType.Canon.cs">
       <Link>TypeSystem\Canon\ArrayType.Canon.cs</Link>
     </Compile>
@@ -44,6 +45,9 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Canon\CanonTypes.cs">
       <Link>TypeSystem\Canon\CanonTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Canon\CanonTypes.Diagnostic.cs">
+      <Link>TypeSystem\Canon\CanonTypes.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Canon\CanonTypes.Interop.cs">
       <Link>TypeSystem\Canon\CanonTypes.Interop.cs</Link>
@@ -117,17 +121,26 @@
     <Compile Include="..\..\Common\TypeSystem\Common\AlignmentHelper.cs">
       <Link>Utilities\AlignmentHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs">
+      <Link>Utilities\ArrayOfTRuntimeInterfacesAlgorithm.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\CastingHelper.cs">
       <Link>TypeSystem\Common\CastingHelper.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\ConstructedTypeRewritingHelpers.cs">
       <Link>TypeSystem\Common\ConstructedTypeRewritingHelpers.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\ExplicitLayoutValidator.cs">
+      <Link>TypeSystem\Common\ExplicitLayoutValidator.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\FunctionPointerType.cs">
       <Link>TypeSystem\Common\FunctionPointerType.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\IAssemblyDesc.cs">
       <Link>TypeSystem\Common\IAssemblyDesc.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\IModuleResolver.cs">
+      <Link>TypeSystem\Common\IModuleResolver.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\Instantiation.cs">
       <Link>TypeSystem\Common\Instantiation.cs</Link>
@@ -156,14 +169,14 @@
     <Compile Include="..\..\Common\TypeSystem\Common\ThrowHelper.Common.cs">
       <Link>TypeSystem\Common\ThrowHelper.Common.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\UniversalCanonLayoutAlgorithm.cs">
+      <Link>TypeSystem\Common\UniversalCanonLayoutAlgorithm.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\Utilities\CustomAttributeTypeNameFormatter.cs">
       <Link>Utilities\CustomAttributeTypeNameFormatter.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\Utilities\CustomAttributeTypeNameParser.cs">
       <Link>Utilities\CustomAttributeTypeNameParser.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\Utilities\DebugNameFormatter.cs">
-      <Link>Utilities\DebugNameFormatter.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\Utilities\GCPointerMap.Algorithm.cs">
       <Link>Utilities\GCPointerMap.Algorithm.cs</Link>
@@ -174,14 +187,14 @@
     <Compile Include="..\..\Common\TypeSystem\Common\Utilities\GCPointerMap.cs">
       <Link>Utilities\GCPointerMap.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\Utilities\DebugNameFormatter.cs">
+      <Link>Utilities\DebugNameFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\Utilities\LockFreeReaderHashtable.cs">
       <Link>Utilities\LockFreeReaderHashtable.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\ArrayType.cs">
       <Link>TypeSystem\Common\ArrayType.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs">
-      <Link>TypeSystem\Common\ArrayOfTRuntimeInterfacesAlgorithm.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs">
       <Link>TypeSystem\Common\BaseTypeRuntimeInterfacesAlgorithm.cs</Link>
@@ -192,8 +205,8 @@
     <Compile Include="..\..\Common\TypeSystem\Common\GenericParameterDesc.cs">
       <Link>TypeSystem\Common\GenericParameterDesc.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\GenericParameterDesc.Dummy.Diagnostic.cs">
-      <Link>TypeSystem\Common\GenericParameterDesc.Dummy.Diagnostic.cs</Link>
+    <Compile Include="..\..\Common\TypeSystem\Common\GenericParameterDesc.Diagnostic.cs">
+      <Link>TypeSystem\Common\GenericParameterDesc.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\ExceptionStringID.cs">
       <Link>TypeSystem\Common\ExceptionStringID.cs</Link>
@@ -213,17 +226,17 @@
     <Compile Include="..\..\Common\TypeSystem\Common\FieldLayoutAlgorithm.cs">
       <Link>TypeSystem\Common\FieldLayoutAlgorithm.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\ExplicitLayoutValidator.cs">
-      <Link>TypeSystem\Common\ExplicitLayoutValidator.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\IModuleResolver.cs">
-      <Link>TypeSystem\Common\IModuleResolver.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedMethod.cs">
       <Link>TypeSystem\Common\InstantiatedMethod.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedMethod.Diagnostic.cs">
+      <Link>TypeSystem\Common\InstantiatedMethod.Diagnostic.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedType.cs">
       <Link>TypeSystem\Common\InstantiatedType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedType.Diagnostic.cs">
+      <Link>TypeSystem\Common\InstantiatedType.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\InstantiatedType.Interfaces.cs">
       <Link>TypeSystem\Common\InstantiatedType.Interfaces.cs</Link>
@@ -234,8 +247,14 @@
     <Compile Include="..\..\Common\TypeSystem\Common\LayoutInt.cs">
       <Link>TypeSystem\Common\LayoutInt.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\LinqPoison.cs">
+      <Link>TypeSystem\Common\LinqPoison.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\MetadataType.cs">
       <Link>TypeSystem\Common\MetadataType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\DefType.Diagnostic.cs">
+      <Link>TypeSystem\Common\DefType.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\MetadataType.Interfaces.cs">
       <Link>TypeSystem\Common\MetadataType.Interfaces.cs</Link>
@@ -254,6 +273,9 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\MethodForInstantiatedType.cs">
       <Link>TypeSystem\Common\MethodForInstantiatedType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\MethodForInstantiatedType.Diagnostic.cs">
+      <Link>TypeSystem\Common\MethodForInstantiatedType.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\ParameterizedType.cs">
       <Link>TypeSystem\Common\ParameterizedType.cs</Link>
@@ -285,17 +307,14 @@
     <Compile Include="..\..\Common\TypeSystem\Common\TypeHashingAlgorithms.cs">
       <Link>TypeSystem\Common\TypeHashingAlgorithms.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemConstraintsHelpers.cs">
+      <Link>TypeSystem\Common\TypeSystemConstraintsHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemContext.cs">
       <Link>TypeSystem\Common\TypeSystemContext.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemHelpers.cs">
       <Link>TypeSystem\Common\TypeSystemHelpers.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemConstraintsHelpers.cs">
-      <Link>TypeSystem\Common\TypeSystemConstraintsHelpers.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\UniversalCanonLayoutAlgorithm.cs">
-      <Link>TypeSystem\Common\UniversalCanonLayoutAlgorithm.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\Utilities\ExceptionTypeNameFormatter.cs">
       <Link>Utilities\ExceptionTypeNameFormatter.cs</Link>
@@ -315,11 +334,14 @@
     <Compile Include="..\..\Common\TypeSystem\Common\MethodDelegator.cs">
       <Link>TypeSystem\Common\MethodDelegator.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\MethodDelegator.Diagnostic.cs">
+      <Link>TypeSystem\Common\MethodDelegator.Diagnostic.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\MethodDesc.cs">
       <Link>TypeSystem\Common\MethodDesc.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\MethodDesc.Dummy.Diagnostic.cs">
-      <Link>TypeSystem\Common\MethodDesc.Dummy.Diagnostic.cs</Link>
+    <Compile Include="..\..\Common\TypeSystem\Common\MethodDesc.Diagnostic.cs">
+      <Link>TypeSystem\Common\MethodDesc.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\MethodDesc.ToString.cs">
       <Link>TypeSystem\Common\MethodDesc.ToString.cs</Link>
@@ -338,9 +360,6 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\DefType.cs">
       <Link>TypeSystem\Common\DefType.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Common\DefType.Dummy.Diagnostic.cs">
-      <Link>TypeSystem\Common\DefType.Dummy.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\DefType.FieldLayout.cs">
       <Link>TypeSystem\Common\DefType.FieldLayout.cs</Link>
@@ -402,7 +421,13 @@
     <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaGenericParameter.cs">
       <Link>Ecma\EcmaGenericParameter.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaGenericParameter.Diagnostic.cs">
+      <Link>Ecma\EcmaGenericParameter.Diagnostic.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaMethod.cs">
+      <Link>Ecma\EcmaMethod.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaMethod.Diagnostic.cs">
       <Link>Ecma\EcmaMethod.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaModule.cs">
@@ -413,6 +438,9 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaType.cs">
       <Link>Ecma\EcmaType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaType.Diagnostic.cs">
+      <Link>Ecma\EcmaType.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Ecma\EcmaType.MethodImpls.cs">
       <Link>Ecma\EcmaType.MethodImpls.cs</Link>
@@ -452,9 +480,6 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeLazyFixupField.Sorting.cs">
       <Link>IL\Stubs\PInvokeLazyFixupField.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs">
-      <Link>IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StructMarshallingThunk.Sorting.cs">
       <Link>IL\Stubs\StructMarshallingThunk.Sorting.cs</Link>
@@ -546,14 +571,20 @@
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeILCodeStreams.cs">
       <Link>IL\Stubs\PInvokeILCodeStreams.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ILEmitter.cs">
+      <Link>IL\Stubs\ILEmitter.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeTargetNativeMethod.cs">
       <Link>IL\Stubs\PInvokeTargetNativeMethod.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeTargetNativeMethod.Diagnostic.cs">
+      <Link>IL\Stubs\PInvokeTargetNativeMethod.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeTargetNativeMethod.Mangling.cs">
       <Link>IL\Stubs\PInvokeTargetNativeMethod.Mangling.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ILEmitter.cs">
-      <Link>IL\Stubs\ILEmitter.cs</Link>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs">
+      <Link>IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DebuggerSteppingHelpers.cs">
       <Link>IL\Stubs\DebuggerSteppingHelpers.cs</Link>
@@ -705,6 +736,9 @@
     <Compile Include="..\..\Common\TypeSystem\RuntimeDetermined\MethodForRuntimeDeterminedType.cs">
       <Link>TypeSystem\RuntimeDetermined\MethodForRuntimeDeterminedType.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\RuntimeDetermined\MethodForRuntimeDeterminedType.Diagnostic.cs">
+      <Link>TypeSystem\RuntimeDetermined\MethodForRuntimeDeterminedType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\RuntimeDetermined\MethodForRuntimeDeterminedType.Sorting.cs">
       <Link>TypeSystem\RuntimeDetermined\MethodForRuntimeDeterminedType.Sorting.cs</Link>
     </Compile>
@@ -725,6 +759,9 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\RuntimeDetermined\RuntimeDeterminedType.cs">
       <Link>TypeSystem\RuntimeDetermined\RuntimeDeterminedType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\RuntimeDetermined\RuntimeDeterminedType.Diagnostic.cs">
+      <Link>TypeSystem\RuntimeDetermined\RuntimeDeterminedType.Diagnostic.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\RuntimeDetermined\RuntimeDeterminedType.Sorting.cs">
       <Link>TypeSystem\RuntimeDetermined\RuntimeDeterminedType.Sorting.cs</Link>


### PR DESCRIPTION
When `DiagnosticName` was introduced into the type system, I didn't want to deal with it and compiled it out of the NativeAOT version of the type system.

In order to have a single ILCompiler.TypeSystem assembly that can be used with both crossgen2 and ILC, this needs to be implemented.

I've also reduced the number of diffs between ILCompiler.TypeSystem.csproj and ILCompiler.TypeSystem.ReadyToRun.csproj.