### PR TITLE
Improve Directory.Move and DirectoryInfo.MoveTo

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Rename.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Rename.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 internal static partial class Interop
 {
@@ -18,5 +19,20 @@ internal static partial class Interop
         /// </returns>
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Rename", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial int Rename(string oldPath, string newPath);
+
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Rename", SetLastError = true)]
+        internal static partial int Rename(ref byte oldPath, ref byte newPath);
+
+        internal static int Rename(ReadOnlySpan<char> oldPath, ReadOnlySpan<char> newPath)
+        {
+            ValueUtf8Converter converterNewPath = new(stackalloc byte[DefaultPathBufferSize]);
+            ValueUtf8Converter converterOldPath = new(stackalloc byte[DefaultPathBufferSize]);
+            int result = Rename(
+                ref MemoryMarshal.GetReference(converterOldPath.ConvertAndTerminateString(oldPath)),
+                ref MemoryMarshal.GetReference(converterNewPath.ConvertAndTerminateString(newPath)));
+            converterNewPath.Dispose();
+            converterOldPath.Dispose();
+            return result;
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Move.cs
@@ -180,7 +180,7 @@ namespace System.IO.Tests
             string testDirDest = Path.Combine(TestDirectory, GetTestFileName());
 
             Directory.CreateDirectory(testDirSource);
-            Directory.Move(testDirSource + Path.DirectorySeparatorChar, testDirDest + Path.DirectorySeparatorChar);
+            Move(testDirSource + Path.DirectorySeparatorChar, testDirDest + Path.DirectorySeparatorChar);
             Assert.True(Directory.Exists(testDirDest));
         }
 
@@ -216,7 +216,7 @@ namespace System.IO.Tests
         public void ThrowIOExceptionWhenMovingDirectoryToItself()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
-            Assert.Throws<IOException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "foo")));
+            Assert.Throws<IOException>(() => Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "foo")));
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
             Directory.CreateDirectory(Path.Combine(TestDirectory, "bar", "foo"));
-            Assert.Throws<IOException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "foo")));
+            Assert.Throws<IOException>(() => Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "foo")));
         }
 
         [Fact]
@@ -233,7 +233,7 @@ namespace System.IO.Tests
             Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
             var otherDirectory = Path.Combine(TestDirectory, "bar");
             Directory.CreateDirectory(Path.Combine(otherDirectory));
-            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(otherDirectory, "FOO"));
+            Move(Path.Combine(TestDirectory, "foo"), Path.Combine(otherDirectory, "FOO"));
             Assert.True(Directory.Exists(Path.Combine(otherDirectory, "FOO")));
             Assert.False(Directory.Exists(Path.Combine(TestDirectory, "foo")));
         }
@@ -245,7 +245,7 @@ namespace System.IO.Tests
             var fooDirectoryUppercase = Path.Combine(TestDirectory, "FOO");
             Directory.CreateDirectory(fooDirectory);
             File.WriteAllText(Path.Combine(fooDirectory, "bar.txt"), string.Empty);
-            Directory.Move(fooDirectory, fooDirectoryUppercase);
+            Move(fooDirectory, fooDirectoryUppercase);
             var firstFile = Directory.GetFiles(fooDirectoryUppercase);
             Assert.Equal("bar.txt", Path.GetFileName(firstFile[0]));
         }
@@ -255,7 +255,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory($"{TestDirectory}/bar");
             var root = Path.GetPathRoot(TestDirectory);
-            Directory.Move($"{TestDirectory}/bar".Replace(root, root.ToLower()), $"{TestDirectory}/foo");
+            Move($"{TestDirectory}/bar".Replace(root, root.ToLower()), $"{TestDirectory}/foo");
             Assert.True(Directory.Exists($"{TestDirectory}/foo"));
             Assert.False(Directory.Exists($"{TestDirectory}/bar"));
         }
@@ -267,7 +267,7 @@ namespace System.IO.Tests
             var fooDirectoryPathUpperCase = Path.Combine(TestDirectory, "FOO");
             Directory.CreateDirectory(fooDirectoryPath);
             Directory.CreateDirectory(Path.Combine(fooDirectoryPath, "bar"));
