### PR TITLE
Sign ILVerification.dll

### DIFF
--- a/src/coreclr/tools/ILVerification/ILVerification.csproj
+++ b/src/coreclr/tools/ILVerification/ILVerification.csproj
@@ -8,6 +8,7 @@
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <Import Project="ILVerification.projitems" />


### PR DESCRIPTION
TL;DR: Given the ILVerification ships in a nuget package and as far as I understand the guideline is to strongly name assemblies (even on Core), I'm trying to get ILVerification.dll to be strongly-named.

Background:
Over the break, I've revived the [roslyn PR](https://github.com/dotnet/roslyn/pull/37994) to use ILVerify in the compiler tests (side-by-side with PEVerify).
It's working pretty well, but it hit two issues related to ILVerification.dll not having a strong name:
1. In our correctness build legs, we get an compilation error (`CSC : error CS8002: Referenced assembly 'ILVerification, Version=6.0.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name. [D:\a\_work\1\s\src\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj]`)
2. The validation fails in tests on desktop environment because the desktop runtime won't load the assembly (`System.IO.FileLoadException : Could not load file or assembly 'ILVerification, Version=6.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)`)

Relates to https://github.com/dotnet/roslyn/issues/22872
