### PR TITLE
Fix GetSpanDataFrom

### DIFF
--- a/src/coreclr/classlibnative/bcltype/arraynative.h
+++ b/src/coreclr/classlibnative/bcltype/arraynative.h
@@ -48,7 +48,7 @@ public:
 
     // This method will acquire data to create a span from a TypeHandle
     // to a field.
-    static FCDECL3_VVI(void*, GetSpanDataFrom, FCALLRuntimeFieldHandle structField, FCALLRuntimeTypeHandle targetType, INT32* count);
+    static FCDECL3_VVI(void*, GetSpanDataFrom, FCALLRuntimeFieldHandle structField, FCALLRuntimeTypeHandle targetTypeUnsafe, INT32* count);
 
 private:
     // Helper for CreateInstance

--- a/src/coreclr/classlibnative/bcltype/arraynative.h
+++ b/src/coreclr/classlibnative/bcltype/arraynative.h
@@ -48,7 +48,7 @@ public:
 
     // This method will acquire data to create a span from a TypeHandle
     // to a field.
-    static FCDECL3(void*, GetSpanDataFrom, FCALLRuntimeFieldHandle structField, FCALLRuntimeTypeHandle targetType, INT32* count);
+    static FCDECL3_VVI(void*, GetSpanDataFrom, FCALLRuntimeFieldHandle structField, FCALLRuntimeTypeHandle targetType, INT32* count);
 
 private:
     // Helper for CreateInstance

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -57,9 +57,6 @@
         <ExcludeList Include="$(XUnitTestBinBase)/JIT/HardwareIntrinsics/X86/X86Base/Pause*/**">
             <Issue>https://github.com/dotnet/runtime/issues/62423</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/Intrinsics/CreateSpan_il/*">
-            <Issue>https://github.com/dotnet/runtime/issues/62285</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Loader/binding/tracing/BinderTracingTest.Basic/*">
             <Issue>https://github.com/dotnet/runtime/issues/57786</Issue>
         </ExcludeList>


### PR DESCRIPTION
- GC Protect the type parameter
- set data to value before asserting that it isn't NULL

Fixes #62285