### PR TITLE
Unify threading between crossgen2 and ilc

### DIFF
--- a/docs/workflow/debugging/coreclr/debugging-aot-compilers.md
+++ b/docs/workflow/debugging/coreclr/debugging-aot-compilers.md
@@ -19,7 +19,7 @@ Built in debugging aids in the managed compilers
 ---------------------------------
 
 - When debugging a multi-threaded component of the compiler and not investigating a multi-threading issue itself, it is generally advisable to disable the use of multiple threads.
-To do this use the `--parallelism 1` switch (for crossgen2) or `--singlethreaded` (for ILC) to specify that the maximum parallelism of the process shall be 1.
+To do this use the `--parallelism 1` switch to specify that the maximum parallelism of the process shall be 1.
 
 - When debugging the behavior of compiling a single method, the compiler may be instructed to only compile a single method. This is done via the various --singlemethod options
 

--- a/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
@@ -23,6 +23,7 @@ namespace ILCompiler
         private DependencyTrackingLevel _dependencyTrackingLevel = DependencyTrackingLevel.None;
         protected IEnumerable<ICompilationRootProvider> _compilationRoots = Array.Empty<ICompilationRootProvider>();
         protected OptimizationMode _optimizationMode = OptimizationMode.None;
+        protected int _parallelism = -1;
 
         public CompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler nameMangler)
         {
@@ -38,6 +39,12 @@ namespace ILCompiler
         public CompilationBuilder UseLogger(Logger logger)
         {
             _logger = logger;
+            return this;
+        }
+
+        public CompilationBuilder UseParallelism(int parallelism)
+        {
+            _parallelism = parallelism;
             return this;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -22,7 +22,6 @@ namespace ILCompiler
         protected MethodImportationErrorProvider _methodImportationErrorProvider = new MethodImportationErrorProvider();
         protected IInliningPolicy _inliningPolicy;
         protected bool _methodBodyFolding;
-        protected bool _singleThreaded;
         protected InstructionSetSupport _instructionSetSupport;
         protected SecurityMitigationOptions _mitigationOptions;
 
@@ -89,12 +88,6 @@ namespace ILCompiler
         public CompilationBuilder UseMethodBodyFolding(bool enable)
         {
             _methodBodyFolding = enable;
-            return this;
-        }
-
-        public CompilationBuilder UseSingleThread(bool enable)
-        {
-            _singleThreaded = enable;
             return this;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScannerBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScannerBuilder.cs
@@ -27,7 +27,7 @@ namespace ILCompiler
         private IEnumerable<ICompilationRootProvider> _compilationRoots = Array.Empty<ICompilationRootProvider>();
         private MetadataManager _metadataManager;
         private InteropStubManager _interopStubManager = new EmptyInteropStubManager();
-        private bool _singleThreaded;
+        private int _parallelism = -1;
 
         internal ILScannerBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler mangler, ILProvider ilProvider, PreinitializationManager preinitializationManager)
         {
@@ -63,9 +63,9 @@ namespace ILCompiler
             return this;
         }
 
-        public ILScannerBuilder UseSingleThread(bool enable)
+        public ILScannerBuilder UseParallelism(int parallelism)
         {
-            _singleThreaded = enable;
+            _parallelism = parallelism;
             return this;
         }
 
@@ -74,7 +74,7 @@ namespace ILCompiler
             var nodeFactory = new ILScanNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _preinitializationManager);
             DependencyAnalyzerBase<NodeFactory> graph = _dependencyTrackingLevel.CreateDependencyGraph(nodeFactory);
 
-            return new ILScanner(graph, nodeFactory, _compilationRoots, _ilProvider, new NullDebugInformationProvider(), _logger, _singleThreaded);
+            return new ILScanner(graph, nodeFactory, _compilationRoots, _ilProvider, new NullDebugInformationProvider(), _logger, _parallelism);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -33,7 +33,6 @@ namespace ILCompiler
         private string _perfMapPath;
         private int _perfMapFormatVersion;
         private bool _generateProfileFile;
-        private int _parallelism;
         Func<MethodDesc, string> _printReproInstructions;
         private InstructionSetSupport _instructionSetSupport;
         private ProfileDataManager _profileData;
@@ -167,12 +166,6 @@ namespace ILCompiler
         public ReadyToRunCodegenCompilationBuilder UseProfileFile(bool generateProfileFile)
         {
             _generateProfileFile = generateProfileFile;
-            return this;
-        }
-
-        public ReadyToRunCodegenCompilationBuilder UseParallelism(int parallelism)
-        {
-            _parallelism = parallelism;
             return this;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -107,9 +107,6 @@ namespace ILCompiler
             if (_methodBodyFolding)
                 options |= RyuJitCompilationOptions.MethodBodyFolding;
 
-            if (_singleThreaded)
-                options |= RyuJitCompilationOptions.SingleThreadedCompilation;
-
             if ((_mitigationOptions & SecurityMitigationOptions.ControlFlowGuardAnnotations) != 0)
                 options |= RyuJitCompilationOptions.ControlFlowGuardAnnotations;
 
@@ -117,7 +114,7 @@ namespace ILCompiler
 
             JitConfigProvider.Initialize(_context.Target, jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, _methodImportationErrorProvider, options);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, _methodImportationErrorProvider, options, _parallelism);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>ILCompiler</RootNamespace>
     <AssemblyName>ILCompiler.RyuJit</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Platforms>x64;x86</Platforms>

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -57,7 +57,7 @@ namespace ILCompiler
         private bool _reflectedOnly;
         private bool _scanReflection;
         private bool _methodBodyFolding;
-        private bool _singleThreaded;
+        private int _parallelism = Environment.ProcessorCount;
         private string _instructionSet;
         private string _guard;
 
@@ -205,7 +205,7 @@ namespace ILCompiler
                 syntax.DefineOptionList("appcontextswitch", ref _appContextSwitches, "System.AppContext switches to set (format: 'Key=Value')");
                 syntax.DefineOptionList("feature", ref _featureSwitches, "Feature switches to apply (format: 'Namespace.Name=[true|false]'");
                 syntax.DefineOptionList("runtimeopt", ref _runtimeOptions, "Runtime options to set");
-                syntax.DefineOption("singlethreaded", ref _singleThreaded, "Run compilation on a single thread");
+                syntax.DefineOption("parallelism", ref _parallelism, "Maximum number of threads to use during compilation");
                 syntax.DefineOption("instructionset", ref _instructionSet, "Instruction set to allow or disallow");
                 syntax.DefineOption("guard", ref _guard, "Enable mitigations. Options: 'cf': CFG (Control Flow Guard, Windows only)");
                 syntax.DefineOption("preinitstatics", ref _preinitStatics, "Interpret static constructors at compile time if possible (implied by -O)");
@@ -730,7 +730,7 @@ namespace ILCompiler
                 ILScannerBuilder scannerBuilder = builder.GetILScannerBuilder()
                     .UseCompilationRoots(compilationRoots)
                     .UseMetadataManager(metadataManager)
-                    .UseSingleThread(enable: _singleThreaded)
+                    .UseParallelism(_parallelism)
                     .UseInteropStubManager(interopStubManager);
 
                 if (_scanDgmlLogFileName != null)
@@ -759,7 +759,7 @@ namespace ILCompiler
                 .UseInstructionSetSupport(instructionSetSupport)
                 .UseBackendOptions(_codegenOptions)
                 .UseMethodBodyFolding(enable: _methodBodyFolding)
-                .UseSingleThread(enable: _singleThreaded)
+                .UseParallelism(_parallelism)
                 .UseMetadataManager(metadataManager)
                 .UseInteropStubManager(interopStubManager)
                 .UseLogger(logger)

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -736,7 +736,6 @@ namespace ILCompiler
                         .UsePdbFile(_commandLineOptions.Pdb, _commandLineOptions.PdbPath)
                         .UsePerfMapFile(_commandLineOptions.PerfMap, _commandLineOptions.PerfMapPath, _commandLineOptions.PerfMapFormatVersion)
                         .UseProfileFile(jsonProfile != null)
-                        .UseParallelism(_commandLineOptions.Parallelism)
                         .UseProfileData(profileDataManager)
                         .FileLayoutAlgorithms(_methodLayout, _fileLayout)
                         .UseCompositeImageSettings(compositeImageSettings)
@@ -748,6 +747,7 @@ namespace ILCompiler
                         .UseILProvider(ilProvider)
                         .UseBackendOptions(_commandLineOptions.CodegenOptions)
                         .UseLogger(logger)
+                        .UseParallelism(_commandLineOptions.Parallelism)
                         .UseDependencyTracking(trackingLevel)
                         .UseCompilationRoots(compilationRoots)
                         .UseOptimizationMode(optimizationMode);


### PR DESCRIPTION
They don't have to differ in the `--parallelism` vs `--singlethreaded` argument.

Capping the number of threads seems to improve compile throughput by about 0.5%, although I was hoping for a better improvement compared to the brute force "throw workitems on the threadpool" approach.