### PR TITLE
Extend case optimization in MatchCharacterClass to all chars that differ by one bit

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1048,6 +1048,14 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Determines whether the 'a' and 'b' values differ by only a single bit, setting that bit in 'mask'.</summary>
+        /// <remarks>This isn't specific to RegexCharClass; it's just a convenient place to host it.</remarks>
+        public static bool DifferByOneBit(char a, char b, out int mask)
+        {
+            mask = a ^ b;
+            return mask != 0 && (mask & (mask - 1)) == 0;
+        }
+
         /// <summary>Determines a character's membership in a character class (via the string representation of the class).</summary>
         /// <param name="ch">The character.</param>
         /// <param name="set">The string representation of the character class.</param>

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -279,6 +279,11 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (".[abc]", "xYZAbC", RegexOptions.IgnoreCase, 0, 6, true, "ZA");
                 yield return (".[abc]", "xYzXyZx", RegexOptions.IgnoreCase, 0, 6, false, "");
 
+                // Sets containing characters that differ by a bit
+                yield return ("123[Aa]", "123a", RegexOptions.None, 0, 4, true, "123a");
+                yield return ("123[0p]", "123p", RegexOptions.None, 0, 4, true, "123p");
+                yield return ("123[Aa@]", "123@", RegexOptions.None, 0, 4, true, "123@");
+
                 // "\D+"
                 yield return (@"\D+", "12321", RegexOptions.None, 0, 5, false, string.Empty);
 


### PR DESCRIPTION
In RegexCompiler / source generator, we optimize matching a set like [Aa] to just do `(ch | 0x20) == 'a'`.  But we can trivially extend this to any pair of characters that differ by only a single bit and not just to casing.