### PR TITLE
Add NativeAOT libraries tests annotations

### DIFF
--- a/src/libraries/Common/tests/System/Collections/DebugView.Tests.cs
+++ b/src/libraries/Common/tests/System/Collections/DebugView.Tests.cs
@@ -60,7 +60,7 @@ namespace System.Collections.Tests
             yield return new object[] { new SortedList<float, long>{{1f, 1L}, {2f, 2L}}.Values };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         [MemberData(nameof(TestDebuggerAttributes_Inputs))]
         public static void TestDebuggerAttributes(object obj)
         {
@@ -71,7 +71,7 @@ namespace System.Collections.Tests
             Assert.Equal((obj as IEnumerable).Cast<object>().ToArray(), items.Cast<object>());
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsDebuggerTypeProxyAttributeSupported))]
         [MemberData(nameof(TestDebuggerAttributes_Inputs))]
         public static void TestDebuggerAttributes_Null(object obj)
         {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -28,6 +28,7 @@ namespace System
         public static bool IsMonoInterpreter => GetIsRunningOnMonoInterpreter();
         public static bool IsMonoAOT => Environment.GetEnvironmentVariable("MONO_AOT_MODE") == "aot";
         public static bool IsNotMonoAOT => Environment.GetEnvironmentVariable("MONO_AOT_MODE") != "aot";
+        public static bool IsNativeAot => IsNotMonoRuntime && !RuntimeFeature.IsDynamicCodeSupported;
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsAndroid => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
@@ -52,7 +53,7 @@ namespace System
         public static bool IsNotArmNorArm64Process => !IsArmOrArm64Process;
         public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
         public static bool IsNotX86Process => !IsX86Process;
-        public static bool IsArgIteratorSupported => IsMonoRuntime || (IsWindows && IsNotArmProcess);
+        public static bool IsArgIteratorSupported => IsMonoRuntime || (IsWindows && IsNotArmProcess && !IsNativeAot);
         public static bool IsArgIteratorNotSupported => !IsArgIteratorSupported;
         public static bool Is32BitProcess => IntPtr.Size == 4;
         public static bool Is64BitProcess => IntPtr.Size == 8;
@@ -62,7 +63,7 @@ namespace System
         public static bool IsCaseSensitiveOS => !IsCaseInsensitiveOS;
 
         public static bool IsThreadingSupported => !IsBrowser;
-        public static bool IsBinaryFormatterSupported => IsNotMobile;
+        public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
         public static bool IsSymLinkSupported => !IsiOS && !IstvOS;
 
         public static bool IsSpeedOptimized => !IsSizeOptimized;
@@ -116,10 +117,10 @@ namespace System
 
         public static bool IsAsyncFileIOSupported => !IsBrowser && !(IsWindows && IsMonoRuntime); // https://github.com/dotnet/runtime/issues/34582
 
-        public static bool IsLineNumbersSupported => true;
+        public static bool IsLineNumbersSupported => !IsNativeAot;
 
         public static bool IsInContainer => GetIsInContainer();
-        public static bool SupportsComInterop => IsWindows && IsNotMonoRuntime; // matches definitions in clr.featuredefines.props
+        public static bool SupportsComInterop => IsWindows && IsNotMonoRuntime && !IsNativeAot; // matches definitions in clr.featuredefines.props
         public static bool SupportsSsl3 => GetSsl3Support();
         public static bool SupportsSsl2 => IsWindows && !PlatformDetection.IsWindows10Version1607OrGreater;
 
@@ -130,7 +131,9 @@ namespace System
         public static bool IsReflectionEmitSupported => true;
 #endif
 
-        public static bool IsInvokingStaticConstructorsSupported => true;
+        public static bool IsInvokingStaticConstructorsSupported => !IsNativeAot;
+
+        public static bool IsMetadataUpdateSupported => !IsNativeAot;
 
         // System.Security.Cryptography.Xml.XmlDsigXsltTransform.GetOutput() relies on XslCompiledTransform which relies
         // heavily on Reflection.Emit
@@ -139,6 +142,10 @@ namespace System
         public static bool IsPreciseGcSupported => !IsMonoRuntime;
 
         public static bool IsNotIntMaxValueArrayIndexSupported => s_largeArrayIsNotSupported.Value;
+
+        public static bool IsAssemblyLoadingSupported => !IsNativeAot;
+        public static bool IsMethodBodySupported => !IsNativeAot;
+        public static bool IsDebuggerTypeProxyAttributeSupported => !IsNativeAot;
 
         private static volatile Tuple<bool> s_lazyNonZeroLowerBoundArraySupported;
         public static bool IsNonZeroLowerBoundArraySupported
@@ -159,6 +166,28 @@ namespace System
                     s_lazyNonZeroLowerBoundArraySupported = Tuple.Create<bool>(nonZeroLowerBoundArraysSupported);
                 }
                 return s_lazyNonZeroLowerBoundArraySupported.Item1;
