### PR TITLE
Improve Regex UpdateBumpalong optimization for non-atomic and lazy loops

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1815,7 +1815,10 @@ namespace System.Text.RegularExpressions.Generator
                 Debug.Assert(node.Type is RegexNode.UpdateBumpalong, $"Unexpected type: {node.Type}");
 
                 TransferSliceStaticPosToPos();
-                writer.WriteLine("base.runtextpos = pos;");
+                using (EmitBlock(writer, "if (base.runtextpos < pos)"))
+                {
+                    writer.WriteLine("base.runtextpos = pos;");
+                }
             }
 
             // Emits code for a concatenation

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1997,11 +1997,19 @@ namespace System.Text.RegularExpressions
             {
                 Debug.Assert(node.Type is RegexNode.UpdateBumpalong, $"Unexpected type: {node.Type}");
 
-                // base.runtextpos = pos;
+                // if (base.runtextpos < pos)
+                // {
+                //     base.runtextpos = pos;
+                // }
                 TransferSliceStaticPosToPos();
+                Ldthisfld(s_runtextposField);
+                Ldloc(pos);
+                Label skipUpdate = DefineLabel();
+                Bge(skipUpdate);
                 Ldthis();
                 Ldloc(pos);
                 Stfld(s_runtextposField);
+                MarkLabel(skipUpdate);
             }
 
             // Emits code for a concatenation

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -1103,6 +1103,7 @@ namespace System.Text.RegularExpressions
                         // of the backtracking stack contains the runtextpos from the start of this Go call. Replace
                         // that tracking value with the current runtextpos value if it's greater.
                         {
+                            Debug.Assert(!_rightToLeft, "UpdateBumpalongs aren't added for RTL");
                             ref int trackingpos = ref runtrack![runtrack.Length - 1];
                             if (trackingpos < runtextpos)
                             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -1101,10 +1101,16 @@ namespace System.Text.RegularExpressions
                     case RegexCode.UpdateBumpalong:
                         // UpdateBumpalong should only exist in the code stream at such a point where the root
                         // of the backtracking stack contains the runtextpos from the start of this Go call. Replace
-                        // that tracking value with the current runtextpos value.
-                        runtrack![runtrack.Length - 1] = runtextpos;
-                        advance = 0;
-                        continue;
+                        // that tracking value with the current runtextpos value if it's greater.
+                        {
+                            ref int trackingpos = ref runtrack![runtrack.Length - 1];
+                            if (trackingpos < runtextpos)
+                            {
+                                trackingpos = runtextpos;
+                            }
+                            advance = 0;
+                            continue;
+                        }
 
                     default:
                         Debug.Fail($"Unimplemented state: {_operator:X8}");

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -58,9 +58,15 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"a{1,3}b", "abc", RegexOptions.None, 0, 3, true, "ab");
                 yield return (@"a{1,3}b", "aaabc", RegexOptions.None, 0, 5, true, "aaab");
                 yield return (@"a{1,3}b", "aaaabc", RegexOptions.None, 0, 6, true, "aaab");
+                yield return (@"a{1,3}?b", "bc", RegexOptions.None, 0, 2, false, string.Empty);
+                yield return (@"a{1,3}?b", "abc", RegexOptions.None, 0, 3, true, "ab");
+                yield return (@"a{1,3}?b", "aaabc", RegexOptions.None, 0, 5, true, "aaab");
+                yield return (@"a{1,3}?b", "aaaabc", RegexOptions.None, 0, 6, true, "aaab");
 
                 yield return (@"a{2,}b", "abc", RegexOptions.None, 0, 3, false, string.Empty);
                 yield return (@"a{2,}b", "aabc", RegexOptions.None, 0, 4, true, "aab");
+                yield return (@"a{2,}?b", "abc", RegexOptions.None, 0, 3, false, string.Empty);
+                yield return (@"a{2,}?b", "aabc", RegexOptions.None, 0, 4, true, "aab");
 
                 // {,n} is treated as a literal rather than {0,n} as it should be
                 yield return (@"a{,3}b", "a{,3}bc", RegexOptions.None, 0, 6, true, "a{,3}b");
