### PR TITLE
Fix ArgIterator::GetArgLoc by-ref check for HFAs/HVAs

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -1606,9 +1606,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                         int byteArgSize = GetArgSize();
 
-                        // Composites greater than 16bytes are passed by reference
-                        TypeHandle dummy;
-                        if (GetArgType(out dummy) == CorElementType.ELEMENT_TYPE_VALUETYPE && GetArgSize() > _transitionBlock.EnregisteredParamTypeMaxSize)
+                        // On ARM64 some composites are implicitly passed by reference.
+                        if (IsArgPassedByRef())
                         {
                             byteArgSize = _transitionBlock.PointerSize;
                         }

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -694,9 +694,8 @@ public:
 
         unsigned byteArgSize = GetArgSize();
 
-        // Question: why do not arm and x86 have similar checks?
-        // Composites greater than 16 bytes are passed by reference
-        if ((GetArgType() == ELEMENT_TYPE_VALUETYPE) && (byteArgSize > ENREGISTERED_PARAMTYPE_MAXSIZE))
+        // On ARM64 some composites are implicitly passed by reference.
+        if (IsArgPassedByRef())
         {
             byteArgSize = TARGET_POINTER_SIZE;
         }

--- a/src/tests/JIT/Stress/ABI/Callee.cs
+++ b/src/tests/JIT/Stress/ABI/Callee.cs
@@ -12,8 +12,10 @@ namespace ABIStress
 {
     class Callee
     {
-        private static readonly MethodInfo s_hashCodeAddMethod =
-            typeof(HashCode).GetMethods().Single(mi => mi.Name == "Add" && mi.GetParameters().Length == 1);
+        private static readonly MethodInfo s_memoryMarshalCreateReadOnlySpanMethod =
+            typeof(MemoryMarshal).GetMethod("CreateReadOnlySpan").MakeGenericMethod(typeof(byte));
+        private static readonly MethodInfo s_hashCodeAddBytesMethod =
+            typeof(HashCode).GetMethod("AddBytes");
         private static readonly MethodInfo s_hashCodeToHashCodeMethod =
             typeof(HashCode).GetMethod("ToHashCode");
 
@@ -51,8 +53,12 @@ namespace ABIStress
             {
                 TypeEx pm = Parameters[i];
                 g.Emit(OpCodes.Ldloca, hashCode);
-                g.Emit(OpCodes.Ldarg, checked((short)i));
-                g.Emit(OpCodes.Call, s_hashCodeAddMethod.MakeGenericMethod(pm.Type));
+
+                g.Emit(OpCodes.Ldarga, checked((short)i));
+                g.Emit(OpCodes.Ldc_I4, pm.Size);
+                g.Emit(OpCodes.Call, s_memoryMarshalCreateReadOnlySpanMethod);
+
+                g.Emit(OpCodes.Call, s_hashCodeAddBytesMethod);
             }
 
             g.Emit(OpCodes.Ldloca, hashCode);

--- a/src/tests/JIT/Stress/ABI/Config.cs
+++ b/src/tests/JIT/Stress/ABI/Config.cs
@@ -12,7 +12,7 @@ namespace ABIStress
         internal const string PInvokerPrefix = "ABIStress_PInvoker";
         internal const string PInvokeePrefix = "ABIStress_PInvokee";
 
-        internal const string InstantiatingStubPrefix = "ABIStress_InstantiatingStub_";
+        internal const string StubPrefix = "ABIStress_Stub_";
 
         internal static StressModes StressModes { get; set; } = StressModes.None;
         

--- a/src/tests/JIT/Stress/ABI/Program.cs
+++ b/src/tests/JIT/Stress/ABI/Program.cs
@@ -21,10 +21,10 @@ namespace ABIStress
         {
             static void Usage()
             {
-                Console.WriteLine("Usage: [--verbose] [--caller-index <number>] [--num-calls <number>] [--tailcalls] [--pinvokes] [--instantiatingstubs] [--unboxingstubs] [--sharedgenericunboxingstubs] [--max-params <number>] [--no-ctrlc-summary]");
+                Console.WriteLine("Usage: [--verbose] [--caller-index <number>] [--num-calls <number>] [--tailcalls] [--pinvokes] [--instantiatingstubs] [--unboxingstubs] [--sharedgenericunboxingstubs] [--shufflethunks] [--max-params <number>] [--no-ctrlc-summary]");
                 Console.WriteLine("Either --caller-index or --num-calls must be specified.");
                 Console.WriteLine("Example: --num-calls 100");
-                Console.WriteLine("  Stress first 100 tailcalls and pinvokes");
+                Console.WriteLine("  Stress first 100 of all kinds");
                 Console.WriteLine("Example: --tailcalls --caller-index 37 --verbose");
                 Console.WriteLine("  Stress tailcaller 37, verbose output");
                 Console.WriteLine("Example: --pinvokes --num-calls 1000");
@@ -263,7 +263,7 @@ namespace ABIStress
                 Console.WriteLine("Invoking caller through reflection with args");
                 for (int j = 0; j < outerArgs.Length; j++)
                 {
-                    Console.Write($"arg{j}=");
+                    Console.Write($"arg{j}({outerArgs[j].GetType().Name})=");
                     DumpObject(outerArgs[j]);
                 }
             }
@@ -275,7 +275,7 @@ namespace ABIStress
                 Console.WriteLine("Invoking callee through reflection with args");
                 for (int j = 0; j < innerArgs.Length; j++)
                 {
-                    Console.Write($"arg{j}=");
+                    Console.Write($"arg{j}({innerArgs[j].GetType().Name})=");
                     DumpObject(innerArgs[j]);
                 }
             }
@@ -329,7 +329,7 @@ namespace ABIStress
             int index = 0;
             foreach (Value v in values)
             {
-                g.Emit(OpCodes.Ldstr, $"arg{index}=");
+                g.Emit(OpCodes.Ldstr, $"arg{index}({v.Type.Type.Name})=");
                 g.Emit(OpCodes.Call, s_writeString);
 
                 v.Emit(g);

--- a/src/tests/JIT/Stress/ABI/Program.cs
+++ b/src/tests/JIT/Stress/ABI/Program.cs
@@ -21,7 +21,7 @@ namespace ABIStress
         {
             static void Usage()
             {
-                Console.WriteLine("Usage: [--verbose] [--caller-index <number>] [--num-calls <number>] [--tailcalls] [--pinvokes] [--instantiatingstubs] [--unboxingstubs] [--sharedgenericunboxingstubs] [--shufflethunks] [--max-params <number>] [--no-ctrlc-summary]");
+                Console.WriteLine("Usage: [--verbose] [--caller-index <number>] [--num-calls <number>] [--tailcalls] [--pinvokes] [--instantiatingstubs] [--unboxingstubs] [--sharedgenericunboxingstubs] [--max-params <number>] [--no-ctrlc-summary]");
                 Console.WriteLine("Either --caller-index or --num-calls must be specified.");
                 Console.WriteLine("Example: --num-calls 100");
                 Console.WriteLine("  Stress first 100 of all kinds");

--- a/src/tests/JIT/Stress/ABI/Stubs.cs
+++ b/src/tests/JIT/Stress/ABI/Stubs.cs
@@ -112,18 +112,18 @@ namespace ABIStress
 
         private static bool DoStubCall(int callerIndex, bool staticMethod, bool onValueType, GenericShape typeGenericShape, GenericShape methodGenericShape)
         {
-            string callerNameSeed = Config.InstantiatingStubPrefix + "Caller" + callerIndex; // Use a consistent seed value here so that the various various of unboxing/instantiating stubs are generated with the same arg shape
+            string callerNameSeed = Config.StubPrefix + "Caller" + callerIndex; // Use a consistent seed value here so that the various various of unboxing/instantiating stubs are generated with the same arg shape
             string callerName = callerNameSeed + (staticMethod ? "Static" : "Instance") + (onValueType ? "Class" : "ValueType") + typeGenericShape.ToString() + methodGenericShape.ToString();
             Random rand = new Random(GetSeed(callerName));
             List<TypeEx> pms;
             do
             {
                 pms = RandomParameters(s_allTypes, rand);
-            } while (pms.Count > 16);
+            } while (pms.Count > 16); // GetDelegateType supports only up to 16 arguments
 
             Type delegateType = GetDelegateType(pms, typeof(int));
 
-            Callee callee = new Callee(callerName+"Callee", pms);// CreateCallee(Config.PInvokeePrefix + calleeIndex, s_allTypes);
+            Callee callee = new Callee(callerName+"Callee", pms);
             callee.Emit();
 
             Delegate calleeDelegate = callee.Method.CreateDelegate(delegateType);


### PR DESCRIPTION
This check was not taking into account that HFAs and HVAs are not passed
by ref (except for in varargs), even when they are larger than 16 bytes.
However we do not hit this bug in reflection invocation as we do not use
the size from ArgLocDesc but rather end up calling
MethodTable::GetNumInstanceFieldBytes to get the size.

cc @jkotas