+            }
+        }
+
+        private static volatile Tuple<bool> s_lazyMetadataTokensSupported;
+        public static bool IsMetadataTokenSupported
+        {
+            get
+            {
+                if (s_lazyMetadataTokensSupported == null)
+                {
+                    bool metadataTokensSupported = false;
+                    try
+                    {
+                        _ = typeof(PlatformDetection).MetadataToken;
+                        metadataTokensSupported = true;
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+                    s_lazyMetadataTokensSupported = Tuple.Create<bool>(metadataTokensSupported);
+                }
+                return s_lazyMetadataTokensSupported.Item1;
             }
         }
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -28,7 +28,7 @@ namespace System
         public static bool IsMonoInterpreter => GetIsRunningOnMonoInterpreter();
         public static bool IsMonoAOT => Environment.GetEnvironmentVariable("MONO_AOT_MODE") == "aot";
         public static bool IsNotMonoAOT => Environment.GetEnvironmentVariable("MONO_AOT_MODE") != "aot";
-        public static bool IsNativeAot => IsNotMonoRuntime && !RuntimeFeature.IsDynamicCodeSupported;
+        public static bool IsNativeAot => IsNotMonoRuntime && !IsReflectionEmitSupported;
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsAndroid => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));

--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -7320,6 +7320,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/155", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static unsafe void InternTest()
         {
             AssertExtensions.Throws<ArgumentNullException>("str", () => string.Intern(null));

--- a/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/libraries/System.Collections/tests/System.Collections.Tests.csproj
@@ -5,6 +5,9 @@
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
   </PropertyGroup>
   <ItemGroup>
+    <RdXmlFile Include="default.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
     <!-- Common Collections tests -->
     <Compile Include="$(CommonTestPath)System\Collections\CollectionAsserts.cs"
              Link="Common\System\Collections\CollectionAsserts.cs" />

--- a/src/libraries/System.Collections/tests/default.rd.xml
+++ b/src/libraries/System.Collections/tests/default.rd.xml
@@ -1,0 +1,154 @@
+<Directives>
+  <Application>
+    <Assembly Name="System.Collections.Tests">
+      <Type Name="System.Collections.Tests.BitArray_GetSetTests">
+        <Method Name="CopyTo_Size_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="CopyTo_Size_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="CopyTo_Size_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+
+        <Method Name="CopyTo" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="CopyTo" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="CopyTo" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+      </Type>
+
+      <Type Name="System.Collections.Generic.Tests.EqualityComparerTests">
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int16Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.SByteEnum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int32Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int64Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Collections.Tests.NonEquatableValueType, System.Collections.Tests" />
+        </Method>
+
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int16Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.SByteEnum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int32Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int64Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="EqualsTest" Dynamic="Required All">
+          <GenericArgument Name="System.Collections.Tests.NonEquatableValueType, System.Collections.Tests" />
+        </Method>
+
+        <Method Name="NullableEquals" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="NullableEquals" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="NullableEquals" Dynamic="Required All">
+          <GenericArgument Name="System.Int16Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableEquals" Dynamic="Required All">
+          <GenericArgument Name="System.SByteEnum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableEquals" Dynamic="Required All">
+          <GenericArgument Name="System.Int32Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableEquals" Dynamic="Required All">
+          <GenericArgument Name="System.Int64Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableEquals" Dynamic="Required All">
+          <GenericArgument Name="System.Collections.Tests.NonEquatableValueType, System.Collections.Tests" />
+        </Method>
+
+        <Method Name="GetHashCodeTest" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="GetHashCodeTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="GetHashCodeTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int16Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="GetHashCodeTest" Dynamic="Required All">
+          <GenericArgument Name="System.SByteEnum, System.Collections.Tests" />
+        </Method>
+        <Method Name="GetHashCodeTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int32Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="GetHashCodeTest" Dynamic="Required All">
+          <GenericArgument Name="System.Int64Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="GetHashCodeTest" Dynamic="Required All">
+          <GenericArgument Name="System.Collections.Tests.NonEquatableValueType, System.Collections.Tests" />
+        </Method>
+
+        <Method Name="NullableGetHashCode" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="NullableGetHashCode" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="NullableGetHashCode" Dynamic="Required All">
+          <GenericArgument Name="System.Int16Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableGetHashCode" Dynamic="Required All">
+          <GenericArgument Name="System.SByteEnum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableGetHashCode" Dynamic="Required All">
+          <GenericArgument Name="System.Int32Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableGetHashCode" Dynamic="Required All">
+          <GenericArgument Name="System.Int64Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="NullableGetHashCode" Dynamic="Required All">
+          <GenericArgument Name="System.Collections.Tests.NonEquatableValueType, System.Collections.Tests" />
+        </Method>
+      </Type>
+
+      <Type Name="System.Collections.Generic.Tests.ComparerTests">
+        <Method Name="MostComparisons" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="MostComparisons" Dynamic="Required All">
+          <GenericArgument Name="System.Int32Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="MostComparisons" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32Enum, System.Collections.Tests" />
+        </Method>
+        <Method Name="MostComparisons" Dynamic="Required All">
+          <GenericArgument Name="System.Int64Enum, System.Collections.Tests" />
+        </Method>
+      </Type>
+    </Assembly>
+  </Application>
+</Directives>

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -299,6 +299,7 @@ namespace System.IO.Tests
             Assert.False(Exists(component));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/901", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Theory,
             MemberData(nameof(UncPathsWithoutShareName))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51371", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]

--- a/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
@@ -231,6 +231,7 @@ namespace System.IO.Tests
             Assert.False(Exists(component));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/901", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Theory,
             MemberData(nameof(UncPathsWithoutShareName))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51371", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -14,6 +14,9 @@
     <DefineConstants Condition="'$(FeatureGenericMath)' == 'true'">$(DefineConstants);FEATURE_GENERIC_MATH</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <RdXmlFile Include="default.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="$(CommonTestPath)System\EnumTypes.cs" Link="Common\System\EnumTypes.cs" />
     <Compile Include="$(CommonTestPath)System\MockType.cs" Link="Common\System\MockType.cs" />
     <Compile Include="$(CommonTestPath)System\Collections\CollectionAsserts.cs" Link="Common\System\Collections\CollectionAsserts.cs" />

--- a/src/libraries/System.Runtime/tests/System/ActivatorTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ActivatorTests.cs
@@ -621,7 +621,7 @@ namespace System.Tests
             Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(type, nonPublic: false));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsAssemblyLoadingSupported))]
         [MemberData(nameof(TestingCreateInstanceFromObjectHandleData))]
         public static void TestingCreateInstanceFromObjectHandle(string assemblyFile, string type, string returnedFullNameType, Type exceptionType)
         {
@@ -660,8 +660,7 @@ namespace System.Tests
             { "TestLoadAssembly.dll", "publicclassnodefaultconstructorsample", "PublicClassNoDefaultConstructorSample", typeof(TypeLoadException) }
         };
 
