### PR TITLE
[release/6.0] bump sourcebuild leg timeout

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -336,6 +336,7 @@ stages:
         extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
         extraStepsParameters:
           name: SourceBuildPackages
+        timeoutInMinutes: 95
       
 
   #

--- a/src/installer/tests/TestUtils/Command.cs
+++ b/src/installer/tests/TestUtils/Command.cs
@@ -206,11 +206,9 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                     Process.Start();
                     break;
                 }
-                catch (Win32Exception e) when (i < 3 && e.Message.Contains("Text file busy"))
+                catch (Win32Exception e) when (i < 4 && e.Message.Contains("Text file busy"))
                 {
-                    // 10 ms is short, but the race we're trying to avoid is in-between
-                    // "fork" and "exec", so it should be fast
-                    Thread.Sleep(10);
+                    Thread.Sleep(i * 20);
                 }
             }
 


### PR DESCRIPTION
This leg sometimes hits timeout on the official build as the 60 mins default timeout is too tight to how long it takes to finish. 

This is a port of: https://github.com/dotnet/runtime/pull/61436