### PR TITLE
[Android] Throw PNSE for unavailable network information

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
@@ -123,9 +123,11 @@ namespace System.Net.NetworkInformation
     public abstract partial class IPGlobalProperties
     {
         protected IPGlobalProperties() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract string DhcpScopeName { get; }
         public abstract string DomainName { get; }
         public abstract string HostName { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool IsWinsProxy { get; }
         public abstract System.Net.NetworkInformation.NetBiosNodeType NodeType { get; }
         public virtual System.IAsyncResult BeginGetUnicastAddresses(System.AsyncCallback? callback, object? state) { throw null; }
@@ -136,16 +138,22 @@ namespace System.Net.NetworkInformation
         public abstract System.Net.IPEndPoint[] GetActiveTcpListeners();
         [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.IPEndPoint[] GetActiveUdpListeners();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.IcmpV4Statistics GetIcmpV4Statistics();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.IcmpV6Statistics GetIcmpV6Statistics();
         [System.Runtime.Versioning.UnsupportedOSPlatform("illumos")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("solaris")]
         public static System.Net.NetworkInformation.IPGlobalProperties GetIPGlobalProperties() { throw null; }
         public abstract System.Net.NetworkInformation.IPGlobalStatistics GetIPv4GlobalStatistics();
         public abstract System.Net.NetworkInformation.IPGlobalStatistics GetIPv6GlobalStatistics();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.TcpStatistics GetTcpIPv4Statistics();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.TcpStatistics GetTcpIPv6Statistics();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.UdpStatistics GetUdpIPv4Statistics();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.UdpStatistics GetUdpIPv6Statistics();
         public virtual System.Net.NetworkInformation.UnicastIPAddressInformationCollection GetUnicastAddresses() { throw null; }
         public virtual System.Threading.Tasks.Task<System.Net.NetworkInformation.UnicastIPAddressInformationCollection> GetUnicastAddressesAsync() { throw null; }
@@ -153,41 +161,69 @@ namespace System.Net.NetworkInformation
     public abstract partial class IPGlobalStatistics
     {
         protected IPGlobalStatistics() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract int DefaultTtl { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool ForwardingEnabled { get; }
         public abstract int NumberOfInterfaces { get; }
         public abstract int NumberOfIPAddresses { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract int NumberOfRoutes { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long OutputPacketRequests { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long OutputPacketRoutingDiscards { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long OutputPacketsDiscarded { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long OutputPacketsWithNoRoute { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long PacketFragmentFailures { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long PacketReassembliesRequired { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long PacketReassemblyFailures { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long PacketReassemblyTimeout { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long PacketsFragmented { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long PacketsReassembled { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long ReceivedPackets { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsDelivered { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsDiscarded { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsForwarded { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsWithAddressErrors { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsWithHeadersErrors { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsWithUnknownProtocol { get; }
     }
     public abstract partial class IPInterfaceProperties
     {
         protected IPInterfaceProperties() { }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.IPAddressInformationCollection AnycastAddresses { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.IPAddressCollection DhcpServerAddresses { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.IPAddressCollection DnsAddresses { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract string DnsSuffix { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.GatewayIPAddressInformationCollection GatewayAddresses { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool IsDnsEnabled { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool IsDynamicDnsEnabled { get; }
         public abstract System.Net.NetworkInformation.MulticastIPAddressInformationCollection MulticastAddresses { get; }
         public abstract System.Net.NetworkInformation.UnicastIPAddressInformationCollection UnicastAddresses { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract System.Net.NetworkInformation.IPAddressCollection WinsServersAddresses { get; }
         public abstract System.Net.NetworkInformation.IPv4InterfaceProperties GetIPv4Properties();
         public abstract System.Net.NetworkInformation.IPv6InterfaceProperties GetIPv6Properties();
@@ -212,11 +248,16 @@ namespace System.Net.NetworkInformation
     {
         protected IPv4InterfaceProperties() { }
         public abstract int Index { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool IsAutomaticPrivateAddressingActive { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool IsAutomaticPrivateAddressingEnabled { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool IsDhcpEnabled { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool IsForwardingEnabled { get; }
         public abstract int Mtu { get; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public abstract bool UsesWins { get; }
     }
     public abstract partial class IPv4InterfaceStatistics
@@ -316,7 +357,9 @@ namespace System.Net.NetworkInformation
         [System.Runtime.Versioning.UnsupportedOSPlatform("solaris")]
         public static System.Net.NetworkInformation.NetworkInterface[] GetAllNetworkInterfaces() { throw null; }
         public virtual System.Net.NetworkInformation.IPInterfaceProperties GetIPProperties() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public virtual System.Net.NetworkInformation.IPInterfaceStatistics GetIPStatistics() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("android")]
         public virtual System.Net.NetworkInformation.IPv4InterfaceStatistics GetIPv4Statistics() { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatform("illumos")]
         [System.Runtime.Versioning.UnsupportedOSPlatform("solaris")]

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-Solaris;$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-Android;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-Solaris;$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
@@ -118,8 +118,8 @@
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Errors.cs" Link="Common\Interop\CoreLib\Unix\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)System\IO\RowConfigReader.cs" Link="Common\System\IO\RowConfigReader.cs" />
   </ItemGroup>
-  <!-- Linux -->
-  <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+  <!-- Linux (other than Android) -->
+  <ItemGroup Condition="'$(TargetsLinux)' == 'true' and '$(TargetsAndroid)' != 'true'">
     <Compile Include="System\Net\NetworkInformation\ExceptionHelper.Linux.cs" />
     <Compile Include="System\Net\NetworkInformation\LinuxIcmpV4Statistics.cs" />
     <Compile Include="System\Net\NetworkInformation\LinuxIcmpV6Statistics.cs" />
@@ -143,6 +143,18 @@
     <!-- Linux Common -->
     <Compile Include="$(CommonPath)System\IO\StringParser.cs" Link="Common\System\IO\StringParser.cs" />
     <Compile Include="$(CommonPath)Interop\Linux\Interop.LinuxNetDeviceFlags.cs" Link="Common\Interop\Linux\Interop.LinuxNetDeviceFlags.cs" />
+  </ItemGroup>
+  <!-- Android -->
+  <ItemGroup Condition="'$(TargetsAndroid)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Android\Interop.Libraries.cs" Link="Common\Interop\Android\Interop.Libraries.cs" />
+    <Compile Include="System\Net\NetworkInformation\IPGlobalPropertiesPal.Android.cs" />
+    <Compile Include="System\Net\NetworkInformation\AndroidIPGlobalProperties.cs" />
+    <Compile Include="System\Net\NetworkInformation\AndroidIPGlobalStatistics.cs" />
+    <Compile Include="System\Net\NetworkInformation\AndroidIPInterfaceProperties.cs" />
+    <Compile Include="System\Net\NetworkInformation\AndroidIPv4InterfaceProperties.cs" />
+    <Compile Include="System\Net\NetworkInformation\AndroidIPv6InterfaceProperties.cs" />
+    <Compile Include="System\Net\NetworkInformation\NetworkInterfacePal.Android.cs" />
+    <Compile Include="System\Net\NetworkInformation\AndroidNetworkInterface.cs" />
   </ItemGroup>
   <!-- OSX -->
   <ItemGroup Condition="'$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsFreeBSD)' == 'true'">

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -146,7 +146,6 @@
   </ItemGroup>
   <!-- Android -->
   <ItemGroup Condition="'$(TargetsAndroid)' == 'true'">
-    <Compile Include="$(CommonPath)Interop\Android\Interop.Libraries.cs" Link="Common\Interop\Android\Interop.Libraries.cs" />
     <Compile Include="System\Net\NetworkInformation\IPGlobalPropertiesPal.Android.cs" />
     <Compile Include="System\Net\NetworkInformation\AndroidIPGlobalProperties.cs" />
     <Compile Include="System\Net\NetworkInformation\AndroidIPGlobalStatistics.cs" />

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPGlobalProperties.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.NetworkInformation
+{
+    internal sealed class AndroidIPGlobalProperties : UnixIPGlobalProperties
+    {
+        public override TcpConnectionInformation[] GetActiveTcpConnections() => throw new PlatformNotSupportedException();
+
+        public override IPEndPoint[] GetActiveTcpListeners() => throw new PlatformNotSupportedException();
+
+        public override IPEndPoint[] GetActiveUdpListeners() => throw new PlatformNotSupportedException();
+
+        public override IcmpV4Statistics GetIcmpV4Statistics() => throw new PlatformNotSupportedException();
+
+        public override IcmpV6Statistics GetIcmpV6Statistics() => throw new PlatformNotSupportedException();
+
+        public override IPGlobalStatistics GetIPv4GlobalStatistics()
+            => new AndroidIPGlobalStatistics(ipv4: true);
+
+        public override IPGlobalStatistics GetIPv6GlobalStatistics()
+            => new AndroidIPGlobalStatistics(ipv4: false);
+
+        public override TcpStatistics GetTcpIPv4Statistics() => throw new PlatformNotSupportedException();
+
+        public override TcpStatistics GetTcpIPv6Statistics() => throw new PlatformNotSupportedException();
+
+        public override UdpStatistics GetUdpIPv4Statistics() => throw new PlatformNotSupportedException();
+
+        public override UdpStatistics GetUdpIPv6Statistics() => throw new PlatformNotSupportedException();
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPGlobalStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPGlobalStatistics.cs
@@ -13,9 +13,9 @@ namespace System.Net.NetworkInformation
     {
         public AndroidIPGlobalStatistics(bool ipv4)
         {
-            NetworkInterface[] networkInterfaces = AndroidNetworkInterface.GetAndroidNetworkInterfaces();
+            AndroidNetworkInterface[] networkInterfaces = NetworkInterfacePal.GetAndroidNetworkInterfaces();
 
-            foreach (NetworkInterface networkInterface in networkInterfaces)
+            foreach (var networkInterface in networkInterfaces)
             {
                 var component = ipv4 ? NetworkInterfaceComponent.IPv4 : NetworkInterfaceComponent.IPv6;
                 if (networkInterface.Supports(component))
@@ -23,74 +23,51 @@ namespace System.Net.NetworkInformation
                     NumberOfInterfaces++;
                 }
 
-                if (networkInterface is AndroidNetworkInterface androidNetworkInterface)
+                foreach (UnixUnicastIPAddressInformation addressInformation in networkInterface.UnicastAddress)
                 {
-                    foreach (UnixUnicastIPAddressInformation addressInformation in androidNetworkInterface.UnicastAddress)
+                    bool isIPv4 = addressInformation.Address.AddressFamily == AddressFamily.InterNetwork;
+                    if (isIPv4 == ipv4)
                     {
-                        bool isIPv4 = addressInformation.Address.AddressFamily == AddressFamily.InterNetwork;
+                        NumberOfIPAddresses++;
+                    }
+                }
+
+                if (networkInterface.MulticastAddresess != null)
+                {
+                    foreach (IPAddress address in networkInterface.MulticastAddresess)
+                    {
+                        bool isIPv4 = address.AddressFamily == AddressFamily.InterNetwork;
                         if (isIPv4 == ipv4)
                         {
                             NumberOfIPAddresses++;
-                        }
-                    }
-
-                    if (androidNetworkInterface.MulticastAddresess != null)
-                    {
-                        foreach (IPAddress address in androidNetworkInterface.MulticastAddresess)
-                        {
-                            bool isIPv4 = address.AddressFamily == AddressFamily.InterNetwork;
-                            if (isIPv4 == ipv4)
-                            {
-                                NumberOfIPAddresses++;
-                            }
                         }
                     }
                 }
             }
         }
 
-        public override int DefaultTtl => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        public override bool ForwardingEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override int NumberOfInterfaces { get; }
-
         public override int NumberOfIPAddresses { get; }
 
+        public override int DefaultTtl => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+        public override bool ForwardingEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
         public override int NumberOfRoutes => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long OutputPacketRequests => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long OutputPacketRoutingDiscards => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long OutputPacketsDiscarded => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long OutputPacketsWithNoRoute => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long PacketFragmentFailures => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long PacketReassembliesRequired => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long PacketReassemblyFailures => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long PacketReassemblyTimeout => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long PacketsFragmented => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long PacketsReassembled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long ReceivedPackets => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long ReceivedPacketsDelivered => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long ReceivedPacketsDiscarded => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long ReceivedPacketsForwarded => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long ReceivedPacketsWithAddressErrors => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long ReceivedPacketsWithHeadersErrors => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override long ReceivedPacketsWithUnknownProtocol => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPGlobalStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPGlobalStatistics.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Net.Sockets;
+
+namespace System.Net.NetworkInformation
+{
+    internal sealed class AndroidIPGlobalStatistics : IPGlobalStatistics
+    {
+        public AndroidIPGlobalStatistics(bool ipv4)
+        {
+            NetworkInterface[] networkInterfaces = AndroidNetworkInterface.GetAndroidNetworkInterfaces();
+
+            foreach (NetworkInterface networkInterface in networkInterfaces)
+            {
+                var component = ipv4 ? NetworkInterfaceComponent.IPv4 : NetworkInterfaceComponent.IPv6;
+                if (networkInterface.Supports(component))
+                {
+                    NumberOfInterfaces++;
+                }
+
+                if (networkInterface is AndroidNetworkInterface androidNetworkInterface)
+                {
+                    foreach (UnixUnicastIPAddressInformation addressInformation in androidNetworkInterface.UnicastAddress)
+                    {
+                        bool isIPv4 = addressInformation.Address.AddressFamily == AddressFamily.InterNetwork;
+                        if (isIPv4 == ipv4)
+                        {
+                            NumberOfIPAddresses++;
+                        }
+                    }
+
+                    if (androidNetworkInterface.MulticastAddresess != null)
+                    {
+                        foreach (IPAddress address in androidNetworkInterface.MulticastAddresess)
+                        {
+                            bool isIPv4 = address.AddressFamily == AddressFamily.InterNetwork;
+                            if (isIPv4 == ipv4)
+                            {
+                                NumberOfIPAddresses++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public override int DefaultTtl => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override bool ForwardingEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override int NumberOfInterfaces { get; }
+
+        public override int NumberOfIPAddresses { get; }
+
+        public override int NumberOfRoutes => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long OutputPacketRequests => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long OutputPacketRoutingDiscards => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long OutputPacketsDiscarded => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long OutputPacketsWithNoRoute => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long PacketFragmentFailures => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long PacketReassembliesRequired => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long PacketReassemblyFailures => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long PacketReassemblyTimeout => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long PacketsFragmented => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long PacketsReassembled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long ReceivedPackets => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long ReceivedPacketsDelivered => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long ReceivedPacketsDiscarded => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long ReceivedPacketsForwarded => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long ReceivedPacketsWithAddressErrors => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long ReceivedPacketsWithHeadersErrors => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override long ReceivedPacketsWithUnknownProtocol => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPInterfaceProperties.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace System.Net.NetworkInformation
+{
+    internal sealed class AndroidIPInterfaceProperties : UnixIPInterfaceProperties
+    {
+        private readonly AndroidIPv4InterfaceProperties _ipv4Properties;
+        private readonly AndroidIPv6InterfaceProperties _ipv6Properties;
+
+        public AndroidIPInterfaceProperties(AndroidNetworkInterface ani)
+            : base(ani, globalConfig: true)
+        {
+            _ipv4Properties = new AndroidIPv4InterfaceProperties(ani);
+            _ipv6Properties = new AndroidIPv6InterfaceProperties(ani);
+        }
+
+        public override bool IsDynamicDnsEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override IPAddressInformationCollection AnycastAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override GatewayIPAddressInformationCollection GatewayAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override IPAddressCollection DhcpServerAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override IPAddressCollection WinsServersAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override IPv4InterfaceProperties GetIPv4Properties() => _ipv4Properties;
+
+        public override IPv6InterfaceProperties GetIPv6Properties() => _ipv6Properties;
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPInterfaceProperties.cs
@@ -18,18 +18,13 @@ namespace System.Net.NetworkInformation
             _ipv6Properties = new AndroidIPv6InterfaceProperties(ani);
         }
 
-        public override bool IsDynamicDnsEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        public override IPAddressInformationCollection AnycastAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        public override GatewayIPAddressInformationCollection GatewayAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        public override IPAddressCollection DhcpServerAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        public override IPAddressCollection WinsServersAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override IPv4InterfaceProperties GetIPv4Properties() => _ipv4Properties;
-
         public override IPv6InterfaceProperties GetIPv6Properties() => _ipv6Properties;
+
+        public override bool IsDynamicDnsEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+        public override IPAddressInformationCollection AnycastAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+        public override GatewayIPAddressInformationCollection GatewayAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+        public override IPAddressCollection DhcpServerAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+        public override IPAddressCollection WinsServersAddresses => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPv4InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPv4InterfaceProperties.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Runtime.Versioning;
+
+namespace System.Net.NetworkInformation
+{
+    internal sealed class AndroidIPv4InterfaceProperties : UnixIPv4InterfaceProperties
+    {
+        private readonly AndroidNetworkInterface _androidNetworkInterface;
+
+        public AndroidIPv4InterfaceProperties(AndroidNetworkInterface androidNetworkInterface)
+            : base(androidNetworkInterface)
+        {
+            _androidNetworkInterface = androidNetworkInterface;
+        }
+
+        public override int Mtu => _androidNetworkInterface._mtu;
+
+        [UnsupportedOSPlatform("android")]
+        public override bool IsAutomaticPrivateAddressingActive => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        [UnsupportedOSPlatform("android")]
+        public override bool IsAutomaticPrivateAddressingEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        [UnsupportedOSPlatform("android")]
+        public override bool IsDhcpEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        [UnsupportedOSPlatform("android")]
+        public override bool IsForwardingEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        [UnsupportedOSPlatform("android")]
+        public override bool UsesWins => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPv4InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPv4InterfaceProperties.cs
@@ -2,35 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
-using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
     internal sealed class AndroidIPv4InterfaceProperties : UnixIPv4InterfaceProperties
     {
-        private readonly AndroidNetworkInterface _androidNetworkInterface;
-
         public AndroidIPv4InterfaceProperties(AndroidNetworkInterface androidNetworkInterface)
             : base(androidNetworkInterface)
         {
-            _androidNetworkInterface = androidNetworkInterface;
+            Mtu = androidNetworkInterface._mtu;
         }
 
-        public override int Mtu => _androidNetworkInterface._mtu;
+        public override int Mtu { get; }
 
-        [UnsupportedOSPlatform("android")]
         public override bool IsAutomaticPrivateAddressingActive => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        [UnsupportedOSPlatform("android")]
         public override bool IsAutomaticPrivateAddressingEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        [UnsupportedOSPlatform("android")]
         public override bool IsDhcpEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        [UnsupportedOSPlatform("android")]
         public override bool IsForwardingEnabled => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        [UnsupportedOSPlatform("android")]
         public override bool UsesWins => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPv6InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidIPv6InterfaceProperties.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+
+namespace System.Net.NetworkInformation
+{
+    internal sealed class AndroidIPv6InterfaceProperties : UnixIPv6InterfaceProperties
+    {
+        private readonly AndroidNetworkInterface _androidNetworkInterface;
+
+        public AndroidIPv6InterfaceProperties(AndroidNetworkInterface androidNetworkInterface)
+            : base(androidNetworkInterface)
+        {
+            _androidNetworkInterface = androidNetworkInterface;
+        }
+
+        public override int Mtu => _androidNetworkInterface._mtu;
+
+        public override long GetScopeId(ScopeLevel scopeLevel)
+        {
+            if (scopeLevel == ScopeLevel.None || scopeLevel == ScopeLevel.Interface ||
+                scopeLevel == ScopeLevel.Link || scopeLevel == ScopeLevel.Subnet)
+            {
+                return _androidNetworkInterface.Index;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidNetworkInterface.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Net;
+
+namespace System.Net.NetworkInformation
+{
+    /// <summary>
+    /// Implements a NetworkInterface on Android.
+    /// </summary>
+    internal sealed class AndroidNetworkInterface : UnixNetworkInterface
+    {
+        private OperationalStatus _operationalStatus;
+        private bool _supportsMulticast;
+        private long _speed;
+        internal int _mtu;
+        private NetworkInterfaceType _interfaceType = NetworkInterfaceType.Unknown;
+        private readonly AndroidIPInterfaceProperties _ipProperties;
+
+        internal AndroidNetworkInterface(string name, int index) : base(name)
+        {
+            _index = index;
+            _ipProperties = new AndroidIPInterfaceProperties(this);
+        }
+
+        public static unsafe NetworkInterface[] GetAndroidNetworkInterfaces()
+        {
+            int interfaceCount=0;
+            int addressCount=0;
+            Interop.Sys.NetworkInterfaceInfo * nii = null;
+            Interop.Sys.IpAddressInfo * ai = null;
+            IntPtr globalMemory = (IntPtr)null;
+
+            if (Interop.Sys.GetNetworkInterfaces(&interfaceCount, &nii, &addressCount, &ai) != 0)
+            {
+                string message = Interop.Sys.GetLastErrorInfo().GetErrorMessage();
+                throw new NetworkInformationException(message);
+            }
+
+            globalMemory = (IntPtr)nii;
+            try
+            {
+                NetworkInterface[] interfaces = new NetworkInterface[interfaceCount];
+                Dictionary<int, AndroidNetworkInterface> interfacesByIndex = new Dictionary<int, AndroidNetworkInterface>(interfaceCount);
+
+                for (int i = 0; i < interfaceCount; i++)
+                {
+                    var ani = new AndroidNetworkInterface(Marshal.PtrToStringAnsi((IntPtr)nii->Name)!, nii->InterfaceIndex);
+                    ani._interfaceType = (NetworkInterfaceType)nii->HardwareType;
+                    ani._operationalStatus = (OperationalStatus)nii->OperationalState;
+                    ani._mtu = nii->Mtu;
+                    ani._speed = nii->Speed;
+                    ani._supportsMulticast = nii->SupportsMulticast != 0;
+
+                    if (nii->NumAddressBytes > 0)
+                    {
+                        ani._physicalAddress = new PhysicalAddress(new ReadOnlySpan<byte>(nii->AddressBytes, nii->NumAddressBytes).ToArray());
+                    }
+
+                    interfaces[i] = ani;
+                    interfacesByIndex.Add(nii->InterfaceIndex, ani);
+                    nii++;
+                }
+
+                while (addressCount != 0)
+                {
+                    var address = new IPAddress(new ReadOnlySpan<byte>(ai->AddressBytes, ai->NumAddressBytes));
+                    if (address.IsIPv6LinkLocal)
+                    {
+                        address.ScopeId = ai->InterfaceIndex;
+                    }
+
+                    if (interfacesByIndex.TryGetValue(ai->InterfaceIndex, out AndroidNetworkInterface? ani))
+                    {
+                        ani.AddAddress(address, ai->PrefixLength);
+                    }
+
+                    ai++;
+                    addressCount--;
+                }
+
+                return interfaces;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(globalMemory);
+            }
+        }
+
+        public override bool SupportsMulticast => _supportsMulticast;
+
+        public override IPInterfaceProperties GetIPProperties() => _ipProperties;
+
+        public override IPInterfaceStatistics GetIPStatistics() => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override IPv4InterfaceStatistics GetIPv4Statistics() => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+
+        public override OperationalStatus OperationalStatus { get { return _operationalStatus; } }
+
+        public override NetworkInterfaceType NetworkInterfaceType { get { return _interfaceType; } }
+
+        public override long Speed => _speed;
+
+        public override bool IsReceiveOnly { get { return false; } }
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/AndroidNetworkInterface.cs
@@ -1,11 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
-using System.Text;
 using System.Net;
 
 namespace System.Net.NetworkInformation
@@ -15,97 +10,45 @@ namespace System.Net.NetworkInformation
     /// </summary>
     internal sealed class AndroidNetworkInterface : UnixNetworkInterface
     {
-        private OperationalStatus _operationalStatus;
-        private bool _supportsMulticast;
-        private long _speed;
-        internal int _mtu;
-        private NetworkInterfaceType _interfaceType = NetworkInterfaceType.Unknown;
+        internal readonly int _mtu;
         private readonly AndroidIPInterfaceProperties _ipProperties;
 
-        internal AndroidNetworkInterface(string name, int index) : base(name)
+        internal unsafe AndroidNetworkInterface(string name, Interop.Sys.NetworkInterfaceInfo *networkInterfaceInfo)
+            : base(name)
         {
-            _index = index;
+            _index = networkInterfaceInfo->InterfaceIndex;
+            if (networkInterfaceInfo->NumAddressBytes > 0)
+            {
+                _physicalAddress = new PhysicalAddress(new ReadOnlySpan<byte>(networkInterfaceInfo->AddressBytes, networkInterfaceInfo->NumAddressBytes).ToArray());
+            }
+
+            _mtu = networkInterfaceInfo->Mtu;
             _ipProperties = new AndroidIPInterfaceProperties(this);
+
+            OperationalStatus = (OperationalStatus)networkInterfaceInfo->OperationalState;
+            Speed = networkInterfaceInfo->Speed;
+            SupportsMulticast = networkInterfaceInfo->SupportsMulticast != 0;
+            NetworkInterfaceType = (NetworkInterfaceType)networkInterfaceInfo->HardwareType;
         }
 
-        public static unsafe NetworkInterface[] GetAndroidNetworkInterfaces()
+        internal unsafe void AddAddress(Interop.Sys.IpAddressInfo *addressInfo)
         {
-            int interfaceCount=0;
-            int addressCount=0;
-            Interop.Sys.NetworkInterfaceInfo * nii = null;
-            Interop.Sys.IpAddressInfo * ai = null;
-            IntPtr globalMemory = (IntPtr)null;
-
-            if (Interop.Sys.GetNetworkInterfaces(&interfaceCount, &nii, &addressCount, &ai) != 0)
+            var address = new IPAddress(new ReadOnlySpan<byte>(addressInfo->AddressBytes, addressInfo->NumAddressBytes));
+            if (address.IsIPv6LinkLocal)
             {
-                string message = Interop.Sys.GetLastErrorInfo().GetErrorMessage();
-                throw new NetworkInformationException(message);
+                address.ScopeId = addressInfo->InterfaceIndex;
             }
 
-            globalMemory = (IntPtr)nii;
-            try
-            {
-                NetworkInterface[] interfaces = new NetworkInterface[interfaceCount];
-                Dictionary<int, AndroidNetworkInterface> interfacesByIndex = new Dictionary<int, AndroidNetworkInterface>(interfaceCount);
-
-                for (int i = 0; i < interfaceCount; i++)
-                {
-                    var ani = new AndroidNetworkInterface(Marshal.PtrToStringAnsi((IntPtr)nii->Name)!, nii->InterfaceIndex);
-                    ani._interfaceType = (NetworkInterfaceType)nii->HardwareType;
-                    ani._operationalStatus = (OperationalStatus)nii->OperationalState;
-                    ani._mtu = nii->Mtu;
-                    ani._speed = nii->Speed;
-                    ani._supportsMulticast = nii->SupportsMulticast != 0;
-
-                    if (nii->NumAddressBytes > 0)
-                    {
-                        ani._physicalAddress = new PhysicalAddress(new ReadOnlySpan<byte>(nii->AddressBytes, nii->NumAddressBytes).ToArray());
-                    }
-
-                    interfaces[i] = ani;
-                    interfacesByIndex.Add(nii->InterfaceIndex, ani);
-                    nii++;
-                }
-
-                while (addressCount != 0)
-                {
-                    var address = new IPAddress(new ReadOnlySpan<byte>(ai->AddressBytes, ai->NumAddressBytes));
-                    if (address.IsIPv6LinkLocal)
-                    {
-                        address.ScopeId = ai->InterfaceIndex;
-                    }
-
-                    if (interfacesByIndex.TryGetValue(ai->InterfaceIndex, out AndroidNetworkInterface? ani))
-                    {
-                        ani.AddAddress(address, ai->PrefixLength);
-                    }
-
-                    ai++;
-                    addressCount--;
-                }
-
-                return interfaces;
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(globalMemory);
-            }
+            AddAddress(address, addressInfo->PrefixLength);
         }
 
-        public override bool SupportsMulticast => _supportsMulticast;
-
+        public override bool SupportsMulticast { get; }
         public override IPInterfaceProperties GetIPProperties() => _ipProperties;
-
         public override IPInterfaceStatistics GetIPStatistics() => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
         public override IPv4InterfaceStatistics GetIPv4Statistics() => throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-
-        public override OperationalStatus OperationalStatus { get { return _operationalStatus; } }
-
-        public override NetworkInterfaceType NetworkInterfaceType { get { return _interfaceType; } }
-
-        public override long Speed => _speed;
-
-        public override bool IsReceiveOnly { get { return false; } }
+        public override OperationalStatus OperationalStatus { get; }
+        public override NetworkInterfaceType NetworkInterfaceType { get; }
+        public override long Speed { get; }
+        public override bool IsReceiveOnly => false;
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
@@ -40,6 +40,7 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets the Dynamic Host Configuration Protocol (DHCP) scope name.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract string DhcpScopeName { get; }
 
         /// <summary>
@@ -55,6 +56,7 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets a bool value that specifies whether the local computer is acting as a Windows Internet Name Service (WINS) proxy.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool IsWinsProxy { get; }
 
         /// <summary>
@@ -72,25 +74,31 @@ namespace System.Net.NetworkInformation
             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
         }
 
+        [UnsupportedOSPlatform("android")]
         public abstract TcpStatistics GetTcpIPv4Statistics();
 
+        [UnsupportedOSPlatform("android")]
         public abstract TcpStatistics GetTcpIPv6Statistics();
 
         /// <summary>
         /// Provides User Datagram Protocol (UDP) statistical data for the local computer.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract UdpStatistics GetUdpIPv4Statistics();
 
+        [UnsupportedOSPlatform("android")]
         public abstract UdpStatistics GetUdpIPv6Statistics();
 
         /// <summary>
         /// Provides Internet Control Message Protocol (ICMP) version 4 statistical data for the local computer.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IcmpV4Statistics GetIcmpV4Statistics();
 
         /// <summary>
         /// Provides Internet Control Message Protocol (ICMP) version 6 statistical data for the local computer.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IcmpV6Statistics GetIcmpV6Statistics();
 
         /// <summary>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalPropertiesPal.Android.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalPropertiesPal.Android.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.NetworkInformation
+{
+    internal static class IPGlobalPropertiesPal
+    {
+        public static IPGlobalProperties GetIPGlobalProperties()
+        {
+            return new AndroidIPGlobalProperties();
+        }
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalStatistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     /// <summary>
@@ -11,11 +13,13 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets the default time-to-live (TTL) value for Internet Protocol (IP) packets.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract int DefaultTtl { get; }
 
         /// <summary>
         /// Gets a bool value that specifies whether Internet Protocol (IP) packet forwarding is enabled.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool ForwardingEnabled { get; }
 
         /// <summary>
@@ -31,91 +35,109 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets the number of outbound Internet Protocol (IP) packets.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long OutputPacketRequests { get; }
 
         /// <summary>
         /// Gets the number of routes in the routing table that have been discarded.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long OutputPacketRoutingDiscards { get; }
 
         /// <summary>
         /// Gets the number of transmitted Internet Protocol (IP) packets that have been discarded.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long OutputPacketsDiscarded { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets for which the local computer could not determine a route to the destination address.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long OutputPacketsWithNoRoute { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets that could not be fragmented.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long PacketFragmentFailures { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets that required reassembly.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long PacketReassembliesRequired { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets that were not successfully reassembled.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long PacketReassemblyFailures { get; }
 
         /// <summary>
         /// Gets the maximum amount of time within which all fragments of an Internet Protocol (IP) packet must arrive.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long PacketReassemblyTimeout { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets fragmented.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long PacketsFragmented { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets reassembled.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long PacketsReassembled { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets received.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long ReceivedPackets { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol(IP) packets received and delivered.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsDelivered { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets that have been received and discarded.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsDiscarded { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets forwarded.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsForwarded { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets with address errors that were received.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsWithAddressErrors { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets with header errors that were received.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsWithHeadersErrors { get; }
 
         /// <summary>
         /// Gets the number of Internet Protocol (IP) packets received on the local machine with an unknown protocol in the header.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract long ReceivedPacketsWithUnknownProtocol { get; }
 
         /// <summary>
         /// Gets the number of routes in the Internet Protocol (IP) routing table.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract int NumberOfRoutes { get; }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPInterfaceProperties.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     /// <summary>
@@ -12,16 +14,19 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets a bool value that indicates whether this interface is configured to send name resolution queries to a Domain Name System (DNS) server.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool IsDnsEnabled { get; }
 
         /// <summary>
         /// Gets the Domain Name System (DNS) suffix associated with this interface.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract string DnsSuffix { get; }
 
         /// <summary>
         /// Gets a bool value that indicates whether this interface is configured to automatically register its IP address information with the Domain Name System (DNS).
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool IsDynamicDnsEnabled { get; }
 
         /// <summary>
@@ -37,26 +42,31 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// The address identifies multiple computers. Packets sent to an anycast address are sent to one of the computers identified by the address.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IPAddressInformationCollection AnycastAddresses { get; }
 
         /// <summary>
         /// The address is that of a Domain Name Service (DNS) server for the local computer.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IPAddressCollection DnsAddresses { get; }
 
         /// <summary>
         /// Gets the network gateway addresses.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract GatewayIPAddressInformationCollection GatewayAddresses { get; }
 
         /// <summary>
         /// Gets the addresses for Dynamic Host Configuration Protocol (DHCP) servers.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IPAddressCollection DhcpServerAddresses { get; }
 
         /// <summary>
         /// Gets the list of Wins Servers registered with this interface
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract IPAddressCollection WinsServersAddresses { get; }
 
         /// <summary>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPv4InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPv4InterfaceProperties.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     /// <summary>
@@ -11,21 +13,25 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets a bool value that indicates whether an interface uses Windows Internet Name Service (WINS).
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool UsesWins { get; }
 
         /// <summary>
         /// Gets a bool value that indicates whether the interface is configured to use a dynamic host configuration protocol (DHCP) server to obtain an IP address.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool IsDhcpEnabled { get; }
 
         /// <summary>
         /// Gets a bool value that indicates whether this interface has an automatic private IP addressing (APIPA) address.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool IsAutomaticPrivateAddressingActive { get; }
 
         /// <summary>
         /// Gets a bool value that indicates whether this interface has automatic private IP addressing (APIPA) enabled.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool IsAutomaticPrivateAddressingEnabled { get; }
 
         /// <summary>
@@ -36,6 +42,7 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets a bool value that indicates whether this interface can route packets.
         /// </summary>
+        [UnsupportedOSPlatform("android")]
         public abstract bool IsForwardingEnabled { get; }
 
         /// <summary>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterface.cs
@@ -70,6 +70,7 @@ namespace System.Net.NetworkInformation
         /// Provides Internet Protocol (IP) statistical data for this network interface.
         /// </summary>
         /// <returns>The interface's IP statistics.</returns>
+        [UnsupportedOSPlatform("android")]
         public virtual IPInterfaceStatistics GetIPStatistics()
         {
             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
@@ -81,6 +82,7 @@ namespace System.Net.NetworkInformation
         /// Do not use this method, use GetIPStatistics instead.
         /// </summary>
         /// <returns>The interface's IP statistics.</returns>
+        [UnsupportedOSPlatform("android")]
         public virtual IPv4InterfaceStatistics GetIPv4Statistics()
         {
             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.Android.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.Android.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.NetworkInformation
+{
+    internal static class NetworkInterfacePal
+    {
+        /// Returns objects that describe the network interfaces on the local computer.
+        public static NetworkInterface[] GetAllNetworkInterfaces()
+        {
+            return AndroidNetworkInterface.GetAndroidNetworkInterfaces();
+        }
+
+        public static bool GetIsNetworkAvailable()
+        {
+            foreach (var ni in GetAllNetworkInterfaces())
+            {
+                if (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback
+                    || ni.NetworkInterfaceType == NetworkInterfaceType.Tunnel)
+                {
+                    continue;
+                }
+                if (ni.OperationalStatus == OperationalStatus.Up)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static int IPv6LoopbackInterfaceIndex { get { return LoopbackInterfaceIndex; } }
+
+        public static int LoopbackInterfaceIndex
+        {
+            get
+            {
+                NetworkInterface[] interfaces = AndroidNetworkInterface.GetAndroidNetworkInterfaces();
+                for (int i = 0; i < interfaces.Length; i++)
+                {
+                    if (interfaces[i].NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                    {
+                        return ((UnixNetworkInterface)interfaces[i]).Index;
+                    }
+                }
+
+                throw new NetworkInformationException(SR.net_NoLoopback);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.Android.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.Android.cs
@@ -9,44 +9,14 @@ namespace System.Net.NetworkInformation
     {
         /// Returns objects that describe the network interfaces on the local computer.
         public static NetworkInterface[] GetAllNetworkInterfaces() => GetAndroidNetworkInterfaces();
-
-        public static bool GetIsNetworkAvailable()
-        {
-            foreach (var ni in GetAndroidNetworkInterfaces())
-            {
-                if (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback
-                    || ni.NetworkInterfaceType == NetworkInterfaceType.Tunnel)
-                {
-                    continue;
-                }
-                if (ni.OperationalStatus == OperationalStatus.Up)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
+        public static bool GetIsNetworkAvailable() => TransformNetworkInterfacess(IsSomeNetworkUp);
         public static int IPv6LoopbackInterfaceIndex => LoopbackInterfaceIndex;
-
-        public static int LoopbackInterfaceIndex
-        {
-            get
-            {
-                foreach (var networkInterface in GetAndroidNetworkInterfaces())
-                {
-                    if (networkInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
-                    {
-                        return networkInterface.Index;
-                    }
-                }
-
-                throw new NetworkInformationException(SR.net_NoLoopback);
-            }
-        }
+        public static int LoopbackInterfaceIndex => TransformNetworkInterfacess(FindLoopbackInterfaceIndex);
 
         internal static unsafe AndroidNetworkInterface[] GetAndroidNetworkInterfaces()
+            => TransformNetworkInterfacess(ToAndroidNetworkInterfaceArray);
+
+        private static unsafe T TransformNetworkInterfacess<T>(Func<int, IntPtr, int, IntPtr, T> transform)
         {
             int interfaceCount = 0;
             int addressCount = 0;
@@ -66,34 +36,75 @@ namespace System.Net.NetworkInformation
 
             try
             {
-                var networkInterfaces = new AndroidNetworkInterface[interfaceCount];
-
-                for (int i = 0; i < interfaceCount; i++, networkInterfaceInfo++)
-                {
-                    var name = Marshal.PtrToStringAnsi((IntPtr)networkInterfaceInfo->Name);
-                    networkInterfaces[i] = new AndroidNetworkInterface(name!, networkInterfaceInfo);
-                }
-
-                for (int i = 0; i < addressCount; i++, addressInfo++)
-                {
-                    // there is usually just a handful of few network interfaces on Android devices
-                    // and this linear search does not have any impact on performance
-                    foreach (var networkInterface in networkInterfaces)
-                    {
-                        if (networkInterface.Index == addressInfo->InterfaceIndex)
-                        {
-                            networkInterface.AddAddress(addressInfo);
-                            break;
-                        }
-                    }
-                }
-
-                return networkInterfaces;
+                return transform(interfaceCount, (IntPtr)networkInterfaceInfo, addressCount, (IntPtr)addressInfo);
             }
             finally
             {
                 Marshal.FreeHGlobal(globalMemory);
             }
+        }
+
+        private static unsafe AndroidNetworkInterface[] ToAndroidNetworkInterfaceArray(int interfaceCount, IntPtr networkInterfacesPtr, int addressCount, IntPtr addressPtr)
+        {
+            var networkInterfaces = new AndroidNetworkInterface[interfaceCount];
+
+            var networkInterfaceInfo = (Interop.Sys.NetworkInterfaceInfo*)networkInterfacesPtr;
+            for (int i = 0; i < interfaceCount; i++, networkInterfaceInfo++)
+            {
+                var name = Marshal.PtrToStringAnsi((IntPtr)networkInterfaceInfo->Name);
+                networkInterfaces[i] = new AndroidNetworkInterface(name!, networkInterfaceInfo);
+            }
+
+            var addressInfo = (Interop.Sys.IpAddressInfo*)addressPtr;
+            for (int i = 0; i < addressCount; i++, addressInfo++)
+            {
+                // there is usually just a handful of few network interfaces on Android devices
+                // and this linear search does not have any impact on performance
+                foreach (var networkInterface in networkInterfaces)
+                {
+                    if (networkInterface.Index == addressInfo->InterfaceIndex)
+                    {
+                        networkInterface.AddAddress(addressInfo);
+                        break;
+                    }
+                }
+            }
+
+            return networkInterfaces;
+        }
+
+        private static unsafe int FindLoopbackInterfaceIndex(int interfaceCount, IntPtr networkInterfacesPtr, int addressCount, IntPtr addressPtr)
+        {
+            var networkInterfaceInfo = (Interop.Sys.NetworkInterfaceInfo*)networkInterfacesPtr;
+            for (int i = 0; i < interfaceCount; i++, networkInterfaceInfo++)
+            {
+                if (networkInterfaceInfo->HardwareType == (int)NetworkInterfaceType.Loopback)
+                {
+                    return networkInterfaceInfo->InterfaceIndex;
+                }
+            }
+
+            throw new NetworkInformationException(SR.net_NoLoopback);
+        }
+
+        private static unsafe bool IsSomeNetworkUp(int interfaceCount, IntPtr networkInterfacesPtr, int addressCount, IntPtr addressPtr)
+        {
+            var networkInterfaceInfo = (Interop.Sys.NetworkInterfaceInfo*)networkInterfacesPtr;
+            for (int i = 0; i < interfaceCount; i++, networkInterfaceInfo++)
+            {
+                if (networkInterfaceInfo->HardwareType == (int)NetworkInterfaceType.Loopback
+                    || networkInterfaceInfo->HardwareType == (int)NetworkInterfaceType.Tunnel)
+                {
+                    continue;
+                }
+
+                if (networkInterfaceInfo->OperationalState == (int)OperationalStatus.Up)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
@@ -13,6 +13,7 @@ namespace System.Net.NetworkInformation
     internal abstract class UnixIPGlobalProperties : IPGlobalProperties
     {
         [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("android")]
         [UnsupportedOSPlatform("osx")]
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
@@ -26,6 +27,7 @@ namespace System.Net.NetworkInformation
         public override string HostName { get { return HostInformation.HostName; } }
 
         [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("android")]
         [UnsupportedOSPlatform("osx")]
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -60,7 +60,7 @@ namespace System.Net.NetworkInformation
         public List<UnixUnicastIPAddressInformation> UnicastAddress { get { return _unicastAddresses; } }
 
         /// <summary>
-        /// Returns a list of all Unicast addresses of the interface's IP Addresses.
+        /// Returns a list of all Multicast addresses of the interface's IP Addresses.
         /// </summary>
         public List<IPAddress>? MulticastAddresess { get { return _multicastAddresses; } }
 

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -26,7 +26,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
+        [SkipOnPlatform(TestPlatforms.Android, "Expected behavior is different on Android")]
         public void IPGlobalProperties_AccessAllMethods_NoErrors()
         {
             IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
@@ -50,9 +50,71 @@ namespace System.Net.NetworkInformation.Tests
             Assert.NotNull(gp.GetUdpIPv6Statistics());
         }
 
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Android)]
+        public void IPGlobalProperties_AccessAllMethods_NoErrors_Android()
+        {
+            IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
+
+            Assert.NotNull(gp.GetIPv4GlobalStatistics());
+            Assert.NotNull(gp.GetIPv6GlobalStatistics());
+
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetActiveTcpConnections());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetActiveTcpListeners());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetActiveUdpListeners());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetIcmpV4Statistics());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetIcmpV6Statistics());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetTcpIPv4Statistics());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetTcpIPv6Statistics());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetUdpIPv4Statistics());
+            Assert.Throws<PlatformNotSupportedException>(() => gp.GetUdpIPv6Statistics());
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(6)]
+        [PlatformSpecific(TestPlatforms.Android)]
+        public void IPGlobalProperties_IPv4_IPv6_NoErrors_Android(int ipVersion)
+        {
+            IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
+            IPGlobalStatistics statistics = ipVersion switch {
+                4 => gp.GetIPv4GlobalStatistics(),
+                6 => gp.GetIPv6GlobalStatistics(),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            _log.WriteLine($"- IPv{ipVersion} statistics: -");
+            _log.WriteLine($"Number of interfaces: {statistics.NumberOfInterfaces}");
+            _log.WriteLine($"Number of IP addresses: {statistics.NumberOfIPAddresses}");
+
+            Assert.InRange(statistics.NumberOfInterfaces, 1, int.MaxValue);
+            Assert.InRange(statistics.NumberOfIPAddresses, 1, int.MaxValue);
+
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.DefaultTtl);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ForwardingEnabled);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.OutputPacketRequests);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.OutputPacketRoutingDiscards);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.OutputPacketsDiscarded);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.OutputPacketsWithNoRoute);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.PacketFragmentFailures);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.PacketReassembliesRequired);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.PacketReassemblyFailures);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.PacketReassemblyTimeout);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.PacketsFragmented);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.PacketsReassembled);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ReceivedPackets);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ReceivedPacketsDelivered);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ReceivedPacketsDiscarded);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ReceivedPacketsForwarded);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ReceivedPacketsWithAddressErrors);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ReceivedPacketsWithHeadersErrors);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.ReceivedPacketsWithUnknownProtocol);
+            Assert.Throws<PlatformNotSupportedException>(() => statistics.NumberOfRoutes);
+        }
+
         [Theory]
         [MemberData(nameof(Loopbacks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
+        [SkipOnPlatform(TestPlatforms.Android, "Unsupported on Android")]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
@@ -78,9 +140,8 @@ namespace System.Net.NetworkInformation.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [PlatformSpecific(~(TestPlatforms.iOS | TestPlatforms.tvOS))]
+        [PlatformSpecific(~(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.Android))]
         [MemberData(nameof(Loopbacks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
         public async Task IPGlobalProperties_TcpActiveConnections_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
@@ -110,7 +171,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
+        [SkipOnPlatform(TestPlatforms.Android, "Unsupported on Android")]
         public void IPGlobalProperties_TcpActiveConnections_NotListening()
         {
             TcpConnectionInformation[] tcpCconnections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Android.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Android.cs
@@ -1,0 +1,221 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Net.Http.Functional.Tests;
+using System.Net.Sockets;
+using System.Net.Test.Common;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.NetworkInformation.Tests
+{
+    [PlatformSpecific(TestPlatforms.Android)]
+    public class IPInterfacePropertiesTest_Android
+    {
+        private readonly ITestOutputHelper _log;
+
+        public IPInterfacePropertiesTest_Android(ITestOutputHelper output)
+        {
+            _log = output;
+        }
+
+        [Fact]
+        public async Task IPInfoTest_AccessAllProperties_NoErrors()
+        {
+            await Task.Run(() =>
+            {
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    _log.WriteLine("Nic: " + nic.Name);
+                    _log.WriteLine("- Speed:" + nic.Speed);
+                    Assert.Equal(-1, nic.Speed);
+                    _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
+                    _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
+                    Assert.False(nic.IsReceiveOnly);
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    Assert.NotNull(ipProperties);
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.AnycastAddresses);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DhcpServerAddresses);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DnsAddresses);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DnsSuffix);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.GatewayAddresses);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDnsEnabled);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDynamicDnsEnabled);
+
+                    Assert.NotNull(ipProperties.MulticastAddresses);
+                    _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
+                    foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
+                    {
+                        _log.WriteLine("-- " + multi.Address.ToString());
+                        Assert.Throws<PlatformNotSupportedException>(() => multi.IsDnsEligible);
+                        Assert.Throws<PlatformNotSupportedException>(() => multi.IsTransient);
+                    }
+
+                    Assert.NotNull(ipProperties.UnicastAddresses);
+                    _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
+                    foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
+                    {
+                        _log.WriteLine("-- " + uni.Address.ToString());
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.AddressPreferredLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.AddressValidLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.DhcpLeaseLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.DuplicateAddressDetectionState);
+
+                        Assert.NotNull(uni.IPv4Mask);
+                        _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.IsDnsEligible);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.IsTransient);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixOrigin);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.SuffixOrigin);
+
+                        // Prefix Length
+                        _log.WriteLine("--- PrefixLength: " + uni.PrefixLength);
+                        Assert.True(uni.PrefixLength > 0);
+                        Assert.True((uni.Address.AddressFamily == AddressFamily.InterNetwork ? 33 : 129) > uni.PrefixLength);
+                    }
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.WinsServersAddresses);
+                }
+            }).WaitAsync(TestHelper.PassingTestTimeout);
+        }
+
+        [Fact]
+        public async Task IPInfoTest_AccessAllIPv4Properties_NoErrors()
+        {
+            await Task.Run(() =>
+            {
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    _log.WriteLine("IPv4 Properties:");
+
+                    IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
+
+                    _log.WriteLine("Index: " + ipv4Properties.Index);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingActive);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingEnabled);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsDhcpEnabled);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsForwardingEnabled);
+                    _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.UsesWins);
+                }
+            }).WaitAsync(TestHelper.PassingTestTimeout);
+        }
+
+        [Fact]
+        public async Task IPInfoTest_AccessAllIPv6Properties_NoErrors()
+        {
+            await Task.Run(() =>
+            {
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    _log.WriteLine("IPv6 Properties:");
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    if (ipv6Properties == null)
+                    {
+                        _log.WriteLine("IPv6Properties is null");
+                        continue;
+                    }
+
+                    _log.WriteLine("Index: " + ipv6Properties.Index);
+                    _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
+                    _log.WriteLine("Scope: " + ipv6Properties.GetScopeId(ScopeLevel.Link));
+                }
+            }).WaitAsync(TestHelper.PassingTestTimeout);
+        }
+
+        [Fact]
+        [Trait("IPv6", "true")]
+        public async Task IPv6ScopeId_AccessAllValues_Success()
+        {
+            await Task.Run(() =>
+            {
+                Assert.True(Capability.IPv6Support());
+
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                    {
+                        continue;
+                    }
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    Array values = Enum.GetValues(typeof(ScopeLevel));
+                    foreach (ScopeLevel level in values)
+                    {
+                        _log.WriteLine("-- Level: " + level + "; " + ipv6Properties.GetScopeId(level));
+                    }
+                }
+            }).WaitAsync(TestHelper.PassingTestTimeout);
+        }
+
+        [Fact]
+        [Trait("IPv4", "true")]
+        public async Task IPInfoTest_IPv4Loopback_ProperAddress()
+        {
+            await Task.Run(() =>
+            {
+                Assert.True(Capability.IPv4Support());
+
+                _log.WriteLine("Loopback IPv4 index: " + NetworkInterface.LoopbackInterfaceIndex);
+
+                NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo");
+                Assert.NotNull(loopback);
+
+                foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
+                {
+                    if (unicast.Address.Equals(IPAddress.Loopback))
+                    {
+                        Assert.Equal(IPAddress.Parse("255.0.0.0"), unicast.IPv4Mask);
+                        Assert.Equal(8, unicast.PrefixLength);
+                        break;
+                    }
+                }
+            }).WaitAsync(TestHelper.PassingTestTimeout);
+        }
+
+        [Fact]
+        [Trait("IPv6", "true")]
+        public async Task IPInfoTest_IPv6Loopback_ProperAddress()
+        {
+            await Task.Run(() =>
+            {
+                Assert.True(Capability.IPv6Support());
+
+                _log.WriteLine("Loopback IPv6 index: " + NetworkInterface.IPv6LoopbackInterfaceIndex);
+
+                NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo");
+                Assert.NotNull(loopback);
+
+                foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
+                {
+                    if (unicast.Address.Equals(IPAddress.IPv6Loopback))
+                    {
+                        Assert.Equal(128, unicast.PrefixLength);
+                        break;
+                    }
+                }
+            }).WaitAsync(TestHelper.PassingTestTimeout);
+        }
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -56,7 +56,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Linux|TestPlatforms.Android)]  // Some APIs are not supported on Linux and Android
+        [PlatformSpecific(TestPlatforms.Linux|TestPlatforms.Android)]  // Some APIs are not supported on Linux
         public void BasicTest_AccessInstanceProperties_NoExceptions_Linux()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -56,7 +56,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Linux|TestPlatforms.Android)]  // Some APIs are not supported on Linux
+        [PlatformSpecific(TestPlatforms.Linux|TestPlatforms.Android)]  // Some APIs are not supported on Linux and Android
         public void BasicTest_AccessInstanceProperties_NoExceptions_Linux()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceIPv4Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceIPv4Statistics.cs
@@ -70,6 +70,17 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Android)]  // This API is not supported on Android
+        public void BasicTest_GetIPv4InterfaceStatistics_NotSupported_Android()
+        {
+            // This API is not actually IPv4 specific.
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => nic.GetIPv4Statistics());
+            }
+        }
+
+        [Fact]
         [PlatformSpecific(TestPlatforms.OSX)]  // Some APIs are not supported on OSX
         public void BasicTest_GetIPv4InterfaceStatistics_Success_OSX()
         {


### PR DESCRIPTION
This PR is a follow-up of #62780.

I went through the Android APIs that provide information about IP interfaces' properties and network usage stats (e.g., [ConnectivytManager](https://developer.android.com/reference/android/net/ConnectivityManager#getLinkProperties(android.net.Network)), [TrafficStats](https://developer.android.com/reference/android/net/TrafficStats)) and I couldn't find a way to populate most of the properties we expose in `IPGlobalProperties`, `IPInterfaceProperties`, `IPGlobalStatistics`, and `IPInterfaceStatistics`. I updated the implementation to throw PNSE for those properties on Android and marked the properties with `UnsupportedOSPlatform("android")` attributes.

Closes #50567
Closes #51303
Closes #58374