@@ -68,6 +74,7 @@ namespace System.Text.RegularExpressions.Tests
 
                 // Using [a-z], \s, \w: Actual - "([a-zA-Z]+)\\s(\\w+)"
                 yield return (@"([a-zA-Z]+)\s(\w+)", "David Bau", RegexOptions.None, 0, 9, true, "David Bau");
+                yield return (@"([a-zA-Z]+?)\s(\w+)", "David Bau", RegexOptions.None, 0, 9, true, "David Bau");
 
                 // \\S, \\d, \\D, \\W: Actual - "(\\S+):\\W(\\d+)\\s(\\D+)"
                 yield return (@"(\S+):\W(\d+)\s(\D+)", "Price: 5 dollars", RegexOptions.None, 0, 16, true, "Price: 5 dollars");
@@ -107,6 +114,7 @@ namespace System.Text.RegularExpressions.Tests
 
                     if (!RegexHelpers.IsNonBacktracking(engine))
                     {
+                        // Atomic greedy
                         yield return (Case("(?>[0-9]+)abc"), "abc12345abc", options, 3, 8, true, "12345abc");
                         yield return (Case("(?>(?>[0-9]+))abc"), "abc12345abc", options, 3, 8, true, "12345abc");
                         yield return (Case("(?>[0-9]*)abc"), "abc12345abc", options, 3, 8, true, "12345abc");
@@ -116,8 +124,21 @@ namespace System.Text.RegularExpressions.Tests
                         yield return (Case("(?>a+)123"), "aa1234", options, 0, 5, true, "aa123");
                         yield return (Case("(?>a*)123"), "aa1234", options, 0, 5, true, "aa123");
                         yield return (Case("(?>(?>a*))123"), "aa1234", options, 0, 5, true, "aa123");
-                        yield return (Case("(?>a+?)a"), "aaaaa", options, 0, 2, true, "aa");
-                        yield return (Case("(?>a*?)a"), "aaaaa", options, 0, 1, true, "a");
+                        yield return (Case("(?>a{2,})b"), "aaab", options, 0, 4, true, "aaab");
+
+                        // Atomic lazy
+                        yield return (Case("(?>[0-9]+?)abc"), "abc12345abc", options, 3, 8, true, "5abc");
+                        yield return (Case("(?>(?>[0-9]+?))abc"), "abc12345abc", options, 3, 8, true, "5abc");
+                        yield return (Case("(?>[0-9]*?)abc"), "abc12345abc", options, 3, 8, true, "abc");
+                        yield return (Case("(?>[^z]+?)z"), "zzzzxyxyxyz123", options, 4, 9, true, "yz");
+                        yield return (Case("(?>(?>[^z]+?))z"), "zzzzxyxyxyz123", options, 4, 9, true, "yz");
+                        yield return (Case("(?>[^z]*?)z123"), "zzzzxyxyxyz123", options, 4, 10, true, "z123");
+                        yield return (Case("(?>a+?)123"), "aa1234", options, 0, 5, true, "a123");
+                        yield return (Case("(?>a*?)123"), "aa1234", options, 0, 5, true, "123");
+                        yield return (Case("(?>(?>a*?))123"), "aa1234", options, 0, 5, true, "123");
+                        yield return (Case("(?>a{2,}?)b"), "aaab", options, 0, 4, true, "aab");
+
+                        // Alternations
                         yield return (Case("(?>hi|hello|hey)hi"), "hellohi", options, 0, 0, false, string.Empty);
                         yield return (Case("(?>hi|hello|hey)hi"), "hihi", options, 0, 4, true, "hihi");
                     }
