### PR TITLE
global-build-job: Add missing closing paren to unbreak ci

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -80,9 +80,9 @@ jobs:
       # Building the llvm backend is fairly slow, so we don't want to build it unless required.
       - name: _EnableLLVMParameter
         value: /p:MonoEnableLLVM=false
-        ${{ if or( eq(parameters.runtimevariant, 'llvmaot'),  eq(parameters.runtimevariant, 'llvmfullaot') }}:
+        ${{ if or( eq(parameters.runtimevariant, 'llvmaot'),  eq(parameters.runtimevariant, 'llvmfullaot')) }}:
           value: /p:MonoEnableLLVM=true
-     
+
       - name: _officialBuildParameter
         ${{ if eq(parameters.isOfficialBuild, true) }}:
           value: /p:OfficialBuildId=$(Build.BuildNumber)


### PR DESCRIPTION
Typo got added in https://github.com/dotnet/runtime/pull/63311

```
dotnet-linker-tests 1533580 / Pipeline Definition Validation
❌ /eng/pipelines/common/global-build-job.yml (Line: 83, Col: 9): Unclosed function: 'or'. Located at position 1 within expression: or( eq(parameters.runtimevariant, 'llvmaot'), eq(parameters.runtimevariant, 'llvmfullaot'). For more help, refer to go.microsoft.com/fwlink/?linkid=842996
```