-            Directory.Move(fooDirectoryPath, fooDirectoryPathUpperCase);
+            Move(fooDirectoryPath, fooDirectoryPathUpperCase);
             var firstFile = Directory.GetDirectories(fooDirectoryPathUpperCase);
             Assert.Equal("bar", Path.GetFileName(firstFile[0]));
         }
@@ -282,7 +282,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
             Directory.CreateDirectory(Path.Combine(TestDirectory, "bar"));
-            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "FOO"));
+            Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "FOO"));
         }
 
         [Fact]
@@ -290,7 +290,7 @@ namespace System.IO.Tests
         public void DirectoryWithDifferentCasingThanFileSystem_ToItself()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
-            Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "FOO"));
+            Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "FOO"));
             Assert.True(Directory.Exists(Path.Combine(TestDirectory, "FOO")));
         }
 
@@ -300,7 +300,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
             Directory.CreateDirectory(Path.Combine(TestDirectory, "bar"));
-            Assert.Throws<DirectoryNotFoundException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "FOO")));
+            Assert.Throws<DirectoryNotFoundException>(() => Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "bar", "FOO")));
         }
 
         [Fact]
@@ -308,7 +308,7 @@ namespace System.IO.Tests
         public void DirectoryWithDifferentCasingThanFileSystem_ToItself_CaseSensitiveOS()
         {
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO"));
-            Assert.Throws<DirectoryNotFoundException>(() => Directory.Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "FOO")));
+            Assert.Throws<DirectoryNotFoundException>(() => Move(Path.Combine(TestDirectory, "foo"), Path.Combine(TestDirectory, "FOO")));
         }
 
         [Fact]
@@ -320,7 +320,7 @@ namespace System.IO.Tests
             Directory.CreateDirectory(Path.Combine(TestDirectory, "FOO", "bar"));
             Directory.CreateDirectory(Path.Combine(TestDirectory, "foo"));
 
-            Assert.Throws<IOException>(() => Directory.Move(directoryToBeMoved, Path.Combine(newPath, "bar")));
+            Assert.Throws<IOException>(() => Move(directoryToBeMoved, Path.Combine(newPath, "bar")));
         }
 
         [Fact]
@@ -329,7 +329,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");
             Directory.CreateDirectory($"{TestDirectory}/bar/foo");
-            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo"));
+            Assert.Throws<IOException>(() => Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo"));
         }
 
         [Fact]
@@ -338,7 +338,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory($"{TestDirectory}/FOO");
             Directory.CreateDirectory($"{TestDirectory}/bar/foo");
-            Directory.Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo");
+            Move($"{TestDirectory}/FOO", $"{TestDirectory}/bar/foo");
             Assert.True(Directory.Exists(Path.Combine(TestDirectory, "bar", "foo")));
         }
 
@@ -348,7 +348,7 @@ namespace System.IO.Tests
         {
             Directory.CreateDirectory($"{TestDirectory}/bar/FOO");
             Directory.CreateDirectory($"{TestDirectory}/foo");
-            Assert.Throws<IOException>(() => Directory.Move($"{TestDirectory}/foo", $"{TestDirectory}/bar/foo"));
+            Assert.Throws<IOException>(() => Move($"{TestDirectory}/foo", $"{TestDirectory}/bar/foo"));
         }
 
         [ConditionalFact(nameof(AreAllLongPathsAvailable))]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -248,10 +248,7 @@ namespace System.IO
             if (destDirName.Length == 0)
                 throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destDirName));
 
-            string destinationFullPath = Path.GetFullPath(destDirName);
-            string destinationWithSeparator = PathInternal.EnsureTrailingSeparator(destinationFullPath);
-
-            FileSystem.MoveDirectory(Path.GetFullPath(sourceDirName), destinationFullPath, destinationWithSeparator);
+            FileSystem.MoveDirectory(Path.GetFullPath(sourceDirName), Path.GetFullPath(destDirName));
         }
 
         public static void Delete(string path)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -248,48 +248,10 @@ namespace System.IO
             if (destDirName.Length == 0)
                 throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destDirName));
 
