### PR TITLE
Improve use of {Last}IndexOf{Any} in Regex loops

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1897,7 +1897,7 @@ namespace System.Text.RegularExpressions.Generator
 
                             if (i < exclusiveEnd)
                             {
-                                EmitNode(node.Child(i), GetSubsequent(i, node, subsequent), emitLengthChecksIfRequired: false);
+                                EmitNode(node.Child(i), GetSubsequentOrDefault(i, node, subsequent), emitLengthChecksIfRequired: false);
                                 if (i < childCount - 1)
                                 {
                                     writer.WriteLine();
@@ -1911,7 +1911,7 @@ namespace System.Text.RegularExpressions.Generator
                         continue;
                     }
 
-                    EmitNode(node.Child(i), GetSubsequent(i, node, subsequent), emitLengthChecksIfRequired: emitLengthChecksIfRequired);
+                    EmitNode(node.Child(i), GetSubsequentOrDefault(i, node, subsequent), emitLengthChecksIfRequired: emitLengthChecksIfRequired);
                     if (i < childCount - 1)
                     {
                         writer.WriteLine();
@@ -1919,7 +1919,7 @@ namespace System.Text.RegularExpressions.Generator
                 }
 
                 // Gets the node to treat as the subsequent one to node.Child(index)
-                static RegexNode? GetSubsequent(int index, RegexNode node, RegexNode? subsequent)
+                static RegexNode? GetSubsequentOrDefault(int index, RegexNode node, RegexNode? defaultNode)
                 {
                     int childCount = node.ChildCount();
                     for (int i = index + 1; i < childCount; i++)
@@ -1931,7 +1931,7 @@ namespace System.Text.RegularExpressions.Generator
                         }
                     }
 
-                    return subsequent;
+                    return defaultNode;
                 }
             }
 

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3472,8 +3472,8 @@ namespace System.Text.RegularExpressions.Generator
                 RegexNode.Prevent => $"Zero-width negative lookahead assertion.",
                 RegexNode.Ref => $"Match the same text as matched by the {DescribeCapture(node.M, regexCode)}.",
                 RegexNode.Require => $"Zero-width positive lookahead assertion.",
-                RegexNode.Set => $"Match a character in the set {RegexCharClass.SetDescription(node.Str!)}.",
-                RegexNode.Setloop or RegexNode.Setloopatomic or RegexNode.Setlazy => $"Match a character in the set {RegexCharClass.SetDescription(node.Str!)} {DescribeLoop(node)}.",
+                RegexNode.Set => $"Match {DescribeSet(node.Str!)}.",
+                RegexNode.Setloop or RegexNode.Setloopatomic or RegexNode.Setlazy => $"Match {DescribeSet(node.Str!)} {DescribeLoop(node)}.",
                 RegexNode.Start => "Match if at the start position.",
                 RegexNode.Testgroup => $"Conditionally match one of two expressions depending on whether an initial expression matches.",
                 RegexNode.Testref => $"Conditionally match one of two expressions depending on whether the {DescribeCapture(node.M, regexCode)} matched.",
@@ -3507,6 +3507,26 @@ namespace System.Text.RegularExpressions.Generator
 
             return $"{name} capture group";
         }
