### PR TITLE
Improved HTTP/1 header parser

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <WindowsRID>win</WindowsRID>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -80,6 +80,7 @@
     <Compile Include="System\Net\Http\RequestRetryType.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpMessageHandlerStage.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RuntimeSettingParser.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SimdPaddedArray.cs" />
     <Compile Include="System\Net\Http\StreamContent.cs" />
     <Compile Include="System\Net\Http\StreamToStreamCopy.cs" />
     <Compile Include="System\Net\Http\StringContent.cs" />
@@ -668,6 +669,7 @@
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.InteropServices" />
+    <Reference Include="System.Runtime.Intrinsics" />
     <Reference Include="System.Security.Claims" Condition="'$(TargetsWindows)' == 'true'" />
     <Reference Include="System.Security.Cryptography" />
     <Reference Include="System.Security.Cryptography.Algorithms" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -21,18 +21,21 @@ namespace System.Net.Http
             /// infinite chunk length is sent.  This value is arbitrary and can be changed as needed.
             /// </remarks>
             private const int MaxChunkBytesAllowed = 16 * 1024;
-            /// <summary>How long a trailing header can be.  This value is arbitrary and can be changed as needed.</summary>
-            private const int MaxTrailingHeaderLength = 16 * 1024;
             /// <summary>The number of bytes remaining in the chunk.</summary>
             private ulong _chunkBytesRemaining;
             /// <summary>The current state of the parsing state machine for the chunked response.</summary>
             private ParsingState _state = ParsingState.ExpectChunkHeader;
             private readonly HttpResponseMessage _response;
+            private readonly int _trailingHeaderBytesAllowed;
 
             public ChunkedEncodingReadStream(HttpConnection connection, HttpResponseMessage response) : base(connection)
             {
                 Debug.Assert(response != null, "The HttpResponseMessage cannot be null.");
                 _response = response;
+
+                // _allowedReadLineBytes is reset when reading chunk indicators.
+                // save the original here, which will be the total header bytes minus already received headers.
+                _trailingHeaderBytesAllowed = connection._allowedReadLineBytes;
             }
 
             public override int Read(Span<byte> buffer)
@@ -361,6 +364,7 @@ namespace System.Net.Http
                             }
                             else
                             {
+                                _connection._allowedReadLineBytes = _trailingHeaderBytesAllowed;
                                 _state = ParsingState.ConsumeTrailers;
                                 goto case ParsingState.ConsumeTrailers;
                             }
@@ -406,39 +410,24 @@ namespace System.Net.Http
                         case ParsingState.ConsumeTrailers:
                             Debug.Assert(_chunkBytesRemaining == 0, $"Expected {nameof(_chunkBytesRemaining)} == 0, got {_chunkBytesRemaining}");
 
-                            while (true)
+                            // Consume receive buffer. If the stream is disposed, pass a null response to avoid
+                            // processing headers for a connection returned to the pool.
+
+                            if (_connection!.ParseHeaders(IsDisposed ? null : _response, isFromTrailer: true))
                             {
-                                _connection._allowedReadLineBytes = MaxTrailingHeaderLength;
-                                if (!_connection.TryReadNextLine(out currentLine))
-                                {
-                                    break;
-                                }
+                                // Dispose of the registration and then check whether cancellation has been
+                                // requested. This is necessary to make determinstic a race condition between
+                                // cancellation being requested and unregistering from the token.  Otherwise,
+                                // it's possible cancellation could be requested just before we unregister and
+                                // we then return a connection to the pool that has been or will be disposed
+                                // (e.g. if a timer is used and has already queued its callback but the
+                                // callback hasn't yet run).
+                                cancellationRegistration.Dispose();
+                                CancellationHelper.ThrowIfCancellationRequested(cancellationRegistration.Token);
 
-                                if (currentLine.IsEmpty)
-                                {
-                                    // Dispose of the registration and then check whether cancellation has been
-                                    // requested. This is necessary to make determinstic a race condition between
-                                    // cancellation being requested and unregistering from the token.  Otherwise,
-                                    // it's possible cancellation could be requested just before we unregister and
-                                    // we then return a connection to the pool that has been or will be disposed
-                                    // (e.g. if a timer is used and has already queued its callback but the
-                                    // callback hasn't yet run).
-                                    cancellationRegistration.Dispose();
-                                    CancellationHelper.ThrowIfCancellationRequested(cancellationRegistration.Token);
-
-                                    _state = ParsingState.Done;
-                                    _connection.CompleteResponse();
-                                    _connection = null;
-
-                                    break;
-                                }
-                                // Parse the trailer.
-                                else if (!IsDisposed)
-                                {
-                                    // Make sure that we don't inadvertently consume trailing headers
-                                    // while draining a connection that's being returned back to the pool.
-                                    HttpConnection.ParseHeaderNameValue(_connection, currentLine, _response, isFromTrailer: true);
-                                }
+                                _state = ParsingState.Done;
+                                _connection.CompleteResponse();
+                                _connection = null;
                             }
 
                             return default;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SimdPaddedArray.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SimdPaddedArray.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.Intrinsics.X86;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// An array that ensures valid address space before
