### PR TITLE
Fix NullabilityInfoContext.Create to properly analyze types with nested generic types

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -425,10 +425,10 @@ namespace System.Reflection
                     else if (o is ReadOnlyCollection<CustomAttributeTypedArgument> args &&
                             index < args.Count &&
                             args[index].Value is byte elementB)
-                    {
-                        state = TranslateByte(elementB);
-                        return true;
-                    }
+                        {
+                            state = TranslateByte(elementB);
+                            return true;
+                        }
 
                     break;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -341,10 +341,13 @@ namespace System.Reflection
             return NotAnnotatedStatus.None;
         }
 
-        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes) =>
-            GetNullabilityInfo(memberInfo, type, customAttributes, 0);
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes)
+        {
+            int index = 0;
+            return GetNullabilityInfo(memberInfo, type, customAttributes, ref index);
+        }
 
-        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes, int index)
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes, ref int index)
         {
             NullabilityState state = NullabilityState.Unknown;
             NullabilityInfo? elementState = null;
@@ -364,17 +367,22 @@ namespace System.Reflection
                     underlyingType = type;
                     state = NullabilityState.NotNull;
                 }
+
+                if (underlyingType.IsGenericType)
+                {
+                    index++;
+                }
             }
             else
             {
-                if (!ParseNullableState(customAttributes, index, ref state))
+                if (!ParseNullableState(customAttributes, index++, ref state))
                 {
                     state = GetNullableContext(memberInfo);
                 }
 
                 if (type.IsArray)
                 {
-                    elementState = GetNullabilityInfo(memberInfo, type.GetElementType()!, customAttributes, index + 1);
+                    elementState = GetNullabilityInfo(memberInfo, type.GetElementType()!, customAttributes, ref index);
                 }
             }
 
@@ -383,16 +391,9 @@ namespace System.Reflection
                 Type[] genericArguments = underlyingType.GetGenericArguments();
                 genericArgumentsState = new NullabilityInfo[genericArguments.Length];
 
-                for (int i = 0, offset = 0; i < genericArguments.Length; i++)
+                for (int i = 0; i < genericArguments.Length; i++)
                 {
-                    Type t = Nullable.GetUnderlyingType(genericArguments[i]) ?? genericArguments[i];
-
-                    if (!t.IsValueType || t.IsGenericType)
-                    {
-                        offset++;
-                    }
-
-                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], customAttributes, index + offset);
+                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], customAttributes, ref index);
                 }
             }
 
@@ -424,10 +425,10 @@ namespace System.Reflection
                     else if (o is ReadOnlyCollection<CustomAttributeTypedArgument> args &&
                             index < args.Count &&
                             args[index].Value is byte elementB)
-                        {
-                            state = TranslateByte(elementB);
-                            return true;
-                        }
+                    {
+                        state = TranslateByte(elementB);
+                        return true;
+                    }
 
                     break;
                 }
@@ -500,7 +501,8 @@ namespace System.Reflection
                     {
                         if (genericArguments[i].IsGenericParameter)
                         {
-                            NullabilityInfo n = GetNullabilityInfo(metaMember, genericArguments[i], genericArguments[i].GetCustomAttributesData(), i + 1);
+                            int index = i + 1;
+                            NullabilityInfo n = GetNullabilityInfo(metaMember, genericArguments[i], genericArguments[i].GetCustomAttributesData(), ref index);
                             nullability.GenericTypeArguments[i].ReadState = n.ReadState;
                             nullability.GenericTypeArguments[i].WriteState = n.WriteState;
                         }
@@ -523,7 +525,8 @@ namespace System.Reflection
                 && metaType.GetElementType()!.IsGenericParameter)
             {
                 Type elementType = metaType.GetElementType()!;
-                NullabilityInfo n = GetNullabilityInfo(metaMember, elementType, elementType.GetCustomAttributesData(), 0);
+                int index = 0;
+                NullabilityInfo n = GetNullabilityInfo(metaMember, elementType, elementType.GetCustomAttributesData(), ref index);
                 elementState.ReadState = n.ReadState;
                 elementState.WriteState = n.WriteState;
             }


### PR DESCRIPTION
Consider the following method signature:

```cs
public static Tuple<Tuple<string?, string?>, string> Field2() { }
```

Attempting to interpret the nullability attributes of `Field2`, it will report that the final `string` is nullable when in fact it is not.  For a complete demonstration, please view this file:

https://github.com/graphql-dotnet/graphql-dotnet/blob/f190a1566f61f29e1909fe6b7dcbb7140c404908/src/GraphQL.Tests/NRTTests.cs

The problem is that when enumerating the generic type definitions of `Tuple<Tuple<string?, string?>, string>`, and specifically the first generic type `Tuple<string?, string?>`, the code does not increment the index of the nullability byte in the metadata by 3 (non-null, nullable, nullable) but instead only increments it by 1.  So it reads the wrong byte value from the attribute for the second generic type argument.

I have changed the `GetNullabilityInfo` private method to accept a `ref` index argument so that it can update the index properly based on the number of nested types (and whether or not those nested types utilize a nullability byte, since non-generic value types do not).

I would be happy to add tests, but I'm not sure where in the codebase to do so.