+
+        /// <summary>Gets a textual description of what characters match a set.</summary>
+        private static string DescribeSet(string charClass) =>
+            charClass switch
+            {
+                RegexCharClass.AnyClass => "any character",
+                RegexCharClass.DigitClass => "a Unicode digit",
+                RegexCharClass.ECMADigitClass => "'0' through '9'",
+                RegexCharClass.ECMASpaceClass => "a whitespace character (ECMA)",
+                RegexCharClass.ECMAWordClass => "a word character (ECMA)",
+                RegexCharClass.NotDigitClass => "any character other than a Unicode digit",
+                RegexCharClass.NotECMADigitClass => "any character other than '0' through '9'",
+                RegexCharClass.NotECMASpaceClass => "any character other than a space character (ECMA)",
+                RegexCharClass.NotECMAWordClass => "any character other than a word character (ECMA)",
+                RegexCharClass.NotSpaceClass => "any character other than a space character",
+                RegexCharClass.NotWordClass => "any character other than a word character",
+                RegexCharClass.SpaceClass => "a whitespace character",
+                RegexCharClass.WordClass => "a word character",
+                _ => $"a character in the set {RegexCharClass.SetDescription(charClass)}",
+            };
 
         /// <summary>Writes a textual description of the node tree fit for rending in source.</summary>
         /// <param name="writer">The writer to which the description should be written.</param>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -51,6 +51,7 @@ namespace System.Text.RegularExpressions
         private static readonly MethodInfo s_spanIndexOfAnyCharCharChar = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanIndexOfAnySpan = typeof(MemoryExtensions).GetMethod("IndexOfAny", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanLastIndexOfChar = typeof(MemoryExtensions).GetMethod("LastIndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), Type.MakeGenericMethodParameter(0) })!.MakeGenericMethod(typeof(char));
+        private static readonly MethodInfo s_spanLastIndexOfSpan = typeof(MemoryExtensions).GetMethod("LastIndexOf", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
         private static readonly MethodInfo s_spanSliceIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int) })!;
         private static readonly MethodInfo s_spanSliceIntIntMethod = typeof(ReadOnlySpan<char>).GetMethod("Slice", new Type[] { typeof(int), typeof(int) })!;
         private static readonly MethodInfo s_spanStartsWith = typeof(MemoryExtensions).GetMethod("StartsWith", new Type[] { typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)), typeof(ReadOnlySpan<>).MakeGenericType(Type.MakeGenericMethodParameter(0)) })!.MakeGenericMethod(typeof(char));
@@ -58,6 +59,7 @@ namespace System.Text.RegularExpressions
         private static readonly MethodInfo s_stringGetCharsMethod = typeof(string).GetMethod("get_Chars", new Type[] { typeof(int) })!;
         private static readonly MethodInfo s_textInfoToLowerMethod = typeof(TextInfo).GetMethod("ToLower", new Type[] { typeof(char) })!;
         private static readonly MethodInfo s_arrayResize = typeof(Array).GetMethod("Resize")!.MakeGenericMethod(typeof(int));
+        private static readonly MethodInfo s_mathMinIntInt = typeof(Math).GetMethod("Min", new Type[] { typeof(int), typeof(int) })!;
 
         /// <summary>The ILGenerator currently in use.</summary>
         protected ILGenerator? _ilg;
@@ -2391,32 +2393,48 @@ namespace System.Text.RegularExpressions
                 EmitStackPop();
                 Stloc(startingPos);
 
-                // if (startingPos >= endingPos) goto originalDoneLabel;
-                Label originalDoneLabel = doneLabel;
+                // if (startingPos >= endingPos) goto doneLabel;
                 Ldloc(startingPos);
                 Ldloc(endingPos);
-                BgeFar(originalDoneLabel);
-                doneLabel = backtrackingLabel; // leave set to the backtracking label for all subsequent nodes
+                BgeFar(doneLabel);
 
-                if (subsequent?.FindStartingCharacter() is char subsequentCharacter)
+                if (subsequent?.FindStartingCharacterOrString() is ValueTuple<char, string?> literal)
                 {
-                    // endingPos = inputSpan.Slice(startingPos, endingPos - startingPos).LastIndexOf(subsequentCharacter);
+                    // endingPos = inputSpan.Slice(startingPos, Math.Min(inputSpan.Length, endingPos + literal.Length - 1) - startingPos).LastIndexOf(literal);
                     // if (endingPos < 0)
                     // {
-                    //     goto originalDoneLabel;
+                    //     goto doneLabel;
                     // }
                     Ldloca(inputSpan);
                     Ldloc(startingPos);
-                    Ldloc(endingPos);
-                    Ldloc(startingPos);
-                    Sub();
-                    Call(s_spanSliceIntIntMethod);
-                    Ldc(subsequentCharacter);
-                    Call(s_spanLastIndexOfChar);
+                    if (literal.Item2 is not null)
+                    {
+                        Ldloca(inputSpan);
+                        Call(s_spanGetLengthMethod);
+                        Ldloc(endingPos);
+                        Ldc(literal.Item2.Length - 1);
+                        Add();
+                        Call(s_mathMinIntInt);
+                        Ldloc(startingPos);
+                        Sub();
+                        Call(s_spanSliceIntIntMethod);
+                        Ldstr(literal.Item2);
+                        Call(s_stringAsSpanMethod);
+                        Call(s_spanLastIndexOfSpan);
+                    }
+                    else
+                    {
+                        Ldloc(endingPos);
+                        Ldloc(startingPos);
+                        Sub();
+                        Call(s_spanSliceIntIntMethod);
+                        Ldc(literal.Item1);
+                        Call(s_spanLastIndexOfChar);
+                    }
                     Stloc(endingPos);
                     Ldloc(endingPos);
                     Ldc(0);
-                    BltFar(originalDoneLabel);
+                    BltFar(doneLabel);
 
                     // endingPos += startingPos;
                     Ldloc(endingPos);
@@ -2448,6 +2466,8 @@ namespace System.Text.RegularExpressions
                 {
                     EmitStackPush(() => Ldloc(capturepos!));
                 }
+
+                doneLabel = backtrackingLabel; // leave set to the backtracking label for all subsequent nodes
             }
 
             void EmitSingleCharLazy(RegexNode node, bool emitLengthChecksIfRequired = true)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2023,14 +2023,30 @@ namespace System.Text.RegularExpressions
                         EmitSpanLengthCheck(requiredLength);
                         for (; i < exclusiveEnd; i++)
                         {
-                            EmitNode(node.Child(i), i + 1 < childCount ? node.Child(i + 1) : subsequent, emitLengthChecksIfRequired: false);
+                            EmitNode(node.Child(i), GetSubsequent(i, node, subsequent), emitLengthChecksIfRequired: false);
                         }
 
                         i--;
                         continue;
                     }
 
