### PR TITLE
Update runtime.json with manjaro information

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -4206,6 +4206,26 @@
     "any",
     "base"
   ],
+  "manjaro": [
+    "manjaro",
+    "arch",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "manjaro-x64": [
+    "manjaro-x64",
+    "manjaro",
+    "arch-x64",
+    "arch",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "ol": [
     "ol",
     "rhel",

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -1729,6 +1729,17 @@
         "maccatalyst.14-x64"
       ]
     },
+    "manjaro": {
+      "#import": [
+        "arch"
+      ]
+    },
+    "manjaro-x64": {
+      "#import": [
+        "manjaro",
+        "arch-x64"
+      ]
+    },
     "ol": {
       "#import": [
         "rhel"

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -31,6 +31,11 @@
       <Architectures>x64</Architectures>
     </RuntimeGroup>
 
+    <RuntimeGroup Include="manjaro">
+      <Parent>arch</Parent>
+      <Architectures>x64</Architectures>
+    </RuntimeGroup>
+
     <RuntimeGroup Include="browser">
       <Parent>any</Parent>
       <Architectures>wasm</Architectures>


### PR DESCRIPTION
Without specifying runtime on manjaro we cannot run the projects.
Shameless copy of arch entries

I'd like to point out that while /etc/os-release points to "manjaro" and not "manjaro-x64" i have to use the linux-x64 runtime. 
Perhaps manjaro simply does not have non x64 values? ( I have not compared to a arch system, do they have arch/arch-x64?)

FYI: Manjaro has a "ID_LIKE" param in os_release that has arch as input. Perhaps that would be another way forward.