### PR TITLE
[release/6.0] Fix bug where we reference the entry #0 in the pinned plug queue

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -2725,7 +2725,7 @@ alloc_list gc_heap::poh_alloc_list [NUM_POH_ALIST-1];
 #ifdef DOUBLY_LINKED_FL
 // size we removed with no undo; only for recording purpose
 size_t gc_heap::gen2_removed_no_undo = 0;
-size_t gc_heap::saved_pinned_plug_index = 0;
+size_t gc_heap::saved_pinned_plug_index = INVALID_SAVED_PINNED_PLUG_INDEX;
 #endif //DOUBLY_LINKED_FL
 
 #ifdef FEATURE_EVENT_TRACE
@@ -13903,7 +13903,20 @@ void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen)
                         uint8_t* old_loc = generation_last_free_list_allocated (gen);
 
                         // check if old_loc happens to be in a saved plug_and_gap with a pinned plug after it
-                        uint8_t* saved_plug_and_gap = pinned_plug (pinned_plug_of (saved_pinned_plug_index)) - sizeof(plug_and_gap);
+                        uint8_t* saved_plug_and_gap = nullptr;
+                        if (saved_pinned_plug_index != INVALID_SAVED_PINNED_PLUG_INDEX)
+                        {
+                            saved_plug_and_gap = pinned_plug (pinned_plug_of (saved_pinned_plug_index)) - sizeof(plug_and_gap);
+
+                            dprintf (3333, ("[h%d] sppi: %Id mtos: %Id old_loc: %Ix pp: %Ix(%Id) offs: %Id",
+                                heap_number,
+                                saved_pinned_plug_index,
+                                mark_stack_tos,
+                                old_loc,
+                                pinned_plug (pinned_plug_of (saved_pinned_plug_index)),
+                                pinned_len (pinned_plug_of (saved_pinned_plug_index)),
+                                old_loc - saved_plug_and_gap));
+                        }
                         size_t offset = old_loc - saved_plug_and_gap;
                         if (offset < sizeof(gap_reloc_pair))
                         {
@@ -27519,7 +27532,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
 #ifdef DOUBLY_LINKED_FL
     gen2_removed_no_undo = 0;
-    saved_pinned_plug_index = 0;
+    saved_pinned_plug_index = INVALID_SAVED_PINNED_PLUG_INDEX;
 #endif //DOUBLY_LINKED_FL
 
     while (1)

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -4496,6 +4496,8 @@ protected:
     PER_HEAP
     size_t gen2_removed_no_undo;
 
+#define INVALID_SAVED_PINNED_PLUG_INDEX ((size_t)~0)
+
     PER_HEAP
     size_t saved_pinned_plug_index;
 #endif //DOUBLY_LINKED_FL


### PR DESCRIPTION
Backport of #60966 to release/6.0

We reference entry #0 in the pinned plug queue even if there are no pinned plugs at all and thus the pinned plug queue contains left-over data from the mark phase.

## Customer Impact
Customers reported [frequent](https://github.com/dotnet/runtime/issues/63070) [crashes](https://github.com/dotnet/runtime/issues/63127) when they upgraded their services to .NET 6 with Server GC.

## Testing
Customers have tried and [reported](https://github.com/dotnet/runtime/issues/63070#issuecomment-1003166854) [repeatedly](https://github.com/dotnet/runtime/issues/63070#issuecomment-1003428843) and [independently](https://github.com/dotnet/runtime/issues/63070#issuecomment-1004610579) that their crashing services have no more crashes after the fix is applied. @PeterSolMS can comment on the testing he did when he checked in the initial fix.

## Risk
Low. If we did have a pinned plug, the fix does nothing. If we do have a pinned plug, this fix does the right thing. 