-                    EmitNode(node.Child(i), i + 1 < childCount ? node.Child(i + 1) : subsequent);
+                    EmitNode(node.Child(i), GetSubsequent(i, node, subsequent));
+                }
+
+                // Gets the node to treat as the subsequent one to node.Child(index)
+                static RegexNode? GetSubsequent(int index, RegexNode node, RegexNode? subsequent)
+                {
+                    int childCount = node.ChildCount();
+                    for (int i = index + 1; i < childCount; i++)
+                    {
+                        RegexNode next = node.Child(i);
+                        if (next.Type is not RegexNode.UpdateBumpalong) // skip node types that don't have a semantic impact
+                        {
+                            return next;
+                        }
+                    }
+
+                    return subsequent;
                 }
             }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1907,7 +1907,7 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Onelazy:
                     case RegexNode.Notonelazy:
                     case RegexNode.Setlazy:
-                        EmitSingleCharLazy(node, emitLengthChecksIfRequired);
+                        EmitSingleCharLazy(node, subsequent, emitLengthChecksIfRequired);
                         break;
 
                     case RegexNode.Oneloopatomic:
@@ -2486,7 +2486,7 @@ namespace System.Text.RegularExpressions
                 doneLabel = backtrackingLabel; // leave set to the backtracking label for all subsequent nodes
             }
 
