### PR TITLE
Fix the MacOS remote unwinder for VS4Mac

### DIFF
--- a/src/coreclr/debug/dbgutil/machoreader.cpp
+++ b/src/coreclr/debug/dbgutil/machoreader.cpp
@@ -229,9 +229,8 @@ MachOModule::ReadLoadCommands()
                 m_segments.push_back(segment);
 
                 // Calculate the load bias for the module. This is the value to add to the vmaddr of a
-                // segment to get the actual address. For shared modules, this is 0 since those segments
-                // are absolute address.
-                if (segment->fileoff == 0 && segment->filesize > 0)
+                // segment to get the actual address.
+                if (strcmp(segment->segname, SEG_TEXT) == 0)
                 {
                     m_loadBias = m_baseAddress - segment->vmaddr;
                 }


### PR DESCRIPTION
The wrong module was being passed to the remote unwinder because the load bias for shared modules was being calculated incorrectly.  This PR undo's the regression from PR #60995.

https://github.com/dotnet/runtime/issues/63309