-
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsAssemblyLoadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51912", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         [MemberData(nameof(TestingCreateInstanceObjectHandleData))]
         public static void TestingCreateInstanceObjectHandle(string assemblyName, string type, string returnedFullNameType, Type exceptionType, bool returnNull)
@@ -718,7 +717,7 @@ namespace System.Tests
             { "mscorlib", "System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", "", null, true }
         };
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsAssemblyLoadingSupported))]
         [MemberData(nameof(TestingCreateInstanceFromObjectHandleFullSignatureData))]
         public static void TestingCreateInstanceFromObjectHandleFullSignature(string assemblyFile, string type, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes, string returnedFullNameType)
         {
@@ -740,7 +739,7 @@ namespace System.Tests
             yield return new object[] { "TestLoadAssembly.dll", "privateclasssample", true, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, Type.DefaultBinder, new object[1] { 1 }, CultureInfo.InvariantCulture, null, "PrivateClassSample" };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsAssemblyLoadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51912", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         [MemberData(nameof(TestingCreateInstanceObjectHandleFullSignatureData))]
         public static void TestingCreateInstanceObjectHandleFullSignature(string assemblyName, string type, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes, string returnedFullNameType, bool returnNull)

--- a/src/libraries/System.Runtime/tests/System/AttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/AttributeTests.cs
@@ -154,7 +154,6 @@ namespace System.Tests
             public int Field = 0;
         }
 