-            void EmitSingleCharLazy(RegexNode node, bool emitLengthChecksIfRequired = true)
+            void EmitSingleCharLazy(RegexNode node, RegexNode? subsequent = null, bool emitLengthChecksIfRequired = true)
             {
                 Debug.Assert(node.Type is RegexNode.Onelazy or RegexNode.Notonelazy or RegexNode.Setlazy, $"Unexpected type: {node.Type}");
 
@@ -2573,16 +2573,95 @@ namespace System.Text.RegularExpressions
                 // Now match the next item in the lazy loop.  We need to reset the pos to the position
                 // just after the last character in this loop was matched, and we need to store the resulting position
                 // for the next time we backtrack.
-
                 // pos = startingPos;
+                // Match single char;
                 Ldloc(startingPos);
                 Stloc(pos);
                 SliceInputSpan();
-
-                // Match single character
                 EmitSingleChar(node);
                 TransferSliceStaticPosToPos();
 
+                // Now that we've appropriately advanced by one character and are set for what comes after the loop,
+                // see if we can skip ahead more iterations by doing a search for a following literal.
+                if (iterationCount is null &&
+                    node.Type is RegexNode.Notonelazy &&
+                    !IsCaseInsensitive(node) &&
+                    subsequent?.FindStartingCharacterOrString() is ValueTuple<char, string?> literal &&
+                    (literal.Item2?[0] ?? literal.Item1) != node.Ch)
+                {
+                    // e.g. "<[^>]*?>"
+                    // This lazy loop will consume all characters other than node.Ch until the subsequent literal.
+                    // We can implement it to search for either that char or the literal, whichever comes first.
+                    // If it ends up being that node.Ch, the loop fails (we're only here if we're backtracking).
+
+                    // startingPos = slice.IndexOfAny(node.Ch, literal);
+                    Ldloc(slice);
+                    Ldc(node.Ch);
+                    Ldc(literal.Item2?[0] ?? literal.Item1);
+                    Call(s_spanIndexOfAnyCharChar);
+                    Stloc(startingPos);
+
+                    // if ((uint)startingPos >= (uint)slice.Length) goto doneLabel;
+                    Ldloc(startingPos);
+                    Ldloca(slice);
+                    Call(s_spanGetLengthMethod);
+                    BgeUnFar(doneLabel);
+
+                    // if (slice[startingPos] == node.Ch) goto doneLabel;
+                    Ldloca(slice);
+                    Ldloc(startingPos);
+                    Call(s_spanGetItemMethod);
+                    LdindU2();
+                    Ldc(node.Ch);
+                    BeqFar(doneLabel);
+
+                    // pos += startingPos;
+                    // slice = inputSpace.Slice(pos, end - pos);
+                    Ldloc(pos);
+                    Ldloc(startingPos);
+                    Add();
+                    Stloc(pos);
+                    SliceInputSpan();
+                }
+                else if (iterationCount is null &&
+                    node.Type is RegexNode.Setlazy &&
+                    node.Str == RegexCharClass.AnyClass &&
+                    subsequent?.FindStartingCharacterOrString() is ValueTuple<char, string?> literal2)
+                {
+                    // e.g. ".*?string" with RegexOptions.Singleline
+                    // This lazy loop will consume all characters until the subsequent literal. If the subsequent literal
+                    // isn't found, the loop fails. We can implement it to just search for that literal.
+
+                    // startingPos = slice.IndexOf(literal);
+                    Ldloc(slice);
+                    if (literal2.Item2 is not null)
+                    {
+                        Ldstr(literal2.Item2);
+                        Call(s_stringAsSpanMethod);
+                        Call(s_spanIndexOfSpan);
+                    }
+                    else
+                    {
+                        Ldc(literal2.Item1);
+                        Call(s_spanIndexOfChar);
+                    }
+                    Stloc(startingPos);
+
+                    // if (startingPos < 0) goto doneLabel;
+                    Ldloc(startingPos);
+                    Ldc(0);
+                    BltFar(doneLabel);
+
+                    // pos += startingPos;
+                    // slice = inputSpace.Slice(pos, end - pos);
+                    Ldloc(pos);
+                    Ldloc(startingPos);
+                    Add();
+                    Stloc(pos);
+                    SliceInputSpan();
+                }
+
+                // Store the position we've left off at in case we need to iterate again.
                 // startingPos = pos;
                 Ldloc(pos);
                 Stloc(startingPos);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1379,45 +1379,39 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>Finds the guaranteed beginning character of the node, or null if none exists.</summary>
-        public char? FindStartingCharacter()
+        public (char Char, string? String)? FindStartingCharacterOrString()
         {
             RegexNode? node = this;
             while (true)
             {
-                if (node is null || (node.Options & RegexOptions.RightToLeft) != 0)
+                if (node is not null && (node.Options & RegexOptions.RightToLeft) == 0)
                 {
-                    return null;
-                }
+                    switch (node.Type)
+                    {
+                        case One:
+                        case Oneloop or Oneloopatomic or Onelazy when node.M > 0:
+                            if ((node.Options & RegexOptions.IgnoreCase) == 0 || !RegexCharClass.ParticipatesInCaseConversion(node.Ch))
+                            {
+                                return (node.Ch, null);
+                            }
+                            break;
 
-                char c;
-                switch (node.Type)
-                {
-                    case One:
-                    case Oneloop or Oneloopatomic or Onelazy when node.M > 0:
-                        c = node.Ch;
-                        break;
+                        case Multi:
+                            if ((node.Options & RegexOptions.IgnoreCase) == 0 || !RegexCharClass.ParticipatesInCaseConversion(node.Str.AsSpan()))
+                            {
+                                return ('\0', node.Str);
+                            }
+                            break;
 
-                    case Multi:
-                        c = node.Str![0];
-                        break;
-
-                    case Atomic:
-                    case Concatenate:
-                    case Capture:
-                    case Group:
-                    case Loop or Lazyloop when node.M > 0:
-                    case Require:
-                        node = node.Child(0);
-                        continue;
-
-                    default:
-                        return null;
-                }
-
-                if ((node.Options & RegexOptions.IgnoreCase) == 0 ||
-                    !RegexCharClass.ParticipatesInCaseConversion(c))
-                {
-                    return c;
+                        case Atomic:
+                        case Concatenate:
+                        case Capture:
+                        case Group:
+                        case Loop or Lazyloop when node.M > 0:
+                        case Require:
+                            node = node.Child(0);
+                            continue;
+                    }
                 }
 
                 return null;

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.KnownPattern.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.KnownPattern.Tests.cs
@@ -1211,150 +1211,184 @@ namespace System.Text.RegularExpressions.Tests
         // These patterns come from real-world customer usages
         //
 
-        [Theory]
-        [InlineData("https://foo.com:443/bar/17/groups/0ad1/providers/Network/public/4e-ip?version=16", "Network/public/4e-ip")]
-        [InlineData("ftp://443/notproviders/17/groups/0ad1/providers/Network/public/4e-ip?version=16", "Network/public/4e-ip")]
-        [InlineData("ftp://443/providersnot/17/groups/0ad1/providers/Network/public/4e-ip?version=16", "Network/public/4e-ip")]
-        public async Task RealWorld_ExtractResourceUri(string url, string expected)
+        public static IEnumerable<object[]> RealWorld_ExtractResourceUri_MemberData()
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                Regex r = await RegexHelpers.GetRegexAsync(engine, @"/providers/(.+?)\?");
-                Match m = r.Match(url);
-                Assert.True(m.Success);
-                if (!RegexHelpers.IsNonBacktracking(engine))
-                {
-                    Assert.Equal(2, m.Groups.Count);
-                    Assert.Equal(expected, m.Groups[1].Value);
-                }
+                yield return new object[] { engine, "https://foo.com:443/bar/17/groups/0ad1/providers/Network/public/4e-ip?version=16", "Network/public/4e-ip" };
+                yield return new object[] { engine, "ftp://443/notproviders/17/groups/0ad1/providers/Network/public/4e-ip?version=16", "Network/public/4e-ip" };
+                yield return new object[] { engine, "ftp://443/providersnot/17/groups/0ad1/providers/Network/public/4e-ip?version=16", "Network/public/4e-ip" };
             }
         }
 
         [Theory]
-        [InlineData("IsValidCSharpName", true)]
-        [InlineData("_IsValidCSharpName", true)]
-        [InlineData("__", true)]
-        [InlineData("a\u2169", true)] // \u2169 is in {Nl}
-        [InlineData("\u2169b", true)] // \u2169 is in {Nl}
-        [InlineData("a\u0600", true)] // \u0600 is in {Cf}
-        [InlineData("\u0600b", false)] // \u0600 is in {Cf}
-        [InlineData("a\u0300", true)] // \u0300 is in {Mn}
-        [InlineData("\u0300b", false)] // \u0300 is in {Mn}
-        [InlineData("https://foo.com:443/bar/17/groups/0ad1/providers/Network/public/4e-ip?version=16", false)]
-        [InlineData("david.jones@proseware.com", false)]
-        [InlineData("~david", false)]
-        [InlineData("david~", false)]
-        public async Task RealWorld_IsValidCSharpName(string value, bool isExpectedMatch)
+        [MemberData(nameof(RealWorld_ExtractResourceUri_MemberData))]
+        public async Task RealWorld_ExtractResourceUri(RegexEngine engine, string url, string expected)
+        {
+            Regex r = await RegexHelpers.GetRegexAsync(engine, @"/providers/(.+?)\?");
+            Match m = r.Match(url);
+            Assert.True(m.Success);
+            if (!RegexHelpers.IsNonBacktracking(engine))
+            {
+                Assert.Equal(2, m.Groups.Count);
+                Assert.Equal(expected, m.Groups[1].Value);
+            }
+        }
+
+        public static IEnumerable<object[]> RealWorld_IsValidCSharpName_MemberData()
+        {
+            foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
+            {
+                yield return new object[] { engine, "IsValidCSharpName", true };
+                yield return new object[] { engine, "_IsValidCSharpName", true };
+                yield return new object[] { engine, "__", true };
+                yield return new object[] { engine, "a\u2169", true  }; // \u2169 is in {Nl}
+                yield return new object[] { engine, "\u2169b", true  }; // \u2169 is in {Nl}
+                yield return new object[] { engine, "a\u0600", true  }; // \u0600 is in {Cf}
+                yield return new object[] { engine, "\u0600b", false }; // \u0600 is in {Cf}
+                yield return new object[] { engine, "a\u0300", true  }; // \u0300 is in {Mn}
+                yield return new object[] { engine, "\u0300b", false }; // \u0300 is in {Mn}
+                yield return new object[] { engine, "https://foo.com:443/bar/17/groups/0ad1/providers/Network/public/4e-ip?version=16", false };
+                yield return new object[] { engine, "david.jones@proseware.com", false };
+                yield return new object[] { engine, "~david", false };
+                yield return new object[] { engine, "david~", false };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RealWorld_IsValidCSharpName_MemberData))]
+        public async Task RealWorld_IsValidCSharpName(RegexEngine engine, string value, bool isExpectedMatch)
         {
             const string StartCharacterRegex = @"_|[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]";
             const string PartCharactersRegex = @"[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]";
-
             const string IdentifierRegex = @"^(" + StartCharacterRegex + ")(" + PartCharactersRegex + ")*$";
 
+            Regex r = await RegexHelpers.GetRegexAsync(engine, IdentifierRegex);
+            Assert.Equal(isExpectedMatch, r.IsMatch(value));
+        }
+
+        public static IEnumerable<object[]> RealWorld_IsCommentLine_MemberData()
+        {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                Regex r = await RegexHelpers.GetRegexAsync(engine, IdentifierRegex);
-                Assert.Equal(isExpectedMatch, r.IsMatch(value));
+                yield return new object[] { engine, "; this is a comment", true };
+                yield return new object[] { engine, "\t; so is this", true };
+                yield return new object[] { engine, "  ; and this", true };
+                yield return new object[] { engine, ";", true };
+                yield return new object[] { engine, ";comment\nNotThisBecauseOfNewLine", false };
+                yield return new object[] { engine, "-;not a comment", false };
             }
         }
 
         [Theory]
