### PR TITLE
Improve static field access for NativeAOT

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -1649,6 +1649,7 @@ enum CORINFO_FIELD_ACCESSOR
     CORINFO_FIELD_STATIC_ADDR_HELPER,       // static field accessed using address-of helper (argument is FieldDesc *)
     CORINFO_FIELD_STATIC_TLS,               // unmanaged TLS access
     CORINFO_FIELD_STATIC_READYTORUN_HELPER, // static field access using a runtime lookup helper
+    CORINFO_FIELD_STATIC_DATASEGMENT,       // static field access from the data segment
 
     CORINFO_FIELD_INTRINSIC_ZERO,           // intrinsic zero (IntPtr.Zero, UIntPtr.Zero)
     CORINFO_FIELD_INTRINSIC_EMPTY_STRING,   // intrinsic emptry string (String.Empty)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1118,6 +1118,7 @@ namespace Internal.JitInterface
         CORINFO_FIELD_STATIC_ADDR_HELPER,       // static field accessed using address-of helper (argument is FieldDesc *)
         CORINFO_FIELD_STATIC_TLS,               // unmanaged TLS access
         CORINFO_FIELD_STATIC_READYTORUN_HELPER, // static field access using a runtime lookup helper
+        CORINFO_FIELD_STATIC_DATASEGMENT,       // static field access from the data segment
 
         CORINFO_FIELD_INTRINSIC_ZERO,           // intrinsic zero (IntPtr.Zero, UIntPtr.Zero)
         CORINFO_FIELD_INTRINSIC_EMPTY_STRING,   // intrinsic emptry string (String.Empty)


### PR DESCRIPTION
NativeAOT currently goes through a helper call whenever we need to access static fields. For this simple program:

```csharp
class Program
{
    static int s1, s2;
    static int Main() => s1 + s2;
}
```

We generate:

```nasm
repro_Program__Main:
sub         rsp,28h
call        __GetNonGCStaticBase_repro_Program
mov         edx,dword ptr [rax]
add         edx,dword ptr [rax+4]
mov         eax,edx
add         rsp,28h
ret

__GetNonGCStaticBase_repro_Program:
lea         rax,[?__NONGCSTATICS@repro_Program@@]
ret
```

It's not terrible, but also could be better. As far as I can see, JitInterface cannot express the exact way static fields are accessed in NativeAOT. I had a previous attempt to use the existing JitInterface facilities in https://github.com/dotnet/corert/pull/5131 (misusing the facilities that exist to support RVA static fields), but it didn't generate "nice" addressing modes and couldn't support GC statics (see the disassembly there).

I'm adding a way to do that with "nice" addressing modes. After this change, the above program compiles into:

```nasm
repro_Program__Main:
mov         eax,dword ptr [?__NONGCSTATICS@repro_Program@@]
lea         rdx,[?__NONGCSTATICS@repro_Program@@]
add         eax,dword ptr [rdx+4]
ret
```

There's room for improvement:
* It would be nice if we could similarly inline these lookups when we're in shared generic code
* I think the addressing mode could be more compact if RyuJIT generated a reloc with a delta on x64.
* It would be nice if we could do this if there's a static constructor. .NET Native could inline the "did static constructor already run?" checks. There was a previous attempt at that in https://github.com/dotnet/coreclr/pull/12420 (and corresponding https://github.com/dotnet/corert/pull/3962).