### PR TITLE
Make delegates unsupported by JsonSerializer

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -93,6 +93,7 @@ namespace System.Text.Json.SourceGeneration
             private readonly Type? _jsonValueType;
 
             // Unsupported types
+            private readonly Type _delegateType;
             private readonly Type _typeType;
             private readonly Type _serializationInfoType;
             private readonly Type _intPtrType;
@@ -221,6 +222,7 @@ namespace System.Text.Json.SourceGeneration
                 _jsonValueType = _metadataLoadContext.Resolve(JsonValueFullName);
 
                 // Unsupported types.
+                _delegateType = _metadataLoadContext.Resolve(SpecialType.System_Delegate);
                 _typeType = _metadataLoadContext.Resolve(typeof(Type));
                 _serializationInfoType = _metadataLoadContext.Resolve(typeof(Runtime.Serialization.SerializationInfo));
                 _intPtrType = _metadataLoadContext.Resolve(typeof(IntPtr));
@@ -903,7 +905,8 @@ namespace System.Text.Json.SourceGeneration
                     }
                 }
                 else if (_knownUnsupportedTypes.Contains(type) ||
-                    ImplementsIAsyncEnumerableInterface(type))
+                    ImplementsIAsyncEnumerableInterface(type) ||
+                    _delegateType.IsAssignableFrom(type))
                 {
                     classType = ClassType.KnownUnsupportedType;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UnsupportedTypeConverterFactory.cs
@@ -23,6 +23,8 @@ namespace System.Text.Json.Serialization.Converters
                 type == typeof(SerializationInfo) ||
                 type == typeof(IntPtr) ||
                 type == typeof(UIntPtr) ||
+                // Exlude delegates.
+                typeof(Delegate).IsAssignableFrom(type) ||
                 // DateOnly/TimeOnly support to be added in future releases;
                 // guard against invalid object-based serializations for now.
                 // cf. https://github.com/dotnet/runtime/issues/53539

--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
@@ -2817,5 +2817,37 @@ namespace System.Text.Json.Serialization.Tests
         public class BadConverter
         {
         }
+
+        [Fact]
+        public async Task TestClassWithIgnoredCallbacks()
+        {
+            Assert.Equal("{}", await JsonSerializerWrapperForString.SerializeWrapper(new ClassWithIgnoredCallbacks()));
+            var obj = await JsonSerializerWrapperForString.DeserializeWrapper<ClassWithIgnoredCallbacks>(@"{""Func"":"""",""Action"":""""}");
+            Assert.False(obj.Func(""));
+            Assert.Null(obj.Action);
+        }
+
+        [Fact]
+        public async Task TestClassWithCallbacks()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await JsonSerializerWrapperForString.SerializeWrapper(new ClassWithCallbacks()));
+            await Assert.ThrowsAsync<NotSupportedException>(async () => await JsonSerializerWrapperForString.DeserializeWrapper<ClassWithCallbacks>(@"{""Func"":{},""Action"":{}"));
+        }
+
+        public class ClassWithIgnoredCallbacks
+        {
+            [JsonIgnore]
+            public Func<string, bool> Func { get; set; } = (val) => false;
+
+            [JsonIgnore]
+            public Action<bool> Action { get; set; }
+        }
+
+        public class ClassWithCallbacks
+        {
+            public Func<string, bool> Func { get; set; }
+
+            public Action<bool> Action { get; set; } = (val) => Console.WriteLine();
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
@@ -268,6 +268,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(TypeWith_IgnoredRefStringProp))]
         [JsonSerializable(typeof(TypeWith_PropWith_BadConverter))]
         [JsonSerializable(typeof(TypeWith_IgnoredPropWith_BadConverter))]
+        [JsonSerializable(typeof(ClassWithIgnoredCallbacks))]
+        [JsonSerializable(typeof(ClassWithCallbacks))]
         internal sealed partial class PropertyVisibilityTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -439,6 +441,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(TypeWith_IgnoredRefStringProp))]
         [JsonSerializable(typeof(TypeWith_PropWith_BadConverter))]
         [JsonSerializable(typeof(TypeWith_IgnoredPropWith_BadConverter))]
+        [JsonSerializable(typeof(ClassWithIgnoredCallbacks))]
+        [JsonSerializable(typeof(ClassWithCallbacks))]
         internal sealed partial class PropertyVisibilityTestsContext_Default : JsonSerializerContext
         {
         }


### PR DESCRIPTION
Makes delegates unsupported by `JsonSerializer` for both reflection & source-gen modes. If properties of these types are included for serialization, then `NotSupportedException` is thrown. Otherwise if the props are annotated with `[JsonIgnore]`, then they are ignored at runtime as expected. Note that this is not a breaking change since we already throw exceptions when these types are encountered during (de)serialization.

Fixes https://github.com/dotnet/runtime/issues/62354. We avoid treating the `System.Action*` and `System.Func*` types as objects to be deserialized with parameterized ctors and generating invalid C# code that tries to invoke their ctors.

Candidate for 6.0.x backport.