-        [InlineData("; this is a comment", true)]
-        [InlineData("\t; so is this", true)]
-        [InlineData("  ; and this", true)]
-        [InlineData(";", true)]
-        [InlineData(";comment\nNotThisBecauseOfNewLine", false)]
-        [InlineData("-;not a comment", false)]
-        public async Task RealWorld_IsCommentLine(string value, bool isExpectedMatch)
+        [MemberData(nameof(RealWorld_IsCommentLine_MemberData))]
+        public async Task RealWorld_IsCommentLine(RegexEngine engine, string value, bool isExpectedMatch)
         {
             const string CommentLineRegex = @"^\s*;\s*(.*?)\s*$";
 
+            Regex r = await RegexHelpers.GetRegexAsync(engine, CommentLineRegex);
+            Assert.Equal(isExpectedMatch, r.IsMatch(value));
+        }
+
+        public static IEnumerable<object[]> RealWorld_IsSectionLine_MemberData()
+        {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                Regex r = await RegexHelpers.GetRegexAsync(engine, CommentLineRegex);
-                Assert.Equal(isExpectedMatch, r.IsMatch(value));
+                yield return new object[] { engine, "[ThisIsASection]", true };
+                yield return new object[] { engine, " [ThisIsASection] ", true };
+                yield return new object[] { engine, "\t[ThisIs\\ASection]\t", true };
+                yield return new object[] { engine, "\t[This.Is:(A+Section)]\t", true };
+                yield return new object[] { engine, "[This Is Not]", false };
+                yield return new object[] { engine, "This is not[]", false };
+                yield return new object[] { engine, "[Nor This]/", false };
             }
         }
 
         [Theory]
