### PR TITLE
Exception sets: debug checker & fixes

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5432,7 +5432,7 @@ public:
 
     // Requires that "tree" is a GT_IND marked as an array index, and that its address argument
     // has been parsed to yield the other input arguments.  If evaluation of the address
-    // can raise exceptions, those should be captured in the exception set "excVN."
+    // can raise exceptions, those should be captured in the exception set "addrXvnp".
     // Assumes that "elemTypeEq" is the (equivalence class rep) of the array element type.
     // Marks "tree" with the VN for H[elemTypeEq][arrVN][inx][fldSeq] (for the liberal VN; a new unique
     // VN for the conservative VN.)  Also marks the tree's argument as the address of an array element.
@@ -5443,14 +5443,14 @@ public:
                                       CORINFO_CLASS_HANDLE elemTypeEq,
                                       ValueNum             arrVN,
                                       ValueNum             inxVN,
-                                      ValueNum             excVN,
+                                      ValueNumPair         addrXvnp,
                                       FieldSeqNode*        fldSeq);
 
-    // Requires "funcApp" to be a VNF_PtrToArrElem, and "addrXvn" to represent the exception set thrown
+    // Requires "funcApp" to be a VNF_PtrToArrElem, and "addrXvnp" to represent the exception set thrown
     // by evaluating the array index expression "tree".  Returns the value number resulting from
     // dereferencing the array in the current GcHeap state.  If "tree" is non-null, it must be the
     // "GT_IND" that does the dereference, and it is given the returned value number.
-    ValueNum fgValueNumberArrIndexVal(GenTree* tree, struct VNFuncApp* funcApp, ValueNum addrXvn);
+    ValueNum fgValueNumberArrIndexVal(GenTree* tree, VNFuncApp* funcApp, ValueNumPair addrXvnp);
 
     // Compute the value number for a byref-exposed load of the given type via the given pointerVN.
     ValueNum fgValueNumberByrefExposedLoad(var_types type, ValueNum pointerVN);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5560,6 +5560,10 @@ public:
     // Adds the exception sets for the current tree node
     void fgValueNumberAddExceptionSet(GenTree* tree);
 
+#ifdef DEBUG
+    void fgDebugCheckExceptionSets();
+#endif
+
     // These are the current value number for the memory implicit variables while
     // doing value numbering.  These are the value numbers under the "liberal" interpretation
     // of memory values; the "conservative" interpretation needs no VN, since every access of

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -829,7 +829,8 @@ bool Compiler::optValnumCSE_Locate()
                     continue;
                 }
 
-                if (ValueNumStore::isReservedVN(tree->GetVN(VNK_Liberal)))
+                ValueNum valueVN = vnStore->VNNormalValue(tree->GetVN(VNK_Liberal));
+                if (ValueNumStore::isReservedVN(valueVN) && (valueVN != ValueNumStore::VNForNull()))
                 {
                     continue;
                 }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1451,6 +1451,36 @@ ValueNum ValueNumStore::VNUniqueWithExc(var_types type, ValueNum vnExcSet)
     return VNWithExc(normVN, vnExcSet);
 }
 
+//------------------------------------------------------------------------------------
+// VNPUniqueWithExc:
+//
+// Arguments:
+//    type       - The type for the unique Value Numbers
+//    vnExcSet   - The Value Number Pair for the exception set.
+//
+// Return Value:
+//               - VN Pair representing a "new, unique" value (liberal and conservative
+//                 values will be equal), with the exceptions contained in "vnpExcSet".
+//
+// Notes:        - We use the same unique value number both for liberal and conservative
+//                 portions of the pair to save memory (it would not be useful to make
+//                 them different).
+//
+ValueNumPair ValueNumStore::VNPUniqueWithExc(var_types type, ValueNumPair vnpExcSet)
+{
+#ifdef DEBUG
+    VNFuncApp excSetFunc;
+    assert((GetVNFunc(vnpExcSet.GetLiberal(), &excSetFunc) && (excSetFunc.m_func == VNF_ExcSetCons)) ||
+           (vnpExcSet.GetLiberal() == VNForEmptyExcSet()));
+    assert((GetVNFunc(vnpExcSet.GetConservative(), &excSetFunc) && (excSetFunc.m_func == VNF_ExcSetCons)) ||
+           (vnpExcSet.GetConservative() == VNForEmptyExcSet()));
+#endif // DEBUG
+
+    ValueNum normVN = VNForExpr(m_pComp->compCurBB, type);
+
+    return VNPWithExc(ValueNumPair(normVN, normVN), vnpExcSet);
+}
+
 //--------------------------------------------------------------------------------
 // VNNormalValue: - Returns a Value Number that represents the result for the
 //                  normal (non-exceptional) evaluation for the expression.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9230,8 +9230,9 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     }
 
                     case GT_JTRUE:
