### PR TITLE
Validate behavior of ProcessInfo command before and after suspension point

### DIFF
--- a/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
+++ b/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
@@ -408,6 +408,11 @@ namespace Tracing.Tests.PauseOnStartValidation
                         pi2After = ProcessInfo2.TryParse(response.Payload);
                         if (!pi2After.Commandline.Equals(pi2Before.Commandline))
                             break;
+
+                        // recycle
+                        stream = await server.AcceptAsync();
+                        advertise = IpcAdvertise.Parse(stream);
+                        Logger.logger.Log(advertise.ToString());
                     }
 
                     Utils.Assert(pi2Before.Commandline.Equals(currentProcess.MainModule.FileName), $"Before resuming, the commandline should be the mock value of the host executable path '{currentProcess.MainModule.FileName}'. Observed: '{pi2Before.Commandline}'");

--- a/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
+++ b/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
@@ -396,7 +396,7 @@ namespace Tracing.Tests.PauseOnStartValidation
 
                     // The timing is not exact. There is a small window after resuming where the mock
                     // value is still present. Retry several times to catch it.
-                    for (int i = 0; i < 32; i++)
+                    for (int i = 0; i < 1024; i++)
                     {
                         Logger.logger.Log($"Get ProcessInfo after resumption: attempt {i}");
                         // 0x04 = ProcessCommandSet, 0x04 = ProcessInfo2

--- a/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
+++ b/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
@@ -391,17 +391,24 @@ namespace Tracing.Tests.PauseOnStartValidation
                     await eventPipeTask;
                     Logger.logger.Log("Stopped EventPipeSession over standard connection");
 
-
-                    Logger.logger.Log($"Get ProcessInfo after resumption");
-                    // 0x04 = ProcessCommandSet, 0x04 = ProcessInfo2
-                    message = new IpcMessage(0x04, 0x04);
-                    Logger.logger.Log($"Sent: {message.ToString()}");
-                    response = IpcClient.SendMessage(stream, message);
-                    Logger.logger.Log($"received: {response.ToString()}");
-
-                    ProcessInfo2 pi2After = ProcessInfo2.TryParse(response.Payload);
-
+                    ProcessInfo2 pi2After = default;
                     Process currentProcess = Process.GetCurrentProcess();
+
+                    // The timing is not exact. There is a small window after resuming where the mock
+                    // value is still present. Retry several times to catch it.
+                    for (int i = 0; i < 32; i++)
+                    {
+                        Logger.logger.Log($"Get ProcessInfo after resumption: attempt {i}");
+                        // 0x04 = ProcessCommandSet, 0x04 = ProcessInfo2
+                        message = new IpcMessage(0x04, 0x04);
+                        Logger.logger.Log($"Sent: {message.ToString()}");
+                        response = IpcClient.SendMessage(stream, message);
+                        Logger.logger.Log($"received: {response.ToString()}");
+
+                        pi2After = ProcessInfo2.TryParse(response.Payload);
+                        if (!pi2After.Commandline.Equals(pi2Before.Commandline))
+                            break;
+                    }
 
                     Utils.Assert(pi2Before.Commandline.Equals(currentProcess.MainModule.FileName), $"Before resuming, the commandline should be the mock value of the host executable path '{currentProcess.MainModule.FileName}'. Observed: '{pi2Before.Commandline}'");
                     Utils.Assert(!pi2After.Commandline.Equals(pi2Before.Commandline), $"After resuming, the commandline should be the correct value. Observed: Before='{pi2Before.Commandline}' After='{pi2After.Commandline}'");

--- a/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
+++ b/src/tests/tracing/eventpipe/pauseonstart/pauseonstart.cs
@@ -312,6 +312,10 @@ namespace Tracing.Tests.PauseOnStartValidation
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return true;
 
+            // This test only applies to CoreCLR (this checks if we're running on Mono)
+            if (Type.GetType("Mono.RuntimeStructs") != null)
+                return true;
+
             bool fSuccess = true;
             string serverName = ReverseServer.MakeServerAddress();
             Logger.logger.Log($"Server name is '{serverName}'");


### PR DESCRIPTION
Adds a test for the behavior of the commandline property on the ProcessInfo command before and after the diagnostics suspension point.

Before the suspension point, the PAL/Host populates the value to be the path to the host executable.

After the runtime is resumed and `g_EEStarted==true`, this value becomes the correct calculated value from the PAL.

This test validates this behavior and is intended for inclusion in https://github.com/dotnet/runtime/pull/63356.

CC @tommcdon 