### PR TITLE
Fix escaped strings for TryGetDateTime(Offset)

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -117,6 +117,12 @@ namespace System.Text.Json
             return IsInRangeInclusive(length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumEscapedDateTimeOffsetParseLength);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValidUnescapedDateTimeOffsetParseLength(int length)
+        {
+            return IsInRangeInclusive(length, JsonConstants.MinimumDateTimeParseLength, JsonConstants.MaximumDateTimeOffsetParseLength);
+        }
+
         /// <summary>
         /// Parse the given UTF-8 <paramref name="source"/> as extended ISO 8601 format.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -260,7 +260,7 @@ namespace System.Text.Json
             sourceUnescaped = sourceUnescaped.Slice(0, written);
             Debug.Assert(!sourceUnescaped.IsEmpty);
 
-            if (sourceUnescaped.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+            if (JsonHelpers.IsValidUnescapedDateTimeOffsetParseLength(sourceUnescaped.Length)
                 && JsonHelpers.TryParseAsISO(sourceUnescaped, out DateTime tmp))
             {
                 value = tmp;
@@ -285,7 +285,7 @@ namespace System.Text.Json
             sourceUnescaped = sourceUnescaped.Slice(0, written);
             Debug.Assert(!sourceUnescaped.IsEmpty);
 
-            if (sourceUnescaped.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+            if (JsonHelpers.IsValidUnescapedDateTimeOffsetParseLength(sourceUnescaped.Length)
                 && JsonHelpers.TryParseAsISO(sourceUnescaped, out DateTimeOffset tmp))
             {
                 value = tmp;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
@@ -2047,42 +2047,6 @@ namespace System.Text.Json.Tests
             }
         }
 
-        public static IEnumerable<object[]> InvalidDateTimePropertyValueData()
-        {
-            foreach (var str in new string[] { ">", "\u003e" })
-            {
-                // DateTime value length less than System.Text.Json.JsonConstants.MinimumDateTimeParseLength = 10
-                // DateTime value length more than System.Text.Json.JsonConstants.MaximumEscapedDateTimeOffsetParseLength = 252
-                foreach (var count in new int[] { 9, 253 })
-                {
-                    yield return new object[] { string.Join("", Enumerable.Repeat(str, count)) };
-                }
-            }
-        }
-
-
-        [Theory]
-        [MemberData(nameof(InvalidDateTimePropertyValueData))]
-        public static void TryGetDateTimeAndOffset_InvalidPropertyValue(string testData)
-        {
-            string jsonString = $"{{ \"DateTimeProperty\": \"{testData}\" }}";
-
-            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
-
-            using (JsonDocument doc = JsonDocument.Parse(dataUtf8, default))
-            {
-                JsonElement root = doc.RootElement;
-
-                Assert.False(root.GetProperty("DateTimeProperty").TryGetDateTime(out DateTime datetimeValue));
-                Assert.Equal(default, datetimeValue);
-                Assert.Throws<FormatException>(() => root.GetProperty("DateTimeProperty").GetDateTime());
-
-                Assert.False(root.GetProperty("DateTimeProperty").TryGetDateTimeOffset(out DateTimeOffset datetimeOffsetValue));
-                Assert.Equal(default, datetimeOffsetValue);
-                Assert.Throws<FormatException>(() => root.GetProperty("DateTimeProperty").GetDateTimeOffset());
-            }
-        }
-
         [Theory]
         [InlineData(">>")]
         [InlineData(">>>")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
@@ -2084,6 +2084,29 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [InlineData(">>")]
+        [InlineData(">>>")]
+        public static void TryGetDateTimeAndOffset_InvalidPropertyValue(string testData)
+        {
+            string jsonString = JsonSerializer.Serialize(new { DateTimeProperty = testData });
+
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            using (JsonDocument doc = JsonDocument.Parse(dataUtf8, default))
+            {
+                JsonElement root = doc.RootElement;
+
+                Assert.False(root.GetProperty("DateTimeProperty").TryGetDateTime(out DateTime datetimeValue));
+                Assert.Equal(default, datetimeValue);
+                Assert.Throws<FormatException>(() => root.GetProperty("DateTimeProperty").GetDateTime());
+
+                Assert.False(root.GetProperty("DateTimeProperty").TryGetDateTimeOffset(out DateTimeOffset datetimeOffsetValue));
+                Assert.Equal(default, datetimeOffsetValue);
+                Assert.Throws<FormatException>(() => root.GetProperty("DateTimeProperty").GetDateTimeOffset());
+            }
+        }
+
+        [Theory]
         [InlineData("")]
         [InlineData("    ")]
         [InlineData("1 2")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
@@ -2050,6 +2050,8 @@ namespace System.Text.Json.Tests
         [Theory]
         [InlineData(">>")]
         [InlineData(">>>")]
+        [InlineData(">>a")]
+        [InlineData(">a>")]
         public static void TryGetDateTimeAndOffset_InvalidPropertyValue(string testData)
         {
             string jsonString = JsonSerializer.Serialize(new { DateTimeProperty = testData });

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
@@ -255,6 +255,8 @@ namespace System.Text.Json.Tests
 
         [Theory]
         [MemberData(nameof(Utf8JsonReaderTests.InvalidDateTimePropertyValueData))]
+        [InlineData(@"""\u001c\u0001""")]
+        [InlineData(@"""\u001c\u0001\u0001""")]
         public static void TryGetDateTimeAndOffset_InvalidPropertyValue(string testString)
         {
             var dataUtf8 = Encoding.UTF8.GetBytes(testString);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
@@ -252,5 +252,22 @@ namespace System.Text.Json.Tests
             Test(testString, isFinalBlock: true);
             Test(testString, isFinalBlock: false);
         }
+
+        [Theory]
+        [MemberData(nameof(Utf8JsonReaderTests.InvalidDateTimePropertyValueData))]
+        public static void TryGetDateTimeAndOffset_InvalidPropertyValue(string testString)
+        {
+            var dataUtf8 = Encoding.UTF8.GetBytes(testString);
+            var json = new Utf8JsonReader(dataUtf8);
+            Assert.True(json.Read());
+
+            Assert.False(json.TryGetDateTime(out var dateTime));
+            Assert.Equal(default, dateTime);
+            JsonTestHelper.AssertThrows<FormatException>(json, (json) => json.GetDateTime());
+
+            Assert.False(json.TryGetDateTimeOffset(out var dateTimeOffset));
+            Assert.Equal(default, dateTimeOffset);
+            JsonTestHelper.AssertThrows<FormatException>(json, (json) => json.GetDateTimeOffset());
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.TryGet.Date.cs
@@ -254,7 +254,6 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Utf8JsonReaderTests.InvalidDateTimePropertyValueData))]
         [InlineData(@"""\u001c\u0001""")]
         [InlineData(@"""\u001c\u0001\u0001""")]
         public static void TryGetDateTimeAndOffset_InvalidPropertyValue(string testString)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using Microsoft.DotNet.XUnitExtensions;
 using Newtonsoft.Json;
 using Xunit;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
@@ -4535,14 +4535,5 @@ namespace System.Text.Json.Tests
                 return dataList;
             }
         }
-
-        public static IEnumerable<object[]> InvalidDateTimePropertyValueData()
-        {
-            // DateTime value length less than System.Text.Json.JsonConstants.MinimumDateTimeParseLength = 10
-            yield return new object[] { string.Join("", Enumerable.Repeat(@"""\u003e""", 9)) };
-
-            // DateTime value length more than System.Text.Json.JsonConstants.MaximumEscapedDateTimeOffsetParseLength = 252
-            yield return new object[] { string.Join("", Enumerable.Repeat(@"""\u003e""", 253)) };
-        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonReaderTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Microsoft.DotNet.XUnitExtensions;
 using Newtonsoft.Json;
 using Xunit;
@@ -4533,6 +4534,15 @@ namespace System.Text.Json.Tests
 
                 return dataList;
             }
+        }
+
+        public static IEnumerable<object[]> InvalidDateTimePropertyValueData()
+        {
+            // DateTime value length less than System.Text.Json.JsonConstants.MinimumDateTimeParseLength = 10
+            yield return new object[] { string.Join("", Enumerable.Repeat(@"""\u003e""", 9)) };
+
+            // DateTime value length more than System.Text.Json.JsonConstants.MaximumEscapedDateTimeOffsetParseLength = 252
+            yield return new object[] { string.Join("", Enumerable.Repeat(@"""\u003e""", 253)) };
         }
     }
 }


### PR DESCRIPTION
Fix the exception thrown when the escaped DateTime(Offset)
property value is unescaped and it becomes shorter than
the minimum expected length. In such a case, the Try* method
should fail and return false.

Fixes #62720