### PR TITLE
[debugger] Fix reading a byte without checking the version of the Protocol

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5489,7 +5489,8 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 				*/
 				buf2 = buf;
 				decode_byte (buf, &buf, limit);
-				decode_byte (buf, &buf, limit); //ignore is boxed
+				if (CHECK_PROTOCOL_VERSION(2, 61))
+					decode_byte (buf, &buf, limit); //ignore is boxed
 				klass = decode_typeid (buf, &buf, limit, &d, &err);
 				if (err != ERR_NONE)
 					return err;


### PR DESCRIPTION
Should read this byte only in earlier versions.
This can break features while debugging on ios/android.

This is a side-effect of this PR: https://github.com/dotnet/runtime/pull/52300

I think we should backport to 6.0 or at least to 6.0maui