-            string fullsourceDirName = Path.GetFullPath(sourceDirName);
-            string sourcePath = PathInternal.EnsureTrailingSeparator(fullsourceDirName);
+            string destinationFullPath = Path.GetFullPath(destDirName);
+            string destinationWithSeparator = PathInternal.EnsureTrailingSeparator(destinationFullPath);
 
-            string fulldestDirName = Path.GetFullPath(destDirName);
-            string destPath = PathInternal.EnsureTrailingSeparator(fulldestDirName);
-
-            ReadOnlySpan<char> sourceDirNameFromFullPath = Path.GetFileName(fullsourceDirName.AsSpan());
-            ReadOnlySpan<char> destDirNameFromFullPath = Path.GetFileName(fulldestDirName.AsSpan());
-
-            StringComparison fileSystemSensitivity = PathInternal.StringComparison;
-            bool directoriesAreCaseVariants =
-                !sourceDirNameFromFullPath.SequenceEqual(destDirNameFromFullPath) &&
-                sourceDirNameFromFullPath.Equals(destDirNameFromFullPath, StringComparison.OrdinalIgnoreCase);
-            bool sameDirectoryDifferentCase =
-                directoriesAreCaseVariants &&
-                destDirNameFromFullPath.Equals(sourceDirNameFromFullPath, fileSystemSensitivity);
-
-            // If the destination directories are the exact same name
-            if (!sameDirectoryDifferentCase && string.Equals(sourcePath, destPath, fileSystemSensitivity))
-                throw new IOException(SR.IO_SourceDestMustBeDifferent);
-
-            ReadOnlySpan<char> sourceRoot = Path.GetPathRoot(sourcePath.AsSpan());
-            ReadOnlySpan<char> destinationRoot = Path.GetPathRoot(destPath.AsSpan());
-
-            // Compare paths for the same, skip this step if we already know the paths are identical.
-            if (!sourceRoot.Equals(destinationRoot, StringComparison.OrdinalIgnoreCase))
-                throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
-
-            // Windows will throw if the source file/directory doesn't exist, we preemptively check
-            // to make sure our cross platform behavior matches .NET Framework behavior.
-            if (!FileSystem.DirectoryExists(fullsourceDirName) && !FileSystem.FileExists(fullsourceDirName))
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, fullsourceDirName));
-
-            if (!sameDirectoryDifferentCase // This check is to allow renaming of directories
-                && FileSystem.DirectoryExists(fulldestDirName))
-                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
-
-            // If the directories aren't the same and the OS says the directory exists already, fail.
-            if (!sameDirectoryDifferentCase && Directory.Exists(fulldestDirName))
-                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, fulldestDirName));
-
-            FileSystem.MoveDirectory(fullsourceDirName, fulldestDirName);
+            FileSystem.MoveDirectory(Path.GetFullPath(sourceDirName), destinationFullPath, destinationWithSeparator);
         }
 
         public static void Delete(string path)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
@@ -194,13 +194,11 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destDirName));
 
             string destination = Path.GetFullPath(destDirName);
-            string destinationWithSeparator = PathInternal.EnsureTrailingSeparator(destination);
 
-            FileSystem.MoveDirectory(FullPath, destination, destinationWithSeparator,
-                OperatingSystem.IsWindows() ? null : Exists); // on Windows we don't need to perform the extra check
+            FileSystem.MoveDirectory(FullPath, destination);
 
             Init(originalPath: destDirName,
-                 fullPath: destinationWithSeparator,
+                 fullPath: PathInternal.EnsureTrailingSeparator(destination),
                  fileName: null,
                  isNormalized: true);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
@@ -194,28 +194,9 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destDirName));
 
             string destination = Path.GetFullPath(destDirName);
-
             string destinationWithSeparator = PathInternal.EnsureTrailingSeparator(destination);
-            string sourceWithSeparator = PathInternal.EnsureTrailingSeparator(FullPath);
 
