### PR TITLE
Update coverlet and reportgenerator versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "coverlet.console": {
-      "version": "1.7.2",
+      "version": "3.1.0",
       "commands": [
         "coverlet"
       ]
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "4.5.8",
+      "version": "5.0.2",
       "commands": [
         "reportgenerator"
       ]

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,7 +166,7 @@
     <MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>1.0.2-alpha.0.22053.3</MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>
     <XUnitVersion>2.4.2-pre.9</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
-    <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>
+    <CoverletCollectorVersion>3.1.0</CoverletCollectorVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>


### PR DESCRIPTION
There are a bunch of fixes, but in particular this contains a fix for properly handling some newer C# features like switch expressions.  This bumps the versions to 3.0.2 and 4.8.5, which are the latest versions available in the feeds... when those are bumped to be newer, I'll update them to the latest (3.1.0 and 5.0.2).