### PR TITLE
Align rva fields in reflection emit

### DIFF
--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -500,8 +500,10 @@ extern "C" void QCALLTYPE ModuleBuilder_SetFieldRVAContent(QCall::ModuleHandle p
         IfFailThrow( pGen->GetSectionCreate (".sdata", sdReadWrite, &pReflectionModule->m_sdataSection) );
 
     // Define the alignment that the rva will be set to. Since the CoreCLR runtime only has hard alignment requirements
-    // up to 8 bytes, just align everything to an 8 byte alignment
-    DWORD alignment = 8; 
+    // up to 8 bytes, the highest alignment we may need is 8 byte alignment. This hard alignment requirement is only needed
+    // by Runtime.Helpers.CreateSpan<T>. Since the previous alignment was 4 bytes before CreateSpan was implemented, if the
+    // data isn't itself of size divisible by 8, just align to 4 to the memory cost of excess alignment.
+    DWORD alignment = (length % 8 == 0) ? 8 : 4;
 
     // Get the size of current .sdata section. This will be the RVA for this field within the section
     DWORD dwRVA = 0;

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -499,14 +499,18 @@ extern "C" void QCALLTYPE ModuleBuilder_SetFieldRVAContent(QCall::ModuleHandle p
     if (pReflectionModule->m_sdataSection == 0)
         IfFailThrow( pGen->GetSectionCreate (".sdata", sdReadWrite, &pReflectionModule->m_sdataSection) );
 
+    // Define the alignment that the rva will be set to. Since the CoreCLR runtime only has hard alignment requirements
+    // up to 8 bytes, just align everything to an 8 byte alignment
+    DWORD alignment = 8; 
+
     // Get the size of current .sdata section. This will be the RVA for this field within the section
     DWORD dwRVA = 0;
     IfFailThrow( pGen->GetSectionDataLen(pReflectionModule->m_sdataSection, &dwRVA) );
-    dwRVA = (dwRVA + sizeof(DWORD)-1) & ~(sizeof(DWORD)-1);
+    dwRVA = (dwRVA + alignment-1) & ~(alignment-1);
 
     // allocate the space in .sdata section
     void * pvBlob;
-    IfFailThrow( pGen->GetSectionBlock(pReflectionModule->m_sdataSection, length, sizeof(DWORD), (void**) &pvBlob) );
+    IfFailThrow( pGen->GetSectionBlock(pReflectionModule->m_sdataSection, length, alignment, (void**) &pvBlob) );
 
     // copy over the initialized data if specified
     if (pContent != NULL)

--- a/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineInitializedData.cs
+++ b/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineInitializedData.cs
@@ -105,11 +105,11 @@ namespace System.Reflection.Emit.Tests
             void CheckMethod(string name, int minAlignmentRequired, byte[] dataToVerify)
             {
                 var methodToCall = checkType.GetMethod(name);
-                long address = Math.Abs((long)(IntPtr)methodToCall.Invoke(null, null));
+                nint address = (nint)methodToCall.Invoke(null, null);
 
                 for (int i = 0; i < dataToVerify.Length; i++)
                 {
-                    Assert.Equal(dataToVerify[i], Marshal.ReadByte(new IntPtr(address + i)));
+                    Assert.Equal(dataToVerify[i], Marshal.ReadByte(address + (nint)i));
                 }
                 Assert.Equal(name + "_0" + "_" + address.ToString(), name + "_" + (address % minAlignmentRequired).ToString() + "_" + address.ToString());
             }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.Mono.cs
@@ -149,7 +149,16 @@ namespace System.Reflection.Emit
 
         internal void SetRVAData(byte[] data)
         {
+            attrs = attrs | FieldAttributes.HasFieldRVA;
             rva_data = (byte[])data.Clone();
+        }
+
+        internal static PackingSize RVADataPackingSize(int size)
+        {
+            if ((size % 8) == 0) return PackingSize.Size8;
+            if ((size % 4) == 0) return PackingSize.Size4;
+            if ((size % 2) == 0) return PackingSize.Size2;
+            return PackingSize.Size1;
         }
 
         public void SetConstant(object? defaultValue)

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
@@ -165,7 +165,7 @@ namespace System.Reflection.Emit
             {
                 TypeBuilder tb = DefineType(typeName,
                     TypeAttributes.Public | TypeAttributes.ExplicitLayout | TypeAttributes.Sealed,
-                                             typeof(ValueType), null, PackingSize.Size1, size);
+                                             typeof(ValueType), null, FieldBuilder.RVADataPackingSize(size), size);
                 tb.CreateType();
                 datablobtype = tb;
             }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -1616,7 +1616,7 @@ namespace System.Reflection.Emit
             {
                 TypeBuilder tb = DefineNestedType(typeName,
                     TypeAttributes.NestedPrivate | TypeAttributes.ExplicitLayout | TypeAttributes.Sealed,
-                                                   typeof(ValueType), null, PackingSize.Size1, size);
+                                                   typeof(ValueType), null, FieldBuilder.RVADataPackingSize(size), size);
                 tb.CreateType();
                 datablobtype = tb;
             }

