### PR TITLE
Pass configuration as a parameter for local Apple mobile test runs

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -110,13 +110,18 @@
   </Target>
 
   <Target Name="RunTests">
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(TargetsMobile)' != 'true'">
       <RunTestsCommand>"$(RunScriptOutputPath)"</RunTestsCommand>
       <!-- Use runtime path only for the live built shared framework (NetCoreAppCurrent). -->
       <RunTestsCommand Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                   $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">$(RunTestsCommand) --runtime-path "$(NetCoreAppCurrentTestHostPath.TrimEnd('\/'))"</RunTestsCommand>
       <RunTestsCommand Condition="'$(TestRspFile)' != '' and '$(RuntimeFlavor)' != 'Mono'">$(RunTestsCommand) --rsp-file "$(TestRspFile)"</RunTestsCommand>
-      <RunTestsCommand Condition="'$(TargetsMobile)' == 'true'">"$(RunScriptOutputPath)" $(AssemblyName) $(TargetArchitecture) $(TargetOS.ToLowerInvariant()) $(TestProjectName) $(AdditionalXHarnessArguments)</RunTestsCommand>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">
+      <RunTestsCommand>"$(RunScriptOutputPath)" $(AssemblyName) $(TargetArchitecture) $(TargetOS.ToLowerInvariant()) $(TestProjectName)</RunTestsCommand>
+      <RunTestsCommand Condition="'$(TargetsAppleMobile)' == 'true'">$(RunTestsCommand) $(Configuration) $(AdditionalXHarnessArguments)</RunTestsCommand>
+      <RunTestsCommand Condition="'$(TargetOS)' == 'Android'">$(RunTestsCommand) $(AdditionalXHarnessArguments)</RunTestsCommand>
       <RunTestsCommand Condition="'$(TargetOS)' == 'Browser'">"$(RunScriptOutputPath)" $(JSEngine) $(AssemblyName).dll $(Scenario)</RunTestsCommand>
     </PropertyGroup>
 

--- a/src/mono/msbuild/apple/build/AppleApp.InTree.targets
+++ b/src/mono/msbuild/apple/build/AppleApp.InTree.targets
@@ -3,6 +3,11 @@
   <UsingTask TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" />
   <UsingTask TaskName="RuntimeConfigParserTask" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" />
 
+  <!-- For MacCatalyst, adhoc is the default.  Set it here so that we don't have to specify when running local -->
+  <PropertyGroup>
+    <DevTeamProvisioning Condition="'$(DevTeamProvisioning)' == '' and '$(TargetOS)' == 'MacCatalyst'">adhoc</DevTeamProvisioning>
+  </PropertyGroup>
+
   <!-- TODO: this breaks runtime tests on Helix due to the file not being there for some reason. Once this is fixed we can remove the UpdateRuntimePack target here -->
   <!--<Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true'"/>-->
   <Import Project="$(MSBuildThisFileDirectory)AppleApp.targets" />


### PR DESCRIPTION
Reverts https://github.com/dotnet/runtime/pull/62549 as the configuration parameter is needed to let xharness know where the iOS/tvOS/MacCatalyst test app is. 

For example, a debug test app will be under Debug-iphoneos and a release one will be under Release-iphoneos. Xharness won't be able to tell unless provided the right info.