### PR TITLE
Use "read" to fetch misaligned 64bit values from bundle header

### DIFF
--- a/src/native/corehost/bundle/file_entry.cpp
+++ b/src/native/corehost/bundle/file_entry.cpp
@@ -30,7 +30,7 @@ file_entry_t file_entry_t::read(reader_t &reader, uint32_t bundle_major_version,
         reader.read(&fixed_data.compressedSize, sizeof(int64_t));
     }
 
-    fixed_data.type   = *(file_type_t*)reader.read_direct(sizeof(file_type_t));
+    fixed_data.type   = (file_type_t)reader.read_byte();
 
     file_entry_t entry(&fixed_data, force_extraction);
 

--- a/src/native/corehost/bundle/file_entry.cpp
+++ b/src/native/corehost/bundle/file_entry.cpp
@@ -19,13 +19,16 @@ file_entry_t file_entry_t::read(reader_t &reader, uint32_t bundle_major_version,
     // First read the fixed-sized portion of file-entry
     file_entry_fixed_t fixed_data;
 
-    fixed_data.offset = *(int64_t*)reader.read_direct(sizeof(int64_t));
-    fixed_data.size   = *(int64_t*)reader.read_direct(sizeof(int64_t));
+    // NB: the file data is potentially unaligned, thus we use "read" to fetch 64bit values
+    reader.read(&fixed_data.offset, sizeof(int64_t));
+    reader.read(&fixed_data.size, sizeof(int64_t));
 
     // compressedSize is present only in v6+ headers
-    fixed_data.compressedSize = bundle_major_version >= 6 ?
-                        *(int64_t*)reader.read_direct(sizeof(int64_t)) :
-                        0;
+    fixed_data.compressedSize = 0;
+    if (bundle_major_version >= 6)
+    {
+        reader.read(&fixed_data.compressedSize, sizeof(int64_t));
+    }
 
     fixed_data.type   = *(file_type_t*)reader.read_direct(sizeof(file_type_t));
 

--- a/src/native/corehost/bundle/header.cpp
+++ b/src/native/corehost/bundle/header.cpp
@@ -24,23 +24,23 @@ bool header_fixed_t::is_valid() const
 
 header_t header_t::read(reader_t& reader)
 {
-    const header_fixed_t* fixed_header = reinterpret_cast<const header_fixed_t*>(reader.read_direct(sizeof(header_fixed_t)));
+    header_fixed_t fixed_header;
+    reader.read(&fixed_header, sizeof(header_fixed_t));
 
-    if (!fixed_header->is_valid())
+    if (!fixed_header.is_valid())
     {
         trace::error(_X("Failure processing application bundle."));
-        trace::error(_X("Bundle header version compatibility check failed. Header version: %d.%d"), fixed_header->major_version, fixed_header->minor_version);
+        trace::error(_X("Bundle header version compatibility check failed. Header version: %d.%d"), fixed_header.major_version, fixed_header.minor_version);
 
         throw StatusCode::BundleExtractionFailure;
     }
 
-    header_t header(fixed_header->major_version, fixed_header->minor_version, fixed_header->num_embedded_files);
+    header_t header(fixed_header.major_version, fixed_header.minor_version, fixed_header.num_embedded_files);
 
     // bundle_id is a component of the extraction path
     reader.read_path_string(header.m_bundle_id);
 
-    const header_fixed_v2_t *v2_header = reinterpret_cast<const header_fixed_v2_t*>(reader.read_direct(sizeof(header_fixed_v2_t)));
-    header.m_v2_header = *v2_header;
+    reader.read(&header.m_v2_header, sizeof(header_fixed_v2_t));
 
     return header;
 }

--- a/src/native/corehost/bundle/reader.cpp
+++ b/src/native/corehost/bundle/reader.cpp
@@ -54,7 +54,7 @@ size_t reader_t::read_path_length()
 {
     size_t length = 0;
 
-    int8_t first_byte = read();
+    int8_t first_byte = read_byte();
 
     // If the high bit is set, it means there are more bytes to read.
     if ((first_byte & 0x80) == 0)
@@ -63,7 +63,7 @@ size_t reader_t::read_path_length()
     }
     else
     {
-        int8_t second_byte = read();
+        int8_t second_byte = read_byte();
 
         if (second_byte & 0x80)
         {

--- a/src/native/corehost/bundle/reader.h
+++ b/src/native/corehost/bundle/reader.h
@@ -81,7 +81,7 @@ namespace bundle
             return m_ptr;
         }
 
-        int8_t read()
+        int8_t read_byte()
         {
             bounds_check();
             return *m_ptr++;
@@ -98,12 +98,6 @@ namespace bundle
             bounds_check(len);
             memcpy(dest, m_ptr, to_size_t_dbgchecked(len));
             m_ptr += len;
-        }
-
-        uint8_t read_byte()
-        {
-            bounds_check(1);
-            return (uint8_t)*m_ptr++;
         }
 
         size_t read_path_length();

--- a/src/native/corehost/bundle/reader.h
+++ b/src/native/corehost/bundle/reader.h
@@ -100,14 +100,10 @@ namespace bundle
             m_ptr += len;
         }
 
-        // Return a pointer to the requested bytes within the memory-mapped file.
-        // Skip over len bytes.
-        const char* read_direct(int64_t len)
+        uint8_t read_byte()
         {
-            bounds_check(len);
-            const char *ptr = m_ptr;
-            m_ptr += len;
-            return ptr;
+            bounds_check(1);
+            return (uint8_t)*m_ptr++;
         }
 
         size_t read_path_length();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/62273

Misalligned reads may cause crashes on ARM32, depending on system config.