### PR TITLE
improve protocol detection in jail

### DIFF
--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -15,7 +15,8 @@ namespace System.Net
             IntPtr socket = invalid;
             try
             {
-                return Interop.Sys.Socket(af, SocketType.Dgram, 0, &socket) != Interop.Error.EAFNOSUPPORT;
+                Interop.Error result = Interop.Sys.Socket(af, SocketType.Dgram, 0, &socket);
+                return result != Interop.Error.EAFNOSUPPORT && result != Interop.Error.EPROTONOSUPPORT;
             }
             finally
             {

--- a/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -16,6 +16,7 @@ namespace System.Net
             try
             {
                 Interop.Error result = Interop.Sys.Socket(af, SocketType.Dgram, 0, &socket);
+                // we get EAFNOSUPPORT when family is not supported by Kernel, EPROTONOSUPPORT may come from policy enforcement like FreeBSD jail()
                 return result != Interop.Error.EAFNOSUPPORT && result != Interop.Error.EPROTONOSUPPORT;
             }
             finally


### PR DESCRIPTION
When running simple socket code in jail on freebsd with ipv6=disabled (default), we try to use dual mode socket even if that is not supported. 
The problem is that the current detection code expects only `EAFNOSUPPORT` but it fails with `EPROTONOSUPPORT`.
This change makes both errors indicating that given AF is not available. 

contributes to #14537
cc: @Thefrank 
