### PR TITLE
Fix running WASM tests locally on Windows

### DIFF
--- a/eng/testing/WasmRunnerTemplate.cmd
+++ b/eng/testing/WasmRunnerTemplate.cmd
@@ -48,7 +48,7 @@ if /I [%XHARNESS_COMMAND%] == [test] (
         set "JS_ENGINE_ARGS=--engine-arg^=--stack-trace-limit^=1000"
     )
 ) else (
-    if [%BROWSER_PATH%] == [] (
+    if [%BROWSER_PATH%] == [] if not [%HELIX_CORRELATION_PAYLOAD%] == [] (
         set "BROWSER_PATH=--browser-path^=%HELIX_CORRELATION_PAYLOAD%\chrome-win\chrome.exe"
     )
 )

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.cmd
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/data/RunScriptTemplate.cmd
@@ -49,7 +49,7 @@ if /I [%XHARNESS_COMMAND%] == [test] (
         set "JS_ENGINE_ARGS=--engine-arg^=--stack-trace-limit^=1000"
     )
 ) else (
-    if [%BROWSER_PATH%] == [] (
+    if [%BROWSER_PATH%] == [] if not [%HELIX_CORRELATION_PAYLOAD%] == [] (
         set "BROWSER_PATH=--browser-path^=%HELIX_CORRELATION_PAYLOAD%\chrome-win\chrome.exe"
     )
 )


### PR DESCRIPTION
Set `BROWSER_PATH` variable only when `HELIX_CORRELATION_PAYLOAD` variable is set.

Fixes change in the https://github.com/dotnet/runtime/pull/62779.