### PR TITLE
Handle embedded assignments in copy propagation

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7370,11 +7370,8 @@ public:
     typedef ArrayStack<GenTree*> GenTreePtrStack;
     typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, GenTreePtrStack*> LclNumToGenTreePtrStack;
 
-    // Kill set to track variables with intervening definitions.
-    VARSET_TP optCopyPropKillSet;
-
     // Copy propagation functions.
-    void optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, LclNumToGenTreePtrStack* curSsaName);
+    void optCopyProp(Statement* stmt, GenTreeLclVarCommon* tree, unsigned lclNum, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     unsigned optIsSsaLocal(GenTree* tree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7374,7 +7374,7 @@ public:
     void optCopyProp(Statement* stmt, GenTreeLclVarCommon* tree, unsigned lclNum, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
-    unsigned optIsSsaLocal(GenTree* tree);
+    unsigned optIsSsaLocal(GenTreeLclVarCommon* lclNode);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();
     INDEBUG(void optDumpCopyPropStack(LclNumToGenTreePtrStack* curSsaName));

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -192,11 +192,6 @@ void Compiler::optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, Lc
             continue;
         }
 
-        if (newLclDefNode->gtFlags & GTF_VAR_CAST)
-        {
-            continue;
-        }
-
         if ((gsShadowVarInfo != nullptr) && newLclVarDsc->lvIsParam &&
             (gsShadowVarInfo[newLclNum].shadowCopy == lclNum))
         {

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -256,23 +256,17 @@ void Compiler::optCopyProp(Statement*               stmt,
 // optIsSsaLocal : helper to check if the tree is a local that participates in SSA numbering.
 //
 // Arguments:
-//    tree        -  The tree to perform the check on;
+//    lclNode - The local tree to perform the check on;
 //
 // Returns:
 //    - lclNum if the local is participating in SSA;
 //    - fieldLclNum if the parent local can be replaced by its only field;
 //    - BAD_VAR_NUM otherwise.
 //
-unsigned Compiler::optIsSsaLocal(GenTree* tree)
+unsigned Compiler::optIsSsaLocal(GenTreeLclVarCommon* lclNode)
 {
-    if (!tree->IsLocal())
-    {
-        return BAD_VAR_NUM;
-    }
-
-    GenTreeLclVarCommon* lclNode = tree->AsLclVarCommon();
-    unsigned             lclNum  = lclNode->GetLclNum();
-    LclVarDsc*           varDsc  = lvaGetDesc(lclNum);
+    unsigned   lclNum = lclNode->GetLclNum();
+    LclVarDsc* varDsc = lvaGetDesc(lclNum);
 
     if (!lvaInSsa(lclNum) && varDsc->CanBeReplacedWithItsField(this))
     {
@@ -343,7 +337,7 @@ void Compiler::optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curS
             // TODO-CQ: propagate on LCL_FLDs too.
             else if (tree->OperIs(GT_LCL_VAR) && ((tree->gtFlags & GTF_VAR_DEF) == 0))
             {
-                const unsigned lclNum = optIsSsaLocal(tree);
+                const unsigned lclNum = optIsSsaLocal(tree->AsLclVarCommon());
 
                 if (lclNum == BAD_VAR_NUM)
                 {


### PR DESCRIPTION
There are two parts to this change:

First, refactor `optCopyProp` a little, mostly just rename locals to makes things less confusing. This is the first two commits; there are no diffs for them.

Second, and the point of this change: refactor the main copy propagation loop to correctly handle embedded assignments:
```
Previously, as the comments in copy propagation tell us, it
did not handle "intervening", or not-top-level definitions of
locals, instead opting to maintain a dedicated kill set of them.

This is obviously a CQ problem, but also a TP one, as it meant
there had to be a second pass over the statement's IR, where
the definitions would be pushed on the stack.

This change does away with that, instead pushing new definitions
as they are encountered in execution order, and simultaneously
propagating on uses. Notably, this means the code now needs to
look at the real definition nodes, i. e. ASGs, not the LHS locals,
as those are encountered first in canonical execution order, i. e.
for a tree like:

  ASG
    LCL_VAR V00 "def"
    ADD
      LCL_VAR V00
      LCL_VAR V00

Were we to use the "def" as the definition point, we would wrongly
push it as the definition on the stack, even as the assignments
itself hasn't happened yet at that point.

There are nice diffs with this change, all resulting from unblocked
propagations, and mostly coming from setup arguments under calls.
```

This has CQ benefits, however, for me, this is needed because I want copy propagation to stop relying on VNs being assigned to the LHSs of ASGs (they should all have `$VN.Void` VNs). For that to work, I need the context from the parent ASG to properly retain the previous behavior when making that change.

There are also, apparently, (big) TP benefits to this change: PIN reports `0.6%` decrease in instructions retired when replaying the benchmarks collection.

Contributes to #10873.