### PR TITLE
Add blsr

### DIFF
--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -193,7 +193,7 @@ bool IsDstDstSrcAVXInstruction(instruction ins);
 bool IsDstSrcSrcAVXInstruction(instruction ins);
 bool HasRegularWideForm(instruction ins);
 bool HasRegularWideImmediateForm(instruction ins);
-bool DoesWriteZeroFlag(instruction ins);
+static bool DoesWriteZeroFlag(instruction ins);
 bool DoesWriteSignFlag(instruction ins);
 bool DoesResetOverflowAndCarryFlags(instruction ins);
 bool IsFlagsAlwaysModified(instrDesc* id);

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -577,6 +577,25 @@ struct HWIntrinsicInfo
         return lookup(id).ins[type - TYP_BYTE];
     }
 
+    static instruction lookupIns(GenTreeHWIntrinsic* intrinsicNode)
+    {
+        assert(intrinsicNode != nullptr);
+
+        NamedIntrinsic intrinsic = intrinsicNode->GetHWIntrinsicId();
+        var_types      type      = var_types::TYP_UNKNOWN;
+
+        if (lookupCategory(intrinsic) == HWIntrinsicCategory::HW_Category_Scalar)
+        {
+            type = intrinsicNode->TypeGet();
+        }
+        else
+        {
+            type = intrinsicNode->GetSimdBaseType();
+        }
+
+        return lookupIns(intrinsic, type);
+    }
+
     static HWIntrinsicCategory lookupCategory(NamedIntrinsic id)
     {
         return lookup(id).category;

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -582,9 +582,9 @@ struct HWIntrinsicInfo
         assert(intrinsicNode != nullptr);
 
         NamedIntrinsic intrinsic = intrinsicNode->GetHWIntrinsicId();
-        var_types      type      = var_types::TYP_UNKNOWN;
+        var_types      type      = TYP_UNKNOWN;
 
-        if (lookupCategory(intrinsic) == HWIntrinsicCategory::HW_Category_Scalar)
+        if (lookupCategory(intrinsic) == HW_Category_Scalar)
         {
             type = intrinsicNode->TypeGet();
         }

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -595,7 +595,7 @@ INST3(FIRST_BMI_INSTRUCTION, "FIRST_BMI_INSTRUCTION", IUM_WR, BAD_CODE, BAD_CODE
 INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
 INST3(blsi,             "blsi",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
 INST3(blsmsk,           "blsmsk",           IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
-INST3(blsr,             "blsr",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Reset Lowest Set Bit
+INST3(blsr,             "blsr",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Reset Lowest Set Bit
 INST3(bextr,            "bextr",            IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF7),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Bit Field Extract
 
 // BMI2

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2708,11 +2708,12 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 
         if (op2->IsIntegralConst(0) && (op1->gtNext == op2) && (op2->gtNext == cmp) &&
 #ifdef TARGET_XARCH
-                op1->OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG)
+            (op1->OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG)
 #ifdef FEATURE_HW_INTRINSICS
-            || emitter::DoesWriteZeroFlag(
-                   HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet()))
-#endif
+             || emitter::DoesWriteZeroFlag(
+                    HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet()))
+#endif // FEATURE_HW_INTRINSICS
+                 )
 #else // TARGET_ARM64
             op1->OperIs(GT_AND, GT_ADD, GT_SUB)
 #endif

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2712,7 +2712,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 #ifdef FEATURE_HW_INTRINSICS
              || (op1->OperIs(GT_HWINTRINSIC) &&
                  emitter::DoesWriteZeroFlag(
-                    HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet())))
+                     HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet())))
 #endif // FEATURE_HW_INTRINSICS
                  )
 #else // TARGET_ARM64

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2711,8 +2711,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
             (op1->OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG)
 #ifdef FEATURE_HW_INTRINSICS
              || (op1->OperIs(GT_HWINTRINSIC) &&
-                 emitter::DoesWriteZeroFlag(
-                     HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet())))
+                 emitter::DoesWriteZeroFlag(HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic())))
 #endif // FEATURE_HW_INTRINSICS
                  )
 #else // TARGET_ARM64

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2710,8 +2710,9 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 #ifdef TARGET_XARCH
             (op1->OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG)
 #ifdef FEATURE_HW_INTRINSICS