-                        // These nodes never need to have a ValueNumber
-                        tree->gtVNPair.SetBoth(ValueNumStore::NoVN);
+                        // This node does not produce values.
+                        tree->gtVNPair = vnStore->VNPWithExc(vnStore->VNPForVoid(),
+                                                             vnStore->VNPExceptionSet(tree->gtGetOp1()->gtVNPair));
                         break;
 
                     case GT_BOX:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9244,6 +9244,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     case GT_JTRUE:
                     case GT_SWITCH:
                     case GT_RETURN:
+                    case GT_RETFILT:
                     case GT_NULLCHECK:
                         if (tree->gtGetOp1() != nullptr)
                         {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -5952,8 +5952,7 @@ void ValueNumStore::vnDumpValWithExc(Compiler* comp, VNFuncApp* valWithExc)
     GetVNFunc(excVN, &excSeq);
 
     printf("norm=");
-    printf(FMT_VN, normVN);
-    vnDump(comp, normVN);
+    comp->vnPrint(normVN, 1);
     printf(", exc=");
     printf(FMT_VN, excVN);
     vnDumpExcSeq(comp, &excSeq, true);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6812,10 +6812,11 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
         assert(asg->OperIs(GT_ASG));
 
         GenTreeLclVar* newSsaDef = asg->AsOp()->gtGetOp1()->AsLclVar();
+        GenTreePhi*    phiNode   = asg->AsOp()->gtGetOp2()->AsPhi();
         ValueNumPair   phiVNP;
         ValueNumPair   sameVNP;
 
-        for (GenTreePhi::Use& use : asg->AsOp()->gtGetOp2()->AsPhi()->Uses())
+        for (GenTreePhi::Use& use : phiNode->Uses())
         {
             GenTreePhiArg* phiArg         = use.GetNode()->AsPhiArg();
             ValueNum       phiArgSsaNumVN = vnStore->VNForIntCon(phiArg->GetSsaNum());
@@ -6880,6 +6881,10 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
             printf(" %s.\n", sameVNP.BothDefined() ? "(all same)" : "");
         }
 #endif // DEBUG
+
+        newSsaDef->gtVNPair = vnStore->VNPForVoid();
+        phiNode->gtVNPair   = newSsaDefVNP;
+        asg->gtVNPair       = vnStore->VNPForVoid();
     }
 
     // Now do the same for each MemoryKind.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9245,11 +9245,17 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         }
                         break;
 
+                    // BOX is a passthrough node (like NOP).
                     case GT_BOX:
-                        // BOX doesn't do anything at this point, the actual object allocation
-                        // and initialization happens separately (and not numbering BOX correctly
-                        // prevents seeing allocation related assertions through it)
                         tree->gtVNPair = tree->gtGetOp1()->gtVNPair;
+                        break;
+
+                    // CKFINITE is a passthrough node just like BOX. We number it conservatively to preserve previous
+                    // behavior. Note that we'll add the exception for it later.
+                    case GT_CKFINITE:
+                        tree->gtVNPair =
+                            vnStore->VNPUniqueWithExc(tree->TypeGet(),
+                                                      vnStore->VNPExceptionSet(tree->gtGetOp1()->gtVNPair));
                         break;
 
                     case GT_LCLHEAP:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9376,6 +9376,16 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                         vnStore->VNPExceptionSet(tree->AsDynBlk()->gtDynamicSize->gtVNPair));
                 break;
 
