### PR TITLE
Fix ABI stress test coverage

### DIFF
--- a/src/tests/JIT/Stress/ABI/Config.cs
+++ b/src/tests/JIT/Stress/ABI/Config.cs
@@ -15,10 +15,17 @@ namespace ABIStress
         internal const string InstantiatingStubPrefix = "ABIStress_InstantiatingStub_";
 
         internal static StressModes StressModes { get; set; } = StressModes.None;
+        
+        private const int DefaultSeed = 20010415;
         // The base seed. This value combined with the index of the
         // caller/pinvoker/callee will uniquely determine how it is generated
         // and which callee is used.
-        internal const int Seed = 0xeadbeef;
+        internal static int Seed { get; set; } = Environment.GetEnvironmentVariable("CORECLR_SEED") switch
+        {
+            string seedStr when seedStr.Equals("random", StringComparison.OrdinalIgnoreCase) => new Random().Next(),
+            string seedStr when int.TryParse(seedStr, out int envSeed) => envSeed,
+            _ => DefaultSeed
+        };
         internal const int MinParams = 1;
         internal static int MaxParams { get; set; } = 25;
         // The number of callees to use. When stressing tailcalls, this is the number of tailcallee parameter lists to pregenerate.

--- a/src/tests/JIT/Stress/ABI/PInvokes.cs
+++ b/src/tests/JIT/Stress/ABI/PInvokes.cs
@@ -16,7 +16,7 @@ namespace ABIStress
         private static bool DoPInvokes(int callerIndex)
         {
             string callerName = Config.PInvokerPrefix + callerIndex;
-            Random rand = new Random(Seed);
+            Random rand = new Random(GetSeed(callerName));
             List<TypeEx> pms = RandomParameters(s_allTypes, rand);
 
             int calleeIndex = rand.Next(0, Config.NumCallees);

--- a/src/tests/JIT/Stress/ABI/Program.cs
+++ b/src/tests/JIT/Stress/ABI/Program.cs
@@ -17,14 +17,6 @@ namespace ABIStress
 {
     internal partial class Program
     {
-        private const int DefaultSeed = 20010415;
-        private static int Seed = Environment.GetEnvironmentVariable("CORECLR_SEED") switch
-        {
-            string seedStr when seedStr.Equals("random", StringComparison.OrdinalIgnoreCase) => new Random().Next(),
-            string seedStr when int.TryParse(seedStr, out int envSeed) => envSeed,
-            _ => DefaultSeed
-        };
-
         private static int Main(string[] args)
         {
             static void Usage()
@@ -175,7 +167,7 @@ namespace ABIStress
 
         private static Callee CreateCallee(string name, TypeEx[] candidateParamTypes)
         {
-            Random rand = new Random(Seed);
+            Random rand = new Random(GetSeed(name));
             List<TypeEx> pms = RandomParameters(candidateParamTypes, rand);
             var tc = new Callee(name, pms);
             return tc;

--- a/src/tests/JIT/Stress/ABI/Stubs.cs
+++ b/src/tests/JIT/Stress/ABI/Stubs.cs
@@ -13,14 +13,6 @@ namespace ABIStress
 {
     public class StubsTestHelpers
     {
-        private const int DefaultSeed = 20010415;
-        private static int Seed = Environment.GetEnvironmentVariable("CORECLR_SEED") switch
-        {
-            string seedStr when seedStr.Equals("random", StringComparison.OrdinalIgnoreCase) => new Random().Next(),
-            string seedStr when int.TryParse(seedStr, out int envSeed) => envSeed,
-            _ => DefaultSeed
-        };
-
         public static void CompareNumbers(int actual, int expected)
         {
             if (actual != expected)
@@ -122,7 +114,7 @@ namespace ABIStress
         {
             string callerNameSeed = Config.InstantiatingStubPrefix + "Caller" + callerIndex; // Use a consistent seed value here so that the various various of unboxing/instantiating stubs are generated with the same arg shape
             string callerName = callerNameSeed + (staticMethod ? "Static" : "Instance") + (onValueType ? "Class" : "ValueType") + typeGenericShape.ToString() + methodGenericShape.ToString();
-            Random rand = new Random(Seed);
+            Random rand = new Random(GetSeed(callerName));
             List<TypeEx> pms;
             do
             {

--- a/src/tests/JIT/Stress/ABI/TailCalls.cs
+++ b/src/tests/JIT/Stress/ABI/TailCalls.cs
@@ -24,7 +24,7 @@ namespace ABIStress
             }
 
             string callerName = Config.TailCallerPrefix + callerIndex;
-            Random rand = new Random(Seed);
+            Random rand = new Random(GetSeed(callerName));
             List<TypeEx> callerParams;
             List<Callee> callable;
             do


### PR DESCRIPTION
When this test was changed to use a seed from an environment variable it
changed the test to repeatedly create the same Random instance, reducing
coverage to only ever test one variant.

This reverts the changes by #50767 and uses the environment variable in
the existing seed mechanism instead.