### PR TITLE
Fix paramName in CryptoStream ArgumentExceptions

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoStream.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography
                 case CryptoStreamMode.Read:
                     if (!_stream.CanRead)
                     {
-                        throw new ArgumentException(SR.Format(SR.Argument_StreamNotReadable, nameof(stream)));
+                        throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(stream));
                     }
                     _canRead = true;
                     break;
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography
                 case CryptoStreamMode.Write:
                     if (!_stream.CanWrite)
                     {
-                        throw new ArgumentException(SR.Format(SR.Argument_StreamNotWritable, nameof(stream)));
+                        throw new ArgumentException(SR.Argument_StreamNotWritable, nameof(stream));
                     }
                     _canWrite = true;
                     break;

--- a/src/libraries/System.Security.Cryptography/tests/CryptoStream.cs
+++ b/src/libraries/System.Security.Cryptography/tests/CryptoStream.cs
@@ -40,8 +40,8 @@ namespace System.Security.Cryptography.Tests
         {
             var transform = new IdentityTransform(1, 1, true);
             AssertExtensions.Throws<ArgumentException>("mode", () => new CryptoStream(new MemoryStream(), transform, (CryptoStreamMode)12345));
-            AssertExtensions.Throws<ArgumentException>(null, "stream", () => new CryptoStream(new MemoryStream(new byte[0], writable: false), transform, CryptoStreamMode.Write));
-            AssertExtensions.Throws<ArgumentException>(null, "stream", () => new CryptoStream(new CryptoStream(new MemoryStream(new byte[0]), transform, CryptoStreamMode.Write), transform, CryptoStreamMode.Read));
+            AssertExtensions.Throws<ArgumentException>("stream", () => new CryptoStream(new MemoryStream(new byte[0], writable: false), transform, CryptoStreamMode.Write));
+            AssertExtensions.Throws<ArgumentException>("stream", () => new CryptoStream(new CryptoStream(new MemoryStream(new byte[0]), transform, CryptoStreamMode.Write), transform, CryptoStreamMode.Read));
         }
 
         [Theory]


### PR DESCRIPTION
The `ArgumentException`s that `CryptoStream` raise seemed a little peculiar to me. They use `SR.Format` even though the exception messages don't have any format placeholders, and the actual `paramName` in the exception was null. The tests were even written with that expectation, possibly to try and be compatible with .NET Framework. However the test was asserting that the `paramName` is correct in .NET Framework.

Regardless, this fixes the `paramName` and the test. Since these tests don't run against .NET Framework anymore, the parameter for the .NET Framework expectation was removed.