+            // FIELD_LIST is an R-value that we currently don't model.
+            case GT_FIELD_LIST:
+                tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
+                for (GenTreeFieldList::Use& use : tree->AsFieldList()->Uses())
+                {
+                    tree->gtVNPair =
+                        vnStore->VNPWithExc(tree->gtVNPair, vnStore->VNPExceptionSet(use.GetNode()->gtVNPair));
+                }
+                break;
+
             default:
                 assert(!"Unhandled special node in fgValueNumberTree");
                 tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9270,9 +9270,10 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                                                       vnStore->VNPExceptionSet(tree->gtGetOp1()->gtVNPair));
                         break;
 
+                    // These unary nodes will receive a unique VN.
+                    // TODO-CQ: model INIT_VAL properly.
                     case GT_LCLHEAP:
-                        // We will not be modelling the StackOverflowException for LCLHEAP, just
-                        // give this a new and unique VN and pass through the exceptions.
+                    case GT_INIT_VAL:
                         tree->gtVNPair =
                             vnStore->VNPUniqueWithExc(tree->TypeGet(),
                                                       vnStore->VNPExceptionSet(tree->gtGetOp1()->gtVNPair));

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -1423,6 +1423,34 @@ ValueNumPair ValueNumStore::VNPMakeNormalUniquePair(ValueNumPair vnp)
     return ValueNumPair(VNMakeNormalUnique(vnp.GetLiberal()), VNMakeNormalUnique(vnp.GetConservative()));
 }
 
+//------------------------------------------------------------------------------------
+// VNUniqueWithExc:
+//
+// Arguments:
+//    type       - The type for the unique Value Number
+//    vnExcSet   - The Value Number for the exception set.
+//
+// Return Value:
+//               - VN representing a "new, unique" value, with
+//                 the exceptions contained in "vnExcSet".
+//
+ValueNum ValueNumStore::VNUniqueWithExc(var_types type, ValueNum vnExcSet)
+{
+    ValueNum normVN = VNForExpr(m_pComp->compCurBB, type);
+
+    if (vnExcSet == VNForEmptyExcSet())
+    {
+        return normVN;
+    }
+
+#ifdef DEBUG
+    VNFuncApp excSetFunc;
+    assert(GetVNFunc(vnExcSet, &excSetFunc) && (excSetFunc.m_func == VNF_ExcSetCons));
+#endif // DEBUG
+
+    return VNWithExc(normVN, vnExcSet);
+}
+
 //--------------------------------------------------------------------------------
 // VNNormalValue: - Returns a Value Number that represents the result for the
 //                  normal (non-exceptional) evaluation for the expression.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9116,8 +9116,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     if (newVN != ValueNumStore::NoVN)
                     {
                         // We don't care about differences between liberal and conservative for pointer values.
-                        newVN = vnStore->VNWithExc(newVN, excSetPair.GetLiberal());
-                        tree->gtVNPair.SetBoth(newVN);
+                        tree->gtVNPair = vnStore->VNPWithExc(ValueNumPair(newVN, newVN), excSetPair);
                     }
                     else
                     {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9286,6 +9286,14 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         tree->gtVNPair = tree->gtGetOp1()->gtVNPair;
                         break;
 
+                    case GT_LCLHEAP:
+                        // We will not be modelling the StackOverflowException for LCLHEAP, just
+                        // give this a new and unique VN and pass through the exceptions.
+                        tree->gtVNPair =
+                            vnStore->VNPUniqueWithExc(tree->TypeGet(),
+                                                      vnStore->VNPExceptionSet(tree->gtGetOp1()->gtVNPair));
+                        break;
+
                     default:
                         assert(!"Unhandled node in fgValueNumberTree");
                         tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9243,7 +9243,7 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         break;
 
                     default:
-                        // The default action is to give the node a new, unique VN.
+                        assert(!"Unhandled node in fgValueNumberTree");
                         tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
                         break;
                 }
@@ -9311,7 +9311,9 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             }
 
             default:
+                assert(!"Unhandled special node in fgValueNumberTree");
                 tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));
+                break;
         }
     }
 #ifdef DEBUG

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9257,17 +9257,10 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         }
                         break;
 
-                    // BOX is a passthrough node (like NOP).
+                    // BOX and CKFINITE are passthrough nodes (like NOP). We'll add the exception for the latter later.
                     case GT_BOX:
