### PR TITLE
Implement `IEquatable<T>` on the runtime handle types.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -15,7 +15,7 @@ using Internal.Runtime.CompilerServices;
 namespace System
 {
     [NonVersionable]
-    public unsafe partial struct RuntimeTypeHandle : ISerializable
+    public unsafe partial struct RuntimeTypeHandle : IEquatable<RuntimeTypeHandle>, ISerializable
     {
         // Returns handle for interop with EE. The handle is guaranteed to be non-null.
         internal RuntimeTypeHandle GetNativeHandle()
@@ -814,7 +814,7 @@ namespace System
     }
 
     [NonVersionable]
-    public unsafe partial struct RuntimeMethodHandle : ISerializable
+    public unsafe partial struct RuntimeMethodHandle : IEquatable<RuntimeMethodHandle>, ISerializable
     {
         // Returns handle for interop with EE. The handle is guaranteed to be non-null.
         internal static IRuntimeMethodInfo EnsureNonNullMethodInfo(IRuntimeMethodInfo method)
@@ -1139,7 +1139,7 @@ namespace System
     }
 
     [NonVersionable]
-    public unsafe struct RuntimeFieldHandle : ISerializable
+    public unsafe struct RuntimeFieldHandle : IEquatable<RuntimeFieldHandle>, ISerializable
     {
         // Returns handle for interop with EE. The handle is guaranteed to be non-null.
         internal RuntimeFieldHandle GetNativeHandle()

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
@@ -11,7 +11,7 @@ using Internal.Runtime.Augments;
 namespace System
 {
     [StructLayoutAttribute(LayoutKind.Sequential)]
-    public struct RuntimeFieldHandle : ISerializable
+    public struct RuntimeFieldHandle : IEquatable<RuntimeFieldHandle>, ISerializable
     {
         private IntPtr _value;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeMethodHandle.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/RuntimeMethodHandle.cs
@@ -13,7 +13,7 @@ using Internal.Reflection.Augments;
 namespace System
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct RuntimeMethodHandle : ISerializable
+    public struct RuntimeMethodHandle : IEquatable<RuntimeMethodHandle>, ISerializable
     {
         private IntPtr _value;
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5198,7 +5198,7 @@ namespace System
     {
         private int _dummyPrimitive;
     }
-    public partial struct RuntimeFieldHandle : System.Runtime.Serialization.ISerializable
+    public partial struct RuntimeFieldHandle : System.IEquatable<System.RuntimeFieldHandle>, System.Runtime.Serialization.ISerializable
     {
         private object _dummy;
         private int _dummyPrimitive;
@@ -5210,7 +5210,7 @@ namespace System
         public static bool operator ==(System.RuntimeFieldHandle left, System.RuntimeFieldHandle right) { throw null; }
         public static bool operator !=(System.RuntimeFieldHandle left, System.RuntimeFieldHandle right) { throw null; }
     }
-    public partial struct RuntimeMethodHandle : System.Runtime.Serialization.ISerializable
+    public partial struct RuntimeMethodHandle : System.IEquatable<System.RuntimeMethodHandle>, System.Runtime.Serialization.ISerializable
     {
         private object _dummy;
         private int _dummyPrimitive;
@@ -5223,7 +5223,7 @@ namespace System
         public static bool operator ==(System.RuntimeMethodHandle left, System.RuntimeMethodHandle right) { throw null; }
         public static bool operator !=(System.RuntimeMethodHandle left, System.RuntimeMethodHandle right) { throw null; }
     }
-    public partial struct RuntimeTypeHandle : System.Runtime.Serialization.ISerializable
+    public partial struct RuntimeTypeHandle : System.IEquatable<System.RuntimeTypeHandle>, System.Runtime.Serialization.ISerializable
     {
         private object _dummy;
         private int _dummyPrimitive;

--- a/src/libraries/System.Runtime/src/MatchingRefApiCompatBaseline.txt
+++ b/src/libraries/System.Runtime/src/MatchingRefApiCompatBaseline.txt
@@ -25,7 +25,6 @@ CannotMakeMemberAbstract : Member 'public System.String System.IO.FileSystemInfo
 # C# generates backing fields for fixed buffers as public.
 TypesMustExist : Type 'System.IO.Enumeration.FileSystemEntry.<_fileNameBuffer>e__FixedBuffer' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public void System.ModuleHandle..ctor(System.Reflection.Module)' does not exist in the reference but it does exist in the implementation.
-CannotRemoveBaseTypeOrInterface : Type 'System.RuntimeTypeHandle' does not implement interface 'System.IEquatable<System.RuntimeTypeHandle>' in the reference but it does in the implementation.
 MembersMustExist : Member 'public System.String System.String System.Type.DefaultTypeNameWhenMissingMetadata' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.String System.Type.FormatTypeNameForReflection()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'public System.String System.Type.InternalGetNameIfAvailable(System.Type)' does not exist in the reference but it does exist in the implementation.

--- a/src/libraries/System.Runtime/tests/System/HandleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HandleTests.cs
@@ -27,6 +27,7 @@ public static class HandleTests
         Assert.True(default(RuntimeFieldHandle).Equals(default(RuntimeFieldHandle)));
 
         Assert.True(h.Equals((object)h));
+        Assert.True(((IEquatable<RuntimeFieldHandle>)h).Equals(h));
         Assert.False(h.Equals(new object()));
         Assert.False(h.Equals(null));
 
@@ -52,6 +53,7 @@ public static class HandleTests
         Assert.True(default(RuntimeMethodHandle).Equals(default(RuntimeMethodHandle)));
 
         Assert.True(h.Equals((object)h));
+        Assert.True(((IEquatable<RuntimeMethodHandle>)h).Equals(h));
         Assert.False(h.Equals(new object()));
         Assert.False(h.Equals(null));
 
@@ -85,6 +87,7 @@ public static class HandleTests
         Assert.True(default(RuntimeTypeHandle).Equals(default(RuntimeTypeHandle)));
 
         Assert.True(h.Equals((object)h));
+        Assert.True(((IEquatable<RuntimeTypeHandle>)h).Equals(h));
         Assert.False(h.Equals(typeof(int)));
         Assert.False(h.Equals(new object()));
         Assert.False(h.Equals(null));

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeFieldHandle.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 namespace System
 {
     [Serializable]
-    public struct RuntimeFieldHandle : ISerializable
+    public struct RuntimeFieldHandle : IEquatable<RuntimeFieldHandle>, ISerializable
     {
         private readonly IntPtr value;
 

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeMethodHandle.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeMethodHandle.cs
@@ -9,7 +9,7 @@ using System.Text;
 namespace System
 {
     [Serializable]
-    public struct RuntimeMethodHandle : ISerializable
+    public struct RuntimeMethodHandle : IEquatable<RuntimeMethodHandle>, ISerializable
     {
         private readonly IntPtr value;
 

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeTypeHandle.cs
@@ -40,7 +40,7 @@ using System.Threading;
 namespace System
 {
     [Serializable]
-    public struct RuntimeTypeHandle : ISerializable
+    public struct RuntimeTypeHandle : IEquatable<RuntimeTypeHandle>, ISerializable
     {
         private readonly IntPtr value;
 


### PR DESCRIPTION
I also called the `Equals` method via the interface in the tests.

~~Fixes~~ Contributes to #62944.