### PR TITLE
Remove ILStrip usage in mono for source-build

### DIFF
--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -18,7 +18,7 @@
     <ProjectReference Include="Microsoft.NET.Runtime.MonoAOTCompiler.Task\Microsoft.NET.Runtime.MonoAOTCompiler.Task.pkgproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <ProjectReference Include="Microsoft.NET.Runtime.MonoTargets.Sdk\Microsoft.NET.Runtime.MonoTargets.Sdk.pkgproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/60315 tried to remove ILStrip usage in runtime for source-build (through a condition of DotNetBuildFromSource) but it didn't remove the prebuilts in mono. Fix that.

We needed this for building .NET 6 on using source-build on IBM Z.

cc @uweigand who wrote this patch; I am only trying to get it merged here so we don't have to carry this locally.