### PR TITLE
Fix native frame unwind in syscall on arm64 for VS4Mac crash report.

### DIFF
--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -277,6 +277,9 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
             uint64_t start = segment.vmaddr + module.LoadBias();
             uint64_t end = start + segment.vmsize;
 
+            // Add this module segment to the set used by the thread unwinding to lookup the module base address for an ip.
+            AddModuleAddressRange(start, end, module.BaseAddress());
+
             // Round to page boundary
             start = start & PAGE_MASK;
             _ASSERTE(start > 0);
@@ -297,9 +300,6 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
                 }
                 // Add this module segment to the module mappings list
                 m_moduleMappings.insert(moduleRegion);
-
-                // Add this module segment to the set used by the thread unwinding to lookup the module base address for an ip.
-                AddModuleAddressRange(start, end, module.BaseAddress());
             }
             else
             {

--- a/src/coreclr/debug/createdump/stackframe.h
+++ b/src/coreclr/debug/createdump/stackframe.h
@@ -66,9 +66,16 @@ public:
         }
     }
 
+// See comment in threadinfo.cpp UnwindNativeFrames function
+#if defined(__aarch64__)
+    #define STACK_POINTER_MASK ~0x7
+#else
+    #define STACK_POINTER_MASK ~0x0
+#endif
+
     inline uint64_t ModuleAddress() const { return m_moduleAddress; }
     inline uint64_t InstructionPointer() const { return m_instructionPointer; }
-    inline uint64_t StackPointer() const { return m_stackPointer; }
+    inline uint64_t StackPointer() const { return m_stackPointer & STACK_POINTER_MASK; }
     inline uint32_t NativeOffset() const { return m_nativeOffset; }
     inline uint32_t Token() const { return m_token; }
     inline uint32_t ILOffset() const { return m_ilOffset; }

--- a/src/coreclr/debug/createdump/threadinfo.cpp
+++ b/src/coreclr/debug/createdump/threadinfo.cpp
@@ -53,6 +53,16 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
         uint64_t ip = 0, sp = 0;
         GetFrameLocation(pContext, &ip, &sp);
 
+#if defined(__aarch64__)
+        // ARM64 can have frames with the same SP but different IPs. Increment sp so it gets added to the stack
+        // frames in the correct order and to prevent the below loop termination on non-increasing sp. Since stack
+        // pointers are always 8 byte align, this increase is masked off in StackFrame::StackPointer() to get the
+        // original stack pointer.
+        if (sp == previousSp && ip != previousIp)
+        {
+            sp++;
+        }
+#endif
         if (ip == 0 || sp <= previousSp) {
             TRACE_VERBOSE("Unwind: sp not increasing or ip == 0 sp %p ip %p\n", (void*)sp, (void*)ip);
             break;


### PR DESCRIPTION
Add arm64 version of StepWithCompactNoEncoding for syscall leaf node wrappers that have compact encoding of 0.

Fix ReadCompactEncodingRegister so it actually decrements the addr.

Change StepWithCompactEncodingArm64 to match what MacOS libunwind does for framed and frameless stepping.

arm64 can have frames with the same SP (but different IPs). Increment SP for this condition so createdump's unwind
loop doesn't break out on the "SP not increasing" check and the frames are added to the thread frame list in the
correct order.

Add getting the unwind info for tail called functions like this:
```
__ZL14PROCEndProcessPvji:
   36630:       f6 57 bd a9     stp     x22, x21, [sp, #-48]!
   36634:       f4 4f 01 a9     stp     x20, x19, [sp, #16]
   36638:       fd 7b 02 a9     stp     x29, x30, [sp, #32]
   3663c:       fd 83 00 91     add     x29, sp, #32
...
   367ac:       e9 01 80 52     mov     w9, #15
   367b0:       7f 3e 02 71     cmp     w19, #143
   367b4:       20 01 88 1a     csel    w0, w9, w8, eq
   367b8:       2e 00 00 94     bl      _PROCAbort
_TerminateProcess:
-> 367bc:       22 00 80 52     mov     w2, #1
   367c0:       9c ff ff 17     b       __ZL14PROCEndProcessPvji
```
The IP (367bc) returns the (incorrect) frameless encoding with nothing on the stack (uses an incorrect LR to unwind). To fix this
get the unwind info for PC -1 which points to PROCEndProcess with the correct unwind info. This matches how lldb unwinds this frame.

Always address module segment to IP lookup list instead of checking the module regions.

Strip pointer authentication bits on PC/LR.