### PR TITLE
Disable package validation in source-build for reliability

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -1,7 +1,13 @@
 <Project>
 
   <PropertyGroup>
-    <EnablePackageValidation>true</EnablePackageValidation>
+    <!--
+      Package validation causes flaky errors during the build. Validation isn't useful during
+      source-build (it is only a guardrail for devs), so disable it during source-build to avoid the
+      impact on build reliability. https://github.com/dotnet/runtime/issues/60883 tracks fixing the
+      flakiness and removing this condition.
+    -->
+    <EnablePackageValidation Condition="'$(DotNetBuildFromSource)' != 'true'">true</EnablePackageValidation>
     <!-- Don't restore prebuilt packages during sourcebuild. -->
     <DisablePackageBaselineValidation Condition="'$(DotNetBuildFromSource)' == 'true'">true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">$(NetCoreAppLatestStablePackageBaselineVersion)</PackageValidationBaselineVersion>


### PR DESCRIPTION
See https://github.com/dotnet/source-build/issues/2708: The source-build team is making an effort to upstream all of our patches over the next week.

This is a port of https://github.com/dotnet/runtime/pull/60881 to `main`. Description from the comment in the diff:

> Package validation causes flaky errors during the build. Validation isn't useful during
> source-build (it is only a guardrail for devs), so disable it during source-build to avoid the
> impact on build reliability. https://github.com/dotnet/runtime/issues/60883 tracks fixing the
> flakiness and removing this condition.
