### PR TITLE
Fix index in XmlQueryRuntime.MatchesXmlType

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlQueryRuntime.cs
@@ -726,7 +726,7 @@ namespace System.Xml.Xsl.Runtime
             typBase = typBase.Prime;
             for (int i = 0; i < seq.Count; i++)
             {
-                if (!CreateXmlType(seq[0]).IsSubtypeOf(typBase))
+                if (!CreateXmlType(seq[i]).IsSubtypeOf(typBase))
                     return false;
             }
 


### PR DESCRIPTION
These looks wrong both according to the comment on the method and the implementation, but I'm not familiar enough with this code to know what this will actually affect, how to test it, or why it hasn't caused issue previously. @krwq?