### PR TITLE
Mark Regex source generator Go override as SkipLocalsInit if possible

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -49,7 +49,7 @@ namespace System.Text.RegularExpressions.Generator
                 {
                     Debug.Assert(state.Item1 is not null);
                     object? result = GetRegexTypeToEmit(state.Item2, state.Item1, cancellationToken);
-                    return result is RegexType regexType ? EmitRegexType(regexType) : result;
+                    return result is RegexType regexType ? EmitRegexType(regexType, state.Item2) : result;
                 })
                 .Collect();
 

--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Generators.Tests/RegexGeneratorParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Generators.Tests/RegexGeneratorParserTests.cs
@@ -297,8 +297,10 @@ namespace System.Text.RegularExpressions.Generator.Tests
             ", compile: true));
         }
 
-        [Fact]
-        public async Task Valid_ClassWithNamespace()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Valid_ClassWithNamespace(bool allowUnsafe)
         {
             Assert.Empty(await RunGenerator(@"
                 using System.Text.RegularExpressions;
@@ -310,7 +312,7 @@ namespace System.Text.RegularExpressions.Generator.Tests
                         private static partial Regex Valid();
                     }
                 }
-            ", compile: true));
+            ", compile: true, allowUnsafe: allowUnsafe));
         }
 
         [Fact]
@@ -557,13 +559,13 @@ namespace System.Text.RegularExpressions.Generator.Tests
         }
 
         private async Task<IReadOnlyList<Diagnostic>> RunGenerator(
-            string code, bool compile = false, LanguageVersion langVersion = LanguageVersion.Preview, MetadataReference[]? additionalRefs = null, CancellationToken cancellationToken = default)
+            string code, bool compile = false, LanguageVersion langVersion = LanguageVersion.Preview, MetadataReference[]? additionalRefs = null, bool allowUnsafe = false, CancellationToken cancellationToken = default)
         {
             var proj = new AdhocWorkspace()
                 .AddSolution(SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Create()))
                 .AddProject("RegexGeneratorTest", "RegexGeneratorTest.dll", "C#")
                 .WithMetadataReferences(additionalRefs is not null ? s_refs.Concat(additionalRefs) : s_refs)
-                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: allowUnsafe)
                 .WithNullableContextOptions(NullableContextOptions.Enable))
                 .WithParseOptions(new CSharpParseOptions(langVersion))
                 .AddDocument("RegexGenerator.g.cs", SourceText.From(code, Encoding.UTF8)).Project;


### PR DESCRIPTION
It can have so many locals that zero-initing is measurable.