### PR TITLE
[DllImportGenerator] Remove DLLIMPORTGENERATOR_ENABLED define option

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -84,10 +84,6 @@
         <DllImportGenerator_UseInternalUnsafeType>true</DllImportGenerator_UseInternalUnsafeType>
         <DefineConstants>$(DefineConstants);DLLIMPORTGENERATOR_INTERNALUNSAFE</DefineConstants>
     </PropertyGroup>
-
-    <PropertyGroup>
-      <DefineConstants>$(DefineConstants);DLLIMPORTGENERATOR_ENABLED</DefineConstants>
-    </PropertyGroup>
   </Target>
 
   <Import Project="$(LibrariesProjectRoot)System.Runtime.InteropServices/gen/DllImportGenerator/Microsoft.Interop.DllImportGenerator.props" />

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.Designer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named BufferSize to provide the size of the caller-allocated buffer..
+        ///   Looks up a localized string similar to When a constructor taking a Span&lt;byte&gt; is specified on the native type, the type must also have a public integer constant named BufferSize to provide the size of the caller-allocated buffer..
         /// </summary>
         internal static string CallerAllocConstructorMustHaveBufferSizeConstantDescription {
             get {
@@ -223,6 +223,15 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert to &apos;GeneratedDllImport&apos;.
+        /// </summary>
+        internal static string ConvertToGeneratedDllImport {
+            get {
+                return ResourceManager.GetString("ConvertToGeneratedDllImport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use &apos;GeneratedDllImportAttribute&apos; instead of &apos;DllImportAttribute&apos; to generate P/Invoke marshalling code at compile time.
         /// </summary>
         internal static string ConvertToGeneratedDllImportDescription {
@@ -241,15 +250,6 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Convert to &apos;GeneratedDllImport&apos;.
-        /// </summary>
-        internal static string ConvertToGeneratedDllImportNoPreprocessor {
-            get {
-                return ResourceManager.GetString("ConvertToGeneratedDllImportNoPreprocessor", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use &apos;GeneratedDllImportAttribute&apos; instead of &apos;DllImportAttribute&apos; to generate P/Invoke marshalling code at compile time.
         /// </summary>
         internal static string ConvertToGeneratedDllImportTitle {
@@ -264,15 +264,6 @@ namespace Microsoft.Interop {
         internal static string ConvertToGeneratedDllImportWarning {
             get {
                 return ResourceManager.GetString("ConvertToGeneratedDllImportWarning", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Convert to &apos;GeneratedDllImport&apos; under a preprocessor define.
-        /// </summary>
-        internal static string ConvertToGeneratedDllImportWithPreprocessor {
-            get {
-                return ResourceManager.GetString("ConvertToGeneratedDllImportWithPreprocessor", resourceCulture);
             }
         }
         

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Resources.resx
@@ -171,14 +171,14 @@
   <data name="ConstantAndElementCountInfoDisallowed" xml:space="preserve">
     <value>Only one of 'ConstantElementCount' or 'ElementCountInfo' may be used in a 'MarshalUsingAttribute' for a given 'ElementIndirectionLevel'</value>
   </data>
+  <data name="ConvertToGeneratedDllImport" xml:space="preserve">
+    <value>Convert to 'GeneratedDllImport'</value>
+  </data>
   <data name="ConvertToGeneratedDllImportDescription" xml:space="preserve">
     <value>Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time</value>
   </data>
   <data name="ConvertToGeneratedDllImportMessage" xml:space="preserve">
     <value>Mark the method '{0}' with 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time</value>
-  </data>
-  <data name="ConvertToGeneratedDllImportNoPreprocessor" xml:space="preserve">
-    <value>Convert to 'GeneratedDllImport'</value>
   </data>
   <data name="ConvertToGeneratedDllImportTitle" xml:space="preserve">
     <value>Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time</value>
@@ -186,9 +186,6 @@
   <data name="ConvertToGeneratedDllImportWarning" xml:space="preserve">
     <value>Conversion to 'GeneratedDllImport' may change behavior and compatibility. See {0} for more information.</value>
     <comment>{0} is a documentation link</comment>
-  </data>
-  <data name="ConvertToGeneratedDllImportWithPreprocessor" xml:space="preserve">
-    <value>Convert to 'GeneratedDllImport' under a preprocessor define</value>
   </data>
   <data name="CustomTypeMarshallingManagedToNativeUnsupported" xml:space="preserve">
     <value>The specified parameter needs to be marshalled from managed to native, but the native type '{0}' does not support it.</value>

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
@@ -17,10 +17,8 @@ namespace DllImportGenerator.UnitTests
     [ActiveIssue("https://github.com/dotnet/runtime/issues/60650", TestRuntimes.Mono)]
     public class ConvertToGeneratedDllImportFixerTests
     {
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task Basic(bool usePreprocessorDefines)
+        [ConditionalFact]
+        public async Task Basic()
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -30,20 +28,7 @@ partial class Test
     public static extern int [|Method|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"")]
-    public static extern int Method(out int ret);
-#endif
-}}"
-                : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -52,14 +37,11 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task Comments(bool usePreprocessorDefines)
+        [ConditionalFact]
+        public async Task Comments()
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -75,32 +57,7 @@ partial class Test
     public static extern int [|Method2|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    // P/Invoke
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(/*name*/""DoesNotExist"")] // comment
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-#else
-    [DllImport(/*name*/""DoesNotExist"")] // comment
-    public static extern int Method1(out int ret);
-#endif
-
-    /** P/Invoke **/
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"") /*name*/]
-    // < ... >
-    public static partial int {{|CS8795:Method2|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"") /*name*/]
-    // < ... >
-    public static extern int Method2(out int ret);
-#endif
-}}"
-                : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -115,14 +72,11 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task MultipleAttributes(bool usePreprocessorDefines)
+        [ConditionalFact]
+        public async Task MultipleAttributes()
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -137,32 +91,7 @@ partial class Test
     public static extern int [|Method2|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if DLLIMPORTGENERATOR_ENABLED
-    [System.ComponentModel.Description(""Test""), GeneratedDllImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-#else
-    [System.ComponentModel.Description(""Test""), DllImport(""DoesNotExist"")]
-    public static extern int Method1(out int ret);
-#endif
-
-#if DLLIMPORTGENERATOR_ENABLED
-    [System.ComponentModel.Description(""Test"")]
-    [GeneratedDllImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.I4)]
-    public static partial int {{|CS8795:Method2|}}(out int ret);
-#else
-    [System.ComponentModel.Description(""Test"")]
-    [DllImport(""DoesNotExist"")]
-    [return: MarshalAs(UnmanagedType.I4)]
-    public static extern int Method2(out int ret);
-#endif
-}}"
-                : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -176,14 +105,11 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task NamedArguments(bool usePreprocessorDefines)
+        [ConditionalFact]
+        public async Task NamedArguments()
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -196,27 +122,7 @@ partial class Test
     public static extern int [|Method2|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static extern int Method1(out int ret);
-#endif
-
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"", CharSet = CharSet.Unicode)]
-    public static partial int {{|CS8795:Method2|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", CharSet = CharSet.Unicode)]
-    public static extern int Method2(out int ret);
-#endif
-}}" : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -228,14 +134,11 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task RemoveableNamedArguments(bool usePreprocessorDefines)
+        [ConditionalFact]
+        public async Task RemoveableNamedArguments()
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -248,27 +151,7 @@ partial class Test
     public static extern int [|Method2|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", BestFitMapping = false)]
-    public static extern int Method1(out int ret);
-#endif
-
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"")]
-    public static partial int {{|CS8795:Method2|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"", ThrowOnUnmappableChar = false)]
-    public static extern int Method2(out int ret);
-#endif
-}}" : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -280,14 +163,11 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ReplaceableExplicitPlatformDefaultCallingConvention(bool usePreprocessorDefines)
+        [ConditionalFact]
+        public async Task ReplaceableExplicitPlatformDefaultCallingConvention()
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -297,19 +177,7 @@ partial class Test
     public static extern int [|Method1|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", CallingConvention = CallingConvention.Winapi)]
-    public static extern int Method1(out int ret);
-#endif
-}}" : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -318,20 +186,15 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
 
         [ConditionalTheory]
-        [InlineData(CallingConvention.Cdecl, typeof(CallConvCdecl), true)]
-        [InlineData(CallingConvention.Cdecl, typeof(CallConvCdecl), false)]
-        [InlineData(CallingConvention.StdCall, typeof(CallConvStdcall), true)]
-        [InlineData(CallingConvention.StdCall, typeof(CallConvStdcall), false)]
-        [InlineData(CallingConvention.ThisCall, typeof(CallConvThiscall), true)]
-        [InlineData(CallingConvention.ThisCall, typeof(CallConvThiscall), false)]
-        [InlineData(CallingConvention.FastCall, typeof(CallConvFastcall), true)]
-        [InlineData(CallingConvention.FastCall, typeof(CallConvFastcall), false)]
-        public async Task ReplaceableCallingConvention(CallingConvention callConv, Type callConvType, bool usePreprocessorDefines)
+        [InlineData(CallingConvention.Cdecl, typeof(CallConvCdecl))]
+        [InlineData(CallingConvention.StdCall, typeof(CallConvStdcall))]
+        [InlineData(CallingConvention.ThisCall, typeof(CallConvThiscall))]
+        [InlineData(CallingConvention.FastCall, typeof(CallConvFastcall))]
+        public async Task ReplaceableCallingConvention(CallingConvention callConv, Type callConvType)
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -341,20 +204,7 @@ partial class Test
     public static extern int [|Method1|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
-    [UnmanagedCallConv(CallConvs = new System.Type[] {{ typeof({callConvType.FullName}) }})]
-    public static partial int {{|CS8795:Method1|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", CallingConvention = CallingConvention.{callConv})]
-    public static extern int Method1(out int ret);
-#endif
-}}" : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -364,14 +214,11 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
 
-        [ConditionalTheory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task PreferredAttributeOrder(bool usePreprocessorDefines)
+        [ConditionalFact]
+        public async Task PreferredAttributeOrder()
         {
             string source = @$"
 using System.Runtime.InteropServices;
@@ -381,19 +228,7 @@ partial class Test
     public static extern int [|Method|](out int ret);
 }}";
             // Fixed source will have CS8795 (Partial method must have an implementation) without generator run
-            string fixedSource = usePreprocessorDefines
-                ? @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-#if DLLIMPORTGENERATOR_ENABLED
-    [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-    public static partial int {{|CS8795:Method|}}(out int ret);
-#else
-    [DllImport(""DoesNotExist"", EntryPoint = ""Entry"", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-    public static extern int Method(out int ret);
-#endif
-}}" : @$"
+            string fixedSource = @$"
 using System.Runtime.InteropServices;
 partial class Test
 {{
@@ -402,8 +237,7 @@ partial class Test
 }}";
             await VerifyCS.VerifyCodeFixAsync(
                 source,
-                fixedSource,
-                usePreprocessorDefines ? WithPreprocessorDefinesKey : NoPreprocessorDefinesKey);
+                fixedSource);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
@@ -45,22 +45,20 @@ namespace DllImportGenerator.UnitTests.Verifiers
         }
 
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, string)"/>
-        public static async Task VerifyCodeFixAsync(string source, string fixedSource, string? codeActionEquivalenceKey = null)
-            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource, codeActionEquivalenceKey);
+        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+            => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult, string)"/>
-        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource, string? codeActionEquivalenceKey = null)
-            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource, codeActionEquivalenceKey);
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+            => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
 
         /// <inheritdoc cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)"/>
-        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource, string? codeActionEquivalenceKey = null)
+        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
         {
             var test = new Test
             {
                 TestCode = source,
                 FixedCode = fixedSource,
-                CodeActionEquivalenceKey = codeActionEquivalenceKey,
-                CodeActionValidationMode = CodeActionValidationMode.None,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);
@@ -113,9 +111,6 @@ namespace DllImportGenerator.UnitTests.Verifiers
                     return solution;
                 });
             }
-
-            protected override ParseOptions CreateParseOptions()
-                => ((CSharpParseOptions)base.CreateParseOptions()).WithPreprocessorSymbols("DLLIMPORTGENERATOR_ENABLED");
 
             protected override async Task RunImplAsync(CancellationToken cancellationToken)
             {


### PR DESCRIPTION
Remove `DLLIMPORTGENERATOR_ENABLED` define and associated code fix. Now that we have the forwarding via partial extern in and we've been able to switch runtime libraries over to it, this define is no longer useful.

@AaronRobinsonMSFT @jkoritzinsky 