-             || emitter::DoesWriteZeroFlag(
-                    HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet()))
+             || (op1->OperIs(GT_HWINTRINSIC) &&
+                 emitter::DoesWriteZeroFlag(
+                    HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet())))
 #endif // FEATURE_HW_INTRINSICS
                  )
 #else // TARGET_ARM64

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2708,10 +2708,15 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 
         if (op2->IsIntegralConst(0) && (op1->gtNext == op2) && (op2->gtNext == cmp) &&
 #ifdef TARGET_XARCH
-            op1->OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG))
-#else // TARGET_ARM64
-            op1->OperIs(GT_AND, GT_ADD, GT_SUB))
+                op1->OperIs(GT_AND, GT_OR, GT_XOR, GT_ADD, GT_SUB, GT_NEG)
+#ifdef FEATURE_HW_INTRINSICS
+            || emitter::DoesWriteZeroFlag(
+                   HWIntrinsicInfo::lookupIns(op1->AsHWIntrinsic()->GetHWIntrinsicId(), op1->TypeGet()))
 #endif
+#else // TARGET_ARM64
+            op1->OperIs(GT_AND, GT_ADD, GT_SUB)
+#endif
+                )
         {
             op1->gtFlags |= GTF_SET_FLAGS;
             op1->SetUnusedValue();

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -344,7 +344,7 @@ private:
     void LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node);
-    GenTree* LowerAndOpToResetLowestSetBit(GenTreeOp* binOp);
+    GenTree* TryLowerAndOpToResetLowestSetBit(GenTreeOp* binOp);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -344,7 +344,7 @@ private:
     void LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node);
-    bool LowerAndOpToResetLowestSetBit(GenTree* node);
+    GenTree* LowerAndOpToResetLowestSetBit(GenTree* node);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -297,7 +297,7 @@ private:
     void LowerStoreIndir(GenTreeStoreInd* node);
     GenTree* LowerAdd(GenTreeOp* node);
     GenTree* LowerMul(GenTreeOp* mul);
-    GenTree* LowerBinaryArithmeticCommon(GenTreeOp* node);
+    GenTree* LowerBinaryArithmeticCommon(GenTreeOp* binOp);
     GenTree* LowerBinaryArithmetic(GenTreeOp* binOp);
     bool LowerUnsignedDivOrMod(GenTreeOp* divMod);
     GenTree* LowerConstIntDivOrMod(GenTree* node);
@@ -344,7 +344,7 @@ private:
     void LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node);
-    GenTree* LowerAndOpToResetLowestSetBit(GenTree* node);
+    GenTree* LowerAndOpToResetLowestSetBit(GenTreeOp* binOp);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -297,7 +297,8 @@ private:
     void LowerStoreIndir(GenTreeStoreInd* node);
     GenTree* LowerAdd(GenTreeOp* node);
     GenTree* LowerMul(GenTreeOp* mul);
-    GenTree* LowerBinaryArithmetic(GenTreeOp* node);
+    GenTree* LowerBinaryArithmeticCommon(GenTreeOp* node);
+    GenTree* LowerBinaryArithmetic(GenTreeOp* binOp);
     bool LowerUnsignedDivOrMod(GenTreeOp* divMod);
     GenTree* LowerConstIntDivOrMod(GenTree* node);
     GenTree* LowerSignedDivOrMod(GenTree* node);
@@ -343,6 +344,7 @@ private:
     void LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node);
+    bool LowerAndOpToResetLowestSetBit(GenTree* node);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -292,30 +292,6 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 //
 GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 {
-    if (comp->opts.OptimizationEnabled() && binOp->OperIs(GT_AND))
-    {
-        GenTree* opNode  = nullptr;
-        GenTree* notNode = nullptr;
-        if (binOp->gtGetOp1()->OperIs(GT_NOT))
-        {
-            notNode = binOp->gtGetOp1();
-            opNode  = binOp->gtGetOp2();
-        }
-        else if (binOp->gtGetOp2()->OperIs(GT_NOT))
-        {
-            notNode = binOp->gtGetOp2();
-            opNode  = binOp->gtGetOp1();
-        }
-
-        if (notNode != nullptr)
-        {
-            binOp->gtOp1 = opNode;
-            binOp->gtOp2 = notNode->AsUnOp()->gtGetOp1();
-            binOp->ChangeOper(GT_AND_NOT);
-            BlockRange().Remove(notNode);
-        }
-    }
-
     ContainCheckBinary(binOp);
 
     return binOp->gtNext;

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -282,6 +282,46 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 }
 
 //------------------------------------------------------------------------