-        [InlineData("[ThisIsASection]", true)]
-        [InlineData(" [ThisIsASection] ", true)]
-        [InlineData("\t[ThisIs\\ASection]\t", true)]
-        [InlineData("\t[This.Is:(A+Section)]\t", true)]
-        [InlineData("[This Is Not]", false)]
-        [InlineData("This is not[]", false)]
-        [InlineData("[Nor This]/", false)]
-        public async Task RealWorld_IsSectionLine(string value, bool isExpectedMatch)
+        [MemberData(nameof(RealWorld_IsSectionLine_MemberData))]
+        public async Task RealWorld_IsSectionLine(RegexEngine engine, string value, bool isExpectedMatch)
         {
             const string SectionLineRegex = @"^\s*\[([\w\.\-\+:\/\(\)\\]+)\]\s*$";
 
+            Regex r = await RegexHelpers.GetRegexAsync(engine, SectionLineRegex);
+            Assert.Equal(isExpectedMatch, r.IsMatch(value));
+        }
+
+        public static IEnumerable<object[]> RealWorld_ValueParse_MemberData()
+        {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                Regex r = await RegexHelpers.GetRegexAsync(engine, SectionLineRegex);
-                Assert.Equal(isExpectedMatch, r.IsMatch(value));
+                yield return new object[] { engine, "Jiri: 10", "10" };
+                yield return new object[] { engine, "jiri: -10.01", "-10.01" };
+                yield return new object[] { engine, "jiri: .-22", "-22" };
+                yield return new object[] { engine, "jiri: .-22.3", "-22.3" };
+                yield return new object[] { engine, "foo15.0", "15.0" };
+                yield return new object[] { engine, "foo15", "15" };
+                yield return new object[] { engine, "foo16bar", "16" };
+                yield return new object[] { engine, "fds:-4", "-4" };
+                yield return new object[] { engine, "dsa:-20.04", "-20.04" };
+                yield return new object[] { engine, "dsa:15.a", "15" };
             }
         }
 
         [Theory]
