### PR TITLE
disable lltng on FreeBSD

### DIFF
--- a/src/coreclr/pal/src/eventprovider/CMakeLists.txt
+++ b/src/coreclr/pal/src/eventprovider/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(EVENT_MANIFEST ${VM_DIR}/ClrEtwAll.man)
 
-if(CLR_CMAKE_HOST_LINUX OR CLR_CMAKE_HOST_FREEBSD)
+if(CLR_CMAKE_HOST_LINUX)
   add_subdirectory(lttngprovider)
 else()
   add_subdirectory(dummyprovider)


### PR DESCRIPTION
`lltng-ust` package is no longer available as of 13.0 so runtime is failing to build on fresh OS. This makes it similar to macOS. 

contributes to #14537. 