-                        tree->gtVNPair = tree->gtGetOp1()->gtVNPair;
-                        break;
-
-                    // CKFINITE is a passthrough node just like BOX. We number it conservatively to preserve previous
-                    // behavior. Note that we'll add the exception for it later.
                     case GT_CKFINITE:
-                        tree->gtVNPair =
-                            vnStore->VNPUniqueWithExc(tree->TypeGet(),
-                                                      vnStore->VNPExceptionSet(tree->gtGetOp1()->gtVNPair));
+                        tree->gtVNPair = tree->gtGetOp1()->gtVNPair;
                         break;
 
                     // These unary nodes will receive a unique VN.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -11018,6 +11018,12 @@ void Compiler::fgDebugCheckExceptionSets()
     {
         for (Statement* const stmt : block->Statements())
         {
+            // Exclude statements VN hasn't visited for whichever reason...
+            if (stmt->GetRootNode()->GetVN(VNK_Liberal) == ValueNumStore::NoVN)
+            {
+                continue;
+            }
+
             ExceptionSetsChecker::CheckTree(stmt->GetRootNode(), vnStore);
         }
     }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9228,9 +9228,10 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         break;
                     }
 
-                    // These unary nodes do not produce values. Note theat for NULLCHECK the
+                    // These unary nodes do not produce values. Note that for NULLCHECK the
                     // additional exception will be added below by "fgValueNumberAddExceptionSet".
                     case GT_JTRUE:
+                    case GT_SWITCH:
                     case GT_RETURN:
                     case GT_NULLCHECK:
                         if (tree->gtGetOp1() != nullptr)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9365,6 +9365,17 @@ void Compiler::fgValueNumberTree(GenTree* tree)
             }
             break;
 
+            // DYN_BLK is always an L-value.
+            case GT_DYN_BLK:
+                assert(!tree->CanCSE());
+                tree->gtVNPair = vnStore->VNPForVoid();
+                tree->gtVNPair =
+                    vnStore->VNPWithExc(tree->gtVNPair, vnStore->VNPExceptionSet(tree->AsDynBlk()->Addr()->gtVNPair));
+                tree->gtVNPair =
+                    vnStore->VNPWithExc(tree->gtVNPair,
+                                        vnStore->VNPExceptionSet(tree->AsDynBlk()->gtDynamicSize->gtVNPair));
+                break;
+
             default:
                 assert(!"Unhandled special node in fgValueNumberTree");
                 tree->gtVNPair.SetBoth(vnStore->VNForExpr(compCurBB, tree->TypeGet()));

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -528,6 +528,9 @@ public:
     // Keeps any Exception set values
     ValueNumPair VNPMakeNormalUniquePair(ValueNumPair vnp);
 
+    // A new unique value with the given exception set.
+    ValueNum VNUniqueWithExc(var_types type, ValueNum vnExcSet);
+
     // If "vn" is a "VNF_ValWithExc(norm, excSet)" value, returns the "norm" argument; otherwise,
     // just returns "vn".
     // The Normal value is the value number of the expression when no exceptions occurred

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -531,6 +531,9 @@ public:
     // A new unique value with the given exception set.
     ValueNum VNUniqueWithExc(var_types type, ValueNum vnExcSet);
 
+    // A new unique VN pair with the given exception set pair.
+    ValueNumPair VNPUniqueWithExc(var_types type, ValueNumPair vnpExcSet);
+
     // If "vn" is a "VNF_ValWithExc(norm, excSet)" value, returns the "norm" argument; otherwise,
     // just returns "vn".
     // The Normal value is the value number of the expression when no exceptions occurred

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -494,6 +494,8 @@ public:
     // Both arguments must be either VNForEmptyExcSet() or applications of VNF_ExcSetCons.
     bool VNExcIsSubset(ValueNum vnFullSet, ValueNum vnCandidateSet);
 