-        [InlineData("Jiri: 10", "10")]
-        [InlineData("jiri: -10.01", "-10.01")]
-        [InlineData("jiri: .-22", "-22")]
-        [InlineData("jiri: .-22.3", "-22.3")]
-        [InlineData("foo15.0", "15.0")]
-        [InlineData("foo15", "15")]
-        [InlineData("foo16bar", "16")]
-        [InlineData("fds:-4", "-4")]
-        [InlineData("dsa:-20.04", "-20.04")]
-        [InlineData("dsa:15.a", "15")]
-        public async Task RealWorld_ValueParse(string value, string expected)
+        [MemberData(nameof(RealWorld_ValueParse_MemberData))]
+        public async Task RealWorld_ValueParse(RegexEngine engine, string value, string expected)
+        {
+            Regex r = await RegexHelpers.GetRegexAsync(engine, @"(?<value>-?\d+(\.\d+)?)");
+            Match m = r.Match(value);
+            Assert.True(m.Success);
+            if (!RegexHelpers.IsNonBacktracking(engine)) // named capture groups unsupported
+            {
+                Assert.Equal(expected, m.Groups["value"].Value);
+            }
+        }
+
+        public static IEnumerable<object[]> RealWorld_FirebirdVersionString_MemberData()
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                Regex r = await RegexHelpers.GetRegexAsync(engine, @"(?<value>-?\d+(\.\d+)?)");
-                Match m = r.Match(value);
-                Assert.True(m.Success);
-                if (!RegexHelpers.IsNonBacktracking(engine)) // named capture groups unsupported
-                {
-                    Assert.Equal(expected, m.Groups["value"].Value);
-                }
+                yield return new object[] { engine, "WI-T4.0.0.1963 Firebird 4.0 Beta 2", "4.0.0.1963" };
+                yield return new object[] { engine, "WI-V3.0.5.33220 Firebird 3.0", "3.0.5.33220" };
             }
         }
 
         [Theory]
-        [InlineData("WI-T4.0.0.1963 Firebird 4.0 Beta 2", "4.0.0.1963")]
-        [InlineData("WI-V3.0.5.33220 Firebird 3.0", "3.0.5.33220")]
-        public async Task RealWorld_FirebirdVersionString(string value, string expected)
+        [MemberData(nameof(RealWorld_FirebirdVersionString_MemberData))]
+        public async Task RealWorld_FirebirdVersionString(RegexEngine engine, string value, string expected)
+        {
+            Regex r = await RegexHelpers.GetRegexAsync(engine, @"\w{2}-\w(\d+\.\d+\.\d+\.\d+)");
+            Match m = r.Match(value);
+            Assert.True(m.Success);
+            if (!RegexHelpers.IsNonBacktracking(engine))
+            {
+                Assert.Equal(expected, m.Groups[1].Value);
+            }
+        }
+
+        public static IEnumerable<object[]> RealWorld_ExternalEntryPoint_MemberData()
         {
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
-                Regex r = await RegexHelpers.GetRegexAsync(engine, @"\w{2}-\w(\d+\.\d+\.\d+\.\d+)");
-                Match m = r.Match(value);
-                Assert.True(m.Success);
-                if (!RegexHelpers.IsNonBacktracking(engine))
-                {
-                    Assert.Equal(expected, m.Groups[1].Value);
-                }
+                yield return new object[] { engine, "Foo!Bar.M", "Foo", "Bar", "M" };
+                yield return new object[] { engine, "Foo!Bar.A.B.C", "Foo", "Bar.A.B", "C" };
+                yield return new object[] { engine, "Foo1.Foo2.Foo!Bar.A.B.C", "Foo1.Foo2.Foo", "Bar.A.B", "C" };
+                yield return new object[] { engine, @"Foo1\Foo2.Foo!Bar.A.B.C", @"Foo1\Foo2.Foo", "Bar.A.B", "C" };
             }
         }
 
         [Theory]