-            if (string.Equals(sourceWithSeparator, destinationWithSeparator, PathInternal.StringComparison))
-                throw new IOException(SR.IO_SourceDestMustBeDifferent);
-
-            string? sourceRoot = Path.GetPathRoot(sourceWithSeparator);
-            string? destinationRoot = Path.GetPathRoot(destinationWithSeparator);
-
-            if (!string.Equals(sourceRoot, destinationRoot, PathInternal.StringComparison))
-                throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
-
-            // Windows will throw if the source file/directory doesn't exist, we preemptively check
-            // to make sure our cross platform behavior matches .NET Framework behavior.
-            if (!Exists && !FileSystem.FileExists(FullPath))
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, FullPath));
-
-            if (FileSystem.DirectoryExists(destination))
-                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destinationWithSeparator));
-
-            FileSystem.MoveDirectory(FullPath, destination);
+            FileSystem.MoveDirectory(FullPath, destination, destinationWithSeparator, Exists);
 
             Init(originalPath: destDirName,
                  fullPath: destinationWithSeparator,

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
@@ -196,7 +196,8 @@ namespace System.IO
             string destination = Path.GetFullPath(destDirName);
             string destinationWithSeparator = PathInternal.EnsureTrailingSeparator(destination);
 
-            FileSystem.MoveDirectory(FullPath, destination, destinationWithSeparator, Exists);
+            FileSystem.MoveDirectory(FullPath, destination, destinationWithSeparator,
+                OperatingSystem.IsWindows() ? null : Exists); // on Windows we don't need to perform the extra check
 
             Init(originalPath: destDirName,
                  fullPath: destinationWithSeparator,

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -387,7 +387,7 @@ namespace System.IO
             }
         }
 
-        public static void MoveDirectory(string sourceFullPath, string destFullPath)
+        private static void MoveDirectory(string sourceFullPath, string destFullPath)
         {
             // Windows doesn't care if you try and copy a file via "MoveDirectory"...
             if (FileExists(sourceFullPath))

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -387,58 +387,49 @@ namespace System.IO
             }
         }
 
-        private static void MoveDirectory(string sourceFullPath, string destFullPath, bool sameDirectoryDifferentCase, bool? sourceDirectoryExists)
+        private static void MoveDirectory(string sourceFullPath, string destFullPath, bool sameDirectoryDifferentCase)
         {
-            sourceDirectoryExists ??= DirectoryExists(sourceFullPath);
-
-            // Windows will throw if the source file/directory doesn't exist, we preemptively check
-            // to make sure our cross platform behavior matches .NET Framework behavior.
-            if (!sourceDirectoryExists.Value)
-            {
-                if (!FileExists(sourceFullPath))
-                {
-                    throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
-                }
-
-                // Windows doesn't care if you try and copy a file via "MoveDirectory"...
-                // ... but it doesn't like the source to have a trailing slash ...
-
-                // On Windows we end up with ERROR_INVALID_NAME, which is
-                // "The filename, directory name, or volume label syntax is incorrect."
-                //
-                // This surfaces as an IOException, if we let it go beyond here it would
-                // give DirectoryNotFound.
-
-                if (Path.EndsInDirectorySeparator(sourceFullPath))
-                {
-                    throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
-                }
-
-                // ... but it doesn't care if the destination has a trailing separator.
-                destFullPath = Path.TrimEndingDirectorySeparator(destFullPath);
-            }
+            ReadOnlySpan<char> srcNoDirectorySeparator = Path.TrimEndingDirectorySeparator(sourceFullPath.AsSpan());
+            ReadOnlySpan<char> destNoDirectorySeparator = Path.TrimEndingDirectorySeparator(destFullPath.AsSpan());
 
             if (!sameDirectoryDifferentCase) // This check is to allow renaming of directories
             {
-                if (DirectoryExists(destFullPath))
+                if (Interop.Sys.Stat(destNoDirectorySeparator, out _) >= 0)
                 {
-                    throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
-                }
-                else if (FileExists(destFullPath))
-                {
+                    // destination exists, but before we throw we need to check whether source exists or not
+
+                    // Windows will throw if the source file/directory doesn't exist, we preemptively check
+                    // to make sure our cross platform behavior matches .NET Framework behavior.
+                    if (Interop.Sys.Stat(srcNoDirectorySeparator, out Interop.Sys.FileStatus sourceFileStatus) < 0)
+                    {
+                        throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+                    }
+                    else if ((sourceFileStatus.Mode & Interop.Sys.FileTypes.S_IFMT) != Interop.Sys.FileTypes.S_IFDIR
+                        && Path.EndsInDirectorySeparator(sourceFullPath))
+                    {
+                        throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+                    }
+
                     // Some Unix distros will overwrite the destination file if it already exists.
                     // Throwing IOException to match Windows behavior.
                     throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
                 }
             }
 
-            if (Interop.Sys.Rename(sourceFullPath, destFullPath) < 0)
+            if (Interop.Sys.Rename(sourceFullPath, destNoDirectorySeparator) < 0)
             {
                 Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
                 switch (errorInfo.Error)
                 {
                     case Interop.Error.EACCES: // match Win32 exception
                         throw new IOException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, sourceFullPath), errorInfo.RawErrno);
+                    case Interop.Error.ENOENT:
+                        throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path,
+                            Interop.Sys.Stat(srcNoDirectorySeparator, out _) >= 0
+                                ? destFullPath // the source directory exists, so destination does not. Example: Move("/tmp/existing/", "/tmp/nonExisting1/nonExisting2/")
+                                : sourceFullPath));
+                    case Interop.Error.ENOTDIR: // sourceFullPath exists and it's not a directory
+                        throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
                     default:
                         throw Interop.GetExceptionForIoErrno(errorInfo, isDirectory: true);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -154,7 +154,7 @@ namespace System.IO
             return data.ftLastWriteTime.ToDateTimeOffset();
         }
 
