### PR TITLE
Fix time reporting for the merged tests

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -149,7 +149,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
 
         builder.AppendLine("XUnitWrapperLibrary.TestFilter filter = args.Length != 0 ? new XUnitWrapperLibrary.TestFilter(args[0]) : null;");
         builder.AppendLine("XUnitWrapperLibrary.TestSummary summary = new();");
-        builder.AppendLine("System.Diagnostics.Stopwatch stopwatch = new();");
+        builder.AppendLine("System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();");
 
         foreach (ITestInfo test in testInfos)
         {

--- a/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
+++ b/src/tests/Common/XUnitWrapperLibrary/TestSummary.cs
@@ -71,7 +71,7 @@ public class TestSummary
 
         foreach (var test in _testResults)
         {
-            resultsFile.Append($@"<test name=""{test.Name}"" type=""{test.ContainingTypeName}"" method=""{test.MethodName}"" time=""{test.Duration.TotalSeconds}"" ");
+            resultsFile.Append($@"<test name=""{test.Name}"" type=""{test.ContainingTypeName}"" method=""{test.MethodName}"" time=""{test.Duration.TotalSeconds:F6}"" ");
             if (test.Exception is not null)
             {
                 resultsFile.AppendLine($@"result=""Fail""><failure exception-type=""{test.Exception.GetType()}""><message><![CDATA[{test.Exception.Message}]]></message><stack-trace><![CDATA[{test.Exception.StackTrace}]]></stack-trace></failure></test>");


### PR DESCRIPTION
In XUnitWrapperGenerator we need to initialize the stopwatch
variable using Stopwatch.StartNew(), not just new Stopwatch(),
otherwise the stopwatch never starts to run, that's why all the
test case times showed as zero. (Alternatively we could use
new Stopwatch() followed by stopwatch.Start() but I believe that
Stopwatch.StartNew() is generally considered to be more
performant.)

After applying this fix, some short test times started reporting
their running time in scientific notation (e.g. 5.5e-5) so I
modified the formatting to F6 - in the Methodical suite I see
a test running for 55 microseconds.

Thanks

Tomas