### PR TITLE
[DllImportGenerator] Update buffer size field for custom marshalling

### DIFF
--- a/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
@@ -67,7 +67,8 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// Number kept small to ensure that P/Invokes with a lot of array parameters doesn't
         /// blow the stack since this is a new optimization in the code-generated interop.
         /// </summary>
-        public const int StackBufferSize = 0x200;
+        public const int BufferSize = 0x200;
+        public const bool RequiresStackBuffer = true;
 
         public Span<T> ManagedValues => _managedArray;
 
@@ -160,7 +161,8 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// Number kept small to ensure that P/Invokes with a lot of array parameters doesn't
         /// blow the stack since this is a new optimization in the code-generated interop.
         /// </summary>
-        public const int StackBufferSize = 0x200;
+        public const int BufferSize = 0x200;
+        public const bool RequiresStackBuffer = true;
 
         public Span<IntPtr> ManagedValues => Unsafe.As<IntPtr[]>(_managedArray);
 

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Interop.Analyzers
             public const string ValuePropertyMustHaveSetter = Prefix + "008";
             public const string ValuePropertyMustHaveGetter = Prefix + "009";
             public const string GetPinnableReferenceShouldSupportAllocatingMarshallingFallback = Prefix + "010";
-            public const string StackallocMarshallingShouldSupportAllocatingMarshallingFallback = Prefix + "011";
-            public const string StackallocConstructorMustHaveStackBufferSizeConstant = Prefix + "012";
+            public const string CallerAllocMarshallingShouldSupportAllocatingMarshallingFallback = Prefix + "011";
+            public const string CallerAllocConstructorMustHaveStackBufferSizeConstant = Prefix + "012";
             public const string RefValuePropertyUnsupported = Prefix + "014";
             public const string NativeGenericTypeMustBeClosedOrMatchArity = Prefix + "016";
             public const string MarshallerGetPinnableReferenceRequiresValueProperty = Prefix + "018";

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.Designer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.Designer.cs
@@ -79,6 +79,42 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named BufferSize to provide the size of the caller-allocated buffer..
+        /// </summary>
+        internal static string CallerAllocConstructorMustHaveBufferSizeConstantDescription {
+            get {
+                return ResourceManager.GetString("CallerAllocConstructorMustHaveBufferSizeConstantDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The native type &apos;{0}&apos; must have a &apos;public const int BufferSize&apos; field that specifies the size of the stack buffer because it has a constructor that takes a caller-allocated Span&lt;byte&gt;.
+        /// </summary>
+        internal static string CallerAllocConstructorMustHaveBufferSizeConstantMessage {
+            get {
+                return ResourceManager.GetString("CallerAllocConstructorMustHaveBufferSizeConstantMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible..
+        /// </summary>
+        internal static string CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription {
+            get {
+                return ResourceManager.GetString("CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Native type &apos;{0}&apos; has a constructor taking a caller-allocated buffer, but does not support marshalling in scenarios where using a caller-allocated buffer is impossible.
+        /// </summary>
+        internal static string CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackMessage {
+            get {
+                return ResourceManager.GetString("CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;BlittableTypeAttribute&apos; and &apos;NativeMarshallingAttribute&apos; attributes are mutually exclusive..
         /// </summary>
         internal static string CannotHaveMultipleMarshallingAttributesDescription {
@@ -489,42 +525,6 @@ namespace Microsoft.Interop {
         internal static string SafeHandleByRefMustBeConcrete {
             get {
                 return ResourceManager.GetString("SafeHandleByRefMustBeConcrete", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to When constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named StackBufferSize to provide the size of the stack-allocated buffer..
-        /// </summary>
-        internal static string StackallocConstructorMustHaveStackBufferSizeConstantDescription {
-            get {
-                return ResourceManager.GetString("StackallocConstructorMustHaveStackBufferSizeConstantDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The native type &apos;{0}&apos; must have a &apos;public const int StackBufferSize&apos; field that specifies the size of the stack buffer because it has a constructor that takes a stack-allocated Span&lt;byte&gt;.
-        /// </summary>
-        internal static string StackallocConstructorMustHaveStackBufferSizeConstantMessage {
-            get {
-                return ResourceManager.GetString("StackallocConstructorMustHaveStackBufferSizeConstantMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A type that supports marshalling from managed to native by stack allocation should also support marshalling from managed to native where stack allocation is impossible..
-        /// </summary>
-        internal static string StackallocMarshallingShouldSupportAllocatingMarshallingFallbackDescription {
-            get {
-                return ResourceManager.GetString("StackallocMarshallingShouldSupportAllocatingMarshallingFallbackDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Native type &apos;{0}&apos; has a stack-allocating constructor does not support marshalling in scenarios where stack allocation is impossible.
-        /// </summary>
-        internal static string StackallocMarshallingShouldSupportAllocatingMarshallingFallbackMessage {
-            get {
-                return ResourceManager.GetString("StackallocMarshallingShouldSupportAllocatingMarshallingFallbackMessage", resourceCulture);
             }
         }
         

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
@@ -123,6 +123,18 @@
   <data name="BlittableTypeMustBeBlittableMessage" xml:space="preserve">
     <value>Type '{0}' is marked with 'BlittableTypeAttribute' but is not blittable</value>
   </data>
+  <data name="CallerAllocConstructorMustHaveBufferSizeConstantDescription" xml:space="preserve">
+    <value>When constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named BufferSize to provide the size of the caller-allocated buffer.</value>
+  </data>
+  <data name="CallerAllocConstructorMustHaveBufferSizeConstantMessage" xml:space="preserve">
+    <value>The native type '{0}' must have a 'public const int BufferSize' field that specifies the size of the stack buffer because it has a constructor that takes a caller-allocated Span&lt;byte&gt;</value>
+  </data>
+  <data name="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackDescription" xml:space="preserve">
+    <value>A type that supports marshalling from managed to native using a caller-allocated buffer should also support marshalling from managed to native where using a caller-allocated buffer is impossible.</value>
+  </data>
+  <data name="CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackMessage" xml:space="preserve">
+    <value>Native type '{0}' has a constructor taking a caller-allocated buffer, but does not support marshalling in scenarios where using a caller-allocated buffer is impossible</value>
+  </data>
   <data name="CannotHaveMultipleMarshallingAttributesDescription" xml:space="preserve">
     <value>The 'BlittableTypeAttribute' and 'NativeMarshallingAttribute' attributes are mutually exclusive.</value>
   </data>
@@ -261,18 +273,6 @@
   </data>
   <data name="SafeHandleByRefMustBeConcrete" xml:space="preserve">
     <value>An abstract type derived from 'SafeHandle' cannot be marshalled by reference. The provided type must be concrete.</value>
-  </data>
-  <data name="StackallocConstructorMustHaveStackBufferSizeConstantDescription" xml:space="preserve">
-    <value>When constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named StackBufferSize to provide the size of the stack-allocated buffer.</value>
-  </data>
-  <data name="StackallocConstructorMustHaveStackBufferSizeConstantMessage" xml:space="preserve">
-    <value>The native type '{0}' must have a 'public const int StackBufferSize' field that specifies the size of the stack buffer because it has a constructor that takes a stack-allocated Span&lt;byte&gt;</value>
-  </data>
-  <data name="StackallocMarshallingShouldSupportAllocatingMarshallingFallbackDescription" xml:space="preserve">
-    <value>A type that supports marshalling from managed to native by stack allocation should also support marshalling from managed to native where stack allocation is impossible.</value>
-  </data>
-  <data name="StackallocMarshallingShouldSupportAllocatingMarshallingFallbackMessage" xml:space="preserve">
-    <value>Native type '{0}' has a stack-allocating constructor does not support marshalling in scenarios where stack allocation is impossible</value>
   </data>
   <data name="TargetFrameworkNotSupportedDescription" xml:space="preserve">
     <value>P/Invoke source generation is not supported on unknown target framework v{0}. The generated source will not be compatible with other frameworks.</value>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
@@ -124,7 +124,7 @@
     <value>Type '{0}' is marked with 'BlittableTypeAttribute' but is not blittable</value>
   </data>
   <data name="CallerAllocConstructorMustHaveBufferSizeConstantDescription" xml:space="preserve">
-    <value>When constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named BufferSize to provide the size of the caller-allocated buffer.</value>
+    <value>When a constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named BufferSize to provide the size of the caller-allocated buffer.</value>
   </data>
   <data name="CallerAllocConstructorMustHaveBufferSizeConstantMessage" xml:space="preserve">
     <value>The native type '{0}' must have a 'public const int BufferSize' field that specifies the size of the stack buffer because it has a constructor that takes a caller-allocated Span&lt;byte&gt;</value>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Interop
     {
         public const string ValuePropertyName = "Value";
         public const string GetPinnableReferenceName = "GetPinnableReference";
-        public const string StackBufferSizeFieldName = "StackBufferSize";
+        public const string BufferSizeFieldName = "BufferSize";
+        public const string RequiresStackBufferFieldName = "RequiresStackBuffer";
         public const string ToManagedMethodName = "ToManaged";
         public const string FreeNativeMethodName = "FreeNative";
         public const string ManagedValuesPropertyName = "ManagedValues";
@@ -57,7 +58,7 @@ namespace Microsoft.Interop
                 && SymbolEqualityComparer.Default.Equals(managedType, ctor.Parameters[0].Type);
         }
 
-        public static bool IsStackallocConstructor(
+        public static bool IsCallerAllocatedSpanConstructor(
             IMethodSymbol ctor,
             ITypeSymbol managedType,
             ITypeSymbol spanOfByte,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Interop
         {
             if (StackAllocOptimizationValid(info, context))
             {
-                // byte* <managedIdentifier>__stackptr = stackalloc byte[<_nativeLocalType>.StackBufferSize];
+                // byte* <managedIdentifier>__stackptr = stackalloc byte[<_nativeLocalType>.BufferSize];
                 yield return LocalDeclarationStatement(
                 VariableDeclaration(
                     PointerType(PredefinedType(Token(SyntaxKind.ByteKeyword))),
@@ -319,7 +319,7 @@ namespace Microsoft.Interop
                                             SingletonList(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
                                                 MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                                                     AsNativeType(info),
-                                                    IdentifierName(ManualTypeMarshallingHelper.StackBufferSizeFieldName))
+                                                    IdentifierName(ManualTypeMarshallingHelper.BufferSizeFieldName))
                                             ))))))))));
             }
 
@@ -373,7 +373,7 @@ namespace Microsoft.Interop
                             Argument(IdentifierName(GetStackAllocPointerIdentifier(info, context))),
                             Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                                     AsNativeType(info),
-                                    IdentifierName(ManualTypeMarshallingHelper.StackBufferSizeFieldName)))
+                                    IdentifierName(ManualTypeMarshallingHelper.BufferSizeFieldName)))
                         }))));
             }
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -641,7 +641,7 @@ namespace Microsoft.Interop
                 {
                     features |= CustomMarshallingFeatures.ManagedToNative;
                 }
-                else if (ManualTypeMarshallingHelper.IsStackallocConstructor(ctor, type, spanOfByte, marshallingVariant)
+                else if (ManualTypeMarshallingHelper.IsCallerAllocatedSpanConstructor(ctor, type, spanOfByte, marshallingVariant)
                     && (valueProperty is null or { GetMethod: not null }))
                 {
                     features |= CustomMarshallingFeatures.ManagedToNativeStackalloc;

--- a/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/SpanMarshallers.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/Ancillary.Interop/SpanMarshallers.cs
@@ -52,7 +52,8 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// Number kept small to ensure that P/Invokes with a lot of array parameters doesn't
         /// blow the stack since this is a new optimization in the code-generated interop.
         /// </summary>
-        public const int StackBufferSize = 0x200;
+        public const int BufferSize = 0x200;
+        public const bool RequiresStackBuffer = true;
 
         public Span<T> ManagedValues => MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(_managedSpan), _managedSpan.Length);
 
@@ -120,7 +121,8 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// Number kept small to ensure that P/Invokes with a lot of array parameters doesn't
         /// blow the stack since this is a new optimization in the code-generated interop.
         /// </summary>
-        public const int StackBufferSize = ReadOnlySpanMarshaller<T>.StackBufferSize;
+        public const int BufferSize = ReadOnlySpanMarshaller<T>.BufferSize;
+        public const bool RequiresStackBuffer = ReadOnlySpanMarshaller<T>.RequiresStackBuffer;
 
         public Span<T> ManagedValues => _inner.ManagedValues;
 
@@ -180,7 +182,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// Number kept small to ensure that P/Invokes with a lot of span parameters doesn't
         /// blow the stack.
         /// </summary>
-        public const int StackBufferSize = SpanMarshaller<T>.StackBufferSize;
+        public const int BufferSize = SpanMarshaller<T>.BufferSize;
 
         public Span<T> ManagedValues => _inner.ManagedValues;
 
@@ -251,7 +253,8 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// Number kept small to ensure that P/Invokes with a lot of span parameters doesn't
         /// blow the stack.
         /// </summary>
-        public const int StackBufferSize = SpanMarshaller<T>.StackBufferSize;
+        public const int BufferSize = SpanMarshaller<T>.BufferSize;
+        public const bool RequiresStackBuffer = SpanMarshaller<T>.RequiresStackBuffer;
 
         public Span<T> ManagedValues => _inner.ManagedValues;
 
@@ -337,7 +340,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// <summary>
         /// Stack-alloc threshold set to 0 so that the generator can use the constructor that takes a stackSpace to let the marshaller know that the original data span can be used and safely pinned.
         /// </summary>
-        public const int StackBufferSize = 0;
+        public const int BufferSize = 0;
 
         public Span<T> ManagedValues => _data;
 

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -664,7 +664,7 @@ struct Native
 
     public S ToManaged() => new S { b = i != 0 };
 
-    public const int StackBufferSize = 1;
+    public const int BufferSize = 1;
 }
 ";
         public static string CustomStructMarshallingStackallocOnlyRefParameter = BasicParameterWithByRefModifier("ref", "S") + @"
@@ -684,7 +684,7 @@ struct Native
 
     public S ToManaged() => new S { b = i != 0 };
 
-    public const int StackBufferSize = 1;
+    public const int BufferSize = 1;
 }
 ";
         public static string CustomStructMarshallingOptionalStackallocParametersAndModifiers = BasicParametersAndModifiers("S") + @"
@@ -708,7 +708,8 @@ struct Native
 
     public S ToManaged() => new S { b = i != 0 };
 
-    public const int StackBufferSize = 1;
+    public const int BufferSize = 1;
+    public const bool RequiresStackBuffer = true;
 }
 ";
 
@@ -730,7 +731,7 @@ struct Native
 
     public int Value { get; set; }
 
-    public const int StackBufferSize = 1;
+    public const int BufferSize = 1;
 }
 ";
         public static string CustomStructMarshallingValuePropertyParametersAndModifiers = BasicParametersAndModifiers("S") + @"
@@ -828,7 +829,7 @@ unsafe ref struct Native
         }
     }
 
-    public const int StackBufferSize = 1;
+    public const int BufferSize = 1;
 }
 
 partial class Test

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -685,6 +685,7 @@ struct Native
     public S ToManaged() => new S { b = i != 0 };
 
     public const int BufferSize = 1;
+    public const bool RequiresStackBuffer = false;
 }
 ";
         public static string CustomStructMarshallingOptionalStackallocParametersAndModifiers = BasicParametersAndModifiers("S") + @"

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ManualTypeMarshallingAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ManualTypeMarshallingAnalyzerTests.cs
@@ -838,7 +838,7 @@ ref struct {|#0:Native|}
 {
     public Native(S s, Span<byte> stackSpace) : this() {}
 
-    public const int StackBufferSize = 1;
+    public const int BufferSize = 1;
 
     public Span<int> ManagedValues { get; set; }
     public Span<byte> NativeValueStorage { get; set; }
@@ -868,7 +868,7 @@ ref struct {|#0:Native|}
 {
     public Native(S s, Span<byte> stackSpace, int nativeElementSize) : this() {}
 
-    public const int StackBufferSize = 1;
+    public const int BufferSize = 1;
 
     public Span<int> ManagedValues { get; set; }
     public Span<byte> NativeValueStorage { get; set; }
@@ -877,7 +877,7 @@ ref struct {|#0:Native|}
 }";
 
             await VerifyCS.VerifyAnalyzerAsync(source,
-                VerifyCS.Diagnostic(StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native", "S"));
+                VerifyCS.Diagnostic(CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native", "S"));
         }
 
         [ConditionalFact]
@@ -996,11 +996,11 @@ struct {|#0:Native|}
 {
     public Native(S s, Span<byte> buffer) {}
 
-    public const int StackBufferSize = 0x100;
+    public const int BufferSize = 0x100;
 }";
 
             await VerifyCS.VerifyAnalyzerAsync(source,
-                VerifyCS.Diagnostic(StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native"));
+                VerifyCS.Diagnostic(CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("Native"));
         }
 
         [ConditionalFact]
@@ -1023,11 +1023,11 @@ struct {|#1:Native|}
 
     public IntPtr Value => IntPtr.Zero;
 
-    public const int StackBufferSize = 0x100;
+    public const int BufferSize = 0x100;
 }";
 
             await VerifyCS.VerifyAnalyzerAsync(source,
-                VerifyCS.Diagnostic(StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(1).WithArguments("Native"),
+                VerifyCS.Diagnostic(CallerAllocMarshallingShouldSupportAllocatingMarshallingFallbackRule).WithLocation(1).WithArguments("Native"),
                 VerifyCS.Diagnostic(GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackRule).WithLocation(0).WithArguments("S", "Native"));
         }
 
@@ -1620,7 +1620,7 @@ struct Native
 }";
 
             await VerifyCS.VerifyAnalyzerAsync(source,
-                VerifyCS.Diagnostic(StackallocConstructorMustHaveStackBufferSizeConstantRule).WithLocation(0).WithArguments("Native"));
+                VerifyCS.Diagnostic(CallerAllocConstructorMustHaveBufferSizeConstantRule).WithLocation(0).WithArguments("Native"));
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/SharedTypes/NonBlittable.cs
@@ -192,7 +192,8 @@ namespace SharedTypes
             Marshal.FreeCoTaskMem((IntPtr)allocated);
         }
 
-        public const int StackBufferSize = 0x100;
+        public const int BufferSize = 0x100;
+        public const bool RequiresStackBuffer = true;
     }
 
 
@@ -260,7 +261,8 @@ namespace SharedTypes
         /// Number kept small to ensure that P/Invokes with a lot of array parameters doesn't
         /// blow the stack since this is a new optimization in the code-generated interop.
         /// </summary>
-        public const int StackBufferSize = 0x200;
+        public const int BufferSize = 0x200;
+        public const bool RequiresStackBuffer = true;
 
         public Span<T> ManagedValues => CollectionsMarshal.AsSpan(managedList);
 


### PR DESCRIPTION
Update from https://github.com/dotnet/runtime/pull/60374.

This is still always using stackalloc, so `RequiresStackBuffer` is not actually checked yet.

@AaronRobinsonMSFT @jkoritzinsky 