### PR TITLE
[Perf] Enable LLVM on perf runs

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -77,12 +77,6 @@ jobs:
         ${{ if and(eq(parameters.osGroup, 'Linux'), not(eq(parameters.archType, 'arm64'))) }}:
           value: /p:MonoLLVMUseCxx11Abi=false
 
-      # Building the llvm backend is fairly slow, so we don't want to build it unless required.
-      - name: _EnableLLVMParameter
-        value: /p:MonoEnableLLVM=false
-        ${{ if or( eq(parameters.runtimevariant, 'llvmaot'),  eq(parameters.runtimevariant, 'llvmfullaot')) }}:
-          value: /p:MonoEnableLLVM=true
-
       - name: _officialBuildParameter
         ${{ if eq(parameters.isOfficialBuild, true) }}:
           value: /p:OfficialBuildId=$(Build.BuildNumber)
@@ -154,7 +148,7 @@ jobs:
 
     # Build
     - ${{ if eq(parameters.buildingOnSourceBuildImage, false) }}:
-      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_EnableLLVMParameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter)
+      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter)
         displayName: Build product
         ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
           continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -77,6 +77,12 @@ jobs:
         ${{ if and(eq(parameters.osGroup, 'Linux'), not(eq(parameters.archType, 'arm64'))) }}:
           value: /p:MonoLLVMUseCxx11Abi=false
 
+      # Building the llvm backend is fairly slow, so we don't want to build it unless required.
+      - name: _EnableLLVMParameter
+        value: /p:MonoEnableLLVM=false
+        ${{ if or( eq(parameters.runtimevariant, 'llvmaot'),  eq(parameters.runtimevariant, 'llvmfullaot')) }}:
+          value: /p:MonoEnableLLVM=true
+
       - name: _officialBuildParameter
         ${{ if eq(parameters.isOfficialBuild, true) }}:
           value: /p:OfficialBuildId=$(Build.BuildNumber)
@@ -148,7 +154,7 @@ jobs:
 
     # Build
     - ${{ if eq(parameters.buildingOnSourceBuildImage, false) }}:
-      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter)
+      - script: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg) $(_cxx11Parameter) $(_EnableLLVMParameter) $(_richCodeNavigationParam) $(_buildDarwinFrameworksParameter)
         displayName: Build product
         ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
           continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -137,6 +137,7 @@ jobs:
       buildConfig: release
       container: ubuntu-18.04-cross-arm64-20211022152824-b2c2436
       runtimeFlavor: mono
+      runtimeVariant: 'llvmaot'
       platforms:
       - Linux_arm64
       jobParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -141,7 +141,7 @@ jobs:
       platforms:
       - Linux_arm64
       jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
         nameSuffix: AOT
         isOfficialBuild: false
         extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml


### PR DESCRIPTION
The MonoEnableLLVM msbuild property required to build mono with the llvm backend was not being used on perf runs. This PR fixes it. Trying again.