### PR TITLE
Handle race condition when HttpListener is stopped or closed

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -624,10 +624,20 @@ namespace System.Net
                 {
                     throw new InvalidOperationException(SR.Format(SR.net_listener_mustcall, "Start()"));
                 }
+                
+                HttpListenerSession session = _currentSession;
+
+                // Because there is no synchronization, the listener can be stopped or closed while the method is executing,
+                // resulting in a null session
+                if (session == null)
+                {
+                    throw new HttpListenerException((int)Interop.HttpApi.ERROR_INVALID_PARAMETER);
+                }
+
                 // prepare the ListenerAsyncResult object (this will have it's own
                 // event that the user can wait on for IO completion - which means we
                 // need to signal it when IO completes)
-                asyncResult = new ListenerAsyncResult(_currentSession!, state, callback);
+                asyncResult = new ListenerAsyncResult(session, state, callback);
                 uint statusCode = asyncResult.QueueBeginGetContext();
                 if (statusCode != Interop.HttpApi.ERROR_SUCCESS &&
                     statusCode != Interop.HttpApi.ERROR_IO_PENDING)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -624,7 +624,7 @@ namespace System.Net
                 {
                     throw new InvalidOperationException(SR.Format(SR.net_listener_mustcall, "Start()"));
                 }
-                
+
                 HttpListenerSession? session = _currentSession;
 
                 // Because there is no synchronization, the listener can be stopped or closed while the method is executing,

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -508,7 +508,7 @@ namespace System.Net
                 uint size = 4096;
                 ulong requestId = 0;
                 memoryBlob = new SyncRequestContext((int)size);
-                HttpListenerSession session = _currentSession;
+                HttpListenerSession? session = _currentSession;
 
                 // Because there is no synchronization, the listener can be stopped or closed while the method is executing,
                 // resulting in a null session
@@ -625,7 +625,7 @@ namespace System.Net
                     throw new InvalidOperationException(SR.Format(SR.net_listener_mustcall, "Start()"));
                 }
                 
-                HttpListenerSession session = _currentSession;
+                HttpListenerSession? session = _currentSession;
 
                 // Because there is no synchronization, the listener can be stopped or closed while the method is executing,
                 // resulting in a null session

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -508,7 +508,14 @@ namespace System.Net
                 uint size = 4096;
                 ulong requestId = 0;
                 memoryBlob = new SyncRequestContext((int)size);
-                HttpListenerSession session = _currentSession!;
+                HttpListenerSession session = _currentSession;
+
+                // Because there is no synchronization, the listener can be stopped or closed while the method is executing,
+                // resulting in a null session
+                if (session == null)
+                {
+                    throw new HttpListenerException((int)Interop.HttpApi.ERROR_INVALID_PARAMETER);
+                }
 
                 while (true)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/63345

If the HttpListener is stopped or closed while `GetContext` is executing, the `_currentSession` field may be null. This PR detects this case and throws a `HttpListenerException` instead of a `NullReferenceException`.