### PR TITLE
JIT: rework logic for when OSR imports method entry

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2145,6 +2145,20 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
 
     block->dspFlags();
 
+    // Display OSR info
+    //
+    if (opts.IsOSR())
+    {
+        if (block == fgEntryBB)
+        {
+            printf("original-entry");
+        }
+        if (block == fgOSREntryBB)
+        {
+            printf("osr-entry");
+        }
+    }
+
     printf("\n");
 }
 


### PR DESCRIPTION
OSR wasn't aggressive enough in importing the original method entry,
so if an inlinee introduced a recursive tail call that we wanted to
turn into a loop, we might find that the target block for the loop
branch never got created.

Update the logic so that we import the entry if we're in the root
method and we have an inlineable call in tail position. This will
over-import in many cases but if those blocks turn out to be unreachable
they will usually be removed without impacting final code gen.

Fixes one of the OSR stress mode failures seen in #62980.