### PR TITLE
Fix exception propagation over HW exception frame on macOS arm64

### DIFF
--- a/src/coreclr/pal/src/exception/machexception.cpp
+++ b/src/coreclr/pal/src/exception/machexception.cpp
@@ -383,9 +383,9 @@ void PAL_DispatchException(PCONTEXT pContext, PEXCEPTION_RECORD pExRecord, MachE
 #if defined(HOST_ARM64)
         // RtlRestoreContext assembly corrupts X16 & X17, so it cannot be
         // used for GCStress=C restore
-        MachSetThreadContext(pContext);
+        MachSetThreadContext(exception.ExceptionPointers.ContextRecord);
 #else
-        RtlRestoreContext(pContext, pExRecord);
+        RtlRestoreContext(exception.ExceptionPointers.ContextRecord, pExRecord);
 #endif
     }
 

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -496,7 +496,9 @@ void GetContextPointers(unw_cursor_t *cursor, unw_context_t *unwContext, KNONVOL
 
 #ifndef HOST_WINDOWS
 
-extern int g_common_signal_handler_context_locvar_offset;
+// Frame pointer relative offset of a local containing a pointer to the windows style context of a location
+// where a hardware exception occured.
+int g_hardware_exception_context_locvar_offset = 0;
 
 BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers)
 {
@@ -506,19 +508,17 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
 
     DWORD64 curPc = CONTEXTGetPC(context);
 
-#ifndef __APPLE__
-    // Check if the PC is the return address from the SEHProcessException in the common_signal_handler.
-    // If that's the case, extract its local variable containing the windows style context of the hardware
+    // Check if the PC is the return address from the SEHProcessException.
+    // If that's the case, extract its local variable containing a pointer to the windows style context of the hardware
     // exception and return that. This skips the hardware signal handler trampoline that the libunwind
-    // cannot cross on some systems.
+    // cannot cross on some systems. On macOS, it skips a similar trampoline we create in HijackFaultingThread.
     if ((void*)curPc == g_SEHProcessExceptionReturnAddress)
     {
-        CONTEXT* signalContext = (CONTEXT*)(CONTEXTGetFP(context) + g_common_signal_handler_context_locvar_offset);
-        memcpy_s(context, sizeof(CONTEXT), signalContext, sizeof(CONTEXT));
+        CONTEXT* exceptionContext = *(CONTEXT**)(CONTEXTGetFP(context) + g_hardware_exception_context_locvar_offset);
+        memcpy_s(context, sizeof(CONTEXT), exceptionContext, sizeof(CONTEXT));
 
         return TRUE;
     }
-#endif
 
     if ((context->ContextFlags & CONTEXT_EXCEPTION_ACTIVE) != 0)
     {

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -116,10 +116,6 @@ struct sigaction g_previous_sigabrt;
 
 #if !HAVE_MACH_EXCEPTIONS
 
-// Offset of the local variable containing pointer to windows style context in the common_signal_handler function.
-// This offset is relative to the frame pointer.
-int g_common_signal_handler_context_locvar_offset = 0;
-
 // TOP of special stack for handling stack overflow
 volatile void* g_stackOverflowHandlerStack = NULL;
 
@@ -942,11 +938,12 @@ static bool common_signal_handler(int code, siginfo_t *siginfo, void *sigcontext
 #if !HAVE_MACH_EXCEPTIONS
     sigset_t signal_set;
     CONTEXT signalContextRecord;
+    CONTEXT* signalContextRecordPtr = &signalContextRecord;
     EXCEPTION_RECORD exceptionRecord;
     native_context_t *ucontext;
 
     ucontext = (native_context_t *)sigcontext;
-    g_common_signal_handler_context_locvar_offset = (int)((char*)&signalContextRecord - (char*)__builtin_frame_address(0));
+    g_hardware_exception_context_locvar_offset = (int)((char*)&signalContextRecordPtr - (char*)__builtin_frame_address(0));
 
     if (code == (SIGSEGV | StackOverflowFlag))
     {

--- a/src/coreclr/pal/src/include/pal/seh.hpp
+++ b/src/coreclr/pal/src/include/pal/seh.hpp
@@ -145,5 +145,10 @@ CorUnix::PAL_ERROR SEHDisable(CorUnix::CPalThread *pthrCurrent);
 
 }
 
+// Offset of the local variable containing pointer to windows style context in the common_signal_handler / PAL_DispatchException function.
+// This offset is relative to the frame pointer.
+extern int g_hardware_exception_context_locvar_offset;
+
+
 #endif /* _PAL_SEH_HPP_ */
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -334,11 +334,6 @@ Roslyn4.0.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' and '$(RuntimeFlavor)' != 'Mono' and '$(RunDisabledAppleSiliconTests)' != 'true'">
-    <!-- Issue: https://github.com/dotnet/runtime/issues/63439 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\DllImportGenerator.UnitTests\DllImportGenerator.Unit.Tests.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetArchitecture)' == 's390x' and '$(RunDisableds390xTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Drawing.Common\tests\System.Drawing.Common.Tests.csproj" />
   </ItemGroup>

--- a/src/tests/Regressions/coreclr/GitHub_62058/test62058.cs
+++ b/src/tests/Regressions/coreclr/GitHub_62058/test62058.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+public class Program
+{
+    private interface IFoo
+    {
+        bool IsValid { get; }
+    }
+
+    private class Foo : IFoo
+    {
+        public bool IsValid { get; set; }
+    }
+
+    public static int Main(string[] args)
+    {
+        bool warmup = new Foo().IsValid;
+        CatchIgnore(() =>
+        CatchRethrow(() =>
+        {
+            IFoo[] foos = {new Foo(), null};
+            foreach (var foo in foos)
+            {
+                bool check = foo.IsValid;
+            }
+        }));
+
+        return 100;
+    }
+
+    public static void CatchRethrow(Action action)
+    {
+        try
+        {
+            action.Invoke();
+        }
+        catch (Exception e)
+        {
+            Console.Out.WriteLine("catch");
+            Console.Out.Flush();
+            throw new Exception("catch", e);  // throw; doesn't work either
+        }
+    }
+
+    public static void CatchIgnore(Action action)
+    {
+        try
+        {
+            action.Invoke();
+        }
+        catch (Exception)
+        {
+            Console.Out.WriteLine("ignore");
+            Console.Out.Flush();
+        }
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_62058/test62058.cs
+++ b/src/tests/Regressions/coreclr/GitHub_62058/test62058.cs
@@ -41,7 +41,7 @@ public class Program
         {
             Console.Out.WriteLine("catch");
             Console.Out.Flush();
-            throw new Exception("catch", e);  // throw; doesn't work either
+            throw new Exception("catch", e);
         }
     }
 

--- a/src/tests/Regressions/coreclr/GitHub_62058/test62058.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_62058/test62058.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test62058.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is a problem unwinding over the PAL_DispatchExceptionWrapper
to the actual hardware exception location. The unwinder is unable
to get distinct LR and PC in that frame and sets both of them to
the same value. This is caused by the fact that the
PAL_DispatchExceptionWrapper is just an injected fake frame and
there was no real call. Calls always return with LR and PC set
to the same value.

The fix unifies the hardware exception frame unwinding with Linux
where we had problems unwinding over signal handler trampoline, so
PAL_VirtualUnwind skips the trampoline and now also the
PAL_DispatchExceptionWrapper frame by copying the context of
the exception as the unwound context.