### PR TITLE
[release/6.0] Fix GENERIC_MATH_FEATURE by making sure we always choose the right ref

### DIFF
--- a/src/libraries/System.Runtime.Experimental/ref/System.Runtime.Experimental.csproj
+++ b/src/libraries/System.Runtime.Experimental/ref/System.Runtime.Experimental.csproj
@@ -34,7 +34,7 @@
       <_FileVersionMin>$(FileVersion.Split('.')[1])</_FileVersionMin>
       <_FileVersionBld>$(FileVersion.Split('.')[2])</_FileVersionBld>
       <_FileVersionRev>$(FileVersion.Split('.')[3])</_FileVersionRev>
-      <FileVersion>$(_FileVersionMaj).$([MSBuild]::Add($(_FileVersionMin), 100)).$(_FileVersionRev)</FileVersion>
+      <FileVersion>$(_FileVersionMaj).$([MSBuild]::Add($(_FileVersionMin), 100)).$(_FileVersionBld).$(_FileVersionRev)</FileVersion>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/libraries/System.Runtime.Experimental/ref/System.Runtime.Experimental.csproj
+++ b/src/libraries/System.Runtime.Experimental/ref/System.Runtime.Experimental.csproj
@@ -17,6 +17,8 @@
     <BuildOutputTargetFolder>ref</BuildOutputTargetFolder>
     <DefineConstants>$(DefineConstants);FEATURE_GENERIC_MATH</DefineConstants>
     <IsPackable>true</IsPackable>
+    <ServicingVersion>1</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageDescription>Exposes new experimental APIs from System.Runtime</PackageDescription>
     <PackageId>$(MSBuildProjectName)</PackageId>
     <!-- TODO: Remove when the package shipped with NET6. -->
@@ -32,7 +34,7 @@
       <_FileVersionMin>$(FileVersion.Split('.')[1])</_FileVersionMin>
       <_FileVersionBld>$(FileVersion.Split('.')[2])</_FileVersionBld>
       <_FileVersionRev>$(FileVersion.Split('.')[3])</_FileVersionRev>
-      <FileVersion>$(_FileVersionMaj).$(_FileVersionMin).$([MSBuild]::Add($(_FileVersionBld), 100)).$(_FileVersionRev)</FileVersion>
+      <FileVersion>$(_FileVersionMaj).$([MSBuild]::Add($(_FileVersionMin), 100)).$(_FileVersionRev)</FileVersion>
     </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Fixes: #62840 

## Customer Impact

With the current file version approach, every servicing release we produce of the ref assembly pack will cause `System.Runtime.dll` to have a higher file version than the one we ship in `System.Runtime.Experimental` package, causing assembly conflict resolution to prefer the ref assembly that ships inbox as part of the targeting pack, causing compile errors to users when upgrade to a new SDK like:
```
error CS0246: The type or namespace name 'IComparisonOperators<,>' could not be found (are you missing a using directive or an assembly reference?
```

By upgrading the min version of the file version we ensure that it is always greater as now the file version for the experimental one will be 6.100.x.x vs the one inbox will be 6.0.x.x

## Testing

I tested with the sample repro by referencing a new package produced locally with the fix and the compiler errors go away. Also visually validated via a binlog that the right `System.Runtime.dll` is chosen as a reference when compiling. 

## Risk

Low, we are just changing the assembly file version scheme to make sure it is always greater for the current SDK band. 