### PR TITLE
Use generic collections in System.ComponentModel.TypeConverter implementation

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.ComponentModel
@@ -19,7 +20,7 @@ namespace System.ComponentModel
         /// </summary>
         public static readonly AttributeCollection Empty = new AttributeCollection(null);
 
-        private static Hashtable? s_defaultAttributes;
+        private static Dictionary<Type, Attribute?>? s_defaultAttributes;
 
         private readonly Attribute[] _attributes;
 
@@ -268,13 +269,13 @@ namespace System.ComponentModel
             {
                 if (s_defaultAttributes == null)
                 {
-                    s_defaultAttributes = new Hashtable();
+                    s_defaultAttributes = new Dictionary<Type, Attribute?>();
                 }
 
                 // If we have already encountered this, use what's in the table.
-                if (s_defaultAttributes.ContainsKey(attributeType))
+                if (s_defaultAttributes.TryGetValue(attributeType, out Attribute? defaultAttribute))
                 {
-                    return (Attribute?)s_defaultAttributes[attributeType];
+                    return defaultAttribute;
                 }
 
                 Attribute? attr = null;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentResourceManager.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ComponentResourceManager.cs
@@ -17,7 +17,7 @@ namespace System.ComponentModel
     /// </summary>
     public class ComponentResourceManager : ResourceManager
     {
-        private Hashtable? _resourceSets;
+        private Dictionary<CultureInfo, SortedList<string, object?>?>? _resourceSets;
         private CultureInfo? _neutralResourcesCulture;
 
         public ComponentResourceManager()
@@ -93,13 +93,13 @@ namespace System.ComponentModel
 
             if (_resourceSets == null)
             {
-                _resourceSets = new Hashtable();
+                _resourceSets = new Dictionary<CultureInfo, SortedList<string, object?>?>();
                 resources = FillResources(culture, out _);
                 _resourceSets[culture] = resources;
             }
             else
             {
-                resources = (SortedList<string, object?>?)_resourceSets[culture];
+                resources = _resourceSets.GetValueOrDefault(culture, defaultValue: null);
                 if (resources == null || (resources.Comparer.Equals(StringComparer.OrdinalIgnoreCase) != IgnoreCase))
                 {
                     resources = FillResources(culture, out _);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/ContextStack.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/ContextStack.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
+using System.Collections.Generic;
 
 namespace System.ComponentModel.Design.Serialization
 {
@@ -23,7 +23,7 @@ namespace System.ComponentModel.Design.Serialization
     /// </summary>
     public sealed class ContextStack
     {
-        private ArrayList? _contextStack;
+        private List<object>? _contextStack;
 
         /// <summary>
         /// Retrieves the current object on the stack, or null
@@ -108,7 +108,7 @@ namespace System.ComponentModel.Design.Serialization
 
             if (_contextStack == null)
             {
-                _contextStack = new ArrayList();
+                _contextStack = new List<object>();
             }
             _contextStack.Insert(0, context);
         }
@@ -143,7 +143,7 @@ namespace System.ComponentModel.Design.Serialization
 
             if (_contextStack == null)
             {
-                _contextStack = new ArrayList();
+                _contextStack = new List<object>();
             }
             _contextStack.Add(context);
         }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.LicenseInteropHelper.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.LicenseInteropHelper.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel.Design;
-using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace System.ComponentModel
 {
@@ -64,9 +62,9 @@ namespace System.ComponentModel
         // Used from IClassFactory2 when retrieving LicInfo
         private sealed class LicInfoHelperLicenseContext : LicenseContext
         {
-            private readonly Hashtable _savedLicenseKeys = new Hashtable();
+            private readonly Dictionary<string, string> _savedLicenseKeys = new Dictionary<string, string>();
 
-            public bool Contains(string assemblyName) => _savedLicenseKeys.Contains(assemblyName);
+            public bool Contains(string assemblyName) => _savedLicenseKeys.ContainsKey(assemblyName);
 
             public override LicenseUsageMode UsageMode => LicenseUsageMode.Designtime;
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -15,7 +16,7 @@ namespace System.ComponentModel
         internal const string PropertyDescriptorPropertyTypeMessage = "PropertyDescriptor's PropertyType cannot be statically discovered.";
 
         private TypeConverter? _converter;
-        private Hashtable? _valueChangedHandlers;
+        private Dictionary<object, EventHandler?>? _valueChangedHandlers;
         private object?[]? _editors;
         private Type[]? _editorTypes;
         private int _editorCount;
@@ -134,11 +135,11 @@ namespace System.ComponentModel
 
             if (_valueChangedHandlers == null)
             {
-                _valueChangedHandlers = new Hashtable();
+                _valueChangedHandlers = new Dictionary<object, EventHandler?>();
             }
 
-            EventHandler? h = (EventHandler?)_valueChangedHandlers[component];
-            _valueChangedHandlers[component] = Delegate.Combine(h, handler);
+            EventHandler? h = _valueChangedHandlers.GetValueOrDefault(component, defaultValue: null);
+            _valueChangedHandlers[component] = (EventHandler?)Delegate.Combine(h, handler);
         }
 
         /// <summary>
@@ -392,7 +393,7 @@ namespace System.ComponentModel
         {
             if (component != null)
             {
-                ((EventHandler?)_valueChangedHandlers?[component])?.Invoke(component, e);
+                _valueChangedHandlers?.GetValueOrDefault(component, defaultValue: null)?.Invoke(component, e);
             }
         }
 
@@ -412,7 +413,7 @@ namespace System.ComponentModel
 
             if (_valueChangedHandlers != null)
             {
-                EventHandler? h = (EventHandler?)_valueChangedHandlers[component];
+                EventHandler? h = _valueChangedHandlers.GetValueOrDefault(component, defaultValue: null);
                 h = (EventHandler?)Delegate.Remove(h, handler);
                 if (h != null)
                 {
@@ -434,7 +435,7 @@ namespace System.ComponentModel
         {
             if (component != null && _valueChangedHandlers != null)
             {
-                return (EventHandler?)_valueChangedHandlers[component];
+                return _valueChangedHandlers.GetValueOrDefault(component, defaultValue: null);
             }
             else
             {


### PR DESCRIPTION
Fix #17217 by replacing non-generic collections classes with their generic counterparts. Of specific interest are:

- The EditorTable related collections are public, and thus can't be converted without changing the public API
- In a couple of places we have public APIs that return the Hashtable's enumerator, so we need to leave those as-is so the enumerated items are `DictionaryEntry` and not `KeyValuePair`
- In places where the `Hashtables` were static, I verified that every use was either already under a lock, or switched to a `ConcurrentDictionary` to more closely match the Hashtable semantics of allowing multiple readers and a single writer