### PR TITLE
Remove dependency of type system tests on ILCompiler.ReadyToRun

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -11,63 +11,10 @@ using ILLocalVariable = Internal.IL.Stubs.ILLocalVariable;
 
 namespace Internal.TypeSystem.Interop
 {
-    enum MarshallerKind
-    {
-        Unknown,
-        BlittableValue,
-        Array,
-        BlittableArray,
-        Bool,   // 4 byte bool
-        CBool,  // 1 byte bool
-        VariantBool,  // Variant bool
-        Enum,
-        AnsiChar,  // Marshal char (Unicode 16bits) for byte (Ansi 8bits)
-        UnicodeChar,
-        AnsiCharArray,
-        ByValArray,
-        ByValAnsiCharArray, // Particular case of ByValArray because the conversion between wide Char and Byte need special treatment.
-        AnsiString,
-        UnicodeString,
-        UTF8String,
-        AnsiBSTRString,
-        BSTRString,
-        ByValAnsiString,
-        ByValUnicodeString,
-        AnsiStringBuilder,
-        UnicodeStringBuilder,
-        FunctionPointer,
-        SafeHandle,
-        CriticalHandle,
-        HandleRef,
-        VoidReturn,
-        Variant,
-        Object,
-        OleDateTime,
-        Decimal,
-        OleCurrency,
-        Guid,
-        Struct,
-        BlittableStruct,
-        BlittableStructPtr,   // Additional indirection on top of blittable struct. Used by MarshalAs(LpStruct)
-        LayoutClass,
-        LayoutClassPtr,
-        AsAnyA,
-        AsAnyW,
-        ComInterface,
-        BlittableValueClassWithCopyCtor,
-        Invalid
-    }
     public enum MarshalDirection
     {
         Forward,    // safe-to-unsafe / managed-to-native
         Reverse,    // unsafe-to-safe / native-to-managed
-    }
-
-    public enum MarshallerType
-    {
-        Argument,
-        Element,
-        Field
     }
 
     // Each type of marshaller knows how to generate the marshalling code for the argument it marshals.

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshallerKind.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshallerKind.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Internal.TypeSystem.Interop
+{
+    enum MarshallerKind
+    {
+        Unknown,
+        BlittableValue,
+        Array,
+        BlittableArray,
+        Bool,   // 4 byte bool
+        CBool,  // 1 byte bool
+        VariantBool,  // Variant bool
+        Enum,
+        AnsiChar,  // Marshal char (Unicode 16bits) for byte (Ansi 8bits)
+        UnicodeChar,
+        AnsiCharArray,
+        ByValArray,
+        ByValAnsiCharArray, // Particular case of ByValArray because the conversion between wide Char and Byte need special treatment.
+        AnsiString,
+        UnicodeString,
+        UTF8String,
+        AnsiBSTRString,
+        BSTRString,
+        ByValAnsiString,
+        ByValUnicodeString,
+        AnsiStringBuilder,
+        UnicodeStringBuilder,
+        FunctionPointer,
+        SafeHandle,
+        CriticalHandle,
+        HandleRef,
+        VoidReturn,
+        Variant,
+        Object,
+        OleDateTime,
+        Decimal,
+        OleCurrency,
+        Guid,
+        Struct,
+        BlittableStruct,
+        BlittableStructPtr,   // Additional indirection on top of blittable struct. Used by MarshalAs(LpStruct)
+        LayoutClass,
+        LayoutClassPtr,
+        AsAnyA,
+        AsAnyW,
+        ComInterface,
+        BlittableValueClassWithCopyCtor,
+        Invalid
+    }
+
+    public enum MarshallerType
+    {
+        Argument,
+        Element,
+        Field
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -74,6 +74,9 @@
     <Compile Include="..\..\Common\TypeSystem\Interop\IL\Marshaller.Aot.cs">
       <Link>Interop\IL\Marshaller.Aot.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshallerKind.cs">
+      <Link>Interop\IL\MarshallerKind.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Interop\IL\NativeStructType.Sorting.cs">
       <Link>TypeSystem\Interop\IL\NativeStructType.Sorting.cs</Link>
     </Compile>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -44,6 +44,7 @@
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\VolatileIntrinsics.cs" Link="IL\Stubs\VolatileIntrinsics.cs" />
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\PInvokeILCodeStreams.cs" Link="IL\Stubs\PInvokeILCodeStreams.cs" />
     <Compile Include="..\..\Common\TypeSystem\Interop\IL\Marshaller.cs" Link="Interop\IL\Marshaller.cs" />
+    <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshallerKind.cs" Link="Interop\IL\MarshallerKind.cs" />
     <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalHelpers.cs" Link="Interop\IL\MarshalHelpers.cs" />
     <Compile Include="..\..\Common\TypeSystem\Interop\IL\MarshalUtils.cs" Link="Interop\IL\MarshalUtils.cs" />
     <Compile Include="..\..\Common\Compiler\CodeGenerationFailedException.cs" Link="Compiler\CodeGenerationFailedException.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ILCompiler.TypeSystem.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ILCompiler.TypeSystem.Tests.csproj
@@ -14,6 +14,8 @@
     <Platforms>AnyCPU;x64</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    
+    <!-- Avoids having to include InteropStateManager.cs to get files in Common/TypeSystem/Interop/IL building -->
     <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ILCompiler.TypeSystem.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/ILCompiler.TypeSystem.Tests.csproj
@@ -14,6 +14,7 @@
     <Platforms>AnyCPU;x64</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>READYTORUN;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>    
@@ -23,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ILCompiler.ReadyToRun\ILCompiler.ReadyToRun.csproj" />
     <ProjectReference Include="..\ILCompiler.TypeSystem\ILCompiler.TypeSystem.csproj" />
     <!-- Make sure the test data gets built -->
     <ProjectReference Include="CoreTestAssembly\CoreTestAssembly.csproj">
@@ -40,6 +40,11 @@
   <ItemGroup>
     <Compile Include="../../Common/TypeSystem/MetadataEmitter/TypeSystemMetadataEmitter.cs" />
     <Compile Include="../../Common/TypeSystem/IL/ILReader.cs" />
+    <Compile Include="../../Common/TypeSystem/Interop/IL/MarshalUtils.cs" Link="TypeSystem/Interop/IL/MarshalUtils.cs" />
+    <Compile Include="../../Common/TypeSystem/Interop/IL/MarshalHelpers.cs" Link="TypeSystem/Interop/IL/MarshalHelpers.cs" />
+    <Compile Include="../../Common/TypeSystem/Interop/IL/MarshallerKind.cs" Link="TypeSystem/Interop/IL/MarshallerKind.cs" />
+    <Compile Include="../../Common/TypeSystem/Interop/InteropTypes.cs" Link="TypeSystem/Interop/InteropTypes.cs" />
+    <Compile Include="../../Common/TypeSystem/IL/HelperExtensions.cs" Link="TypeSystem/IL/HelperExtensions" />
     <Compile Include="ArchitectureSpecificFieldLayoutTests.cs" />
     <Compile Include="CanonicalizationTests.cs" />
     <Compile Include="ConstraintsValidationTest.cs" />

--- a/src/coreclr/tools/aot/ilc.sln
+++ b/src/coreclr/tools/aot/ilc.sln
@@ -20,6 +20,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ILLink.Shared", "ILLink.Sha
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.Compiler.Tests", "ILCompiler.Compiler.Tests\ILCompiler.Compiler.Tests.csproj", "{24CBA9C6-EDBA-47D6-A0B5-04417BDE5FE3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.TypeSystem.Tests", "ILCompiler.TypeSystem.Tests\ILCompiler.TypeSystem.Tests.csproj", "{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		ILLink.Shared\ILLink.Shared.projitems*{ff598e93-8e9e-4091-9f50-61a7572663ae}*SharedItemsImports = 13
@@ -160,6 +162,24 @@ Global
 		{24CBA9C6-EDBA-47D6-A0B5-04417BDE5FE3}.Release|x64.Build.0 = Release|x64
 		{24CBA9C6-EDBA-47D6-A0B5-04417BDE5FE3}.Release|x86.ActiveCfg = Release|x86
 		{24CBA9C6-EDBA-47D6-A0B5-04417BDE5FE3}.Release|x86.Build.0 = Release|x86
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Checked|Any CPU.ActiveCfg = Checked|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Checked|Any CPU.Build.0 = Checked|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Checked|x64.ActiveCfg = Checked|x64
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Checked|x64.Build.0 = Checked|x64
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Checked|x86.ActiveCfg = Checked|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Checked|x86.Build.0 = Checked|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Debug|x64.ActiveCfg = Debug|x64
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Debug|x64.Build.0 = Debug|x64
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Debug|x86.Build.0 = Debug|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Release|x64.ActiveCfg = Release|x64
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Release|x64.Build.0 = Release|x64
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Release|x86.ActiveCfg = Release|Any CPU
+		{740CDFF4-B8EC-4A37-951B-C9FE9980EF2A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is now shared unit test project that is not AOT/JIT specific.

The recently added MarshalUtilsTests.cs created a dependency on these.