### PR TITLE
Make DllImportGenerator unit tests' compilations use live refs

### DIFF
--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -38,6 +38,10 @@
     <RunScriptCommands Condition="'$(TargetsWindows)' != 'true'" Include="export MONO_ENV_OPTIONS='$(MonoEnvOptions)'" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TestRunRequiresLiveRefPack)' == 'true'">
+    <None Include="$(MicrosoftNetCoreAppRefPackRefDir)**/*.dll" CopyToOutputDirectory="PreserveNewest" LinkBase="live-ref-pack/" Visible="false" />
+  </ItemGroup>
+
   <!--
     Unit/Functional/Integration test support.
     Supported runners: xunit.

--- a/src/libraries/Common/tests/SourceGenerators/LiveReferencePack.cs
+++ b/src/libraries/Common/tests/SourceGenerators/LiveReferencePack.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+namespace SourceGenerators.Tests
+{
+    internal static class LiveReferencePack
+    {
+        /// <summary>
+        /// Get the metadata references for the reference assemblies from the live build.
+        /// </summary>
+        /// <returns>The metadata references</returns>
+        /// <remarks>
+        /// This function assumes the references are in a live-ref-pack subfolder next to the
+        /// containing assembly. Test projects can set TestRunRequiresLiveRefPack to copy the
+        /// live references to a live-ref-pack subfolder in their output directory.
+        /// </remarks>
+        public static ImmutableArray<MetadataReference> GetMetadataReferences()
+        {
+            string testDirectory = Path.GetDirectoryName(typeof(LiveReferencePack).Assembly.Location)!;
+            return Directory.EnumerateFiles(Path.Combine(testDirectory, "live-ref-pack"))
+                .Select<string, MetadataReference>(f => MetadataReference.CreateFromFile(f))
+                .ToImmutableArray();
+        }
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -193,22 +193,7 @@ partial class Test
     public static extern partial void Method();
 }}
 ";
-            // Only this test case needs the ancillary reference, so it creates/runs the test directly
-            // instead of going through VerifyAnalyzerAsync
-            (_, MetadataReference ancillary) = TestUtils.GetReferenceAssemblies();
-            var test = new VerifyCS.Test()
-            {
-                TestCode = source
-            };
-            test.SolutionTransforms.Add((solution, projectId) =>
-            {
-                Project project = solution.GetProject(projectId)!;
-                var refs = new List<MetadataReference>(project.MetadataReferences.Count + 1);
-                refs.AddRange(project.MetadataReferences);
-                refs.Add(ancillary);
-                return solution.WithProjectMetadataReferences(projectId, refs);
-            });
-            await test.RunAsync(default);
+            await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
         [ConditionalFact]

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/DllImportGenerator.Unit.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/DllImportGenerator.Unit.Tests.csproj
@@ -5,7 +5,13 @@
     <IsPackable>false</IsPackable>
     <LangVersion>Preview</LangVersion>
     <Nullable>enable</Nullable>
+    <TestRunRequiresLiveRefPack>true</TestRunRequiresLiveRefPack>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(CommonTestPath)SourceGenerators\LiveReferencePack.cs"
+             Link="Common\SourceGenerators\LiveReferencePack.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />


### PR DESCRIPTION
- Add property (`TestRunRequiresLiveRefPack`) to indicate live refs should be copied to test output, such that they get included in the helix work item payload.
- Make DllImportGenerator unit tests use the live-built references during test run when compiling for the latest .NET version

Resolves https://github.com/dotnet/runtime/issues/60605

@AaronRobinsonMSFT @jkoritzinsky 