### PR TITLE
[wasm] Load assets earlier

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -4,6 +4,15 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
+    <!-- This doesn't run on V8 shell because https://bugs.chromium.org/p/v8/issues/detail?id=12541 -->
+    <Scenario>WasmTestOnBrowser</Scenario>
+    <TestArchiveTestsRoot>$(TestArchiveRoot)browserornodejs/</TestArchiveTestsRoot>
+    <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="ZipFile.Create.cs" />
     <Compile Include="ZipFile.Extract.cs" />

--- a/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -3,6 +3,15 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
+    <!-- This doesn't run on V8 shell because https://bugs.chromium.org/p/v8/issues/detail?id=12541 -->
+    <Scenario>WasmTestOnBrowser</Scenario>
+    <TestArchiveTestsRoot>$(TestArchiveRoot)browserornodejs/</TestArchiveTestsRoot>
+    <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="CompressionStreamUnitTests.ZLib.cs" />
     <Compile Include="CompressionStreamUnitTests.Deflate.cs" />

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -2,6 +2,15 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
+    <!-- This doesn't run on V8 shell because https://bugs.chromium.org/p/v8/issues/detail?id=12541 -->
+    <Scenario>WasmTestOnBrowser</Scenario>
+    <TestArchiveTestsRoot>$(TestArchiveRoot)browserornodejs/</TestArchiveTestsRoot>
+    <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="Errata4.cs" />
     <Compile Include="OutputSettings.cs" />

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
@@ -2,6 +2,15 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
+    <!-- This doesn't run on V8 shell because https://bugs.chromium.org/p/v8/issues/detail?id=12541 -->
+    <Scenario>WasmTestOnBrowser</Scenario>
+    <TestArchiveTestsRoot>$(TestArchiveRoot)browserornodejs/</TestArchiveTestsRoot>
+    <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="cthread.cs" />
     <Compile Include="CThreads.cs" />

--- a/src/libraries/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XsltCompiler/XsltCompiler.Tests.csproj
@@ -2,6 +2,15 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
+    <!-- This doesn't run on V8 shell because https://bugs.chromium.org/p/v8/issues/detail?id=12541 -->
+    <Scenario>WasmTestOnBrowser</Scenario>
+    <TestArchiveTestsRoot>$(TestArchiveRoot)browserornodejs/</TestArchiveTestsRoot>
+    <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="CommonScenarios\XsltcTestBasicFunctionality.cs" />
     <Compile Include="CommonScenarios\XsltcTestCaseBase.cs" />

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -492,6 +492,9 @@
       <_WorkItem Include="$(WorkItemArchiveWildCard)" Exclude="$(HelixCorrelationPayload)" />
 
       <_WorkItem Include="$(TestArchiveRoot)browseronly/**/*.zip" Condition="'$(TargetOS)' == 'Browser' and '$(Scenario)' == 'WasmTestOnBrowser'" />
+      <_WorkItem Include="$(TestArchiveRoot)browserornodejs/**/*.zip" Condition="'$(TargetOS)' == 'Browser' and '$(Scenario)' == 'WasmTestOnBrowser'" />
+      <_WorkItem Include="$(TestArchiveRoot)browserornodejs/**/*.zip" Condition="'$(TargetOS)' == 'Browser' and '$(Scenario)' == 'WasmTestOnNodeJs'" />
+      <_WorkItem Include="$(TestArchiveRoot)nodejsonly/**/*.zip" Condition="'$(TargetOS)' == 'Browser' and '$(Scenario)' == 'WasmTestOnNodeJs'" />
 
       <HelixWorkItem Include="@(_WorkItem -> '$(WorkItemPrefix)%(FileName)')" Condition="'$(DefaultHelixWorkItems)' == 'true'">
         <PayloadArchive>%(Identity)</PayloadArchive>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -333,9 +333,6 @@ Roslyn4.0.Tests.csproj" />
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BrowserHost)' == 'windows' and '$(RunDisabledWasmTestsOnWindows)' != 'true'">
     <!-- Issue: https://github.com/dotnet/runtime/issues/52138 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression.ZipFile\tests\System.IO.Compression.ZipFile.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\console-v8-es6\Wasm.Console.V8.ES6.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\console-v8-cjs\Wasm.Console.V8.CJS.Sample.csproj" />
     <ProjectExclusions Include="$(MonoProjectRoot)sample\wasm\console-node-es6\Wasm.Console.Node.ES6.Sample.csproj" />

