### PR TITLE
[release/6.0] Change macOS activatin injection failure handling

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -845,6 +845,15 @@ PAL_ERROR InjectActivationInternal(CorUnix::CPalThread* pThread)
     // We can get EAGAIN when printing stack overflow stack trace and when other threads hit
     // stack overflow too. Those are held in the sigsegv_handler with blocked signals until
     // the process exits.
+
+#ifdef __APPLE__
+    // On Apple, pthread_kill is not allowed to be sent to dispatch queue threads
+    if (status == ENOTSUP)
+    {
+        return ERROR_NOT_SUPPORTED;
+    }
+#endif
+
     if ((status != 0) && (status != EAGAIN))
     {
         // Failure to send the signal is fatal. There are only two cases when sending


### PR DESCRIPTION
Backport of #59045 to release/6.0

The pthread_kill can fail with ENOTSUP on macOS when the target thread
is a dispatch queue thread. Instead of aborting the process, it is
better to fail to inject the activation and rely on return address
hijacking and other means of syncing with GC.

## Customer Impact
Without this change, .NET 6 apps that execute code on dispatch queue threads were reported to abort during GC thread suspension by the Excel team and another 3rd party customer. While Excel team was able to work around the problem by not executing managed code on dispatch queue threads, the other customer was unable to do that due to their heavy usage of these threads.

## Testing
coreclr and libraries tests locally. The change has been in main branch for about three months without issues.

## Risk
Low, the change only prevents the process from dying immediately when `pthread_kill` is not supported for the target thread. 