### PR TITLE
Special-case ERROR_INVALID_PARAMETER in PosixSignalRegistration.Unregister

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PosixSignalRegistration.Windows.cs
@@ -53,7 +53,14 @@ namespace System.Runtime.InteropServices
                     if (s_registrations.Count == 0 &&
                         !Interop.Kernel32.SetConsoleCtrlHandler(&HandlerRoutine, Add: false))
                     {
-                        throw Win32Marshal.GetExceptionForLastWin32Error();
+                        // Ignore errors due to the handler no longer being registered; this can happen, for example, with
+                        // direct use of Alloc/Attach/FreeConsole which result in the table of control handlers being reset.
+                        // Throw for everything else.
+                        int error = Marshal.GetLastWin32Error();
+                        if (error != Interop.Errors.ERROR_INVALID_PARAMETER)
+                        {
+                            throw Win32Marshal.GetExceptionForWin32Error(error);
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Windows.cs
@@ -4,6 +4,8 @@
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
 
 namespace System.Tests
 {
@@ -26,5 +28,23 @@ namespace System.Tests
         }
 
         private static IEnumerable<PosixSignal> SupportedPosixSignals => new[] { PosixSignal.SIGINT, PosixSignal.SIGQUIT, PosixSignal.SIGTERM, PosixSignal.SIGHUP };
+
+        [Fact]
+        public void ExternalConsoleManipulation_RegistrationRemoved_UnregisterSucceeds()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                PosixSignalRegistration r = PosixSignalRegistration.Create(PosixSignal.SIGINT, _ => { });
+                FreeConsole();
+                AllocConsole();
+                r.Dispose(); // validate this doesn't throw even though the use of Free/AllocConsole likely removed our registration
+            }).Dispose();
+        }
+
+        [DllImport("kernel32.dll")]
+        private static extern bool FreeConsole();
+
+        [DllImport("kernel32.dll")]
+        private static extern bool AllocConsole();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/62192