--- a/src/mono/mono/metadata/class-accessors.c
+++ b/src/mono/mono/metadata/class-accessors.c
@@ -393,7 +393,7 @@ mono_class_get_field_def_values_with_swizzle (MonoClass *klass, int swizzle)
 		dataKind = PROP_FIELD_DEF_VALUES_2BYTESWIZZLE;
 	else if (swizzle == 4)
 		dataKind = PROP_FIELD_DEF_VALUES_4BYTESWIZZLE;
-	else
+	else if (swizzle == 8)
 		dataKind = PROP_FIELD_DEF_VALUES_8BYTESWIZZLE;
 	return (MonoFieldDefaultValue*)get_pointer_property (klass, dataKind);
 }
@@ -413,7 +413,7 @@ mono_class_set_field_def_values_with_swizzle (MonoClass *klass, MonoFieldDefault
 		dataKind = PROP_FIELD_DEF_VALUES_2BYTESWIZZLE;
 	else if (swizzle == 4)
 		dataKind = PROP_FIELD_DEF_VALUES_4BYTESWIZZLE;
-	else
+	else if (swizzle == 8)
 		dataKind = PROP_FIELD_DEF_VALUES_8BYTESWIZZLE;
 	set_pointer_property (klass, dataKind, values);
 }

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2002,6 +2002,12 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		min_align = 16;
 	 */
 
+	/* Respect the specified packing size at least to the extent necessary to align double variables.
+	 * This should avoid any GC problems, and will allow packing_size to be respected to support
+	 * CreateSpan<T>
+	 */
+	min_align = MIN (MONO_ABI_ALIGNOF (double), MAX (min_align, packing_size));
+
 	/*
 	 * When we do generic sharing we need to have layout
 	 * information for open generic classes (either with a generic


### PR DESCRIPTION
In support of CreateSpan (#60948), improve alignment for RVA static pre-initialized fields to align memory blocks which may contain long, ulong, or double primitive arrays on 8 byte boundaries.

Mono fix is more involved
- Fix Ref-Emit generated RVA statics
 - Set the HasFieldRVA bit. NOTE: earlier code that attempts to set the bit doesn't actually do that as the FieldRVA bit is in  FieldAttributes.ReservedMask which is masked away in the FieldBuilder constructor
 - Fix the Swizzle lookup. We should not be using the 8 byte swizzle in the final else clause.
- Enhance ref-emitted field to allow for use with CreateSpan
  - Ref-emitted fields should specify a pack size appropriate for minimum alignment of the CreateSpan targetted data
  - Respect the packing_size specified so that RVA static fields generated for CreateSpan can be properly aligned

Fixes #62314