--- a/src/mono/sample/wasm/browser/main.js
+++ b/src/mono/sample/wasm/browser/main.js
@@ -17,10 +17,18 @@ async function loadRuntime() {
 async function main() {
     try {
         const createDotnetRuntime = await loadRuntime();
-        const { MONO, BINDING, Module, RuntimeBuildInfo } = await createDotnetRuntime(() => ({
-            disableDotnet6Compatibility: true,
-            configSrc: "./mono-config.json",
-        }));
+        const { MONO, BINDING, Module, RuntimeBuildInfo } = await createDotnetRuntime(() => {
+            console.log('user code in createDotnetRuntime')
+            return {
+                disableDotnet6Compatibility: true,
+                configSrc: "./mono-config.json",
+                preInit: () => { console.log('user code Module.preInit') },
+                preRun: () => { console.log('user code Module.preRun') },
+                onRuntimeInitialized: () => { console.log('user code Module.onRuntimeInitialized') },
+                postRun: () => { console.log('user code Module.postRun') },
+            }
+        });
+        console.log('after createDotnetRuntime')
 
         const testMeaning = BINDING.bind_static_method("[Wasm.Browser.CJS.Sample] Sample.Test:TestMeaning");
         const ret = testMeaning();

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -155,6 +155,7 @@ declare type AssetEntry = {
     culture?: string;
     load_remote?: boolean;
     is_optional?: boolean;
+    buffer?: ArrayBuffer;
 };
 interface AssemblyEntry extends AssetEntry {
     name: "assembly";
@@ -196,7 +197,7 @@ declare type DotnetModuleConfig = {
     config?: MonoConfig | MonoConfigError;
     configSrc?: string;
     scriptDirectory?: string;
-    onConfigLoaded?: () => void;
+    onConfigLoaded?: (config: MonoConfig) => Promise<void>;
     onDotnetReady?: () => void;
     imports?: DotnetModuleConfigImports;
 } & Partial<EmscriptenModule>;

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -31,9 +31,7 @@ import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
     mono_wasm_load_data_archive, mono_wasm_asm_loaded,
-    mono_wasm_pre_init,
-    mono_wasm_runtime_is_initialized,
-    mono_wasm_on_runtime_initialized
+    configure_emscripten_startup
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
@@ -66,7 +64,7 @@ import {
 import { create_weak_ref } from "./weak-ref";
 import { fetch_like, readAsync_like } from "./polyfills";
 import { EmscriptenModule } from "./types/emscripten";
-import { mono_on_abort, mono_run_main, mono_run_main_and_exit } from "./run";
+import { mono_run_main, mono_run_main_and_exit } from "./run";
 
 const MONO = {
     // current "public" MONO API
@@ -163,18 +161,6 @@ function initializeImportsAndExports(
         module.configSrc = "./mono-config.json";
     }
 
-    // these could be overriden on DotnetModuleConfig
-    if (!module.preInit) {
-        module.preInit = [];
-    } else if (typeof module.preInit === "function") {
-        module.preInit = [module.preInit];
-    }
-    if (!module.preRun) {
-        module.preRun = [];
-    } else if (typeof module.preRun === "function") {
-        module.preRun = [module.preRun];
-    }
-
     if (!module.print) {
         module.print = console.log.bind(console);
     }
@@ -254,37 +240,6 @@ function initializeImportsAndExports(
         warnWrap("removeRunDependency", () => module.removeRunDependency);
     }
 
-    // this is registration of the runtime pre_init, when user set configSrc
-    if (module.configSrc) {
-        module.preInit.push(async () => {
-            module.addRunDependency("mono_wasm_pre_init");
-            // execution order == [0] ==
-            await mono_wasm_pre_init();
-            module.removeRunDependency("mono_wasm_pre_init");
-        });
-    }
-
-    // if onRuntimeInitialized is set it's probably Blazor, we let them to do their own init sequence
-    if (!module.onRuntimeInitialized) {
-        // note this would keep running in async-parallel with emscripten's `run()` and `postRun()` 
-        // because it's loading files asynchronously and the emscripten is not awaiting onRuntimeInitialized
-        // execution order == [1] ==
-        module.onRuntimeInitialized = () => mono_wasm_on_runtime_initialized();
-
-        module.ready = module.ready.then(async () => {
-            // mono_wasm_runtime_is_initialized is set when finalize_startup is done
-            await mono_wasm_runtime_is_initialized;
-            // TODO we could take over Module.postRun and call it from here if necessary
-
-            // execution order == [2] ==
-            return exportedAPI;
-        });
-    }
-
-    if (!module.onAbort) {
-        module.onAbort = () => mono_on_abort;
-    }
-
     // this code makes it possible to find dotnet runtime on a page via global namespace, even when there are multiple runtimes at the same time
     let list: RuntimeList;
     if (!globalThisAny.getDotnetRuntime) {
@@ -295,6 +250,8 @@ function initializeImportsAndExports(
         list = globalThisAny.getDotnetRuntime.__list;
     }
     list.registerRuntime(exportedAPI);
+
+    configure_emscripten_startup(module, exportedAPI);
 
     return exportedAPI;
 }

--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -21,6 +21,8 @@ export async function fetch_like(url: string): Promise<Response> {
             };
         }
         else if (typeof (read) === "function") {
+            // note that it can't open files with unicode names, like Straße.xml
+            // https://bugs.chromium.org/p/v8/issues/detail?id=12541
             const arrayBuffer = new Uint8Array(read(url, "binary"));
             return <Response><any>{
                 ok: true,

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { AllAssetEntryTypes, AssetEntry, CharPtrNull, DotnetModule, GlobalizationMode, MonoConfig, MonoConfigError, wasm_type_symbol } from "./types";
+import { AllAssetEntryTypes, assert, AssetEntry, CharPtrNull, DotnetModule, GlobalizationMode, MonoConfig, MonoConfigError, wasm_type_symbol } from "./types";
 import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, locateFile, Module, MONO, runtimeHelpers } from "./imports";
 import cwraps from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
@@ -12,6 +12,8 @@ import { mono_wasm_load_bytes_into_heap } from "./buffers";
 import { bind_runtime_method, get_method, _create_primitive_converters } from "./method-binding";
 import { find_corlib_class } from "./class-loader";
 import { VoidPtr, CharPtr } from "./types/emscripten";
+import { DotnetPublicAPI } from "./exports";
+import { mono_on_abort } from "./run";
 
 export let runtime_is_initialized_resolve: Function;
 export let runtime_is_initialized_reject: Function;
@@ -20,42 +22,118 @@ export const mono_wasm_runtime_is_initialized = new Promise((resolve, reject) =>
     runtime_is_initialized_reject = reject;
 });
 
+let ctx: DownloadAssetsContext | null = null;
 
-export async function mono_wasm_pre_init(): Promise<void> {
+export function configure_emscripten_startup(module: DotnetModule, exportedAPI: DotnetPublicAPI): void {
+    // these could be overriden on DotnetModuleConfig
+    if (!module.preInit) {
+        module.preInit = [];
+    } else if (typeof module.preInit === "function") {
+        module.preInit = [module.preInit];
+    }
+    if (!module.preRun) {
+        module.preRun = [];
+    } else if (typeof module.preRun === "function") {
+        module.preRun = [module.preRun];
+    }
+    if (!module.postRun) {
+        module.postRun = [];
+    } else if (typeof module.postRun === "function") {
+        module.postRun = [module.postRun];
+    }
+
+    // when user set configSrc or config, we are running our default startup sequence. 
+    if (module.configSrc || module.config) {
+        // execution order == [0] ==
+        // - default or user Module.instantiateWasm (will start downloading dotnet.wasm)
+        // - all user Module.preInit
+
+        // execution order == [1] ==
+        module.preInit.push(mono_wasm_pre_init);
+        // - download Module.config from configSrc
+        // - download assets like DLLs
+
+        // execution order == [2] ==
+        // - all user Module.preRun callbacks
+
+        // execution order == [3] ==
+        // - user Module.onRuntimeInitialized callback
+
+        // execution order == [4] ==
+        module.postRun.unshift(mono_wasm_after_runtime_initialized);
+        // - load DLLs into WASM memory
+        // - apply globalization and other env variables
+        // - call mono_wasm_load_runtime
+
+        // execution order == [5] ==
+        // - all user Module.postRun callbacks
+
+        // execution order == [6] ==
+        module.ready = module.ready.then(async () => {
+            // mono_wasm_runtime_is_initialized promise is resolved when finalize_startup is done
+            await mono_wasm_runtime_is_initialized;
+            // - here we resolve the promise returned by createDotnetRuntime export
+            return exportedAPI;
+            // - any code after createDotnetRuntime is executed now
+        });
+
+    }
+    // Otherwise startup sequence is up to user code, like Blazor
+
+    if (!module.onAbort) {
+        module.onAbort = () => mono_on_abort;
+    }
+}
+
+async function mono_wasm_pre_init(): Promise<void> {
     const moduleExt = Module as DotnetModule;
-    if (!moduleExt.configSrc) {
-        return;
-    }
 
-    try {
-        // sets MONO.config implicitly
-        await mono_wasm_load_config(moduleExt.configSrc);
-    }
-    catch (err: any) {
-        runtime_is_initialized_reject(err);
-        throw err;
-    }
+    Module.addRunDependency("mono_wasm_pre_init");
 
-    if (moduleExt.onConfigLoaded) {
+    if (moduleExt.configSrc) {
         try {
-            moduleExt.onConfigLoaded();
+            // sets MONO.config implicitly
+            await mono_wasm_load_config(moduleExt.configSrc);
         }
         catch (err: any) {
-            Module.printErr("MONO_WASM: onConfigLoaded () failed: " + err);
-            Module.printErr("MONO_WASM: Stacktrace: \n");
-            Module.printErr(err.stack);
+            runtime_is_initialized_reject(err);
+            throw err;
+        }
+
+        if (moduleExt.onConfigLoaded) {
+            try {
+                await moduleExt.onConfigLoaded(<MonoConfig>runtimeHelpers.config);
+            }
+            catch (err: any) {
+                Module.printErr("MONO_WASM: onConfigLoaded () failed: " + err);
+                Module.printErr("MONO_WASM: Stacktrace: \n");
+                Module.printErr(err.stack);
+                runtime_is_initialized_reject(err);
+                throw err;
+            }
+        }
+    }
+
+    if (moduleExt.config) {
+        try {
+            // start downloading assets asynchronously
+            // next event of emscripten would bre triggered by last `removeRunDependency`
+            await mono_download_assets(Module.config);
+        }
+        catch (err: any) {
             runtime_is_initialized_reject(err);
             throw err;
         }
     }
 
+    Module.removeRunDependency("mono_wasm_pre_init");
 }
 
-export async function mono_wasm_on_runtime_initialized(): Promise<void> {
+function mono_wasm_after_runtime_initialized(): void {
     if (!Module.config || Module.config.isError) {
         return;
     }
-    await mono_load_runtime_and_bcl_args(Module.config);
+    finalize_assets(Module.config);
     finalize_startup(Module.config);
 }
 
@@ -76,8 +154,12 @@ export function mono_wasm_set_runtime_options(options: string[]): void {
     cwraps.mono_wasm_parse_runtime_options(options.length, argv);
 }
 
-function _handle_fetched_asset(ctx: MonoInitContext, asset: AssetEntry, url: string, blob: ArrayBuffer) {
-    const bytes = new Uint8Array(blob);
+// this need to be run only after onRuntimeInitialized event, when the memory is ready
+function _handle_fetched_asset(asset: AssetEntry, url?: string) {
+    assert(ctx, "Context is expected");
+    assert(asset.buffer, "asset.buffer is expected");
+
+    const bytes = new Uint8Array(asset.buffer);
     if (ctx.tracing)
         console.log(`MONO_WASM: Loaded:${asset.name} as ${asset.behavior} size ${bytes.length} from ${url}`);
 
@@ -110,7 +192,7 @@ function _handle_fetched_asset(ctx: MonoInitContext, asset: AssetEntry, url: str
                 if (ctx.tracing)
                     console.log(`MONO_WASM: Creating directory '${parentDirectory}'`);
 
-                ctx.createPath(
+                Module.FS_createPath(
                     "/", parentDirectory, true, true // fixme: should canWrite be false?
                 );
             } else {
@@ -121,7 +203,7 @@ function _handle_fetched_asset(ctx: MonoInitContext, asset: AssetEntry, url: str
                 console.log(`MONO_WASM: Creating file '${fileName}' in directory '${parentDirectory}'`);
 
             if (!mono_wasm_load_data_archive(bytes, parentDirectory)) {
-                ctx.createDataFile(
+                Module.FS_createDataFile(
                     parentDirectory, fileName,
                     bytes, true /* canRead */, true /* canWrite */, true /* canOwn */
                 );
@@ -302,6 +384,11 @@ export function bindings_lazy_init(): void {
 
 // Initializes the runtime and loads assemblies, debug information, and other files.
 export async function mono_load_runtime_and_bcl_args(config: MonoConfig | MonoConfigError | undefined): Promise<void> {
+    await mono_download_assets(config);
+    finalize_assets(config);
+}
+
+async function mono_download_assets(config: MonoConfig | MonoConfigError | undefined): Promise<void> {
     if (!config || config.isError) {
         return;
     }
@@ -312,14 +399,15 @@ export async function mono_load_runtime_and_bcl_args(config: MonoConfig | MonoCo
 
 
         config.diagnostic_tracing = config.diagnostic_tracing || false;
-        const ctx: MonoInitContext = {
+        ctx = {
             tracing: config.diagnostic_tracing,
             pending_count: config.assets.length,
+            downloading_count: config.assets.length,
+            fetch_all_promises: null,
+            resolved_promises: [],
             loaded_assets: Object.create(null),
             // dlls and pdbs, used by blazor and the debugger
             loaded_files: [],
-            createPath: Module.FS_createPath,
-            createDataFile: Module.FS_createDataFile
         };
 
         // fetch_file_cb is legacy do we really want to support it ?
@@ -327,11 +415,18 @@ export async function mono_load_runtime_and_bcl_args(config: MonoConfig | MonoCo
             runtimeHelpers.fetch = (<any>config).fetch_file_cb;
         }
 
-        const load_asset = async (config: MonoConfig, asset: AllAssetEntryTypes): Promise<void> => {
-            // TODO Module.addRunDependency(asset.name);
+        const load_asset = async (config: MonoConfig, asset: AllAssetEntryTypes): Promise<MonoInitFetchResult | undefined> => {
+            Module.addRunDependency(asset.name);
 
             const sourcesList = asset.load_remote ? config.remote_sources! : [""];
             let error = undefined;
+            let result: MonoInitFetchResult | undefined = undefined;
+
+            if (asset.buffer) {
+                --ctx!.downloading_count;
+                return { asset, attemptUrl: undefined };
+            }
+
             for (let sourcePrefix of sourcesList) {
                 // HACK: Special-case because MSBuild doesn't allow "" as an attribute
                 if (sourcePrefix === "./")
@@ -351,10 +446,10 @@ export async function mono_load_runtime_and_bcl_args(config: MonoConfig | MonoCo
                     attemptUrl = sourcePrefix + asset.name;
                 }
                 if (asset.name === attemptUrl) {
-                    if (ctx.tracing)
+                    if (ctx!.tracing)
                         console.log(`MONO_WASM: Attempting to fetch '${attemptUrl}'`);
                 } else {
-                    if (ctx.tracing)
+                    if (ctx!.tracing)
                         console.log(`MONO_WASM: Attempting to fetch '${attemptUrl}' for ${asset.name}`);
                 }
                 try {
@@ -364,9 +459,9 @@ export async function mono_load_runtime_and_bcl_args(config: MonoConfig | MonoCo
                         continue;// next source
                     }
 
-                    const buffer = await response.arrayBuffer();
-                    _handle_fetched_asset(ctx, asset, attemptUrl, buffer);
-                    --ctx.pending_count;
+                    asset.buffer = await response.arrayBuffer();
+                    result = { asset, attemptUrl };
+                    --ctx!.downloading_count;
                     error = undefined;
                 }
                 catch (err) {
@@ -383,15 +478,36 @@ export async function mono_load_runtime_and_bcl_args(config: MonoConfig | MonoCo
                 if (!isOkToFail)
                     throw error;
             }
-            // TODO Module.removeRunDependency(asset.name);
+            Module.removeRunDependency(asset.name);
+            return result;
         };
-        const fetch_promises: Promise<void>[] = [];
+        const fetch_promises: Promise<(MonoInitFetchResult | undefined)>[] = [];
+
         // start fetching all assets in parallel
         for (const asset of config.assets) {
             fetch_promises.push(load_asset(config, asset));
         }
 
-        await Promise.all(fetch_promises);
+        ctx.fetch_all_promises = Promise.all(fetch_promises);
+        ctx.resolved_promises = await ctx.fetch_all_promises;
+    } catch (err: any) {
+        Module.printErr("MONO_WASM: Error in mono_download_assets: " + err);
+        runtime_is_initialized_reject(err);
+        throw err;
+    }
+}
+
+function finalize_assets(config: MonoConfig | MonoConfigError | undefined): void {
+    assert(config && !config.isError, "Expected config");
+    assert(ctx && ctx.downloading_count == 0, "Expected assets to be downloaded");
+
+    try {
+        for (const fetch_result of ctx.resolved_promises!) {
+            if (fetch_result) {
+                _handle_fetched_asset(fetch_result.asset, fetch_result.attemptUrl);
+                --ctx.pending_count;
+            }
+        }
 
         ctx.loaded_files.forEach(value => MONO.loaded_files.push(value.url));
         if (ctx.tracing) {
@@ -399,7 +515,7 @@ export async function mono_load_runtime_and_bcl_args(config: MonoConfig | MonoCo
             console.log("MONO_WASM: loaded_files: " + JSON.stringify(ctx.loaded_files));
         }
     } catch (err: any) {
-        Module.printErr("MONO_WASM: Error in mono_load_runtime_and_bcl_args: " + err);
+        Module.printErr("MONO_WASM: Error in finalize_assets: " + err);
         runtime_is_initialized_reject(err);
         throw err;
     }
@@ -525,11 +641,17 @@ export function mono_wasm_set_main_args(name: string, allRuntimeArguments: strin
     cwraps.mono_wasm_set_main_args(main_argc, main_argv);
 }
 
-export type MonoInitContext = {
+type MonoInitFetchResult = {
+    asset: AllAssetEntryTypes,
+    attemptUrl?: string,
+}
+
+export type DownloadAssetsContext = {
     tracing: boolean,
+    downloading_count: number,
     pending_count: number,
-    loaded_files: { url: string, file: string }[],
+    fetch_all_promises: Promise<(MonoInitFetchResult | undefined)[]> | null;
+    resolved_promises: (MonoInitFetchResult | undefined)[] | null;
+    loaded_files: { url?: string, file: string }[],
     loaded_assets: { [id: string]: [VoidPtr, number] },
-    createPath: Function,
-    createDataFile: Function
 }

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -81,6 +81,7 @@ export type AssetEntry = {
     culture?: string,
     load_remote?: boolean, // if true, an attempt will be made to load the asset from each location in @args.remote_sources.
     is_optional?: boolean // if true, any failure to load this asset will be ignored.
+    buffer?: ArrayBuffer // if provided, we don't have to fetch it
 }
 
 export interface AssemblyEntry extends AssetEntry {
@@ -162,7 +163,7 @@ export type DotnetModuleConfig = {
     config?: MonoConfig | MonoConfigError,
     configSrc?: string,
     scriptDirectory?: string,
-    onConfigLoaded?: () => void;
+    onConfigLoaded?: (config: MonoConfig) => Promise<void>;
     onDotnetReady?: () => void;
 
     imports?: DotnetModuleConfigImports;
@@ -186,4 +187,10 @@ export type DotnetModuleConfigImports = {
         dirname?: (path: string) => string,
     };
     url?: any;
+}
+
+export function assert(condition: unknown, messsage: string): asserts condition {
+    if (!condition) {
+        throw new Error(`Assert failed: ${messsage}`);
+    }
 }

--- a/src/mono/wasm/test-main.js
+++ b/src/mono/wasm/test-main.js
@@ -124,7 +124,7 @@ loadDotnet("./dotnet.js").then((createDotnetRuntime) => {
         disableDotnet6Compatibility: true,
         config: null,
         configSrc: "./mono-config.json",
-        onConfigLoaded: () => {
+        onConfigLoaded: (config) => {
             if (!Module.config) {
                 const err = new Error("Could not find ./mono-config.json. Cancelling run");
                 set_exit_code(1,);
@@ -132,9 +132,11 @@ loadDotnet("./dotnet.js").then((createDotnetRuntime) => {
             }
             // Have to set env vars here to enable setting MONO_LOG_LEVEL etc.
             for (let variable in processedArguments.setenv) {
-                Module.config.environment_variables[variable] = processedArguments.setenv[variable];
+                config.environment_variables[variable] = processedArguments.setenv[variable];
             }
-
+            config.diagnostic_tracing = !!processedArguments.diagnostic_tracing;
+        },
+        preRun: () => {
             if (!processedArguments.enable_gc) {
                 INTERNAL.mono_wasm_enable_on_demand_gc(0);
             }
@@ -281,6 +283,7 @@ function processArguments(incomingArguments) {
     let setenv = {};
     let runtime_args = [];
     let enable_gc = true;
+    let diagnostic_tracing = false;
     let working_dir = '/';
     while (incomingArguments && incomingArguments.length > 0) {
         const currentArg = incomingArguments[0];
@@ -298,6 +301,8 @@ function processArguments(incomingArguments) {
             runtime_args.push(arg);
         } else if (currentArg == "--disable-on-demand-gc") {
             enable_gc = false;
+        } else if (currentArg == "--diagnostic_tracing") {
+            diagnostic_tracing = true;
         } else if (currentArg.startsWith("--working-dir=")) {
             const arg = currentArg.substring("--working-dir=".length);
             working_dir = arg;
@@ -318,6 +323,7 @@ function processArguments(incomingArguments) {
         setenv,
         runtime_args,
         enable_gc,
+        diagnostic_tracing,
         working_dir,
     }
 }


### PR DESCRIPTION
## Assets download

- split asset download from copying it into memory
    - do the async fetch in `Module.preInit`
    - do `mono_wasm_after_runtime_initialized` synchronously on `postRun`. It loads assets into memory. This is when `malloc` is ready. 
    - It also keeps `onRuntimeInitialized` free for user code
    - If we do something similar in Blazor, it would solve https://github.com/dotnet/aspnetcore/issues/13915
    - throttle parallel download of assets to prevent `net::ERR_INSUFFICIENT_RESOURCES`
- moved startup sequence to `configure_emscripten_startup` and documented it there
- allow `Module.config` to have assets with `buffer` instead of url
- pass config into `onConfigLoaded` and made it async
- change sample to show how emscripten callbacks are triggered
- `/p:WasmXHarnessMonoArgs="--diagnostic_tracing"` as CLI parameter for tests.

## CI changes
- move tests which fail on V8 to browser or nodeJS scenarios. 
    - Fixes https://github.com/dotnet/runtime/issues/52136
- new `browserornodejs` `<TestArchiveTestsDir>` for things which don't run on V8