### PR TITLE
Fix case where we fail to commit the start of a new region.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -29779,6 +29779,12 @@ heap_segment* gc_heap::allocate_new_region (gc_heap* hp, int gen_num, bool uoh_p
     heap_segment* res = make_heap_segment (start, (end - start), hp, gen_num);
 
     dprintf (REGIONS_LOG, ("got a new region %Ix %Ix->%Ix", (size_t)res, start, end));
+
+    if (res == nullptr)
+    {
+        global_region_allocator.delete_region (start);
+    }
+
     return res;
 }
 


### PR DESCRIPTION
We don't clean up the entry in the region allocator map though, so the entry looks like an allocated region entry.

The region itself though looks like it is on a region free list (heap_segment_allocated is null), so we crash when we try to remove it from its free list, as its containing_free_list is null.