+// LowerBinaryArithmetic: lowers the given binary arithmetic node.
+//
+// Arguments:
+//    node - the arithmetic node to lower
+//
+// Returns:
+//    The next node to lower.
+//
+GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
+{
+    if (comp->opts.OptimizationEnabled() && binOp->OperIs(GT_AND))
+    {
+        GenTree* opNode  = nullptr;
+        GenTree* notNode = nullptr;
+        if (binOp->gtGetOp1()->OperIs(GT_NOT))
+        {
+            notNode = binOp->gtGetOp1();
+            opNode  = binOp->gtGetOp2();
+        }
+        else if (binOp->gtGetOp2()->OperIs(GT_NOT))
+        {
+            notNode = binOp->gtGetOp2();
+            opNode  = binOp->gtGetOp1();
+        }
+
+        if (notNode != nullptr)
+        {
+            binOp->gtOp1 = opNode;
+            binOp->gtOp2 = notNode->AsUnOp()->gtGetOp1();
+            binOp->ChangeOper(GT_AND_NOT);
+            BlockRange().Remove(notNode);
+        }
+    }
+
+    ContainCheckBinary(binOp);
+
+    return binOp->gtNext;
+}
+
+//------------------------------------------------------------------------
 // LowerBlockStore: Lower a block store node
 //
 // Arguments:

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -173,7 +173,7 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 #ifdef FEATURE_HW_INTRINSICS
     if (comp->opts.OptimizationEnabled() && binOp->OperIs(GT_AND) && varTypeIsIntegral(binOp))
     {
-        GenTree* blsrNode = LowerAndOpToResetLowestSetBit(binOp);
+        GenTree* blsrNode = TryLowerAndOpToResetLowestSetBit(binOp);
         if (blsrNode != nullptr)
         {
             return blsrNode->gtNext;
@@ -3722,7 +3722,7 @@ void Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
 }
 
 //----------------------------------------------------------------------------------------------
-// Lowering::LowerAndOpToResetLowestSetBit: Lowers a tree AND(X, ADD(X, -1) to HWIntrinsic::ResetLowestSetBit
+// Lowering::TryLowerAndOpToResetLowestSetBit: Lowers a tree AND(X, ADD(X, -1) to HWIntrinsic::ResetLowestSetBit
 //
 // Arguments:
 //    andNode - GT_AND node of integral type
@@ -3730,7 +3730,7 @@ void Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
 // Return Value:
 //    Returns the replacement node if one is created else nullptr indicating no replacement
 //
-GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
+GenTree* Lowering::TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
 {
     assert(andNode->OperIs(GT_AND) && varTypeIsIntegral(andNode));
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3740,9 +3740,14 @@ GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
         return nullptr;
     }
 
-    GenTree* op2    = andNode->gtGetOp2();
+    GenTree* op2 = andNode->gtGetOp2();
+    if (!op2->OperIs(GT_ADD))
+    {
+        return nullptr;
+    }
+
     GenTree* addOp2 = op2->gtGetOp2();
-    if (!op2->OperIs(GT_ADD) || !addOp2->IsIntegralConst(-1))
+    if (!addOp2->IsIntegralConst(-1))
     {
         return nullptr;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3760,9 +3760,9 @@ GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
                                                              ? NamedIntrinsic::NI_BMI1_ResetLowestSetBit
                                                              : NamedIntrinsic::NI_BMI1_X64_ResetLowestSetBit);
 
-                    JITDUMP("Lower: optimize AND(X, ADD(X, -1)): ");
+                    JITDUMP("Lower: optimize AND(X, ADD(X, -1))\n");
                     DISPNODE(andNode);
-                    JITDUMP("Replaced with: ");
+                    JITDUMP("to:\n");
                     DISPNODE(blsrNode);
 
                     use.ReplaceWith(blsrNode);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3730,10 +3730,7 @@ void Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
 // Return Value:
 //    Returns the replacement node if one is created else nullptr indicating no replacement
 //
-// Assumptions:
-//    andNode is GT_AND and (TYP_INT or TYP_LONG)
-//
-GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTree* andNode)
+GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
 {
     assert(andNode->OperIs(GT_AND) && varTypeIsIntegral(andNode));
 
@@ -3746,8 +3743,7 @@ GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTree* andNode)
         if (addOp2->IsIntegralConst(-1) && addOp1->OperIs(GT_LCL_VAR) &&
             (addOp1->AsLclVar()->GetLclNum() == op1->AsLclVar()->GetLclNum()) &&
             ((op1->TypeIs(TYP_LONG) && comp->compOpportunisticallyDependsOn(InstructionSet_BMI1_X64)) ||
-             comp->compOpportunisticallyDependsOn(InstructionSet_BMI1))
-            )
+             comp->compOpportunisticallyDependsOn(InstructionSet_BMI1)))
         {
             LIR::Use use;
             if (BlockRange().TryGetUse(andNode, &use))
@@ -3776,7 +3772,6 @@ GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTree* andNode)
                     BlockRange().Remove(op2);
                     BlockRange().Remove(addOp1);
                     BlockRange().Remove(addOp2);