+    /// and after the array's bytes, to support SIMD loads.
+    /// </summary>
+    internal readonly struct SimdPaddedArray
+    {
+        private static int PaddingLength =>
+            Avx2.IsSupported ? 31 :
+            0;
+
+        private readonly byte[] _array;
+
+        public int Length => _array.Length - PaddingLength;
+        public byte[] BackingArray => _array;
+
+
+        public SimdPaddedArray(int length)
+            : this(new byte[length + PaddingLength])
+        {
+        }
+
+        private SimdPaddedArray(byte[] array)
+        {
+            _array = array;
+        }
+
+        public static SimdPaddedArray FromPool(int length) => new SimdPaddedArray(ArrayPool<byte>.Shared.Rent(length));
+
+        public Span<byte> AsSpan() => AsSpan(0, Length);
+        public Span<byte> AsSpan(int offset, int length)
+        {
+            Debug.Assert(length - offset <= Length);
+            return new Span<byte>(_array, offset, length);
+        }
+
+        public Memory<byte> AsMemory() => AsMemory(0, Length);
+        public Memory<byte> AsMemory(int offset, int length)
+        {
+            Debug.Assert(length - offset <= Length);
+            return new Memory<byte>(_array, offset, length);
+        }
+
+        public ref byte this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < Length);
+                return ref _array[index];
+            }
+        }
+    }
+}


### PR DESCRIPTION
This replaces the SocketsHttpHandler header parser with two implementations: AVX2, and portable. This ports over the work done as part of the LLHTTP project.

