### PR TITLE
[metadata] Borrow bits from MonoClassField:parent for flags

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -4084,5 +4084,12 @@ mono_classes_init (void)
 void
 m_field_set_parent (MonoClassField *field, MonoClass *klass)
 {
-	field->parent_ = klass;
+	uintptr_t old_flags = m_field_get_meta_flags (field);
+	field->parent_and_flags = ((uintptr_t)klass) | old_flags;
+}
+
+void
+m_field_set_meta_flags (MonoClassField *field, unsigned int flags)
+{
+	field->parent_and_flags |= (field->parent_and_flags & ~MONO_CLASS_FIELD_META_FLAG_MASK) | flags;
 }

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -147,7 +147,8 @@ struct _MonoClassField {
 
 	/* Type where the field was defined */
 	/* Do not access directly, use m_field_get_parent */
-	MonoClass       *parent_;
+	/* We use the lowest bits of the pointer to store some flags, see m_field_get_meta_flags */
+	uintptr_t	parent_and_flags;
 
 	/*
 	 * Offset where this field is stored; if it is an instance
@@ -1536,20 +1537,47 @@ mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method);
 		}								\
 	}									\
 
+/* Metadata flags for MonoClassField.  These are stored in the lowest bits of a pointer, so there
+ * can't be too many. */
+enum {
+	/* This MonoClassField was added by EnC metadata update, it's not part of the
+	 * MonoClass:fields array, and at runtime it is not stored like ordinary instance or static
+	 * fields. */
+	MONO_CLASS_FIELD_META_FLAG_FROM_UPDATE = 0x01u,
+
+	/* Lowest 2 bits of a pointer reserved for flags */
+	MONO_CLASS_FIELD_META_FLAG_MASK = 0x03u,
+};
+
 static inline MonoClass *
 m_field_get_parent (MonoClassField *field)
 {
-	return field->parent_;
+	return (MonoClass*)(field->parent_and_flags & ~MONO_CLASS_FIELD_META_FLAG_MASK);
+}
+
+static inline unsigned int
+m_field_get_meta_flags (MonoClassField *field)
+{
+	return (unsigned int)(field->parent_and_flags & MONO_CLASS_FIELD_META_FLAG_MASK);
 }
 
 void
 m_field_set_parent (MonoClassField *field, MonoClass *klass);
+
+void
+m_field_set_meta_flags (MonoClassField *field, unsigned int flags);
 
 static inline gboolean
 m_field_get_offset (MonoClassField *field)
 {
 	g_assert (m_class_is_fields_inited (m_field_get_parent (field)));
 	return field->offset;
+}
+
+static inline gboolean
+m_field_is_from_update (MonoClassField *field)
+{
+	return (m_field_get_meta_flags (field) & MONO_CLASS_FIELD_META_FLAG_FROM_UPDATE) != 0;
 }
 
 /*


### PR DESCRIPTION
We need a way to indicate that a `MonoClassField` isn't from the `MonoClass:fields` array, that it was added later by EnC metadata update.

Use the lowest two bits from the parent pointer for this.

Added EnC fields will be allocated separately, so field index calculations using pointer arithmetic won't work on them.