### PR TITLE
Fix MethodDesc::CbStackPop for string ctors on x86

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1656,6 +1656,13 @@ UINT MethodDesc::CbStackPop()
     SUPPORTS_DAC;
     MetaSig msig(this);
     ArgIterator argit(&msig);
+
+    bool fCtorOfVariableSizedObject = msig.HasThis() && (GetMethodTable() == g_pStringClass) && IsCtor();
+    if (fCtorOfVariableSizedObject)
+    {
+        msig.ClearHasThis();
+    }
+    
     return argit.CbStackPop();
 }
 #endif // TARGET_X86


### PR DESCRIPTION
This method was not taking into account the fact that string ctors
don't have dummy this argument after a recent change. Stack walking
in cases where prestub for the ctor was invoked resulted in a wrong
unwinding of ESP for ctors with more than one argument.

This change fixes it by removing "has this" flag from the signature
before getting the stack arguments size.

Close #63003