This gives a 5-10% end-to-end perf improvement over localhost:

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, chunkedResponse |      1.09 |         34244.28 |         31391.45 |         |
| System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get(ssl: False, chunkedResponse |      1.08 |         33410.35 |         30836.15 |         |
| System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get_EnumerateHeaders_Validated( |      1.08 |         34049.97 |         31524.56 |         |
| System.Net.Http.Tests.SocketsHttpHandlerPerfTest.Get_EnumerateHeaders_Unvalidate |      1.07 |         37427.29 |         34867.46 | several?|

The AVX2 parser has 50-100% performance improvement over the portable implementation. It is faster in every situation (few headers, lots of headers, small headers, large headers).

|          Method | HeaderCount | HeaderNameSize | HeaderValueSize |      Mean |    Error |   StdDev |
|---------------- |------------ |--------------- |---------------- |----------:|---------:|---------:|
| PortableHeaders |           1 |              1 |               1 |  14.20 ns | 0.078 ns | 0.073 ns |
|     Avx2Headers |           1 |              1 |               1 |  10.50 ns | 0.094 ns | 0.088 ns |
| PortableHeaders |           1 |              1 |               8 |  15.06 ns | 0.096 ns | 0.090 ns |
|     Avx2Headers |           1 |              1 |               8 |  10.48 ns | 0.069 ns | 0.065 ns |
| PortableHeaders |           1 |              1 |             128 |  18.05 ns | 0.089 ns | 0.084 ns |
|     Avx2Headers |           1 |              1 |             128 |  12.20 ns | 0.112 ns | 0.105 ns |
| PortableHeaders |           1 |              8 |               1 |  14.26 ns | 0.087 ns | 0.081 ns |
|     Avx2Headers |           1 |              8 |               1 |  10.49 ns | 0.080 ns | 0.071 ns |
| PortableHeaders |           1 |              8 |               8 |  14.83 ns | 0.074 ns | 0.065 ns |
|     Avx2Headers |           1 |              8 |               8 |  10.52 ns | 0.073 ns | 0.069 ns |
| PortableHeaders |           1 |              8 |             128 |  16.38 ns | 0.103 ns | 0.091 ns |
|     Avx2Headers |           1 |              8 |             128 |  12.73 ns | 0.075 ns | 0.066 ns |
| PortableHeaders |           1 |             16 |               1 |  14.15 ns | 0.129 ns | 0.108 ns |
|     Avx2Headers |           1 |             16 |               1 |  10.67 ns | 0.115 ns | 0.096 ns |
| PortableHeaders |           1 |             16 |               8 |  15.27 ns | 0.227 ns | 0.201 ns |
|     Avx2Headers |           1 |             16 |               8 |  10.69 ns | 0.115 ns | 0.108 ns |
| PortableHeaders |           1 |             16 |             128 |  18.44 ns | 0.143 ns | 0.133 ns |
|     Avx2Headers |           1 |             16 |             128 |  13.01 ns | 0.243 ns | 0.227 ns |
| PortableHeaders |           8 |              1 |               1 |  56.03 ns | 0.711 ns | 0.665 ns |
|     Avx2Headers |           8 |              1 |               1 |  29.64 ns | 0.430 ns | 0.403 ns |
| PortableHeaders |           8 |              1 |               8 |  67.30 ns | 0.311 ns | 0.275 ns |
|     Avx2Headers |           8 |              1 |               8 |  31.10 ns | 0.180 ns | 0.151 ns |
| PortableHeaders |           8 |              1 |             128 |  82.21 ns | 0.448 ns | 0.397 ns |
|     Avx2Headers |           8 |              1 |             128 |  50.41 ns | 0.593 ns | 0.555 ns |
| PortableHeaders |           8 |              8 |               1 |  58.42 ns | 1.005 ns | 0.940 ns |
|     Avx2Headers |           8 |              8 |               1 |  30.94 ns | 0.189 ns | 0.176 ns |
| PortableHeaders |           8 |              8 |               8 |  72.81 ns | 0.912 ns | 0.853 ns |
|     Avx2Headers |           8 |              8 |               8 |  31.56 ns | 0.133 ns | 0.124 ns |
| PortableHeaders |           8 |              8 |             128 |  86.82 ns | 0.714 ns | 0.633 ns |
|     Avx2Headers |           8 |              8 |             128 |  51.55 ns | 0.286 ns | 0.267 ns |
| PortableHeaders |           8 |             16 |               1 |  55.19 ns | 0.160 ns | 0.149 ns |
|     Avx2Headers |           8 |             16 |               1 |  32.95 ns | 0.297 ns | 0.278 ns |
| PortableHeaders |           8 |             16 |               8 |  74.59 ns | 0.375 ns | 0.351 ns |
|     Avx2Headers |           8 |             16 |               8 |  34.22 ns | 0.121 ns | 0.108 ns |
| PortableHeaders |           8 |             16 |             128 |  84.59 ns | 0.311 ns | 0.276 ns |
|     Avx2Headers |           8 |             16 |             128 |  51.96 ns | 0.298 ns | 0.279 ns |
| PortableHeaders |          16 |              1 |               1 | 119.45 ns | 0.736 ns | 0.688 ns |
|     Avx2Headers |          16 |              1 |               1 |  52.34 ns | 0.367 ns | 0.306 ns |
| PortableHeaders |          16 |              1 |               8 | 134.94 ns | 0.466 ns | 0.436 ns |
|     Avx2Headers |          16 |              1 |               8 |  53.98 ns | 0.322 ns | 0.301 ns |
| PortableHeaders |          16 |              1 |             128 | 171.17 ns | 1.379 ns | 1.290 ns |
|     Avx2Headers |          16 |              1 |             128 | 100.83 ns | 0.502 ns | 0.445 ns |
| PortableHeaders |          16 |              8 |               1 | 109.07 ns | 0.498 ns | 0.465 ns |
|     Avx2Headers |          16 |              8 |               1 |  53.92 ns | 0.129 ns | 0.120 ns |
| PortableHeaders |          16 |              8 |               8 | 140.69 ns | 0.591 ns | 0.553 ns |
|     Avx2Headers |          16 |              8 |               8 |  56.92 ns | 0.243 ns | 0.203 ns |
| PortableHeaders |          16 |              8 |             128 | 169.72 ns | 0.592 ns | 0.494 ns |
|     Avx2Headers |          16 |              8 |             128 |  99.44 ns | 0.401 ns | 0.375 ns |
| PortableHeaders |          16 |             16 |               1 | 114.38 ns | 0.338 ns | 0.282 ns |
|     Avx2Headers |          16 |             16 |               1 |  56.66 ns | 0.152 ns | 0.142 ns |
| PortableHeaders |          16 |             16 |               8 | 142.28 ns | 0.481 ns | 0.402 ns |
|     Avx2Headers |          16 |             16 |               8 |  60.48 ns | 0.328 ns | 0.306 ns |
| PortableHeaders |          16 |             16 |             128 | 167.60 ns | 0.416 ns | 0.389 ns |
|     Avx2Headers |          16 |             16 |             128 | 108.95 ns | 0.446 ns | 0.417 ns |