### PR TITLE
Fix the MacOS remote unwinder case where the compact encoding for a IP can't be found for a syscall wrapper

### DIFF
--- a/src/coreclr/pal/src/exception/remote-unwind.cpp
+++ b/src/coreclr/pal/src/exception/remote-unwind.cpp
@@ -2122,10 +2122,10 @@ PAL_VirtualUnwindOutOfProc(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *cont
     unw_proc_info_t procInfo;
     bool step;
 #if defined(TARGET_AMD64)
-    TRACE("Unwind: rip %p rsp %p rbp %p\n", (void*)context->Rip, (void*)context->Rsp, (void*)context->Rbp);
+    TRACE("Unwind: base %p rip %p rsp %p rbp %p\n", (void*)baseAddress, (void*)context->Rip, (void*)context->Rsp, (void*)context->Rbp);
     result = GetProcInfo(context->Rip, &procInfo, &info, &step, false);
 #elif defined(TARGET_ARM64)
-    TRACE("Unwind: pc %p sp %p fp %p\n", (void*)context->Pc, (void*)context->Sp, (void*)context->Fp);
+    TRACE("Unwind: base %p pc %p sp %p fp %p\n", (void*)baseAddress, (void*)context->Pc, (void*)context->Sp, (void*)context->Fp);
     result = GetProcInfo(context->Pc, &procInfo, &info, &step, false);
 #else
 #error Unexpected architecture


### PR DESCRIPTION
There is a problem in the MacOS remote unwinding code that createdump uses when the top frame is in a syscall.  The VS4Mac team found this problem in the crash report json file createdump generates where the top native frames were missing.  The problem is that the unwinder can’t find any compact or dwarf unwind info for these syscall “wrapper” functions in libsystem_kernel.dylib (see below).  There was already code in the remote unwinder to manually unwind (see the renamed function StepSyscallWrapper in the PR) these syscall wrappers when it found the compact encoding info for the IP but it was 0. Normally this would stop the unwind but stopping caused the top native frames to be missed too. Now the unwinder doesn’t even find the compact unwind info anymore; something changed in newer MacOS versions.  This PR attempts this manual syscall wrapper unwind on get unwind info failures.

```
   0x7fff20483a80       b8 07 00 00 02  mov    eax, 0x2000007
   0x7fff20483a85       49 89 ca        mov    r10, rcx
   0x7fff20483a88       0f 05           syscall
-> 0x7fff20483a8a       73 08           jae    0x7fff20483a94            ; <+20>
   0x7fff20483a8c       48 89 c7        mov    rdi, rax
   0x7fff20483a8f       e9 29 bc ff ff  jmp    0x7fff2047f6bd            ; cerror
   0x7fff20483a94       c3              ret
```
