### PR TITLE
[release/6.0] Support Single-file executable in Windows 7

### DIFF
--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -111,7 +111,7 @@ if(CLR_CMAKE_TARGET_WIN32)
     # invariants (e.g. size of region between Jit_PatchedCodeLast-Jit_PatchCodeStart needs to fit in a page).
     add_linker_flag("/INCREMENTAL:NO")
 
-    # Delay load libraries required for WinRT as that is not supported on all platforms
+    # Delay load libraries required for WinRT as that is not supported on all platforms.
     add_linker_flag("/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll")
 endif()
 

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -110,6 +110,9 @@ if(CLR_CMAKE_TARGET_WIN32)
     # Incremental linking results in the linker inserting extra padding and routing function calls via thunks that can break the
     # invariants (e.g. size of region between Jit_PatchedCodeLast-Jit_PatchCodeStart needs to fit in a page).
     add_linker_flag("/INCREMENTAL:NO")
+
+    # Delay load libraries required for WinRT as that is not supported on all platforms
+    add_linker_flag("/DELAYLOAD:api-ms-win-core-winrt-l1-1-0.dll")
 endif()
 
 if(CLR_CMAKE_TARGET_WIN32)
@@ -130,6 +133,7 @@ if(CLR_CMAKE_TARGET_WIN32)
         shell32.lib
         bcrypt.lib
         RuntimeObject.lib
+        delayimp.lib
     )
 
     set(RUNTIMEINFO_LIB runtimeinfo)


### PR DESCRIPTION
Backport #63196 to .NET 6.0

## Customer Impact
As of .NET 6.0 single file apps are not supported on Windows7. 
A 6.0 singlefile app does not include API set files (`api-ms-win-...` files). It was assumed that the apps cannot run without bundling/extracting these files due to various dependencies.

Turns out the actual API set requirements of .NET runtime are very modest. We only use UCRT and WinRT API sets. 
- UCRT, if present, is known to the loader and does not need API set files
- WinRT API is used to initialize WinRT and only if WinRT is present and detected by a dynamic check.

So the real reason why 6.0 singlefile app does not run on Windows7 is because `api-ms-win-core-winrt-l1-1-0.dll` is eagerly loaded, even though it would not be used.

Making `api-ms-win-core-winrt-l1-1-0.dll` delayloaded in `singlefilehost` enables apps to run. That would also match the behavior of standalone `coreclr.dll` where `api-ms-win-core-winrt-l1-1-0.dll` is also delayloaded.

Basically, with this change, instead of not supporting singlefile apps on Windows7, we can support, as long as SP1 and UCRT are installed, which is reasonable expectation and SP1 is already a requirement.

## Testing

I have verified manually that with this fix singlefile apps run on Windows7 SP1

I've tried:
- default console app
- default wpf app
- default wpf app with `IncludeNativeLibrariesForSelfExtract`

## Risk

Risk is low. 
Currently .net 6.0 singlefile apps do not run on Windows7 at all, so it can't get worse.
For other versions of Windows, singlefile app will just match closer the delayload behavior of standalone `coreclr.dll`. 