-        private static void MoveDirectory(string sourceFullPath, string destFullPath, bool sameDirectoryDifferentCase, bool? sourceDirectoryExists)
+        private static void MoveDirectory(string sourceFullPath, string destFullPath, bool sameDirectoryDifferentCase)
         {
             if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, overwrite: false))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -154,7 +154,7 @@ namespace System.IO
             return data.ftLastWriteTime.ToDateTimeOffset();
         }
 
-        public static void MoveDirectory(string sourceFullPath, string destFullPath)
+        private static void MoveDirectory(string sourceFullPath, string destFullPath)
         {
             if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, overwrite: false))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -154,7 +154,7 @@ namespace System.IO
             return data.ftLastWriteTime.ToDateTimeOffset();
         }
 
-        private static void MoveDirectory(string sourceFullPath, string destFullPath)
+        private static void MoveDirectory(string sourceFullPath, string destFullPath, bool sameDirectoryDifferentCase, bool? sourceDirectoryExists)
         {
             if (!Interop.Kernel32.MoveFile(sourceFullPath, destFullPath, overwrite: false))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
@@ -20,5 +20,52 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_InvalidPathChars, argName);
             }
         }
+
+        internal static void MoveDirectory(string sourceFullPath, string destFullPath, string destinationWithSeparator, bool? sourceDirectoryExists = default)
+        {
+            string sourcePath = PathInternal.EnsureTrailingSeparator(sourceFullPath);
+
+            ReadOnlySpan<char> sourceDirNameFromFullPath = Path.GetFileName(sourceFullPath.AsSpan());
+            ReadOnlySpan<char> destDirNameFromFullPath = Path.GetFileName(destFullPath.AsSpan());
+
+            StringComparison fileSystemSensitivity = PathInternal.StringComparison;
+            bool directoriesAreCaseVariants =
+                !sourceDirNameFromFullPath.SequenceEqual(destDirNameFromFullPath) &&
+                sourceDirNameFromFullPath.Equals(destDirNameFromFullPath, StringComparison.OrdinalIgnoreCase);
+            bool sameDirectoryDifferentCase =
+                directoriesAreCaseVariants &&
+                destDirNameFromFullPath.Equals(sourceDirNameFromFullPath, fileSystemSensitivity);
+
+            // If the destination directories are the exact same name
+            if (!sameDirectoryDifferentCase && string.Equals(sourcePath, destinationWithSeparator, fileSystemSensitivity))
+                throw new IOException(SR.IO_SourceDestMustBeDifferent);
+
+            ReadOnlySpan<char> sourceRoot = Path.GetPathRoot(sourcePath.AsSpan());
+            ReadOnlySpan<char> destinationRoot = Path.GetPathRoot(destinationWithSeparator.AsSpan());
+
+            // Compare paths for the same, skip this step if we already know the paths are identical.
+            if (!sourceRoot.Equals(destinationRoot, StringComparison.OrdinalIgnoreCase))
+                throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
+
+            if (sourceDirectoryExists is null)
+            {
+                sourceDirectoryExists = DirectoryExists(sourceFullPath);
+            }
+
+            // Windows will throw if the source file/directory doesn't exist, we preemptively check
+            // to make sure our cross platform behavior matches .NET Framework behavior.
+            if (!sourceDirectoryExists.Value && !FileExists(sourceFullPath))
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+
+            if (!sameDirectoryDifferentCase // This check is to allow renaming of directories
+                && DirectoryExists(destFullPath))
+                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
+
+            // If the directories aren't the same and the OS says the directory exists already, fail.
+            if (!sameDirectoryDifferentCase && Directory.Exists(destFullPath))
+                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
+
+            MoveDirectory(sourceFullPath, destFullPath);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
@@ -21,9 +21,10 @@ namespace System.IO
             }
         }
 