-
         [ActiveIssue("https://github.com/dotnet/runtimelab/issues/803", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Fact]
         [StringValue("\uDFFF")]

--- a/src/libraries/System.Runtime/tests/System/AttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/AttributeTests.cs
@@ -154,6 +154,8 @@ namespace System.Tests
             public int Field = 0;
         }
 
+
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/803", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Fact]
         [StringValue("\uDFFF")]
         public static void StringArgument_InvalidCodeUnits_FallbackUsed()

--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -42,6 +42,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/linker/issues/2078", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot) /* Stripping ComVisible because descriptors tell us so */)]
         public void IsDefined_PropertyInfo()
         {
             PropertyInfo pi = typeof(TestBase).GetProperty("PropBase3");

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace System.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
+    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/851", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
     public class StackTraceHiddenAttributeTests
     {
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/PseudoCustomAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/PseudoCustomAttributeTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace System.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/830", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
     public static partial class PseudoCustomAttributeTests
     {
         [Theory]

--- a/src/libraries/System.Runtime/tests/System/Reflection/CustomAttributeDataTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/CustomAttributeDataTests.cs
@@ -75,6 +75,7 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ComVisible(false)]
+        [ActiveIssue("https://github.com/dotnet/linker/issues/2078", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot)) /* Descriptors tell us to remove ComVisibleAttribute */]
         public static void Test_CustomAttribute_Constructor_CrossAssembly2()
         {
             MethodInfo m = (MethodInfo)MethodBase.GetCurrentMethod();

--- a/src/libraries/System.Runtime/tests/System/Reflection/InvokeWithRefLikeArgs.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/InvokeWithRefLikeArgs.cs
@@ -17,6 +17,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/155", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void MethodTakesRefStructAsArg_DoesNotCopyValueBack()
         {
             MethodInfo mi = GetMethod(nameof(TestClass.TakesRefStructAsArg));
@@ -28,6 +29,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/155", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void MethodTakesRefStructAsArgWithDefaultValue_DoesNotCopyValueBack()
         {
             MethodInfo mi = GetMethod(nameof(TestClass.TakesRefStructAsArgWithDefaultValue));
@@ -78,6 +80,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/155", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public static void PropertyIndexerWithRefStructArg_DoesNotCopyValueBack()
         {
             PropertyInfo pi = typeof(TestClassWithIndexerWithRefStructArg).GetProperty("Item");

--- a/src/libraries/System.Runtime/tests/System/Reflection/MethodBaseTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/MethodBaseTests.cs
@@ -50,7 +50,7 @@ namespace System.Reflection.Tests
             Assert.NotEqual(expected, mb1 != mb2);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMethodBodySupported))]
         public static void TestMethodBody()
         {
             MethodBase mbase = typeof(MethodBaseTests).GetMethod("MyOtherMethod", BindingFlags.Static | BindingFlags.Public);

--- a/src/libraries/System.Runtime/tests/System/Reflection/MethodBodyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/MethodBodyTests.cs
@@ -11,7 +11,7 @@ namespace System.Reflection.Tests
 {
     public static class MethodBodyTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMethodBodySupported))]
         public static void Test_MethodBody_ExceptionHandlingClause()
         {
             MethodInfo mi = typeof(MethodBodyTests).GetMethod("MethodBodyExample", BindingFlags.NonPublic | BindingFlags.Static);

--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -245,7 +245,7 @@ namespace System.Reflection.Tests
 
         public static IEnumerable<Type> Types => Module.GetTypes();
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         public void ResolveTypes()
         {
             foreach(Type t in Types)
@@ -260,7 +260,7 @@ namespace System.Reflection.Tests
             }
             .Union(NullTokens);
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         [MemberData(nameof(BadResolveTypes))]
         public void ResolveTypeFail(int token)
         {
@@ -273,7 +273,7 @@ namespace System.Reflection.Tests
         public static IEnumerable<MemberInfo> Methods =>
             typeof(ModuleTests).GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         public void ResolveMethodsByMethodInfo()
         {
             foreach(MethodInfo mi in Methods)
@@ -289,7 +289,7 @@ namespace System.Reflection.Tests
             }
             .Union(NullTokens);
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         [MemberData(nameof(BadResolveMethods))]
         public void ResolveMethodFail(int token)
         {
@@ -302,7 +302,7 @@ namespace System.Reflection.Tests
         public static IEnumerable<MemberInfo> Fields =>
             typeof(ModuleTests).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52072", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void ResolveFieldsByFieldInfo()
         {
@@ -319,7 +319,7 @@ namespace System.Reflection.Tests
             }
             .Union(NullTokens);
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         [MemberData(nameof(BadResolveFields))]
         public void ResolveFieldFail(int token)
         {
@@ -338,7 +338,7 @@ namespace System.Reflection.Tests
             }
             .Union(NullTokens);
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         [MemberData(nameof(BadResolveStrings))]
         public void ResolveStringFail(int token)
         {
@@ -348,28 +348,28 @@ namespace System.Reflection.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         public void ResolveTypesByMemberInfo()
         {
             foreach(MemberInfo mi in Types)
                 Assert.Equal(mi, Module.ResolveMember(mi.MetadataToken));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         public void ResolveMethodsByMemberInfo()
         {
             foreach (MemberInfo mi in Methods)
                 Assert.Equal(mi, Module.ResolveMember(mi.MetadataToken));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         public void ResolveFieldsByMemberInfo()
         {
             foreach (MemberInfo mi in Fields)
                 Assert.Equal(mi, Module.ResolveMember(mi.MetadataToken));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataTokenSupported))]
         public void ResolveMethodOfGenericClass()
         {
             Type t = typeof(Foo<>);

--- a/src/libraries/System.Runtime/tests/System/Reflection/ReflectionCacheTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ReflectionCacheTests.cs
@@ -22,7 +22,7 @@ namespace System.Reflection.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50978", TestRuntimes.Mono)]
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataUpdateSupported))]
         public void InvokeClearCache_NoExceptions()
         {
             Action<Type[]> clearCache = GetClearCacheMethod();
@@ -33,7 +33,7 @@ namespace System.Reflection.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50978", TestRuntimes.Mono)]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataUpdateSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public void GetMethod_MultipleCalls_ClearCache_DifferentObjects(bool justSpecificType)

--- a/src/libraries/System.Runtime/tests/System/Reflection/TypeTests.Get.CornerCases.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/TypeTests.Get.CornerCases.cs
@@ -282,6 +282,7 @@ namespace System.Reflection.Tests
             Assert.Equal(0, properties.Length);
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/865", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Fact]
         public static void HideDetectionHappensAfterPrivateInBaseClassChecks()
         {

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
@@ -33,8 +33,16 @@ namespace System.Runtime.CompilerServices.Tests
         [SkipOnMono("IsDynamicCodeCompiled returns false in cases where mono doesn't support these features")]
         public static void DynamicCode_Jit()
         {
-            Assert.True(RuntimeFeature.IsDynamicCodeSupported);
-            Assert.True(RuntimeFeature.IsDynamicCodeCompiled);
+            if (PlatformDetection.IsNativeAot)
+            {
+                Assert.False(RuntimeFeature.IsDynamicCodeSupported);
+                Assert.False(RuntimeFeature.IsDynamicCodeCompiled);
+            }
+            else
+            {
+                Assert.True(RuntimeFeature.IsDynamicCodeSupported);
+                Assert.True(RuntimeFeature.IsDynamicCodeCompiled);
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -154,7 +154,6 @@ namespace System.Runtime.CompilerServices.Tests
 
             if (RuntimeFeature.IsDynamicCodeSupported)
             {
-
                 // Generic definition without instantiation is invalid
                 Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(Array).GetMethod("Resize").MethodHandle,
                     null));

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -104,7 +104,11 @@ namespace System.Runtime.CompilerServices.Tests
                 RuntimeHelpers.PrepareMethod(m.MethodHandle);
 
             Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(default(RuntimeMethodHandle)));
-            Assert.ThrowsAny<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(IList).GetMethod("Add").MethodHandle));
+
+            if (RuntimeFeature.IsDynamicCodeSupported)
+            {
+                Assert.ThrowsAny<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(IList).GetMethod("Add").MethodHandle));
+            }
         }
 
         [Fact]
