### PR TITLE
Add alignment to mapped field stream

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
@@ -121,7 +121,7 @@ namespace System.Reflection.PortableExecutable
 
         public const int MappedFieldDataAlignment = 8;
 
-        public int CalculateOffsetToMappedFieldDataStream()
+        internal int CalculateOffsetToMappedFieldDataStreamUnaligned()
         {
             int result = ComputeOffsetToImportTable();
 
@@ -133,6 +133,16 @@ namespace System.Reflection.PortableExecutable
             }
 
             return result;
+        }
+
+        public int CalculateOffsetToMappedFieldDataStream()
+        {
+             int result = CalculateOffsetToMappedFieldDataStreamUnaligned();
+             if (MappedFieldDataSize != 0)
+             {
+                 result = BitArithmetic.Align(result, MappedFieldDataAlignment);
+             }
+             return result;
         }
 
         internal int ComputeOffsetToDebugDirectory()
@@ -185,7 +195,7 @@ namespace System.Reflection.PortableExecutable
         {
             // TODO: constants
             return RequiresStartupStub ?
-                rva + CalculateOffsetToMappedFieldDataStream() - (Is32Bit ? 6 : 10) :
+                rva + CalculateOffsetToMappedFieldDataStreamUnaligned() - (Is32Bit ? 6 : 10) :
                 0;
         }
 
@@ -293,6 +303,7 @@ namespace System.Reflection.PortableExecutable
             // mapped field data:
             if (mappedFieldDataBuilderOpt != null)
             {
+                builder.Align(MappedFieldDataAlignment);
                 builder.LinkSuffix(mappedFieldDataBuilderOpt);
             }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
@@ -303,7 +303,8 @@ namespace System.Reflection.PortableExecutable
             // mapped field data:
             if (mappedFieldDataBuilderOpt != null)
             {
-                builder.Align(MappedFieldDataAlignment);
+                if (mappedFieldDataBuilderOpt.Count != 0)
+                    builder.Align(MappedFieldDataAlignment);
                 builder.LinkSuffix(mappedFieldDataBuilderOpt);
             }
 


### PR DESCRIPTION
- Align the mapped field data to `ManagedPEBuilder.MappedFieldDataAlignment` (which is 8)
- Add a test to verify that it is correctly aligned

This is in support Roslyn generation of code for #60948

Fixes #62313