-        internal static void MoveDirectory(string sourceFullPath, string destFullPath, string destinationWithSeparator, bool? sourceDirectoryExists = default)
+        internal static void MoveDirectory(string sourceFullPath, string destFullPath)
         {
-            string sourcePath = PathInternal.EnsureTrailingSeparator(sourceFullPath);
+            ReadOnlySpan<char> srcNoDirectorySeparator = Path.TrimEndingDirectorySeparator(sourceFullPath.AsSpan());
+            ReadOnlySpan<char> destNoDirectorySeparator = Path.TrimEndingDirectorySeparator(destFullPath.AsSpan());
 
             ReadOnlySpan<char> sourceDirNameFromFullPath = Path.GetFileName(sourceFullPath.AsSpan());
             ReadOnlySpan<char> destDirNameFromFullPath = Path.GetFileName(destFullPath.AsSpan());
@@ -37,17 +38,17 @@ namespace System.IO
                 destDirNameFromFullPath.Equals(sourceDirNameFromFullPath, fileSystemSensitivity);
 
             // If the destination directories are the exact same name
-            if (!sameDirectoryDifferentCase && string.Equals(sourcePath, destinationWithSeparator, fileSystemSensitivity))
+            if (!sameDirectoryDifferentCase && srcNoDirectorySeparator.Equals(destNoDirectorySeparator, fileSystemSensitivity))
                 throw new IOException(SR.IO_SourceDestMustBeDifferent);
 
-            ReadOnlySpan<char> sourceRoot = Path.GetPathRoot(sourcePath.AsSpan());
-            ReadOnlySpan<char> destinationRoot = Path.GetPathRoot(destinationWithSeparator.AsSpan());
+            ReadOnlySpan<char> sourceRoot = Path.GetPathRoot(srcNoDirectorySeparator);
+            ReadOnlySpan<char> destinationRoot = Path.GetPathRoot(destNoDirectorySeparator);
 
             // Compare paths for the same, skip this step if we already know the paths are identical.
             if (!sourceRoot.Equals(destinationRoot, StringComparison.OrdinalIgnoreCase))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
-            MoveDirectory(sourceFullPath, destFullPath, sameDirectoryDifferentCase, sourceDirectoryExists);
+            MoveDirectory(sourceFullPath, destFullPath, sameDirectoryDifferentCase);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
@@ -61,10 +61,6 @@ namespace System.IO
                 && DirectoryExists(destFullPath))
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
 
