### PR TITLE
Refactor DllImports in Microsoft.Extensions.Hosting.Systemd

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Libraries.cs
@@ -5,6 +5,8 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
+        internal const string Libc = "libc";
+
         // Shims
         internal const string SystemNative = "libSystem.Native";
         internal const string NetSecurityNative = "libSystem.Net.Security.Native";

--- a/src/libraries/Common/src/Interop/Unix/libc/Interop.GetParentPid.cs
+++ b/src/libraries/Common/src/Interop/Unix/libc/Interop.GetParentPid.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class libc
+    {
+        [GeneratedDllImport(Libraries.Libc, EntryPoint = "getppid")]
+        internal static partial int GetParentPid();
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/Microsoft.Extensions.Hosting.Systemd.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/Microsoft.Extensions.Hosting.Systemd.csproj
@@ -19,6 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(CommonPath)Interop\Unix\libc\Interop.GetParentPid.cs" Link="Common\Interop\Unix\libc\Interop.GetParentPid.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs" Link="Common\Interop\Unix\Interop.Libraries.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Hosting\src\Microsoft.Extensions.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHelpers.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Microsoft.Extensions.Hosting.Systemd
@@ -34,7 +33,7 @@ namespace Microsoft.Extensions.Hosting.Systemd
             try
             {
                 // Check whether our direct parent is 'systemd'.
-                int parentPid = GetParentPid();
+                int parentPid = Interop.libc.GetParentPid();
                 string ppidString = parentPid.ToString(NumberFormatInfo.InvariantInfo);
                 byte[] comm = File.ReadAllBytes("/proc/" + ppidString + "/comm");
                 return comm.AsSpan().SequenceEqual(Encoding.ASCII.GetBytes("systemd\n"));
@@ -45,8 +44,5 @@ namespace Microsoft.Extensions.Hosting.Systemd
 
             return false;
         }
-
-        [GeneratedDllImport("libc", EntryPoint = "getppid")]
-        private static partial int GetParentPid();
     }
 }


### PR DESCRIPTION
Refactor the DllImports in Microsoft.Extensions.Hosting.Systemd into
Common/src/Interop in order to adhere to the interop guidelines.

This fixes part but not all of #28035