### PR TITLE
Fix exception propagation over HW exception frame on macOS arm64

### DIFF
--- a/src/coreclr/pal/src/exception/machexception.cpp
+++ b/src/coreclr/pal/src/exception/machexception.cpp
@@ -907,9 +907,13 @@ HijackFaultingThread(
     ts64.__x[1] = (uint64_t)pExceptionRecord;
     ts64.__x[2] = (uint64_t)pMachExceptionInfo;
 
+    FramePointer = (void **)((ULONG_PTR)FramePointer - 2 * sizeof(void *));
     // Make sure it's aligned - SP has 16-byte alignment
     FramePointer = (void **)((ULONG_PTR)FramePointer - ((ULONG_PTR)FramePointer % 16));
+    FramePointer[0] = (void*)pContext->Fp;
+    FramePointer[1] = (void*)pContext->Lr;
     arm_thread_state64_set_sp(ts64, FramePointer);
+    arm_thread_state64_set_fp(ts64, FramePointer);
 
     // Make the call to DispatchException
     arm_thread_state64_set_lr_fptr(ts64, (uint64_t)PAL_DispatchExceptionWrapper + PAL_DispatchExceptionReturnOffset);

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -496,7 +496,9 @@ void GetContextPointers(unw_cursor_t *cursor, unw_context_t *unwContext, KNONVOL
 
 #ifndef HOST_WINDOWS
 
-extern int g_common_signal_handler_context_locvar_offset;
+// Frame pointer relative offset of a local containing a pointer to the windows style context of a location
+// where a hardware exception occured.
+int g_hardware_exception_context_locvar_offset = 0;
 
 BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers)
 {
@@ -506,19 +508,17 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
 
     DWORD64 curPc = CONTEXTGetPC(context);
 
-#ifndef __APPLE__
-    // Check if the PC is the return address from the SEHProcessException in the common_signal_handler.
-    // If that's the case, extract its local variable containing the windows style context of the hardware
+    // Check if the PC is the return address from the SEHProcessException.
+    // If that's the case, extract its local variable containing a pointer to the windows style context of the hardware
     // exception and return that. This skips the hardware signal handler trampoline that the libunwind
-    // cannot cross on some systems.
+    // cannot cross on some systems. On macOS, it skips a similar trampoline we create in HijackFaultingThread.
     if ((void*)curPc == g_SEHProcessExceptionReturnAddress)
     {
-        CONTEXT* signalContext = (CONTEXT*)(CONTEXTGetFP(context) + g_common_signal_handler_context_locvar_offset);
-        memcpy_s(context, sizeof(CONTEXT), signalContext, sizeof(CONTEXT));
+        CONTEXT* exceptionContext = *(CONTEXT**)(CONTEXTGetFP(context) + g_hardware_exception_context_locvar_offset);
+        memcpy_s(context, sizeof(CONTEXT), exceptionContext, sizeof(CONTEXT));
 
         return TRUE;
     }
-#endif
 
     if ((context->ContextFlags & CONTEXT_EXCEPTION_ACTIVE) != 0)
     {

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -116,10 +116,6 @@ struct sigaction g_previous_sigabrt;
 
 #if !HAVE_MACH_EXCEPTIONS
 
-// Offset of the local variable containing pointer to windows style context in the common_signal_handler function.
-// This offset is relative to the frame pointer.
-int g_common_signal_handler_context_locvar_offset = 0;
-
 // TOP of special stack for handling stack overflow
 volatile void* g_stackOverflowHandlerStack = NULL;
 
@@ -939,11 +935,12 @@ static bool common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext
 #if !HAVE_MACH_EXCEPTIONS
     sigset_t signal_set;
     CONTEXT signalContextRecord;
+    CONTEXT* signalContextRecordPtr = &signalContextRecord;
     EXCEPTION_RECORD exceptionRecord;
     native_context_t *ucontext;
 
     ucontext = (native_context_t *)sigcontext;
-    g_common_signal_handler_context_locvar_offset = (int)((char*)&signalContextRecord - (char*)__builtin_frame_address(0));
+    g_hardware_exception_context_locvar_offset = (int)((char*)&signalContextRecordPtr - (char*)__builtin_frame_address(0));
 
     if (code == (SIGSEGV | StackOverflowFlag))
     {

--- a/src/coreclr/pal/src/include/pal/seh.hpp
+++ b/src/coreclr/pal/src/include/pal/seh.hpp
@@ -145,5 +145,10 @@ CorUnix::PAL_ERROR SEHDisable(CorUnix::CPalThread *pthrCurrent);
 
 }
 
+// Offset of the local variable containing pointer to windows style context in the common_signal_handler / PAL_DispatchException function.
+// This offset is relative to the frame pointer.
+extern int g_hardware_exception_context_locvar_offset;
+
+
 #endif /* _PAL_SEH_HPP_ */
 

--- a/src/tests/Regressions/coreclr/GitHub_62058/test62058.cs
+++ b/src/tests/Regressions/coreclr/GitHub_62058/test62058.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+public class Program
+{
+    private interface IFoo
+    {
+        bool IsValid { get; }
+    }
+
+    private class Foo : IFoo
+    {
+        public bool IsValid { get; set; }
+    }
+
+    public static int Main(string[] args)
+    {
+        bool warmup = new Foo().IsValid;
+        CatchIgnore(() =>
+        CatchRethrow(() =>
+        {
+            IFoo[] foos = {new Foo(), null};
+            foreach (var foo in foos)
+            {
+                bool check = foo.IsValid;
+            }
+        }));
+
+        return 100;
+    }
+
+    public static void CatchRethrow(Action action)
+    {
+        try
+        {
+            action.Invoke();
+        }
+        catch (Exception e)
+        {
+            Console.Out.WriteLine("catch");
+            Console.Out.Flush();
+            throw new Exception("catch", e);  // throw; doesn't work either
+        }
+    }
+
+    public static void CatchIgnore(Action action)
+    {
+        try
+        {
+            action.Invoke();
+        }
+        catch (Exception)
+        {
+            Console.Out.WriteLine("ignore");
+            Console.Out.Flush();
+        }
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_62058/test62058.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_62058/test62058.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test62058.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is a bug in setting up the fake stack frame for
the PAL_DispatchExceptionWrapper. The FP and SP were not saved
to the stack frame and the FP of the context was not set to
match the fake prologue. That caused failure to unwind over the
PAL_DispatchExceptionWrapper, reaching an unrelated native
function.

This change fixes it.

Close #62058