@@ -124,13 +128,16 @@ namespace System.Runtime.CompilerServices.Tests
             RuntimeHelpers.PrepareMethod(typeof(List<int>).GetMethod("Add").MethodHandle,
                 null);
 
-            // Generic definition without instantiation is invalid
-            Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(List<>).GetMethod("Add").MethodHandle,
-                null));
+            if (RuntimeFeature.IsDynamicCodeSupported)
+            {
+                // Generic definition without instantiation is invalid
+                Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(List<>).GetMethod("Add").MethodHandle,
+                    null));
 
-            // Wrong instantiation
-            Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(List<>).GetMethod("Add").MethodHandle,
-                new RuntimeTypeHandle[] { typeof(TestStruct).TypeHandle, typeof(TestStruct).TypeHandle }));
+                // Wrong instantiation
+                Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(List<>).GetMethod("Add").MethodHandle,
+                    new RuntimeTypeHandle[] { typeof(TestStruct).TypeHandle, typeof(TestStruct).TypeHandle }));
+            }
 
             //
             // Method instantiations
@@ -145,13 +152,17 @@ namespace System.Runtime.CompilerServices.Tests
                     .MakeGenericMethod(new Type[] { typeof(TestStruct) }).MethodHandle,
                 null);
 
-            // Generic definition without instantiation is invalid
-            Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(Array).GetMethod("Resize").MethodHandle,
-                null));
+            if (RuntimeFeature.IsDynamicCodeSupported)
+            {
 
-            // Wrong instantiation
-            Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(Array).GetMethod("Resize").MethodHandle,
-                new RuntimeTypeHandle[] { typeof(TestStruct).TypeHandle, typeof(TestStruct).TypeHandle }));
+                // Generic definition without instantiation is invalid
+                Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(Array).GetMethod("Resize").MethodHandle,
+                    null));
+
+                // Wrong instantiation
+                Assert.Throws<ArgumentException>(() => RuntimeHelpers.PrepareMethod(typeof(Array).GetMethod("Resize").MethodHandle,
+                    new RuntimeTypeHandle[] { typeof(TestStruct).TypeHandle, typeof(TestStruct).TypeHandle }));
+            }
         }
 
         [Fact]
