### PR TITLE
Fix Fiji time zone time conversion

### DIFF
--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -37,6 +37,7 @@ namespace System.Tests
         private static string s_strLisbon = s_isWindows ? "GMT Standard Time" : "Europe/Lisbon";
         private static string s_strNewfoundland = s_isWindows ? "Newfoundland Standard Time" : "America/St_Johns";
         private static string s_strIran = s_isWindows ? "Iran Standard Time" : "Asia/Tehran";
+        private static string s_strFiji = s_isWindows ? "Fiji Standard Time" : "Pacific/Fiji";
 
         private static TimeZoneInfo s_myUtc = TimeZoneInfo.Utc;
         private static TimeZoneInfo s_myLocal = TimeZoneInfo.Local;
@@ -566,17 +567,7 @@ namespace System.Tests
 
             time1utc = new DateTime(2006, 12, 31, 15, 59, 59, DateTimeKind.Utc);
             time1 = new DateTime(2006, 12, 31, 15, 59, 59);
-            if (s_isWindows)
-            {
-                // ambiguous time between rules
-                // this is not ideal, but the way it works
-                VerifyConvert(time1utc, s_strPerth, time1.AddHours(8));
-            }
-            else
-            {
-                // Linux has the correct rules for Perth for days from December 3, 2006 to the end of the year
-                VerifyConvert(time1utc, s_strPerth, time1.AddHours(9));
-            }
+            VerifyConvert(time1utc, s_strPerth, time1.AddHours(9));
 
             // 2007 rule
             time1utc = new DateTime(2006, 12, 31, 20, 1, 2, DateTimeKind.Utc);
@@ -2872,6 +2863,36 @@ namespace System.Tests
                 TimeZoneInfo.ClearCachedData();
                 Environment.SetEnvironmentVariable("TZ", originalTZ);
             }
+        }
+
+        [Fact]
+        public static void FijiTimeZoneTest()
+        {
+            TimeZoneInfo fijiTZ = TimeZoneInfo.FindSystemTimeZoneById(s_strFiji); // "Fiji Standard Time" - "Pacific/Fiji"
+
+            DateTime utcDT = new DateTime(2021, 1, 1, 14, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(TimeSpan.FromHours(13), fijiTZ.GetUtcOffset(utcDT));
+            Assert.True(fijiTZ.IsDaylightSavingTime(utcDT));
+
+            utcDT = new DateTime(2021, 1, 31, 10, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(TimeSpan.FromHours(12), fijiTZ.GetUtcOffset(utcDT));
+            Assert.False(fijiTZ.IsDaylightSavingTime(utcDT));
+
+            utcDT = new DateTime(2022, 10, 1, 10, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(TimeSpan.FromHours(12), fijiTZ.GetUtcOffset(utcDT));
+            Assert.False(fijiTZ.IsDaylightSavingTime(utcDT));
+
+            utcDT = new DateTime(2022, 12, 31, 11, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(TimeSpan.FromHours(13), fijiTZ.GetUtcOffset(utcDT));
+            Assert.True(fijiTZ.IsDaylightSavingTime(utcDT));
+
+            utcDT = new DateTime(2023, 1, 1, 10, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(TimeSpan.FromHours(13), fijiTZ.GetUtcOffset(utcDT));
+            Assert.True(fijiTZ.IsDaylightSavingTime(utcDT));
+
+            utcDT = new DateTime(2023, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+            Assert.Equal(TimeSpan.FromHours(12), fijiTZ.GetUtcOffset(utcDT));
+            Assert.False(fijiTZ.IsDaylightSavingTime(utcDT));
         }
 
         [Fact]


### PR DESCRIPTION
This change fixes the time conversion for the Fiji time zone when running on Windows. In this time zone, the time reported during last hour of 2022/12/31 will be off by one hour. This time zone is supposed to be in DST period which should be UTC+13. But we report this time as standard time as UTC+12. This problem started to show up after Windows updated the time zone data.

**More Details**

Windows time zone data have rules for different years. The rule for any year contains the date and time when the DST period starts and when it ends. In some non-mainstream cases, Windows uses a specific time stamp `Jan 1st 12:00 AM` inside the rule. This time stamp can be assigned to DST start to tell the year already starts with DST on. Also, it assigns the timestamp to the DST end to tell this year will end while the DST is on. When converting any UTC time to the local time, we use the rule to know when the DST starts and when ends to know if we need to apply the time shift during the DST period or not. When encountering rules has the special case of  `Jan 1st 12:00 AM` timestamp, if this time stamp applied to the start of the DST period, we'll try to get when the DST started by accessing previous year rule. If the timestamp applied to the DST end period, we'll try to know when the DST is ended by accessing the next year rule. We do that because UTC time in specific year can span another year in the local time. Everything was already handled in the code for regular time zone which has the DST start date is before the DST end date. But for southern sphere time zones (like Fiji time zone), Windows data can contain the DST start date be after DST end date because seasons are flipped compared to the northern sphere. We were not handling southern sphere time zone correctly when any of its rules marked with `Jan 1st 12:00 AM` timestamp and the change in the PR is fixing this case.