-            // If the directories aren't the same and the OS says the directory exists already, fail.
-            if (!sameDirectoryDifferentCase && Directory.Exists(destFullPath))
-                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
-
             MoveDirectory(sourceFullPath, destFullPath);
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
@@ -47,21 +47,7 @@ namespace System.IO
             if (!sourceRoot.Equals(destinationRoot, StringComparison.OrdinalIgnoreCase))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
 
-            if (sourceDirectoryExists is null)
-            {
-                sourceDirectoryExists = DirectoryExists(sourceFullPath);
-            }
-
-            // Windows will throw if the source file/directory doesn't exist, we preemptively check
-            // to make sure our cross platform behavior matches .NET Framework behavior.
-            if (!sourceDirectoryExists.Value && !FileExists(sourceFullPath))
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
-
-            if (!sameDirectoryDifferentCase // This check is to allow renaming of directories
-                && DirectoryExists(destFullPath))
-                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
-
-            MoveDirectory(sourceFullPath, destFullPath);
+            MoveDirectory(sourceFullPath, destFullPath, sameDirectoryDifferentCase, sourceDirectoryExists);
         }
     }
 }


### PR DESCRIPTION
Fixes #63287

Explanation: `Directory.Move` already contained the bug fix (https://github.com/dotnet/corefx/pull/40570), so I've just moved this logic to `FileSystem.MoveDirectory` and now both `Directory.Move` and `DirectoryInfo.MoveTo` are using the same code.

Update: I've found few places for improvements and reduced the number of sys-calls and got allocations to zero.

Explanation:
 * on Windows, there is no need to perform checks for file/dictionary existence, the sys-call that we use takes care of that.
 * on Unix, the `rename` sys-call overwrites destination if it exists. To keep old .NET Framework behavior that is inherited from Windows, we perform a check for file/dictionary existence before calling `rename`. But we don't need to do that for source, as `rename` is just going to fail if it does not exist. Moreover, there is no need to perform two sys-calls to check whether destination exists (one to check if directory exists, another to check if file exists). We can perform a single sys-call (stat) which just fails if given path does not exist.


Linux before:
 
 |      Method |     Mean |    Error |   StdDev |   Median |      Min |      Max | Allocated |
 |------------ |---------:|---------:|---------:|---------:|---------:|---------:|----------:|
 | MoveFolders | 11.10 us | 0.442 us | 0.510 us | 10.83 us | 10.61 us | 12.06 us |     144 B |
 |   MoveFiles | 11.30 us | 0.364 us | 0.405 us | 11.38 us | 10.70 us | 12.01 us |     144 B |

Linux after:

|      Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Allocated |
|------------ |---------:|----------:|----------:|---------:|---------:|---------:|----------:|
| MoveFolders | 7.569 us | 0.0945 us | 0.0838 us | 7.591 us | 7.397 us | 7.717 us |         - |
|   MoveFiles | 7.021 us | 0.2085 us | 0.2402 us | 6.985 us | 6.700 us | 7.524 us |         - |

Windows before:

|      Method |     Mean |   Error |  StdDev |   Median |      Min |      Max | Allocated |
|------------ |---------:|--------:|--------:|---------:|---------:|---------:|----------:|
| MoveFolders | 536.9 us | 3.14 us | 2.79 us | 536.5 us | 533.4 us | 542.8 us |     273 B |
|   MoveFiles | 481.0 us | 9.20 us | 8.60 us | 480.4 us | 468.9 us | 492.9 us |     273 B |

Windows after:

|      Method |     Mean |   Error |  StdDev |   Median |      Min |      Max | Allocated |
|------------ |---------:|--------:|--------:|---------:|---------:|---------:|----------:|
| MoveFolders | 506.8 us | 2.26 us | 2.01 us | 506.4 us | 504.0 us | 511.1 us |       0 B |
|   MoveFiles | 422.7 us | 4.71 us | 4.17 us | 424.1 us | 415.6 us | 427.3 us |       0 B |

Source code: https://github.com/dotnet/performance/pull/2208