### PR TITLE
Revert SafeBuffer change around pointer initialization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -153,6 +153,8 @@ namespace System.Runtime.InteropServices
             if (_numBytes == Uninitialized)
                 throw NotInitialized();
 
+            pointer = null;
+
             bool junk = false;
             DangerousAddRef(ref junk);
             pointer = (byte*)handle;

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -40,6 +40,18 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
+        public unsafe void AcquirePointer_Disposed_ThrowsObjectDisposedException()
+        {
+            var buffer = new SubBuffer(true);
+            buffer.Initialize(4);
+            buffer.Dispose();
+
+            byte* pointer = (byte*)12345;
+            Assert.Throws<ObjectDisposedException>(() => buffer.AcquirePointer(ref pointer));
+            Assert.True(pointer is null);
+        }
+
+        [Fact]
         public void ReleasePointer_NotInitialized_ThrowsInvalidOperationException()
         {
             var wrapper = new SubBuffer(true);


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/63020#discussion_r777527230
cc: @marek-safar 