+    bool VNPExcIsSubset(ValueNumPair vnpFullSet, ValueNumPair vnpCandidateSet);
+
     // Returns "true" iff "vn" is an application of "VNF_ValWithExc".
     bool VNHasExc(ValueNum vn)
     {

--- a/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_Hwi.cs
+++ b/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_Hwi.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.CompilerServices;
+
+// We're testing whether HWI nodes with > 2 operands propagate exception sets correctly.
+//
+class ExceptionSetsPropagation_Hwi
+{
+    public static int Main()
+    {
+        try
+        {
+            Problem(-1, false, false);
+        }
+        catch (OverflowException)
+        {
+            return 100;
+        }
+
+        return 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Problem(int a, bool c1, bool c2)
+    {
+        var zero = 0;
+        c1 = a == 0;
+        c2 = c1;
+
+        if ((Vector128.Create((int)checked((uint)a), a, a, a).GetElement(0) * zero) + a == 0)
+        {
+            return false;
+        }
+
+        return c2;
+    }
+}

--- a/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_Hwi.csproj
+++ b/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_Hwi.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_LclHeap.il
+++ b/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_LclHeap.il
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern xunit.core { }
+.assembly extern System.Runtime { }
+.assembly extern System.Console { }
+
+.assembly ExceptionSetsPropagation_LclHeap { }
+
+.class ExceptionSetsPropagation_LclHeap extends [System.Runtime]System.Object
+{
+    .method public static int32 Main()
+    {
+        .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (01 00 00 00)
+        .entrypoint
+
+        .try
+        {
+            ldc.i4 300
+            conv.i
+            call bool ExceptionSetsPropagation_LclHeap::Problem(native int)
+            pop
+            leave FAIL
+        }
+        catch [System.Runtime]System.OverflowException
+        {
+            pop
+            leave SUCCESS
+        }
+
+    SUCCESS:
+        ldc.i4 100
+        ret
+
+    FAIL:
+        ldc.i4 101
+        ret
+    }
+
+    .method private static bool Problem(native int a)
+    {
+        .locals (bool c1, bool c2)
+
+        ldarg a
+        localloc
+        ldc.i4 0
+        conv.i
+        and
+        ldarg a
+        ceq
+        stloc c1
+
+        ldloc c1
+        stloc c2
+
+        ldarg a
+        conv.ovf.i1
+        conv.i
+        localloc
+        ldc.i4 0
+        conv.i
+        and
+        ldarg a
+        ceq
+        brtrue RET
+
+        ldstr "The expected OverflowException was not thrown!"
+        call void [System.Console]System.Console::WriteLine(string)
+
+    RET:
+        ldloc c2
+        ret
+    }
+}
+

--- a/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_LclHeap.ilproj
+++ b/src/tests/JIT/opt/ValueNumbering/ExceptionSetsPropagation_LclHeap.ilproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Value numbering maintains two distinct numbers for each expression (ignoring the liberal/conservative divide): the "normal" value and "the exception set". The purpose of this is very simple: two expressions may compute the same value, but end up throwing different exceptions, which can make certain transformations (CSE / forward substitution) illegal.

This "tuple" is physically represented a `VNFunc` of `ValWithExc`:
```
ValueNumFuncDef(ValWithExc, 2, false, false, false)         // Args: 0: value number from normal execution; 1: VN for set of possible exceptions.
```

Exception sets *must* be propagated up the tree, much like side effects flags, and that propagation *must* preserve all exception sets from child operands. However, in the current implementation, this is not always the case. In particular, the "give up by giving the tree a simple `VNForExpr`" is employed sometimes, but it is not correct, since it effectively loses all exceptions that the node's operands had (another way to put it is that `VNForExpr` is always a "normal" value). This usually does not matter, as such unique expressions contribute to the value the final tree computes, and there is no CSE for two different VNs, obviously. However, it is possible to bypass this by using mathematical identities like `X * 0 => 0`. If `X` "lost" some exceptions, the parent tree will both not know of that and may still compute a CSE-able value number. You can see this pattern employed in tests for existing bugs in exception set propagation that I am adding as part of this change.

To combat this problem, I am adding a new post-VN debug checker phase that will walk over all the VN-ed trees in the method and assert that the exception sets are not lost on any of them (or, at least, that's the aspiration - not all cases have been fixed as part of this PR). The eventual goal is to get to the point where exception sets are fully precise.

We expect diffs, there will be two sources of them:
1) CSEing of `null`s has been allowed.
2) `CKFINITE` is now modeled precisely (I considered preserving previous behavior for it; but it didn't seem necessary, passing the VN through is obviously correct and required less code).