### PR TITLE
JIT: Update bbFlags after replacing RET_EXPR

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1433,6 +1433,13 @@ _Done:
             // Save the basic block flags from the retExpr basic block.
             iciCall->gtInlineCandidateInfo->retExpr->AsRetExpr()->bbFlags = pInlineInfo->retBB->bbFlags;
         }
+
+        if (bottomBlock != nullptr)
+        {
+            // We've split the iciblock into two and the RET_EXPR was possibly moved to the bottomBlock
+            // so let's update its flags with retBB's ones using "split gained" mask
+            bottomBlock->bbFlags |= pInlineInfo->retBB->bbFlags & BBF_SPLIT_GAINED;
+        }
         iciCall->ReplaceWith(pInlineInfo->retExpr, this);
     }
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1437,8 +1437,8 @@ _Done:
         if (bottomBlock != nullptr)
         {
             // We've split the iciblock into two and the RET_EXPR was possibly moved to the bottomBlock
-            // so let's update its flags with retBB's ones using "split gained" mask
-            bottomBlock->bbFlags |= pInlineInfo->retBB->bbFlags & BBF_SPLIT_GAINED;
+            // so let's update its flags with retBB's ones
+            bottomBlock->bbFlags |= pInlineInfo->retBB->bbFlags & BBF_COMPACT_UPD;
         }
         iciCall->ReplaceWith(pInlineInfo->retExpr, this);
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63610/Runtime_63610.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63610/Runtime_63610.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_63610
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Test(int[] x)
+    {
+        try
+        {
+             Callee1(x);
+        }
+        catch
+        {
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Callee1(int[] x) => Callee2(x, 0);
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Callee2(int[] x, int index)
+    {
+        if (x == null)
+            Callee3();
+
+        return x.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Callee3() {}
+
+    public static int Main()
+    {
+        // Make sure it doesn't assert 
+        // https://github.com/dotnet/runtime/issues/63610
+        Test(new int[42]);
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63610/Runtime_63610.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63610/Runtime_63610.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/63610
Closes https://github.com/dotnet/runtime/issues/61705

It's not the first time we forget to propagate them, fortunately most of them are "opportunistic" and only help us to optimize TP.