### PR TITLE
Move things from ILCompiler.TypeSystem to ILCompiler.Compiler

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Sorting.cs
@@ -8,9 +8,9 @@ namespace Internal.IL.Stubs
     // Functionality related to deterministic ordering of methods
     partial class CalliMarshallingMethodThunk
     {
-        protected internal override int ClassCode => 1594107963;
+        protected override int ClassCode => 1594107963;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (CalliMarshallingMethodThunk)other;
             return comparer.Compare(_targetSignature, otherMethod._targetSignature);

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Sorting.cs
@@ -8,9 +8,9 @@ namespace Internal.IL.Stubs
     // Functionality related to deterministic ordering of methods
     partial class DelegateMarshallingMethodThunk
     {
-        protected internal override int ClassCode => 1018037605;
+        protected override int ClassCode => 1018037605;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (DelegateMarshallingMethodThunk)other;
             int result = (int)Kind - (int)otherMethod.Kind;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.Sorting.cs
@@ -8,7 +8,7 @@ namespace Internal.IL.Stubs
     // Functionality related to deterministic ordering of types
     partial class DelegateThunk
     {
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (DelegateThunk)other;
             return comparer.Compare(_delegateInfo.Type, otherMethod._delegateInfo.Type);
@@ -17,39 +17,39 @@ namespace Internal.IL.Stubs
 
     partial class DelegateInvokeOpenStaticThunk
     {
-        protected internal override int ClassCode => 386356101;
+        protected override int ClassCode => 386356101;
     }
 
     public sealed partial class DelegateInvokeOpenInstanceThunk
     {
-        protected internal override int ClassCode => -1787190244;
+        protected override int ClassCode => -1787190244;
     }
 
     partial class DelegateInvokeClosedStaticThunk
     {
-        protected internal override int ClassCode => 28195375;
+        protected override int ClassCode => 28195375;
     }
 
     partial class DelegateInvokeMulticastThunk
     {
-        protected internal override int ClassCode => 639863471;
+        protected override int ClassCode => 639863471;
     }
 
     partial class DelegateInvokeInstanceClosedOverGenericMethodThunk
     {
-        protected internal override int ClassCode => -354480633;
+        protected override int ClassCode => -354480633;
     }
 
     partial class DelegateInvokeObjectArrayThunk
     {
-        protected internal override int ClassCode => 1993292344;
+        protected override int ClassCode => 1993292344;
     }
 
     partial class DelegateGetThunkMethodOverride
     {
-        protected internal override int ClassCode => -321263379;
+        protected override int ClassCode => -321263379;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (DelegateGetThunkMethodOverride)other;
             return comparer.Compare(_delegateInfo.Type, otherMethod._delegateInfo.Type);

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -726,7 +726,8 @@ namespace Internal.IL.Stubs
                     Debug.Assert(_delegateInfo.Thunks[i] == null);
 
                     var sig = new DynamicInvokeMethodSignature(_delegateInfo.Signature);
-                    MethodDesc thunk = Context.GetDynamicInvokeThunk(sig);
+                    // TODO: layering violation. Should move delegate thunk stuff to ILCompiler.Compiler.
+                    MethodDesc thunk = ((ILCompiler.CompilerTypeSystemContext)Context).GetDynamicInvokeThunk(sig);
 
                     if (thunk.HasInstantiation)
                     {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.Sorting.cs
@@ -11,9 +11,9 @@ namespace Internal.IL.Stubs
     // Functionality related to determinstic ordering of types
     partial class DynamicInvokeMethodThunk
     {
-        protected internal override int ClassCode => -1980933220;
+        protected override int ClassCode => -1980933220;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             return CompareTo((DynamicInvokeMethodThunk)other);
         }
@@ -51,9 +51,9 @@ namespace Internal.IL.Stubs
 
         partial class DynamicInvokeThunkGenericParameter
         {
-            protected internal override int ClassCode => -234393261;
+            protected override int ClassCode => -234393261;
 
-            protected internal override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
+            protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
             {
                 var otherType = (DynamicInvokeThunkGenericParameter)other;
                 int result = Index - otherType.Index;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/EnumThunks.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/EnumThunks.Sorting.cs
@@ -8,9 +8,9 @@ namespace Internal.IL.Stubs
     // Functionality related to deterministic ordering of types
     partial class EnumGetHashCodeThunk
     {
-        protected internal override int ClassCode => 261739662;
+        protected override int ClassCode => 261739662;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (EnumGetHashCodeThunk)other;
             return comparer.Compare(_owningType, otherMethod._owningType);
@@ -19,9 +19,9 @@ namespace Internal.IL.Stubs
 
     partial class EnumEqualsThunk
     {
-        protected internal override int ClassCode => -1774524780;
+        protected override int ClassCode => -1774524780;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (EnumEqualsThunk)other;
             return comparer.Compare(_owningType, otherMethod._owningType);

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.Sorting.cs
@@ -8,9 +8,9 @@ namespace Internal.IL.Stubs
     // Functionality related to deterministic ordering of types
     partial class ForwardDelegateCreationThunk
     {
-        protected internal override int ClassCode => 1026039617;
+        protected override int ClassCode => 1026039617;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (ForwardDelegateCreationThunk)other;
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.Sorting.cs
@@ -7,9 +7,9 @@ namespace Internal.IL.Stubs
 {
     partial class PInvokeLazyFixupField
     {
-        protected internal override int ClassCode => -1784477702;
+        protected override int ClassCode => -1784477702;
 
-        protected internal override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
         {
             return comparer.Compare(_targetMethod, ((PInvokeLazyFixupField)other)._targetMethod);
         }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.Sorting.cs
@@ -8,9 +8,9 @@ namespace Internal.IL.Stubs
     // Functionality related to deterministic ordering of types
     partial class StructMarshallingThunk
     {
-        protected internal override int ClassCode => 340834018;
+        protected override int ClassCode => 340834018;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (StructMarshallingThunk)other;
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ValueTypeGetFieldHelperMethodOverride.Sorting.cs
@@ -7,9 +7,9 @@ namespace Internal.IL.Stubs
 {
     partial class ValueTypeGetFieldHelperMethodOverride
     {
-        protected internal override int ClassCode => 2036839816;
+        protected override int ClassCode => 2036839816;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var otherMethod = (ValueTypeGetFieldHelperMethodOverride)other;
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.Sorting.cs
@@ -6,9 +6,9 @@ namespace Internal.TypeSystem.Interop
     // Functionality related to determinstic ordering of types
     partial class InlineArrayType
     {
-        protected internal override int ClassCode => 226817075;
+        protected override int ClassCode => 226817075;
 
-        protected internal override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
         {
             var otherType = (InlineArrayType)other;
             int result = (int)Length - (int)otherType.Length;
@@ -20,9 +20,9 @@ namespace Internal.TypeSystem.Interop
 
         partial class InlineArrayMethod
         {
-            protected internal override int ClassCode => -1303220581;
+            protected override int ClassCode => -1303220581;
 
-            protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+            protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
             {
                 var otherMethod = (InlineArrayMethod)other;
 
@@ -30,19 +30,19 @@ namespace Internal.TypeSystem.Interop
                 if (result != 0)
                     return result;
 
-                return comparer.CompareWithinClass(OwningType, otherMethod.OwningType);
+                return comparer.Compare(OwningType, otherMethod.OwningType);
             }
         }
 
         partial class InlineArrayField
         {
-            protected internal override int ClassCode => 1542668652;
+            protected override int ClassCode => 1542668652;
 
-            protected internal override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+            protected override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
             {
                 var otherField = (InlineArrayField)other;
 
-                return comparer.CompareWithinClass(OwningType, otherField.OwningType);
+                return comparer.Compare(OwningType, otherField.OwningType);
             }
         }
     }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.Sorting.cs
@@ -6,18 +6,18 @@ namespace Internal.TypeSystem.Interop
     // Functionality related to determinstic ordering of types
     partial class NativeStructType
     {
-        protected internal override int ClassCode => -377751537;
+        protected override int ClassCode => -377751537;
 
-        protected internal override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
         {
             return comparer.Compare(ManagedStructType, ((NativeStructType)other).ManagedStructType);
         }
 
         partial class NativeStructField
         {
-            protected internal override int ClassCode => 1580219745;
+            protected override int ClassCode => 1580219745;
 
-            protected internal override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
+            protected override int CompareToImpl(FieldDesc other, TypeSystemComparer comparer)
             {
                 return comparer.Compare(_managedField, ((NativeStructField)other)._managedField);
             }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.Sorting.cs
@@ -6,9 +6,9 @@ namespace Internal.TypeSystem.Interop
     // Functionality related to determinstic ordering of types
     partial class PInvokeDelegateWrapper
     {
-        protected internal override int ClassCode => -262930217;
+        protected override int ClassCode => -262930217;
 
-        protected internal override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
         {
             return comparer.Compare(DelegateType, ((PInvokeDelegateWrapper)other).DelegateType);
         }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.Sorting.cs
@@ -6,9 +6,9 @@ namespace Internal.TypeSystem.Interop
     // Functionality related to deterministic ordering of methods
     partial class PInvokeDelegateWrapperConstructor
     {
-        protected internal override int ClassCode => 1000342011;
+        protected override int ClassCode => 1000342011;
 
-        protected internal override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+        protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
         {
             var owningType = (PInvokeDelegateWrapper)OwningType;
             var otherOwningType = (PInvokeDelegateWrapper)other.OwningType;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -19,7 +19,6 @@ namespace ILCompiler
             get;
         }
 
-        private readonly DelegateFeature _delegateFeatures;
         private readonly MetadataFieldLayoutAlgorithm _metadataFieldLayoutAlgorithm = new CompilerMetadataFieldLayoutAlgorithm();
         private readonly RuntimeDeterminedFieldLayoutAlgorithm _runtimeDeterminedFieldLayoutAlgorithm = new RuntimeDeterminedFieldLayoutAlgorithm();
         private readonly VectorOfTFieldLayoutAlgorithm _vectorOfTFieldLayoutAlgorithm;
@@ -37,7 +36,7 @@ namespace ILCompiler
             _vectorOfTFieldLayoutAlgorithm = new VectorOfTFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
             _vectorFieldLayoutAlgorithm = new VectorFieldLayoutAlgorithm(_metadataFieldLayoutAlgorithm);
 
-            _delegateFeatures = delegateFeatures;
+            _delegateInfoHashtable = new DelegateInfoHashtable(delegateFeatures);
 
             GenericsConfig = new SharedGenericsConfiguration();
         }
@@ -163,11 +162,6 @@ namespace ILCompiler
             IEnumerable<MethodDesc> metadataMethods = virtualOnly ? type.GetVirtualMethods() : type.GetMethods();
             foreach (var m in metadataMethods)
                 yield return m;
-        }
-
-        protected override DelegateInfo CreateDelegateInfo(TypeDesc delegateType)
-        {
-            return new DelegateInfo(delegateType, _delegateFeatures);
         }
 
         internal DefType GetClosestDefType(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.DelegateInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.DelegateInfo.cs
@@ -4,13 +4,19 @@
 using System;
 
 using Internal.IL;
+using Internal.TypeSystem;
 
-namespace Internal.TypeSystem
+namespace ILCompiler
 {
-    public abstract partial class TypeSystemContext
+    partial class CompilerTypeSystemContext
     {
         private class DelegateInfoHashtable : LockFreeReaderHashtable<TypeDesc, DelegateInfo>
         {
+            private readonly DelegateFeature _delegateFeatures;
+
+            public DelegateInfoHashtable(DelegateFeature features)
+                => _delegateFeatures = features;
+
             protected override int GetKeyHashCode(TypeDesc key)
             {
                 return key.GetHashCode();
@@ -29,24 +35,15 @@ namespace Internal.TypeSystem
             }
             protected override DelegateInfo CreateValueFromKey(TypeDesc key)
             {
-                return key.Context.CreateDelegateInfo(key);
+                return new DelegateInfo(key, _delegateFeatures);
             }
         }
 
-        private DelegateInfoHashtable _delegateInfoHashtable = new DelegateInfoHashtable();
+        private readonly DelegateInfoHashtable _delegateInfoHashtable;
 
         public DelegateInfo GetDelegateInfo(TypeDesc delegateType)
         {
             return _delegateInfoHashtable.GetOrCreateValue(delegateType);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="DelegateInfo"/> for a given delegate type.
-        /// </summary>
-        protected virtual DelegateInfo CreateDelegateInfo(TypeDesc key)
-        {
-            // Type system contexts that support creating delegate infos need to override.
-            throw new NotSupportedException();
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.DynamicInvoke.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.DynamicInvoke.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Internal.IL.Stubs;
+using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
 
-namespace Internal.TypeSystem
+namespace ILCompiler
 {
-    partial class TypeSystemContext
+    partial class CompilerTypeSystemContext
     {
         private class DynamicInvokeThunkHashtable : LockFreeReaderHashtable<DynamicInvokeMethodSignature, DynamicInvokeMethodThunk>
         {
@@ -17,7 +18,7 @@ namespace Internal.TypeSystem
             protected override int GetValueHashCode(DynamicInvokeMethodThunk value) => value.TargetSignature.GetHashCode();
             protected override DynamicInvokeMethodThunk CreateValueFromKey(DynamicInvokeMethodSignature key)
             {
-                return new DynamicInvokeMethodThunk(key.Context.GeneratedAssembly.GetGlobalModuleType(), key);
+                return new DynamicInvokeMethodThunk(((CompilerTypeSystemContext)key.Context).GeneratedAssembly.GetGlobalModuleType(), key);
             }
         }
         DynamicInvokeThunkHashtable _dynamicInvokeThunks = new DynamicInvokeThunkHashtable();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.EnumMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.EnumMethods.cs
@@ -3,13 +3,14 @@
 
 using System.Collections.Generic;
 
+using Internal.TypeSystem;
 using Internal.IL.Stubs;
 
 using Debug = System.Diagnostics.Debug;
 
-namespace Internal.TypeSystem
+namespace ILCompiler
 {
-    public abstract partial class TypeSystemContext
+    partial class CompilerTypeSystemContext
     {
         private class EnumInfo
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.Sorting.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.Sorting.cs
@@ -3,16 +3,18 @@
 
 using System;
 
-namespace Internal.TypeSystem
+using Internal.TypeSystem;
+
+namespace ILCompiler
 {
-    partial class TypeSystemContext
+    partial class CompilerTypeSystemContext
     {
         // Functionality related to determinstic ordering of types and members
         partial class CompilerGeneratedType : MetadataType
         {
-            protected internal override int ClassCode => -1036681447;
+            protected override int ClassCode => -1036681447;
 
-            protected internal override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
+            protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
             {
                 // Should be a singleton
                 throw new NotSupportedException();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
@@ -4,14 +4,16 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.TypeSystem;
+
 using TypeHashingAlgorithms = Internal.NativeFormat.TypeHashingAlgorithms;
 using Interlocked = System.Threading.Interlocked;
 using AssemblyName = System.Reflection.AssemblyName;
 using Debug = System.Diagnostics.Debug;
 
-namespace Internal.TypeSystem
+namespace ILCompiler
 {
-    partial class TypeSystemContext
+    partial class CompilerTypeSystemContext
     {
         private ModuleDesc _generatedAssembly;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.IntefaceThunks.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.IntefaceThunks.cs
@@ -149,7 +149,7 @@ namespace ILCompiler
             }
             protected override DefaultInterfaceMethodImplementationInstantiationThunk CreateValueFromKey(DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey key)
             {
-                TypeDesc owningTypeOfThunks = key.TargetMethod.Context.GeneratedAssembly.GetGlobalModuleType();
+                TypeDesc owningTypeOfThunks = ((CompilerTypeSystemContext)key.TargetMethod.Context).GeneratedAssembly.GetGlobalModuleType();
                 return new DefaultInterfaceMethodImplementationInstantiationThunk(owningTypeOfThunks, key.TargetMethod, key.InterfaceIndex);
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.ValueTypeMethods.cs
@@ -3,13 +3,14 @@
 
 using System.Collections.Generic;
 
+using Internal.TypeSystem;
 using Internal.IL.Stubs;
 
 using Debug = System.Diagnostics.Debug;
 
-namespace Internal.TypeSystem
+namespace ILCompiler
 {
-    public abstract partial class TypeSystemContext
+    partial class CompilerTypeSystemContext
     {
         private MethodDesc _objectEqualsMethod;
 
@@ -154,7 +155,7 @@ namespace Internal.TypeSystem
                         // Would be a suprise if this wasn't a valuetype. We checked ContainsGCPointers above.
                         Debug.Assert(fieldType.IsValueType);
 
-                        MethodDesc objectEqualsMethod = fieldType.Context._objectEqualsMethod;
+                        MethodDesc objectEqualsMethod = ((CompilerTypeSystemContext)fieldType.Context)._objectEqualsMethod;
 
                         // If the field overrides Equals, we can't use the fast helper because we need to call the method.
                         if (fieldType.FindVirtualFunctionTargetMethodOnObjectType(objectEqualsMethod).OwningType == fieldType)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
@@ -161,7 +161,7 @@ namespace ILCompiler
         /// </summary>
         public static DelegateCreationInfo Create(TypeDesc delegateType, MethodDesc targetMethod, NodeFactory factory, bool followVirtualDispatch)
         {
-            TypeSystemContext context = delegateType.Context;
+            CompilerTypeSystemContext context = factory.TypeSystemContext;
             DefType systemDelegate = context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType;
 
             int paramCountTargetMethod = targetMethod.Signature.Length;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MultiFileCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MultiFileCompilationModuleGroup.cs
@@ -15,7 +15,7 @@ namespace ILCompiler
     {
         private HashSet<ModuleDesc> _compilationModuleSet;
 
-        public MultiFileCompilationModuleGroup(TypeSystemContext context, IEnumerable<ModuleDesc> compilationModuleSet)
+        public MultiFileCompilationModuleGroup(CompilerTypeSystemContext context, IEnumerable<ModuleDesc> compilationModuleSet)
         {
             _compilationModuleSet = new HashSet<ModuleDesc>(compilationModuleSet);
 
@@ -94,7 +94,7 @@ namespace ILCompiler
     /// </summary>
     public class MultiFileSharedCompilationModuleGroup : MultiFileCompilationModuleGroup
     {
-        public MultiFileSharedCompilationModuleGroup(TypeSystemContext context, IEnumerable<ModuleDesc> compilationModuleSet)
+        public MultiFileSharedCompilationModuleGroup(CompilerTypeSystemContext context, IEnumerable<ModuleDesc> compilationModuleSet)
             : base(context, compilationModuleSet)
         {
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -23,6 +23,144 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Common\TypeSystem\IL\DelegateInfo.cs">
+      <Link>IL\DelegateInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateThunks.Sorting.cs">
+      <Link>IL\Stubs\DelegateThunks.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DynamicInvokeMethodThunk.cs">
+      <Link>IL\Stubs\DynamicInvokeMethodThunk.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DynamicInvokeMethodThunk.Sorting.cs">
+      <Link>IL\Stubs\DynamicInvokeMethodThunk.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\EnumThunks.cs">
+      <Link>IL\Stubs\EnumThunks.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\EnumThunks.Sorting.cs">
+      <Link>IL\Stubs\EnumThunks.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeLazyFixupField.cs">
+      <Link>IL\Stubs\PInvokeLazyFixupField.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeLazyFixupField.Sorting.cs">
+      <Link>IL\Stubs\PInvokeLazyFixupField.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StructMarshallingThunk.Sorting.cs">
+      <Link>IL\Stubs\StructMarshallingThunk.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ValueTypeGetFieldHelperMethodOverride.cs">
+      <Link>IL\Stubs\ValueTypeGetFieldHelperMethodOverride.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ValueTypeGetFieldHelperMethodOverride.Sorting.cs">
+      <Link>IL\Stubs\ValueTypeGetFieldHelperMethodOverride.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\InlineArrayType.Sorting.cs">
+      <Link>TypeSystem\Interop\IL\InlineArrayType.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalHelpers.cs">
+      <Link>Interop\IL\MarshalHelpers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalHelpers.Aot.cs">
+      <Link>Interop\IL\MarshalHelpers.Aot.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalUtils.cs">
+      <Link>Interop\IL\MarshalUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\Marshaller.cs">
+      <Link>Interop\IL\Marshaller.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\Marshaller.Aot.cs">
+      <Link>Interop\IL\Marshaller.Aot.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\NativeStructType.Sorting.cs">
+      <Link>TypeSystem\Interop\IL\NativeStructType.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeILEmitterConfiguration.cs">
+      <Link>Interop\IL\PInvokeILEmitterConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeILEmitter.cs">
+      <Link>IL\Stubs\PInvokeILEmitter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeILCodeStreams.cs">
+      <Link>IL\Stubs\PInvokeILCodeStreams.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DebuggerSteppingHelpers.cs">
+      <Link>IL\Stubs\DebuggerSteppingHelpers.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\CalliMarshallingMethodThunk.cs">
+      <Link>IL\Stubs\CalliMarshallingMethodThunk.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\CalliMarshallingMethodThunk.Mangling.cs">
+      <Link>IL\Stubs\CalliMarshallingMethodThunk.Mangling.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\CalliMarshallingMethodThunk.Sorting.cs">
+      <Link>IL\Stubs\CalliMarshallingMethodThunk.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.cs">
+      <Link>IL\Stubs\DelegateMarshallingMethodThunk.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.Mangling.cs">
+      <Link>IL\Stubs\DelegateMarshallingMethodThunk.Mangling.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.Sorting.cs">
+      <Link>IL\Stubs\DelegateMarshallingMethodThunk.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ForwardDelegateCreationThunk.cs">
+      <Link>IL\Stubs\ForwardDelegateCreationThunk.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ForwardDelegateCreationThunk.Mangling.cs">
+      <Link>IL\Stubs\ForwardDelegateCreationThunk.Mangling.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ForwardDelegateCreationThunk.Sorting.cs">
+      <Link>IL\Stubs\ForwardDelegateCreationThunk.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateThunks.cs">
+      <Link>IL\Stubs\DelegateThunks.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StructMarshallingThunk.cs">
+      <Link>IL\Stubs\StructMarshallingThunk.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StructMarshallingThunk.Mangling.cs">
+      <Link>IL\Stubs\StructMarshallingThunk.Mangling.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\NativeStructType.cs">
+      <Link>TypeSystem\Interop\IL\NativeStructType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\NativeStructType.Mangling.cs">
+      <Link>TypeSystem\Interop\IL\NativeStructType.Mangling.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapper.cs">
+      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapper.Mangling.cs">
+      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapper.Mangling.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapper.Sorting.cs">
+      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapper.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.cs">
+      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.Sorting.cs">
+      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.Sorting.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\InlineArrayType.cs">
+      <Link>TypeSystem\Interop\IL\InlineArrayType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\InteropTypes.cs">
+      <Link>TypeSystem\Interop\InteropTypes.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\InteropStateManager.cs">
+      <Link>TypeSystem\Interop\InteropStateManager.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\CodeGen\INonEmittableType.cs">
+      <Link>TypeSystem\CodeGen\INonEmittableType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\TypeSystem\CodeGen\NativeStructType.CodeGen.cs">
+      <Link>TypeSystem\CodeGen\NativeStructType.CodeGen.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\Compiler\Logging\CompilerGeneratedState.cs">
       <Link>Compiler\Logging\CompilerGeneratedState.cs</Link>
     </Compile>
@@ -179,6 +317,12 @@
     <Compile Include="Compiler\CompilerTypeSystemContext.IntefaceThunks.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.Mangling.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.Sorting.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.DelegateInfo.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.DynamicInvoke.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.GeneratedAssembly.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.GeneratedAssembly.Sorting.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.EnumMethods.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.ValueTypeMethods.cs" />
     <Compile Include="Compiler\CompilerGeneratedInteropStubManager.cs" />
     <Compile Include="Compiler\Dataflow\DynamicallyAccessedMembersBinder.cs" />
     <Compile Include="Compiler\Dataflow\EcmaExtensions.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -457,59 +457,11 @@
     <Compile Include="..\..\Common\TypeSystem\Ecma\CachingMetadataStringDecoder.cs">
       <Link>Ecma\CachingMetadataStringDecoder.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\DelegateInfo.cs">
-      <Link>IL\DelegateInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateThunks.Sorting.cs">
-      <Link>IL\Stubs\DelegateThunks.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DynamicInvokeMethodThunk.cs">
-      <Link>IL\Stubs\DynamicInvokeMethodThunk.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DynamicInvokeMethodThunk.Sorting.cs">
-      <Link>IL\Stubs\DynamicInvokeMethodThunk.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\EnumThunks.cs">
-      <Link>IL\Stubs\EnumThunks.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\EnumThunks.Sorting.cs">
-      <Link>IL\Stubs\EnumThunks.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeLazyFixupField.cs">
-      <Link>IL\Stubs\PInvokeLazyFixupField.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeLazyFixupField.Sorting.cs">
-      <Link>IL\Stubs\PInvokeLazyFixupField.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StructMarshallingThunk.Sorting.cs">
-      <Link>IL\Stubs\StructMarshallingThunk.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ValueTypeGetFieldHelperMethodOverride.cs">
-      <Link>IL\Stubs\ValueTypeGetFieldHelperMethodOverride.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ValueTypeGetFieldHelperMethodOverride.Sorting.cs">
-      <Link>IL\Stubs\ValueTypeGetFieldHelperMethodOverride.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\TypeSystemContext.DelegateInfo.cs">
-      <Link>IL\TypeSystemContext.DelegateInfo.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\TypeSystemContext.DynamicInvoke.cs">
-      <Link>IL\TypeSystemContext.DynamicInvoke.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\TypeSystemContext.GeneratedAssembly.cs">
-      <Link>IL\TypeSystemContext.GeneratedAssembly.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\TypeSystemContext.GeneratedAssembly.Sorting.cs">
-      <Link>IL\TypeSystemContext.GeneratedAssembly.Sorting.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\EcmaMethodIL.cs">
       <Link>IL\EcmaMethodIL.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\EcmaMethodIL.Symbols.cs">
       <Link>IL\EcmaMethodIL.Symbols.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\HelperExtensions.cs">
-      <Link>IL\HelperExtensions.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\MethodIL.cs">
       <Link>IL\MethodIL.cs</Link>
@@ -535,42 +487,6 @@
     <Compile Include="..\..\Common\TypeSystem\IL\ILOpcodeHelper.cs">
       <Link>IL\ILOpcodeHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\TypeSystemContext.EnumMethods.cs">
-      <Link>IL\TypeSystemContext.EnumMethods.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\TypeSystemContext.ValueTypeMethods.cs">
-      <Link>IL\TypeSystemContext.ValueTypeMethods.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\InlineArrayType.Sorting.cs">
-      <Link>TypeSystem\Interop\IL\InlineArrayType.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalHelpers.cs">
-      <Link>Interop\IL\MarshalHelpers.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalHelpers.Aot.cs">
-      <Link>Interop\IL\MarshalHelpers.Aot.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalUtils.cs">
-      <Link>Interop\IL\MarshalUtils.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\Marshaller.cs">
-      <Link>Interop\IL\Marshaller.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\Marshaller.Aot.cs">
-      <Link>Interop\IL\Marshaller.Aot.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\NativeStructType.Sorting.cs">
-      <Link>TypeSystem\Interop\IL\NativeStructType.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeILEmitterConfiguration.cs">
-      <Link>Interop\IL\PInvokeILEmitterConfiguration.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeILEmitter.cs">
-      <Link>IL\Stubs\PInvokeILEmitter.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeILCodeStreams.cs">
-      <Link>IL\Stubs\PInvokeILCodeStreams.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ILEmitter.cs">
       <Link>IL\Stubs\ILEmitter.cs</Link>
     </Compile>
@@ -585,48 +501,6 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs">
       <Link>IL\Stubs\PInvokeTargetNativeMethod.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DebuggerSteppingHelpers.cs">
-      <Link>IL\Stubs\DebuggerSteppingHelpers.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\CalliMarshallingMethodThunk.cs">
-      <Link>IL\Stubs\CalliMarshallingMethodThunk.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\CalliMarshallingMethodThunk.Mangling.cs">
-      <Link>IL\Stubs\CalliMarshallingMethodThunk.Mangling.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\CalliMarshallingMethodThunk.Sorting.cs">
-      <Link>IL\Stubs\CalliMarshallingMethodThunk.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.cs">
-      <Link>IL\Stubs\DelegateMarshallingMethodThunk.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.Mangling.cs">
-      <Link>IL\Stubs\DelegateMarshallingMethodThunk.Mangling.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateMarshallingMethodThunk.Sorting.cs">
-      <Link>IL\Stubs\DelegateMarshallingMethodThunk.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ForwardDelegateCreationThunk.cs">
-      <Link>IL\Stubs\ForwardDelegateCreationThunk.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ForwardDelegateCreationThunk.Mangling.cs">
-      <Link>IL\Stubs\ForwardDelegateCreationThunk.Mangling.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\ForwardDelegateCreationThunk.Sorting.cs">
-      <Link>IL\Stubs\ForwardDelegateCreationThunk.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateThunks.cs">
-      <Link>IL\Stubs\DelegateThunks.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StructMarshallingThunk.cs">
-      <Link>IL\Stubs\StructMarshallingThunk.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\StructMarshallingThunk.Mangling.cs">
-      <Link>IL\Stubs\StructMarshallingThunk.Mangling.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\NativeStructType.cs">
-      <Link>TypeSystem\Interop\IL\NativeStructType.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Serialization\FieldDesc.Serialization.cs">
       <Link>TypeSystem\CodeGen\FieldDesc.Serialization.cs</Link>
@@ -648,33 +522,6 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Sorting\MethodForInstantiatedType.Sorting.cs">
       <Link>TypeSystem\Sorting\MethodForInstantiatedType.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\NativeStructType.Mangling.cs">
-      <Link>TypeSystem\Interop\IL\NativeStructType.Mangling.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapper.cs">
-      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapper.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapper.Mangling.cs">
-      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapper.Mangling.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapper.Sorting.cs">
-      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapper.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.cs">
-      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.Sorting.cs">
-      <Link>TypeSystem\Interop\IL\PInvokeDelegateWrapperConstructor.Sorting.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\IL\InlineArrayType.cs">
-      <Link>TypeSystem\Interop\IL\InlineArrayType.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\InteropTypes.cs">
-      <Link>TypeSystem\Interop\InteropTypes.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\Interop\InteropStateManager.cs">
-      <Link>TypeSystem\Interop\InteropStateManager.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Interop\FieldDesc.Interop.cs">
       <Link>TypeSystem\Interop\FieldDesc.Interop.cs</Link>
@@ -708,12 +555,6 @@
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\LocalVariableDefinition.cs">
       <Link>TypeSystem\Common\LocalVariableDefinition.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\CodeGen\INonEmittableType.cs">
-      <Link>TypeSystem\CodeGen\INonEmittableType.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\TypeSystem\CodeGen\NativeStructType.CodeGen.cs">
-      <Link>TypeSystem\CodeGen\NativeStructType.CodeGen.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs">
       <Link>TypeSystem\RuntimeDetermined\ArrayType.RuntimeDetermined.cs</Link>

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -270,7 +270,7 @@ namespace ILCompiler
             return argSyntax;
         }
 
-        private IReadOnlyCollection<MethodDesc> CreateInitializerList(TypeSystemContext context)
+        private IReadOnlyCollection<MethodDesc> CreateInitializerList(CompilerTypeSystemContext context)
         {
             List<ModuleDesc> assembliesWithInitalizers = new List<ModuleDesc>();
 
@@ -278,7 +278,7 @@ namespace ILCompiler
             // any user code runs.
             foreach (string initAssemblyName in _initAssemblies)
             {
-                ModuleDesc assembly = context.ResolveAssembly(new AssemblyName(initAssemblyName));
+                ModuleDesc assembly = context.ResolveAssembly(new AssemblyName(initAssemblyName), throwIfNotFound: true);
                 assembliesWithInitalizers.Add(assembly);
             }
 


### PR DESCRIPTION
IL generation (stubs/thunks) is not part of the core type system and these files are not included in ILCompiler.TypeSystem.ReadyToRun. Somehow we accumulated them in ILCompiler.TypeSystem but they can be pretty cleanly moved to ILCompiler.Compiler (left one TODO for a subsequent cleanup since some of what's in Common\TypeSystem should actually be in ILCompiler.Compiler proper).