-                    JITDUMP("Remove [%06u], [%06u]\n", andNode->gtTreeID, andNode->gtTreeID);
 
                     ContainCheckHWIntrinsic(blsrNode);
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -170,10 +170,6 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 //
 GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 {
-    // TODO-CQ-XArch: support BMI2 "andn" in codegen and condition
-    // this logic on the support for the instruction set on XArch.
-    CLANG_FORMAT_COMMENT_ANCHOR;
-
 #ifdef FEATURE_HW_INTRINSICS
     if (comp->opts.OptimizationEnabled() && binOp->OperIs(GT_AND) && varTypeIsIntegral(binOp))
     {
@@ -186,6 +182,7 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 #endif
 
     ContainCheckBinary(binOp);
+
     return binOp->gtNext;
 }
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3725,7 +3725,7 @@ void Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
 // Lowering::LowerAndOpToResetLowestSetBit: Lowers a tree AND(X, ADD(X, -1) to HWIntrinsic::ResetLowestSetBit
 //
 // Arguments:
-//    andNode - GentreePtr of binOp
+//    andNode - GT_AND node of integral type
 //
 // Return Value:
 //    Returns the replacement node if one is created else nullptr indicating no replacement

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3752,7 +3752,7 @@ GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
                 // if we prevent the use of BSLR here then "OptimizeConstCompare" may generate TEST_NE or
                 //   TEST_EQ leading to a cheaper "lea, test"
                 GenTree* user = use.User();
-                if (!user->OperIs(GT_EQ, GT_NE))
+                if (!(user->OperIs(GT_EQ, GT_NE) && user->gtGetOp2()->IsIntegralConst()))
                 {
                     GenTreeHWIntrinsic* blsrNode =
                         comp->gtNewScalarHWIntrinsicNode(andNode->TypeGet(), op1,

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3740,7 +3740,7 @@ GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
         return nullptr;
     }
 
-    GenTree* op2 = andNode->gtGetOp2();
+    GenTree* op2    = andNode->gtGetOp2();
     GenTree* addOp2 = op2->gtGetOp2();
     if (!op2->OperIs(GT_ADD) || !addOp2->IsIntegralConst(-1))
     {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3748,35 +3748,28 @@ GenTree* Lowering::LowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
             LIR::Use use;
             if (BlockRange().TryGetUse(andNode, &use))
             {
-                // If we allow the use of BSLR where the parent is NE or EQ it will generate "blsr, test"
-                // if we prevent the use of BSLR here then "OptimizeConstCompare" may generate TEST_NE or
-                //   TEST_EQ leading to a cheaper "lea, test"
-                GenTree* user = use.User();
-                if (!(user->OperIs(GT_EQ, GT_NE) && user->gtGetOp2()->IsIntegralConst()))
-                {
-                    GenTreeHWIntrinsic* blsrNode =
-                        comp->gtNewScalarHWIntrinsicNode(andNode->TypeGet(), op1,
-                                                         andNode->TypeIs(TYP_INT)
-                                                             ? NamedIntrinsic::NI_BMI1_ResetLowestSetBit
-                                                             : NamedIntrinsic::NI_BMI1_X64_ResetLowestSetBit);
+                GenTreeHWIntrinsic* blsrNode =
+                    comp->gtNewScalarHWIntrinsicNode(andNode->TypeGet(), op1,
+                                                     andNode->TypeIs(TYP_INT)
+                                                         ? NamedIntrinsic::NI_BMI1_ResetLowestSetBit
+                                                         : NamedIntrinsic::NI_BMI1_X64_ResetLowestSetBit);
 
-                    JITDUMP("Lower: optimize AND(X, ADD(X, -1))\n");
-                    DISPNODE(andNode);
-                    JITDUMP("to:\n");
-                    DISPNODE(blsrNode);
+                JITDUMP("Lower: optimize AND(X, ADD(X, -1))\n");
+                DISPNODE(andNode);
+                JITDUMP("to:\n");
+                DISPNODE(blsrNode);
 
-                    use.ReplaceWith(blsrNode);
+                use.ReplaceWith(blsrNode);
 
-                    BlockRange().InsertBefore(andNode, blsrNode);
-                    BlockRange().Remove(andNode);
-                    BlockRange().Remove(op2);
-                    BlockRange().Remove(addOp1);
-                    BlockRange().Remove(addOp2);
+                BlockRange().InsertBefore(andNode, blsrNode);
+                BlockRange().Remove(andNode);
+                BlockRange().Remove(op2);
+                BlockRange().Remove(addOp1);
+                BlockRange().Remove(addOp2);
 
-                    ContainCheckHWIntrinsic(blsrNode);
+                ContainCheckHWIntrinsic(blsrNode);
 
-                    return blsrNode;
-                }
+                return blsrNode;
             }
         }
     }


### PR DESCRIPTION
closes https://github.com/dotnet/runtime/issues/63286

This PR adds a new `LowerAndOpToResetLowestSetBit` in xarch to recognise the `AND(x, SUB(x, 1)` pattern and lower it to a `blsr` where it is likely to be profitable. 

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 13363029 (overridden on cmd)
Total bytes of diff: 13363021 (overridden on cmd)
Total bytes of delta: -8 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
          -2 : 12409.dasm (-0.31% of base)
          -2 : 15708.dasm (-0.99% of base)
          -2 : 12421.dasm (-0.03% of base)
          -2 : 15719.dasm (-0.26% of base)

4 total files with Code Size differences (4 improved, 0 regressed), 3 unchanged.

Top method improvements (bytes):
          -2 (-0.31% of base) : 12409.dasm - System.Diagnostics.Tracing.ManifestBuilder:AddKeyword(System.String,long):this
          -2 (-0.03% of base) : 12421.dasm - System.Diagnostics.Tracing.ManifestBuilder:CreateManifestString():System.String:this
          -2 (-0.26% of base) : 15719.dasm - System.IO.RandomAccess:TryPrepareScatterGatherBuffers(System.Collections.Generic.IReadOnlyList`1[Memory`1],MemoryHandler,byref,byref,byref):bool
          -2 (-0.99% of base) : 15708.dasm - System.Runtime.InteropServices.NativeMemory:AlignedAlloc(long,long):long