-        [InlineData("Foo!Bar.M", "Foo", "Bar", "M")]
-        [InlineData("Foo!Bar.A.B.C", "Foo", "Bar.A.B", "C")]
-        [InlineData("Foo1.Foo2.Foo!Bar.A.B.C", "Foo1.Foo2.Foo", "Bar.A.B", "C")]
-        [InlineData(@"Foo1\Foo2.Foo!Bar.A.B.C", @"Foo1\Foo2.Foo", "Bar.A.B", "C")]
-        public async Task RealWorld_ExternalEntryPoint(string value, string a, string b, string c)
+        [MemberData(nameof(RealWorld_ExternalEntryPoint_MemberData))]
+        public async Task RealWorld_ExternalEntryPoint(RegexEngine engine, string value, string a, string b, string c)
         {
-            foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
+            Regex r = await RegexHelpers.GetRegexAsync(engine, @"^(.+)!(.+)\.([^.]+)$");
+            Match m = r.Match(value);
+            Assert.True(m.Success);
+            if (!RegexHelpers.IsNonBacktracking(engine)) // subcaptures aren't supported
             {
-                Regex r = await RegexHelpers.GetRegexAsync(engine, @"^(.+)!(.+)\.([^.]+)$");
-                Match m = r.Match(value);
-                Assert.True(m.Success);
-                if (!RegexHelpers.IsNonBacktracking(engine)) // subcaptures aren't supported
-                {
-                    Assert.Equal(a, m.Groups[1].Value);
-                    Assert.Equal(b, m.Groups[2].Value);
-                    Assert.Equal(c, m.Groups[3].Value);
-                }
+                Assert.Equal(a, m.Groups[1].Value);
+                Assert.Equal(b, m.Groups[2].Value);
+                Assert.Equal(c, m.Groups[3].Value);
             }
         }
 


### PR DESCRIPTION
Fixes #62670 
Fixes #62669 

This makes three perf improvements:
- For non-atomic greedy loops followed by a literal, we previously made an improvement to use LastIndexOf to search for the first character of that literal.  This improves that to allow it to LastIndexOf for the full string if the following literal is multiple chars.  This will automatically get better once #63285 is in and applied to LastIndexOf as well (@egorbo, FYI).
- For non-atomic greedy loops at the beginning of an expression, we weren't applying the LastIndexOf optimization because we were also optimizing the scan loop by inserting an UpdateBumpalong node after the loop node, and that was throwing off the detection of a literal following the loop.  That's fixed.
- For lazy loops followed by a literal, we can in some situations use IndexOf{Any}.  For a notone loop node, we can IndexOfAny(node char, literal char) to skip forward quickly to the next place to look, and for a .* loop in Singleline, we can just IndexOf(literal char).

Along the way I had a few bugs and tweaked some of our tests to make it easier to diagnose.  I also improved how we render set descriptions in comments in the source generator.

Example improvements:
```C#
using System.Text.RegularExpressions;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private Regex _greedy = new Regex(".*test", RegexOptions.Compiled);
    [Benchmark] public void Greedy() => _greedy.IsMatch("This is a test to see the impact the full string search has on throughput when that same character appears multiple times.");

    private Regex _lazy = new Regex(@"\([^)]+?\)", RegexOptions.Compiled);
    [Benchmark] public void Lazy() => _lazy.IsMatch("Let's match a parenthetical (the parens and all of the text between them)!");
}
```

| Method |         Toolchain |      Mean |    Error |   StdDev | Ratio |
|------- |------------------ |----------:|---------:|---------:|------:|
| Greedy | \main\corerun.exe | 466.61 ns | 7.644 ns | 7.150 ns |  1.00 |
| Greedy |   \pr\corerun.exe | 143.36 ns | 1.806 ns | 1.601 ns |  0.31 |
|        |                   |           |          |          |       |
|   Lazy | \main\corerun.exe | 105.75 ns | 1.804 ns | 1.687 ns |  1.00 |
|   Lazy |   \pr\corerun.exe |  49.99 ns | 0.908 ns | 0.849 ns |  0.47 |