### PR TITLE
[Arm64] Don't use D-copies in CopyBlock

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -2840,8 +2840,8 @@ void CodeGen::genCodeForCpBlkUnroll(GenTreeBlk* node)
     // When both addresses are not 16-byte aligned the CopyBlock instruction sequence starts with padding
     // str instruction. For example, when both addresses are 8-byte aligned the instruction sequence looks like
     //
-    // ldr D_simdReg1, [srcReg, #srcOffset]
-    // str D_simdReg1, [dstReg, #dstOffset]
+    // ldr X_intReg1, [srcReg, #srcOffset]
+    // str X_intReg1, [dstReg, #dstOffset]
     // ldp Q_simdReg1, Q_simdReg2, [srcReg, #srcOffset+8]
     // stp Q_simdReg1, Q_simdReg2, [dstReg, #dstOffset+8]
     // ldp Q_simdReg1, Q_simdReg2, [srcReg, #srcOffset+40]

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1772,7 +1772,7 @@ private:
 
     // The following keep track of information about internal (temporary register) intervals
     // during the building of a single node.
-    static const int MaxInternalCount = 4;
+    static const int MaxInternalCount = 5;
     RefPosition*     internalDefs[MaxInternalCount];
     int              internalCount = 0;
     bool             setInternalRegsDelayFree;

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -694,36 +694,40 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                 {
                     buildInternalIntRegisterDefForNode(blkNode);
 #ifdef TARGET_ARM64
-                    const bool dstAddrMayNeedReg = dstAddr->isContained();
-                    const bool srcAddrMayNeedReg = src->OperIs(GT_LCL_VAR, GT_LCL_FLD) ||
-                                                   ((srcAddrOrFill != nullptr) && srcAddrOrFill->isContained());
+                    const bool canUseLoadStorePairIntRegsInstrs = (size >= 2 * REGSIZE_BYTES);
 
-                    if (srcAddrMayNeedReg && dstAddrMayNeedReg)
+                    if (canUseLoadStorePairIntRegsInstrs)
                     {
-                        // The following allocates an additional integer register in a case
-                        // when a load instruction and a store instruction cannot be encoded.
+                        // CodeGen can use ldp/stp instructions sequence.
                         buildInternalIntRegisterDefForNode(blkNode);
-                        // In this case, CodeGen will use a SIMD register for copying.
-                        buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
-                        // And in case of a larger block size, two SIMD registers.
-                        if (size >= 2 * REGSIZE_BYTES)
-                        {
-                            buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
-                        }
                     }
-                    else if (srcAddrMayNeedReg || dstAddrMayNeedReg)
+
+                    const bool isSrcAddrLocal = src->OperIs(GT_LCL_VAR, GT_LCL_FLD) ||
+                                                ((srcAddrOrFill != nullptr) && srcAddrOrFill->OperIsLocalAddr());
+                    const bool isDstAddrLocal = dstAddr->OperIsLocalAddr();
+
+                    // CodeGen can use 16-byte SIMD ldp/stp for larger block sizes
+                    // only when both source and destination base address registers have known alignment.
+                    // This is the case, when both registers are either sp or fp.
+                    bool canUse16ByteWideInstrs = isSrcAddrLocal && isDstAddrLocal && (size >= 2 * FP_REGSIZE_BYTES);
+
+                    // Note that the SIMD registers allocation is speculative - LSRA doesn't know at this point
+                    // whether CodeGen will use SIMD registers (i.e. if such instruction sequence will be more optimal).
+                    // Therefore, it must allocate an additional integer register anyway.
+                    if (canUse16ByteWideInstrs)
                     {
-                        if (size >= 2 * REGSIZE_BYTES)
-                        {
-                            buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
-                            buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
-                        }
-                        else
-                        {
-                            buildInternalIntRegisterDefForNode(blkNode);
-                        }
+                        buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
+                        buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());
                     }
-                    else if (size >= 2 * REGSIZE_BYTES)
+
+                    const bool srcAddrMayNeedReg =
+                        isSrcAddrLocal || ((srcAddrOrFill != nullptr) && srcAddrOrFill->isContained());
+                    const bool dstAddrMayNeedReg = isDstAddrLocal || dstAddr->isContained();
+
+                    // The following allocates an additional integer register in a case
+                    // when a load instruction and a store instruction cannot be encoded using offset
+                    // from a corresponding base register.
+                    if (srcAddrMayNeedReg && dstAddrMayNeedReg)
                     {
                         buildInternalIntRegisterDefForNode(blkNode);
                     }


### PR DESCRIPTION
Resolves #63453:


|                      Method |        Job |                   Toolchain |     Mean |    Error |   StdDev |   Median |      Min |      Max | Ratio | Allocated |
|---------------------------- |----------- |---------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|----------:|
| InequalityOperatorBenchmark | Job-YASJMH | \base\Core_Root\corerun.exe | 11.97 ns | 0.051 ns | 0.043 ns | 11.97 ns | 11.91 ns | 12.07 ns |  1.00 |         - |
| InequalityOperatorBenchmark | Job-RUKPGX | \diff\Core_Root\corerun.exe | 12.24 ns | 0.030 ns | 0.024 ns | 12.24 ns | 12.20 ns | 12.28 ns |  1.02 |         - |

Based on the discussion in https://github.com/dotnet/runtime/issues/63453#issuecomment-1007861814 don't use D-variants ldp/stp for copying 16 bytes and use integer ldp/stp (as before #61030). 

In order to allow this, we would need to allocate an additional integer register even if LSRA has allocated a pair of SIMD registers (the decision whether Q-copies can be used are based on whether both source and destination correspond to locals **and** their base addresses have the same `(startOffset % 16)` values, meaning that at LSRA phase we cannot determine whether the latter condition will hold since assignment of the addresses on the stack to locals is done later - at CodeGen phase).

@dotnet/jit-contrib PTAL
cc @TamarChristinaArm 