### PR TITLE
Bump to macOS 10.14 minimum in libs and mono builds too

### DIFF
--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -17,7 +17,7 @@
     <tvOSVersionMin>10.0</tvOSVersionMin>
     <watchOSVersionMin>2.0</watchOSVersionMin>
     <watchOS64_32VersionMin>5.1</watchOS64_32VersionMin>
-    <macOSVersionMin>10.13</macOSVersionMin>
+    <macOSVersionMin>10.14</macOSVersionMin>
     <!-- FIXME: when we're building ios or tvOS cross-compilers hosted on OSX/arm64 targeting ios/arm64 we should set the min macOS version to 11.0, also -->
     <macOSVersionMin Condition="('$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'MacCatalyst') and '$(TargetArchitecture)' == 'arm64'">11.0</macOSVersionMin>
 

--- a/src/native/libs/build-native.sh
+++ b/src/native/libs/build-native.sh
@@ -70,14 +70,7 @@ else
     fi
 fi
 
-if [[ "$__TargetOS" == OSX ]]; then
-    # set default OSX deployment target
-    if [[ "$__BuildArch" == x64 ]]; then
-        __CMakeArgs="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 $__CMakeArgs"
-    else
-        __CMakeArgs="-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 $__CMakeArgs"
-    fi
-elif [[ "$__TargetOS" == Android && -z "$ROOTFS_DIR" ]]; then
+if [[ "$__TargetOS" == Android && -z "$ROOTFS_DIR" ]]; then
     # Android SDK defaults to c++_static; we only need C support
     __CMakeArgs="-DANDROID_STL=none $__CMakeArgs"
 elif [[ "$__TargetOS" == iOSSimulator ]]; then


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/62822 bumped the minimum CMAKE_OSX_DEPLOYMENT_TARGET to 10.14, but the libs.native and mono parts of the build still used the old 10.13 value.
In build-native.sh for libs.native we can actually remove the explicit setting since we're already setting it in eng/native/configurecompiler.cmake.