@@ -273,6 +284,7 @@ namespace System.Runtime.CompilerServices.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/155", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Fact]
         public static void GetUninitalizedObject_DoesNotRunBeforeFieldInitCctors()
         {

--- a/src/libraries/System.Runtime/tests/System/Runtime/JitInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/JitInfoTests.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.Tests
 
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoAOT))] // JitInfo metrics will be 0 in AOT scenarios
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))] // JitInfo metrics will be 0 in AOT scenarios
         [ActiveIssue("https://github.com/dotnet/runtime/issues/55712", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void JitInfoIsPopulated()
         {
@@ -99,7 +99,7 @@ namespace System.Runtime.Tests
             Assert.True(afterCompiledMethodCount == 0, $"After Compiled method count not eqeual to 0! ({afterCompiledMethodCount})");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         [SkipOnMono("Mono does not track thread specific JIT information")]
         public void JitInfoCurrentThreadIsPopulated()
         {

--- a/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
@@ -147,6 +147,7 @@ namespace System.Tests.Types
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/864", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Fact]
         public void GenericTypeArguments_Get_ReturnsExpected()
         {

--- a/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
@@ -527,6 +527,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/155", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52393", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public void GetTypeByName_InvokeViaReflection_Success()
         {
@@ -928,8 +929,15 @@ namespace System.Tests
         {
             foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
             {
-                Type t = typeof(List<>).MakeGenericType(nonRuntimeType);
-                Assert.NotNull(t);
+                if (PlatformDetection.IsReflectionEmitSupported)
+                {
+                    Type t = typeof(List<>).MakeGenericType(nonRuntimeType);
+                    Assert.NotNull(t);
+                }
+                else
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => typeof(List<>).MakeGenericType(nonRuntimeType));
+                }
             }
         }
 
@@ -1030,6 +1038,7 @@ namespace System.Tests
             };
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/861", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [Theory]
         [MemberData(nameof(GetInterfaceMap_TestData))]
         public void GetInterfaceMap(Type interfaceType, Type classType, Tuple<MethodInfo, MethodInfo>[] expectedMap)

--- a/src/libraries/System.Runtime/tests/default.rd.xml
+++ b/src/libraries/System.Runtime/tests/default.rd.xml
@@ -1,0 +1,505 @@
+<Directives>
+  <Application>
+    <Assembly Name="mscorlib" />
+    <Assembly Name="System.Threading.Overlapped">
+      <Type Name="System.Threading.Overlapped" Dynamic="Required All" />
+    </Assembly>
+
+    <Assembly Name="System.Runtime.Tests">
+      <Type Name="System.Tests.EnumTests">
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Object, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.SimpleEnum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.ByteEnum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.SByteEnum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Int16Enum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16Enum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Int32Enum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32Enum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.Int64Enum, System.Runtime.Tests" />
+        </Method>
+        <Method Name="Parse_Generic_Invalid" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64Enum, System.Runtime.Tests" />
+        </Method>
+      </Type>
+
+      <Type Name="System.Tests.ArrayTests">
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+      </Type>
+
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests">
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestNullRefReturnInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Reflection.BindingFlags, System.Private.CoreLib" />
+        </Method>
+
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnPropertyGetValue" Dynamic="Required All">
+          <GenericArgument Name="System.Reflection.BindingFlags, System.Private.CoreLib" />
+        </Method>
+
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+        <Method Name="TestRefReturnMethodInvoke" Dynamic="Required All">
+          <GenericArgument Name="System.Reflection.BindingFlags, System.Private.CoreLib" />
+        </Method>
+      </Type>
+
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Nullable`1[[System.Int32,System.Private.CoreLib]],System.Private.CoreLib]]" Dynamic="Required All" />
+
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Byte, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.SByte, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.UInt16, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Int16, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.UInt32, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Int32, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.UInt64, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Int64, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.IntPtr, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.UIntPtr, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Char, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Boolean, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Single, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Double, System.Private.CoreLib]]" Dynamic="Required All" />
+      <Type Name="System.Reflection.Tests.InvokeRefReturnNetcoreTests+TestClass`1[[System.Reflection.BindingFlags, System.Private.CoreLib]]" Dynamic="Required All" />
+
+      <Type Name="System.Reflection.Tests.MethodBaseTests">
+        <Method Name="MyFakeGenericMethod" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+      </Type>
+
+      <Type Name="System.Tests.ArrayTests">
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Sort_Array_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+
+        <Method Name="BinarySearch_TypesNotIComparable_ThrowsInvalidOperationException" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_TypesNotIComparable_ThrowsInvalidOperationException" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_TypesNotIComparable_ThrowsInvalidOperationException" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+SByteEnum" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int16Enum" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int32Enum" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int64Enum" />
+        </Method>
+        <Method Name="IndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+NonGenericStruct" />
+        </Method>
+
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+SByteEnum" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int16Enum" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int32Enum" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int64Enum" />
+        </Method>
+        <Method Name="LastIndexOf_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+NonGenericStruct" />
+        </Method>
+
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.IntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.UIntPtr, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="BinarySearch_SZArray" Dynamic="Required All">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.ByteEnum" />
+        </Method>
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int16Enum" />
+        </Method>
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int32Enum" />
+        </Method>
+        <Method Name="Fill_Generic" Dynamic="Required All">
+          <GenericArgument Name="System.Tests.ArrayTests+Int64Enum" />
+        </Method>
+      </Type>
+
+      <Type Name="System.Tests.ArrayTests+GenericStruct`1[[System.Int32,System.Private.CoreLib]][]" Dynamic="Required All" />
+    </Assembly>
+
+    <Assembly Name="System.Private.CoreLib">
+      <Type Name="System.Array">
+        <Method Name="Resize" Dynamic="Required All">
+          <GenericArgument Name="System.Runtime.CompilerServices.Tests.RuntimeHelpersTests+TestStruct, System.Runtime.Tests" />
+        </Method>
+      </Type>
+
+    </Assembly>
+  </Application>
+</Directives>


### PR DESCRIPTION
Adds `ActiveIssue`/`Conditional` attributes to libraries tests so that we can get a clean run with NativeAOT.

Starting with System.Collections, System.Runtime, and System.IO.FileSystem.