### PR TITLE
Revert "Remove extra call to PropertyInfo.GetValue(object) (#60415)"

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -248,17 +248,19 @@ namespace Microsoft.Extensions.Configuration
                 return;
             }
 
+            object? propertyValue = property.GetValue(instance);
             bool hasSetter = property.SetMethod != null && (property.SetMethod.IsPublic || options.BindNonPublicProperties);
 
-            if (!hasSetter)
+            if (propertyValue == null && !hasSetter)
             {
-                // The property cannot be set so there is no point going further
+                // Property doesn't have a value and we cannot set it so there is no
+                // point in going further down the graph
                 return;
             }
 
-            object? propertyValue = GetPropertyValue(property, instance, config, options);
+            propertyValue = GetPropertyValue(property, instance, config, options);
 
-            if (propertyValue != null)
+            if (propertyValue != null && hasSetter)
             {
                 property.SetValue(instance, propertyValue);
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -117,11 +117,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             public byte[] MyByteArray { get; set; }
         }
 
-        public class GetterOnlyOptions
-        {
-            public string MyString => throw new NotImplementedException();
-        }
-
         [Fact]
         public void CanBindIConfigurationSection()
         {
@@ -346,20 +341,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
                 () => config.Bind(instance, o => o.ErrorOnUnknownConfiguration = true));
 
             Assert.Equal(expectedMessage, ex.Message);
-        }
-
-        [Fact]
-        public void DoesNotExecuteGetterIfNoSetter()
-        {
-            var dic = new Dictionary<string, string>
-            {
-                {"MyString", "hello world"}
-            };
-            var configurationBuilder = new ConfigurationBuilder();
-            configurationBuilder.AddInMemoryCollection(dic);
-            var config = configurationBuilder.Build();
-
-            var _ = config.Get<GetterOnlyOptions>();
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/63479

This reverts commit 97ef512a7cbc21d982ce68de805fec2c42e3561c which was trying to fix https://github.com/dotnet/runtime/issues/52905
