### PR TITLE
Fix address mode for `IconHandle + Icon`

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1362,9 +1362,10 @@ AGAIN:
 
     assert(mul == 0);
 
-    /* Special case: keep constants as 'op2' */
+    /* Special case: keep constants as 'op2', but don't do this for constant handles
+       because they don't fit I32 that we're going to check for below anyway. */
 
-    if (op1->IsCnsIntOrI())
+    if (op1->IsCnsIntOrI() && !op1->IsIconHandle())
     {
         // Presumably op2 is assumed to not be a constant (shouldn't happen if we've done constant folding)?
         tmp = op1;


### PR DESCRIPTION
For a NativeAOT change that I'm working on, I'm seeing inefficient address mode getting generated for trees in the shape of `IconHandle + Icon`. The logic I'm touching is swapping this to `Icon + IconHandle` and that makes us miss the if check on the following line because `!op2->IsIntCnsFitsInI32`. That makes us miss generating this tree as `[reg + offset]`. Submitting this as a separate pull request because my actual change will likely need a JitInterface GUID update. This should be no diff for non-AOT scenarios.