Top method improvements (percentages):
          -2 (-0.99% of base) : 15708.dasm - System.Runtime.InteropServices.NativeMemory:AlignedAlloc(long,long):long
          -2 (-0.31% of base) : 12409.dasm - System.Diagnostics.Tracing.ManifestBuilder:AddKeyword(System.String,long):this
          -2 (-0.26% of base) : 15719.dasm - System.IO.RandomAccess:TryPrepareScatterGatherBuffers(System.Collections.Generic.IReadOnlyList`1[Memory`1],MemoryHandler,byref,byref,byref):bool
          -2 (-0.03% of base) : 12421.dasm - System.Diagnostics.Tracing.ManifestBuilder:CreateManifestString():System.String:this

4 total methods with Code Size differences (4 improved, 0 regressed), 3 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 127528257 (overridden on cmd)
Total bytes of diff: 127528255 (overridden on cmd)
Total bytes of delta: -2 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
          -2 : 230250.dasm (-1.41% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 8 unchanged.

Top method improvements (bytes):
          -2 (-1.41% of base) : 230250.dasm - V8.Crypto.BigInteger:bitCount():int:this

Top method improvements (percentages):
          -2 (-1.41% of base) : 230250.dasm - V8.Crypto.BigInteger:bitCount():int:this

1 total methods with Code Size differences (1 improved, 0 regressed), 8 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 46215753 (overridden on cmd)
Total bytes of diff: 46215748 (overridden on cmd)
Total bytes of delta: -5 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
          -3 : 142808.dasm (-0.28% of base)
          -2 : 215581.dasm (-1.47% of base)

2 total files with Code Size differences (2 improved, 0 regressed), 20 unchanged.

Top method improvements (bytes):
          -3 (-0.28% of base) : 142808.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:MatchesNodeKinds(System.Xml.Xsl.Qil.QilTargetType,System.Xml.Xsl.XmlQueryType,System.Xml.Xsl.XmlQueryType):bool:this
          -2 (-1.47% of base) : 215581.dasm - System.Numerics.BigInteger:get_IsPowerOfTwo():bool:this

Top method improvements (percentages):
          -2 (-1.47% of base) : 215581.dasm - System.Numerics.BigInteger:get_IsPowerOfTwo():bool:this
          -3 (-0.28% of base) : 142808.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:MatchesNodeKinds(System.Xml.Xsl.Qil.QilTargetType,System.Xml.Xsl.XmlQueryType,System.Xml.Xsl.XmlQueryType):bool:this

2 total methods with Code Size differences (2 improved, 0 regressed), 20 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 118063813 (overridden on cmd)
Total bytes of diff: 118063785 (overridden on cmd)
Total bytes of delta: -28 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
          -2 : 111078.dasm (-0.59% of base)
          -2 : 110781.dasm (-9.09% of base)
          -2 : 111083.dasm (-0.59% of base)
          -2 : 110793.dasm (-9.09% of base)
          -2 : 6689.dasm (-9.09% of base)
          -2 : 326883.dasm (-0.58% of base)
          -2 : 187034.dasm (-1.27% of base)
          -2 : 326891.dasm (-0.39% of base)
          -2 : 187035.dasm (-1.27% of base)
          -2 : 187036.dasm (-1.24% of base)
          -2 : 187037.dasm (-1.27% of base)
          -2 : 187038.dasm (-1.25% of base)
          -2 : 324730.dasm (-8.70% of base)
          -2 : 187039.dasm (-1.27% of base)

14 total files with Code Size differences (14 improved, 0 regressed), 10 unchanged.

Top method improvements (bytes):
          -2 (-9.09% of base) : 110781.dasm - enumOfType@48-38:Invoke(long):bool:this
          -2 (-9.09% of base) : 110793.dasm - enumOfType@50-44:Invoke(long):bool:this
          -2 (-9.09% of base) : 6689.dasm - Microsoft.CodeAnalysis.Shared.Utilities.IntegerUtilities:CountOfBitsSet(long):int
          -2 (-0.59% of base) : 111078.dasm - reflectShrinkObj@256-17:GenerateNext(byref):int:this
          -2 (-0.59% of base) : 111083.dasm - reflectShrinkObj@257-18:GenerateNext(byref):int:this
          -2 (-1.27% of base) : 187034.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_long(long,bool)
          -2 (-1.24% of base) : 187036.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nint_32(int,bool)
          -2 (-1.27% of base) : 187037.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nint_64(long,bool)
          -2 (-1.25% of base) : 187038.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nuint_32(int,bool)
          -2 (-1.27% of base) : 187039.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nuint_64(long,bool)
          -2 (-1.27% of base) : 187035.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_ulong(long,bool)
          -2 (-0.58% of base) : 326883.dasm - System.Runtime.InteropServices.Tests.NativeMemoryTests:AlignedAllocTest(int):this
          -2 (-0.39% of base) : 326891.dasm - System.Runtime.InteropServices.Tests.NativeMemoryTests:AlignedReallocTest(int):this
          -2 (-8.70% of base) : 324730.dasm - System.Tests.BinaryNumberHelper`1[Int64][System.Int64]:IsPow2(long):bool

Top method improvements (percentages):
          -2 (-9.09% of base) : 110781.dasm - enumOfType@48-38:Invoke(long):bool:this
          -2 (-9.09% of base) : 110793.dasm - enumOfType@50-44:Invoke(long):bool:this
          -2 (-9.09% of base) : 6689.dasm - Microsoft.CodeAnalysis.Shared.Utilities.IntegerUtilities:CountOfBitsSet(long):int
          -2 (-8.70% of base) : 324730.dasm - System.Tests.BinaryNumberHelper`1[Int64][System.Int64]:IsPow2(long):bool
          -2 (-1.27% of base) : 187034.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_long(long,bool)
          -2 (-1.27% of base) : 187037.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nint_64(long,bool)
          -2 (-1.27% of base) : 187039.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nuint_64(long,bool)
          -2 (-1.27% of base) : 187035.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_ulong(long,bool)
          -2 (-1.25% of base) : 187038.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nuint_32(int,bool)
          -2 (-1.24% of base) : 187036.dasm - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_nint_32(int,bool)
          -2 (-0.59% of base) : 111078.dasm - reflectShrinkObj@256-17:GenerateNext(byref):int:this
          -2 (-0.59% of base) : 111083.dasm - reflectShrinkObj@257-18:GenerateNext(byref):int:this
          -2 (-0.58% of base) : 326883.dasm - System.Runtime.InteropServices.Tests.NativeMemoryTests:AlignedAllocTest(int):this
          -2 (-0.39% of base) : 326891.dasm - System.Runtime.InteropServices.Tests.NativeMemoryTests:AlignedReallocTest(int):this

14 total methods with Code Size differences (14 improved, 0 regressed), 10 unchanged.

```

</details>

Improvement example from `V8.Crypto.BigInteger:bitCount():int`

<details>

<summary>improvement diff</summary>

```diff
@@ -14,7 +14,7 @@
 ;  V04 OutArgs      [V04    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
 ;  V05 tmp1         [V05,T03] (  3, 24   )     ref  ->   r8         class-hnd "Inlining Arg"
 ;  V06 tmp2         [V06,T01] (  4, 40   )     int  ->   r8         "Inline stloc first use temp"
-;  V07 tmp3         [V07,T00] (  6,144   )     int  ->  r10         "Inlining Arg"
+;  V07 tmp3         [V07,T00] (  5,112   )     int  ->  r10         "Inlining Arg"
 ;  V08 tmp4         [V08,T04] (  3, 24   )     ref  ->   r8         "arr expr"
 ;  V09 cse0         [V09,T08] (  2,  5   )     ref  ->  rax         "CSE - aggressive"
 ;  V10 cse1         [V10,T07] (  3,  6   )     int  ->  rcx         "CSE - aggressive"
@@ -63,12 +63,11 @@ G_M16143_IG03:        ; gcrefRegs=00000001 {rax}, byrefRegs=00000000 {}, byref,
        align    [4 bytes for IG04]
 						;; bbWeight=4    PerfScore 62.00
 G_M16143_IG04:        ; gcrefRegs=00000001 {rax}, byrefRegs=00000000 {}, loop=IG04, byref, isz
-       lea      r9d, [r10-1]
-       and      r10d, r9d
+       blsr     r10d, r10d
        inc      r8d
        test     r10d, r10d
        jne      SHORT G_M16143_IG04
-						;; bbWeight=16    PerfScore 36.00
+						;; bbWeight=16    PerfScore 32.00
 G_M16143_IG05:        ; gcrefRegs=00000001 {rax}, byrefRegs=00000000 {}, byref, isz
        add      edi, r8d
        inc      edx
@@ -97,7 +96,7 @@ G_M16143_IG09:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 142, prolog size 10, PerfScore 136.95, instruction count 48, allocated bytes for code 142 (MethodHash=2afdc0f0) for method V8.Crypto.BigInteger:bitCount():int:this
+; Total bytes of code 140, prolog size 10, PerfScore 132.75, instruction count 47, allocated bytes for code 140 (MethodHash=2afdc0f0) for method V8.Crypto.BigInteger:bitCount():int:this
 ; ============================================================
 
 Unwind Info:
```

</details>

All improvements. no regressions.

this was created as a first attempt to contribute to the jit with extensive help from @EgorBo @SingleAccretion and others from #lowlevel on the c# discord server. I can change whatever you need me to as long as you can explain what you need to me clearly. If this is a success i can continue to do the same for some of the other simple BMI1 instruction patterns.

/cc @dotnet/jit-contrib

