### PR TITLE
[Test][Revert] Reverted change to global build job

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -77,12 +77,6 @@ jobs:
         ${{ if and(eq(parameters.osGroup, 'Linux'), not(eq(parameters.archType, 'arm64'))) }}:
           value: /p:MonoLLVMUseCxx11Abi=false
 
-      # Building the llvm backend is fairly slow, so we don't want to build it unless required.
-      - name: _EnableLLVMParameter
-        value: /p:MonoEnableLLVM=false
-        ${{ if or( eq(parameters.runtimevariant, 'llvmaot'),  eq(parameters.runtimevariant, 'llvmfullaot') }}:
-          value: /p:MonoEnableLLVM=true
-     
       - name: _officialBuildParameter
         ${{ if eq(parameters.isOfficialBuild, true) }}:
           value: /p:OfficialBuildId=$(Build.BuildNumber)
@@ -154,7 +148,7 @@ jobs:
 
     # Build
     - ${{ if eq(parameters.buildingOnSourceBuildImage, false) }}:
-      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_EnableLLVMParameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter)
+      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter)
         displayName: Build product
         ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
           continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -137,7 +137,6 @@ jobs:
       buildConfig: release
       container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
       runtimeFlavor: mono
-      runtimeVariant: 'llvmaot'
       platforms:
       - Linux_arm64
       jobParameters:


### PR DESCRIPTION
Missing paren got added here: https://github.com/dotnet/runtime/pull/63311, and lanes seem to be failing when it is fixed. So I am reverting the change.