@@ -143,8 +164,44 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(\w+)@\w+.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
                 yield return (@"((\w+))@\w+.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
                 yield return (@"(\w+)c@\w+.com", "abc@def.comabcdef", RegexOptions.None, 0, 17, true, "abc@def.com");
+                yield return (@".+a", "baa", RegexOptions.None, 0, 3, true, "baa");
+                yield return (@"[ab]+a", "cacbaac", RegexOptions.None, 0, 7, true, "baa");
+                yield return (@"^(\d{2,3}){2}$", "1234", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"(\d{2,3}){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"((\d{2,3})){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"(abc\d{2,3}){2}", "abc123abc4567", RegexOptions.None, 0, 12, true, "abc123abc456");
+
+                // Lazy versions of those loops
+                yield return (@"a+?", "aaa", RegexOptions.None, 0, 3, true, "a");
+                yield return (@"a+?\d+?", "a1", RegexOptions.None, 0, 2, true, "a1");
+                yield return (@".+?\d+?", "a1", RegexOptions.None, 0, 2, true, "a1");
+                yield return (".+?\nabc", "a\nabc", RegexOptions.None, 0, 5, true, "a\nabc");
+                yield return (@"\d+?", "abcd123efg", RegexOptions.None, 0, 10, true, "1");
+                yield return (@"\d+?\d+?", "abcd123efg", RegexOptions.None, 0, 10, true, "12");
+                yield return (@"\w+?123\w+?", "abcd123efg", RegexOptions.None, 0, 10, true, "abcd123e");
+                yield return (@"\d+?\w+?", "abcd123efg", RegexOptions.None, 0, 10, true, "12");
+                yield return (@"\w+?@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"\w{3,}?@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"\w{4,}?@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, false, string.Empty);
+                yield return (@"\w{2,5}?@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"\w{3}?@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"\w{0,3}?@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"\w{0,2}?c@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"\w*?@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"(\w+?)@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"((\w+?))@\w+?.com", "abc@def.com", RegexOptions.None, 0, 11, true, "abc@def.com");
+                yield return (@"(\w+?)c@\w+?.com", "abc@def.comabcdef", RegexOptions.None, 0, 17, true, "abc@def.com");
+                yield return (@".+?a", "baa", RegexOptions.None, 0, 3, true, "ba");
+                yield return (@"[ab]+?a", "cacbaac", RegexOptions.None, 0, 7, true, "ba");
+                yield return (@"^(\d{2,3}?){2}$", "1234", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"(\d{2,3}?){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"((\d{2,3}?)){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"(abc\d{2,3}?){2}", "abc123abc4567", RegexOptions.None, 0, 12, true, "abc123abc45");
+
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
+                    // Back references not support with NonBacktracking
+
                     yield return (@"(\w+)c@\w+.com\1", "abc@def.comabcdef", RegexOptions.None, 0, 17, true, "abc@def.comab");
                     yield return (@"(\w+)@def.com\1", "abc@def.comab", RegexOptions.None, 0, 13, false, string.Empty);
                     yield return (@"(\w+)@def.com\1", "abc@def.combc", RegexOptions.None, 0, 13, true, "bc@def.combc");
@@ -153,36 +210,44 @@ namespace System.Text.RegularExpressions.Tests
                     yield return (@"\w+(?<!a)", "aa", RegexOptions.None, 0, 2, false, string.Empty);
                     yield return (@"(?>\w+)(?<!a)", "a", RegexOptions.None, 0, 1, false, string.Empty);
                     yield return (@"(?>\w+)(?<!a)", "aa", RegexOptions.None, 0, 2, false, string.Empty);
+
+                    yield return (@"(\w+?)c@\w+?.com\1", "abc@def.comabcdef", RegexOptions.None, 0, 17, true, "abc@def.comab");
+                    yield return (@"(\w+?)@def.com\1", "abc@def.comab", RegexOptions.None, 0, 13, false, string.Empty);
+                    yield return (@"(\w+?)@def.com\1", "abc@def.combc", RegexOptions.None, 0, 13, true, "bc@def.combc");
+                    yield return (@"(\w*?)@def.com\1", "abc@def.com", RegexOptions.None, 0, 11, true, "@def.com");
+                    yield return (@"\w+?(?<!a)", "a", RegexOptions.None, 0, 1, false, string.Empty);
+                    yield return (@"\w+?(?<!a)", "aa", RegexOptions.None, 0, 2, false, string.Empty);
+                    yield return (@"(?>\w+?)(?<!a)", "a", RegexOptions.None, 0, 1, false, string.Empty);
+                    yield return (@"(?>\w+?)(?<!a)", "aa", RegexOptions.None, 0, 2, false, string.Empty);
                 }
-                yield return (@".+a", "baa", RegexOptions.None, 0, 3, true, "baa");
-                yield return (@"[ab]+a", "cacbaac", RegexOptions.None, 0, 7, true, "baa");
-                yield return (@"^(\d{2,3}){2}$", "1234", RegexOptions.None, 0, 4, true, "1234");
-                yield return (@"(\d{2,3}){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
-                yield return (@"((\d{2,3})){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
-                if (!RegexHelpers.IsNonBacktracking(engine))
-                {
-                    yield return (@"(\d{2,3})+", "1234", RegexOptions.None, 0, 4, true, "123");
-                    yield return (@"(\d{2,3})*", "123456", RegexOptions.None, 0, 4, true, "123");
-                }
-                else
-                {
-                    // In NonBacktracking engine the alternation in the inner loop allows the alternate longer eager match of \d{2}\d{2}
-                    yield return (@"(\d{2,3})+", "1234", RegexOptions.None, 0, 4, true, "1234");
-                    yield return (@"(\d{2,3})*", "123456", RegexOptions.None, 0, 4, true, "1234");
-                }
-                yield return (@"(abc\d{2,3}){2}", "abc123abc4567", RegexOptions.None, 0, 12, true, "abc123abc456");
+
+                yield return (@"(\d{2,3})+", "1234", RegexOptions.None, 0, 4, true, !RegexHelpers.IsNonBacktracking(engine) ? "123" : "1234"); // NonBacktracking engine allows the alternate longer eager match of \d{2}\d{2}
+                yield return (@"(\d{2,3})*", "123456", RegexOptions.None, 0, 4, true, !RegexHelpers.IsNonBacktracking(engine) ? "123" : "1234");
+                yield return (@"(\d{2,3})+?", "1234", RegexOptions.None, 0, 4, true, !RegexHelpers.IsNonBacktracking(engine) ? "123" : "1234");
+                yield return (@"(\d{2,3})*?", "123456", RegexOptions.None, 0, 4, true, "");
+                yield return (@"(\d{2,3}?)+", "1234", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"(\d{2,3}?)*", "123456", RegexOptions.None, 0, 4, true, "1234");
+                yield return (@"(\d{2,3}?)+?", "1234", RegexOptions.None, 0, 4, true, "12");
+                yield return (@"(\d{2,3}?)*?", "123456", RegexOptions.None, 0, 4, true, "");
+
                 foreach (RegexOptions lineOption in new[] { RegexOptions.None, RegexOptions.Singleline, RegexOptions.Multiline })
                 {
                     yield return (@".*", "abc", lineOption, 1, 2, true, "bc");
                     yield return (@".*c", "abc", lineOption, 1, 2, true, "bc");
                     yield return (@"b.*", "abc", lineOption, 1, 2, true, "bc");
                     yield return (@".*", "abc", lineOption, 2, 1, true, "c");
+
+                    yield return (@".*?", "abc", lineOption, 1, 2, true, "");
+                    yield return (@".*?c", "abc", lineOption, 1, 2, true, "bc");
+                    yield return (@"b.*?", "abc", lineOption, 1, 2, true, "b");
+                    yield return (@".*?", "abc", lineOption, 2, 1, true, "");
                 }
 
                 // Nested loops
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     yield return ("a*(?:a[ab]*)*", "aaaababbbbbbabababababaaabbb", RegexOptions.None, 0, 28, true, "aaaa");
+                    yield return ("a*(?:a[ab]*?)*?", "aaaababbbbbbabababababaaabbb", RegexOptions.None, 0, 28, true, "aaaa");
                 }
 
                 // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"
@@ -475,14 +540,28 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@".*\nFoo", $"\nFooThis should match", RegexOptions.None, 0, 21, true, "\nFoo");
                 yield return (@".*\nfoo", "\nfooThis should match", RegexOptions.None, 4, 17, false, "");
 
+                yield return (@".*?\nfoo", "This shouldn't match", RegexOptions.None, 0, 20, false, "");
+                yield return (@"a.*?\nfoo", "This shouldn't match", RegexOptions.None, 0, 20, false, "");
+                yield return (@".*?\nFoo", $"\nFooThis should match", RegexOptions.None, 0, 21, true, "\nFoo");
+                yield return (@".*?\nfoo", "\nfooThis should match", RegexOptions.None, 4, 17, false, "");
+
                 yield return (@".*\dfoo", "This shouldn't match", RegexOptions.None, 0, 20, false, "");
                 yield return (@".*\dFoo", "This1Foo should match", RegexOptions.None, 0, 21, true, "This1Foo");
                 yield return (@".*\dFoo", "This1foo should 2Foo match", RegexOptions.None, 0, 26, true, "This1foo should 2Foo");
                 yield return (@".*\dFoo", "This1foo shouldn't 2foo match", RegexOptions.None, 0, 29, false, "");
                 yield return (@".*\dfoo", "This1foo shouldn't 2foo match", RegexOptions.None, 24, 5, false, "");
 
+                yield return (@".*?\dfoo", "This shouldn't match", RegexOptions.None, 0, 20, false, "");
+                yield return (@".*?\dFoo", "This1Foo should match", RegexOptions.None, 0, 21, true, "This1Foo");
+                yield return (@".*?\dFoo", "This1foo should 2Foo match", RegexOptions.None, 0, 26, true, "This1foo should 2Foo");
+                yield return (@".*?\dFoo", "This1foo shouldn't 2foo match", RegexOptions.None, 0, 29, false, "");
+                yield return (@".*?\dfoo", "This1foo shouldn't 2foo match", RegexOptions.None, 24, 5, false, "");
+
                 yield return (@".*\dfoo", "1fooThis1foo should 1foo match", RegexOptions.None, 4, 9, true, "This1foo");
                 yield return (@".*\dfoo", "This shouldn't match 1foo", RegexOptions.None, 0, 20, false, "");
+
+                yield return (@".*?\dfoo", "1fooThis1foo should 1foo match", RegexOptions.None, 4, 9, true, "This1foo");
+                yield return (@".*?\dfoo", "This shouldn't match 1foo", RegexOptions.None, 0, 20, false, "");
 
                 // Turkish case sensitivity
                 yield return (@"[\u0120-\u0130]", "\u0130", RegexOptions.None, 0, 1, true, "\u0130");
@@ -494,6 +573,17 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@".*\dFoo", "This1Foo should 2fOo match", RegexOptions.IgnoreCase, 0, 26, true, "This1Foo should 2fOo");
                 yield return (@".*\dfoo", "1fooThis1FOO should 1foo match", RegexOptions.IgnoreCase, 4, 9, true, "This1FOO");
 
+                yield return (@".*?\nFoo", "\nfooThis should match", RegexOptions.IgnoreCase, 0, 21, true, "\nfoo");
+                yield return (@".*?\dFoo", "This1foo should match", RegexOptions.IgnoreCase, 0, 21, true, "This1foo");
+                if (!RegexHelpers.IsNonBacktracking(engine)) // TODO: https://github.com/dotnet/runtime/issues/63395
+                {
+                    yield return (@".*?\dFoo", "This1foo should 2FoO match", RegexOptions.IgnoreCase, 0, 26, true, "This1foo");
+                    yield return (@".*?\dFoo", "This1Foo should 2fOo match", RegexOptions.IgnoreCase, 0, 26, true, "This1Foo");
+                    yield return (@".*?\dFo{2}", "This1foo should 2FoO match", RegexOptions.IgnoreCase, 0, 26, true, "This1foo");
+                    yield return (@".*?\dFo{2}", "This1Foo should 2fOo match", RegexOptions.IgnoreCase, 0, 26, true, "This1Foo");
+                }
+                yield return (@".*?\dfoo", "1fooThis1FOO should 1foo match", RegexOptions.IgnoreCase, 4, 9, true, "This1FOO");
+
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     // RightToLeft
@@ -502,6 +592,12 @@ namespace System.Text.RegularExpressions.Tests
                     yield return (@"foo\d+", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 10, 4, true, "foo4");
                     yield return (@"foo\d+", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 10, 3, false, string.Empty);
                     yield return (@"foo\d+", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 11, 21, false, string.Empty);
+
+                    yield return (@"foo\d+?", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 0, 32, true, "foo4567890");
+                    yield return (@"foo\d+?", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 10, 22, true, "foo4567890");
+                    yield return (@"foo\d+?", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 10, 4, true, "foo4");
+                    yield return (@"foo\d+?", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 10, 3, false, string.Empty);
+                    yield return (@"foo\d+?", "0123456789foo4567890foo         ", RegexOptions.RightToLeft, 11, 21, false, string.Empty);
 
                     yield return (@"\s+\d+", "sdf 12sad", RegexOptions.RightToLeft, 0, 9, true, " 12");
                     yield return (@"\s+\d+", " asdf12 ", RegexOptions.RightToLeft, 0, 6, false, string.Empty);
@@ -514,14 +610,28 @@ namespace System.Text.RegularExpressions.Tests
                     yield return (@"a.*\nfoo", "This shouldn't match", RegexOptions.None | RegexOptions.RightToLeft, 0, 20, false, "");
                     yield return (@".*\nFoo", $"This should match\nFoo", RegexOptions.None | RegexOptions.RightToLeft, 0, 21, true, "This should match\nFoo");
 
+                    yield return (@".*?\nfoo", "This shouldn't match", RegexOptions.None | RegexOptions.RightToLeft, 0, 20, false, "");
+                    yield return (@".*?\nfoo", "This should matchfoo\n", RegexOptions.None | RegexOptions.RightToLeft, 4, 13, false, "");
+                    yield return (@"a.*?\nfoo", "This shouldn't match", RegexOptions.None | RegexOptions.RightToLeft, 0, 20, false, "");
+                    yield return (@".*?\nFoo", $"This should match\nFoo", RegexOptions.None | RegexOptions.RightToLeft, 0, 21, true, "\nFoo");
+
                     yield return (@".*\dfoo", "This shouldn't match", RegexOptions.None | RegexOptions.RightToLeft, 0, 20, false, "");
                     yield return (@".*\dFoo", "This1Foo should match", RegexOptions.None | RegexOptions.RightToLeft, 0, 21, true, "This1Foo");
                     yield return (@".*\dFoo", "This1foo should 2Foo match", RegexOptions.None | RegexOptions.RightToLeft, 0, 26, true, "This1foo should 2Foo");
                     yield return (@".*\dFoo", "This1foo shouldn't 2foo match", RegexOptions.None | RegexOptions.RightToLeft, 0, 29, false, "");
                     yield return (@".*\dfoo", "This1foo shouldn't 2foo match", RegexOptions.None | RegexOptions.RightToLeft, 19, 0, false, "");
 
+                    yield return (@".*?\dfoo", "This shouldn't match", RegexOptions.None | RegexOptions.RightToLeft, 0, 20, false, "");
+                    yield return (@".*?\dFoo", "This1Foo should match", RegexOptions.None | RegexOptions.RightToLeft, 0, 21, true, "1Foo");
+                    yield return (@".*?\dFoo", "This1foo should 2Foo match", RegexOptions.None | RegexOptions.RightToLeft, 0, 26, true, "2Foo");
+                    yield return (@".*?\dFoo", "This1foo shouldn't 2foo match", RegexOptions.None | RegexOptions.RightToLeft, 0, 29, false, "");
+                    yield return (@".*?\dfoo", "This1foo shouldn't 2foo match", RegexOptions.None | RegexOptions.RightToLeft, 19, 0, false, "");
+
                     yield return (@".*\dfoo", "1fooThis2foo should 1foo match", RegexOptions.None | RegexOptions.RightToLeft, 8, 4, true, "2foo");
                     yield return (@".*\dfoo", "This shouldn't match 1foo", RegexOptions.None | RegexOptions.RightToLeft, 0, 20, false, "");
+
+                    yield return (@".*?\dfoo", "1fooThis2foo should 1foo match", RegexOptions.None | RegexOptions.RightToLeft, 8, 4, true, "2foo");
+                    yield return (@".*?\dfoo", "This shouldn't match 1foo", RegexOptions.None | RegexOptions.RightToLeft, 0, 20, false, "");
 
                     // .* : RTL, case insensitive
                     yield return (@".*\nFoo", "\nfooThis should match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 21, true, "\nfoo");
@@ -531,6 +641,14 @@ namespace System.Text.RegularExpressions.Tests
                     yield return (@".*\dfoo", "1fooThis2FOO should 1foo match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 8, 4, true, "2FOO");
                     yield return (@"[\w\s].*", "1fooThis2FOO should 1foo match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 30, true, "1fooThis2FOO should 1foo match");
                     yield return (@"i.*", "1fooThis2FOO should 1foo match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 30, true, "is2FOO should 1foo match");
+
+                    yield return (@".*?\nFoo", "\nfooThis should match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 21, true, "\nfoo");
+                    yield return (@".*?\dFoo", "This1foo should match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 21, true, "1foo");
+                    yield return (@".*?\dFoo", "This1foo should 2FoO match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 26, true, "2FoO");
+                    yield return (@".*?\dFoo", "This1Foo should 2fOo match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 26, true, "2fOo");
+                    yield return (@".*?\dfoo", "1fooThis2FOO should 1foo match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 8, 4, true, "2FOO");
+                    yield return (@"[\w\s].*?", "1fooThis2FOO should 1foo match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 30, true, "h");
+                    yield return (@"i.*?", "1fooThis2FOO should 1foo match", RegexOptions.IgnoreCase | RegexOptions.RightToLeft, 0, 30, true, "is2FOO should 1foo match");
                 }
 
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/36149")]


### PR DESCRIPTION
Fixes #62676 
Fixes #62677

In addition to adding more tests for lazy loops, this PR makes two improvements for "update bumpalong".  For the interpreter/compiler/source generator, the scan loop finds the next likely position for a match, then runs the engine at that position, then finds the next likely position for a match, then runs the engine at that position, etc.  Normally after a failed match the scan loop just "bumps" the position by 1 beyond where it previously started.  But it's possible for the matching logic to update that bumpalong position further when it sees that starting from an earlier position would be pointless.  In .NET 5, we added such an optimization for the case where an expression begins with a greedy loop with an infinite upper bound, primarily focused on atomic loops (but we'd add the UpdateBumpalong node for non-atomic as well).  In such cases, we don't need to repeat the matching at any position within the space explored by that loop, since we'll just be re-evaluating the same conditions, and so we bump the runtextpos position to whatever it is after the loop.

That works well for atomic loops, where we won't backtrack.  But for non-atomic loops, this optimization ended up being a nop: in the case of a failed match, we'd backtrack into the loop and back off to a lower position, and then dutifully store that position... that means the runtextpos would initially be bumped to the appropriate place, but by the end of the matching would have worked its way back most or all the way to where we started.  The simple fix here isn't to just always set the position to the one after the loop but instead only set it if it's greater than what's currently stored.

We can also insert UpdateBumpalong for non-atomic lazy loops, since in the case of failure (which is the only case where UpdateBumpalong has an impact), a greedy loop and a lazy loop end up exploring the same search space, just in a different direction.

Example artificial microbenchmarks to highlight the possible impact:
```C#
using System.Linq;
using System.Text.RegularExpressions;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private Regex _greedy = new Regex(".*abcd", RegexOptions.Compiled);
    private Regex _lazy = new Regex(".*?abcd", RegexOptions.Compiled);
    private string _input = string.Concat(Enumerable.Repeat("abcDefghijklmnopqrstuvwxyz", 1000));

    [Benchmark] public void Greedy() => _greedy.IsMatch(_input);
    [Benchmark] public void Lazy() => _lazy.IsMatch(_input);
}
```

| Method |         Toolchain |            Mean | Ratio |
|------- |------------------ |----------------:|------:|
| Greedy | \main\corerun.exe | 1,287,192.23 us | 1.000 |
| Greedy |   \pr\corerun.exe |        85.61 us | 0.000 |
|        |                   |                 |       |
|   Lazy | \main\corerun.exe |   555,555.78 us | 1.000 |
|   Lazy |   \pr\corerun.exe |        42.33 us | 0.000 |