### PR TITLE
Fix Creating Cultures with Sort Names

### DIFF
--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
@@ -440,12 +440,13 @@ namespace System.Globalization.Tests
             Assert.NotEqual(lcid, new CultureInfo(lcid).LCID);
         }
 
-        [InlineData("zh-TW-u-co-zhuyin", "zh-TW_zhuyin")]
-        [InlineData("de-DE-u-co-phoneb", "de-DE_phoneb")]
+        [InlineData("zh-TW-u-co-zhuyin")]
+        [InlineData("de-DE-u-co-phoneb")]
+        [InlineData("de-u-co-phonebk")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
-        public void TestCreationWithMangledSortName(string cultureName, string resolvedSortName)
+        public void TestCreationWithMangledSortName(string cultureName)
         {
-            Assert.Equal(CultureInfo.GetCultureInfo(cultureName).CompareInfo.Name, resolvedSortName);
+            Assert.True(CultureInfo.GetCultureInfo(cultureName).CompareInfo.Name.Equals(cultureName, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
@@ -439,5 +439,13 @@ namespace System.Globalization.Tests
 
             Assert.NotEqual(lcid, new CultureInfo(lcid).LCID);
         }
+
+        [InlineData("zh-TW-u-co-zhuyin", "zh-TW_zhuyin")]
+        [InlineData("de-DE-u-co-phoneb", "de-DE_phoneb")]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        public void TestCreationWithMangledSortName(string cultureName, string resolvedSortName)
+        {
+            Assert.Equal(CultureInfo.GetCultureInfo(cultureName).CompareInfo.Name, resolvedSortName);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -14,7 +14,7 @@ namespace System.Globalization
         [NonSerialized]
         private bool _isAsciiEqualityOrdinal;
 
-        private void IcuInitSortHandle()
+        private void IcuInitSortHandle(string interopCultureName)
         {
             if (GlobalizationMode.Invariant)
             {
@@ -23,6 +23,7 @@ namespace System.Globalization
             else
             {
                 Debug.Assert(!GlobalizationMode.UseNls);
+                Debug.Assert(interopCultureName != null);
 
                 // Inline the following condition to avoid potential implementation cycles within globalization
                 //
@@ -31,7 +32,7 @@ namespace System.Globalization
                 _isAsciiEqualityOrdinal = _sortName.Length == 0 ||
                     (_sortName.Length >= 2 && _sortName[0] == 'e' && _sortName[1] == 'n' && (_sortName.Length == 2 || _sortName[2] == '-'));
 
-                _sortHandle = SortHandleCache.GetCachedSortHandle(_sortName);
+                _sortHandle = SortHandleCache.GetCachedSortHandle(interopCultureName);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -191,7 +191,7 @@ namespace System.Globalization
             }
             else
             {
-                IcuInitSortHandle();
+                IcuInitSortHandle(culture.InteropName!);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -51,11 +51,10 @@ namespace System.Globalization
             if (index >= 0)
             {
                 // It is possible alternateSortName not set even if the normalized culture name has "@collation=".
-                // "zh-TW-u-co-zhuyin" is a good example of that. The term "u-co-" in the name means that the following part will be the sort name.
-                // That is mean "zh-TW-u-co-zhuyin" will have the equivalent ICU name "zh-TW@collation=zhuyin" and .NET name zh-TW_zhuyin.
-                _sName = alternateSortName.Length == 0 ?
-                            string.Concat(_sWindowsName.AsSpan(0, index), "_", _sWindowsName.AsSpan(index + ICU_COLLATION_KEYWORD.Length)) :
-                            string.Concat(_sWindowsName.AsSpan(0, index), "_", alternateSortName);
+                // "zh-TW-u-co-zhuyin" is a good example of that. The term "u-co-" in the name means the following part will be the sort name.
+                // That is mean "zh-TW-u-co-zhuyin" will have the equivalent ICU name "zh-TW@collation=zhuyin".
+                // In this case, we'll not change the original culture name.
+                _sName = alternateSortName.Length == 0 ? realNameBuffer : string.Concat(_sWindowsName.AsSpan(0, index), "_", alternateSortName);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -50,7 +50,12 @@ namespace System.Globalization
             index = _sWindowsName.IndexOf(ICU_COLLATION_KEYWORD, StringComparison.Ordinal);
             if (index >= 0)
             {
-                _sName = string.Concat(_sWindowsName.AsSpan(0, index), "_", alternateSortName);
+                // It is possible alternateSortName not set even if the normalized culture name has "@collation=".
+                // "zh-TW-u-co-zhuyin" is a good example of that. The term "u-co-" in the name means that the following part will be the sort name.
+                // That is mean "zh-TW-u-co-zhuyin" will have the equivalent ICU name "zh-TW@collation=zhuyin" and .NET name zh-TW_zhuyin.
+                _sName = alternateSortName.Length == 0 ?
+                            string.Concat(_sWindowsName.AsSpan(0, index), "_", _sWindowsName.AsSpan(index + ICU_COLLATION_KEYWORD.Length)) :
+                            string.Concat(_sWindowsName.AsSpan(0, index), "_", alternateSortName);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -50,10 +50,10 @@ namespace System.Globalization
             index = _sWindowsName.IndexOf(ICU_COLLATION_KEYWORD, StringComparison.Ordinal);
             if (index >= 0)
             {
-                // It is possible alternateSortName not set even if the normalized culture name has "@collation=".
-                // "zh-TW-u-co-zhuyin" is a good example of that. The term "u-co-" in the name means the following part will be the sort name.
-                // That is mean "zh-TW-u-co-zhuyin" will have the equivalent ICU name "zh-TW@collation=zhuyin".
-                // In this case, we'll not change the original culture name.
+                // Use original culture name if alternateSortName is not set, which is possible even if the normalized
+                // culture name has "@collation=".
+                // "zh-TW-u-co-zhuyin" is a good example. The term "u-co-" means the following part will be the sort name
+                // and it will be treated in ICU as "zh-TW@collation=zhuyin".
                 _sName = alternateSortName.Length == 0 ? realNameBuffer : string.Concat(_sWindowsName.AsSpan(0, index), "_", alternateSortName);
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -414,7 +414,7 @@ namespace System.Globalization
         private static volatile Dictionary<string, string>? s_regionNames;
 
         /// <summary>
-        /// The culture name to use to interop with the underlying native globalization libraries like ICU or Windows NLS APIs. 
+        /// The culture name to use to interop with the underlying native globalization libraries like ICU or Windows NLS APIs.
         /// For example, we can have the name de_DE@collation=phonebook when using ICU for the German culture de-DE with the phonebook sorting behavior.
         /// </summary>
         internal string? InteropName => _sWindowsName;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -413,6 +413,8 @@ namespace System.Globalization
         private static volatile Dictionary<string, CultureData>? s_cachedRegions;
         private static volatile Dictionary<string, string>? s_regionNames;
 
+        internal string? InteropName => _sWindowsName;
+
         internal static CultureData? GetCultureDataForRegion(string? cultureName, bool useUserOverride)
         {
             // First do a shortcut for Invariant

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -413,6 +413,10 @@ namespace System.Globalization
         private static volatile Dictionary<string, CultureData>? s_cachedRegions;
         private static volatile Dictionary<string, string>? s_regionNames;
 
+        /// <summary>
+        /// The culture name to use to interop with the underlying native globalization libraries like ICU or Windows NLS APIs. 
+        /// For example, we can have the name de_DE@collation=phonebook when using ICU for the German culture de-DE with the phonebook sorting behavior.
+        /// </summary>
         internal string? InteropName => _sWindowsName;
 
         internal static CultureData? GetCultureDataForRegion(string? cultureName, bool useUserOverride)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -580,6 +580,10 @@ namespace System.Globalization
         /// </summary>
         internal string SortName => _sortName ??= _cultureData.SortName;
 
+        /// <summary>
+        /// The culture name to use to interop with the underlying native globalization libraries like ICU or Windows NLS APIs. 
+        /// For example, we can have the name de_DE@collation=phonebook when using ICU for the German culture de-DE with the phonebook sorting behavior.
+        /// </summary>
         internal string? InteropName => _cultureData.InteropName;
 
         public string IetfLanguageTag =>

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -580,6 +580,8 @@ namespace System.Globalization
         /// </summary>
         internal string SortName => _sortName ??= _cultureData.SortName;
 
+        internal string? InteropName => _cultureData.InteropName;
+
         public string IetfLanguageTag =>
                 // special case the compatibility cultures
                 Name switch

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -581,7 +581,7 @@ namespace System.Globalization
         internal string SortName => _sortName ??= _cultureData.SortName;
 
         /// <summary>
-        /// The culture name to use to interop with the underlying native globalization libraries like ICU or Windows NLS APIs. 
+        /// The culture name to use to interop with the underlying native globalization libraries like ICU or Windows NLS APIs.
         /// For example, we can have the name de_DE@collation=phonebook when using ICU for the German culture de-DE with the phonebook sorting behavior.
         /// </summary>
         internal string? InteropName => _cultureData.InteropName;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/62929

Unicode defines a notion of how can specify the sorting name inside the culture name. It does that using the term `u-co`. For example, `zh-TW-u-co-zhuyin` meant to be the `zh-TW` culture with sort behavior of `zhuyin`. Such a name will be resolved to `zh-TW@collation=zhuyin` in ICU. 
Names with `u-co` used to work fine in .NET 5.0 when running on Windows but was failing on other platforms like Linux. So, this seems a regression but was not perfect anyway in .NET 5.0 either. The change here is to allow such culture names to work in all platforms and behave as expected too, especially when sort names are specified.