### PR TITLE
Change non-breaking spaces (U00A0) to a plain space in code files

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/Comparers/Comparer.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/Comparers/Comparer.Tests.cs
@@ -235,7 +235,7 @@ namespace System.Collections.Generic.Tests
         [Theory]
         [MemberData(nameof(NullableOfInt32ComparisonsData))]
         [MemberData(nameof(NullableOfInt32EnumComparisonsData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58933", TestPlatforms.iOS | TestPlatforms.tvOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58933", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void NullableComparisons<T>(T leftValue, bool leftHasValue, T rightValue, bool rightHasValue, int expected) where T : struct
         {
             // Comparer<T> is specialized (for perf reasons) when T : U? where U : IComparable<U>

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -42,7 +42,7 @@ namespace System.IO.FileSystem.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
         public void PropertiesOfInvalidDrive()
         {
             string invalidDriveName = "NonExistentDriveName";

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -98,7 +98,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Theory]
         [InlineData(AddressFamily.Packet)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
-        [SkipOnPlatform(TestPlatforms.Android | TestPlatforms.Linux | TestPlatforms.Browser, "Expected behavior is different on Android, Linux, or Browser")]
+        [SkipOnPlatform(TestPlatforms.Android | TestPlatforms.Linux | TestPlatforms.Browser, "Expected behavior is different on Android, Linux, or Browser")]
         public static void ToString_UnsupportedFamily_Throws(AddressFamily family)
         {
             Assert.Throws<PlatformNotSupportedException>(() => new SocketAddress(family));

--- a/src/mono/mono/tests/bug-81673-interface.cs
+++ b/src/mono/mono/tests/bug-81673-interface.cs
@@ -1,5 +1,5 @@
 // IMyInterface.cs created with MonoDevelop
-// User: lluis at 15:47 18/05/2007
+// User: lluis at 15:47 18/05/2007
 //
 
 using System;

--- a/src/mono/mono/tests/bug-81673.cs
+++ b/src/mono/mono/tests/bug-81673.cs
@@ -1,5 +1,5 @@
 // App.cs created with MonoDevelop
-// User: lluis at 15:46 18/05/2007
+// User: lluis at 15:46 18/05/2007
 //
 
 using System;
@@ -30,7 +30,7 @@ namespace Application
 			return 1;
 		}
 	}
-	
+
 	class MyClass: IMyInterface
 	{
 		public void Run ()

--- a/src/tests/Common/XUnitWrapperGenerator/TestPlatforms.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/TestPlatforms.cs
@@ -20,7 +20,7 @@ namespace Xunit
         Android = 512,
         Browser = 1024,
         MacCatalyst = 2048,
-        AnyUnix = FreeBSD | Linux | NetBSD | OSX | illumos | Solaris | iOS | tvOS | MacCatalyst | Android | Browser,
+        AnyUnix = FreeBSD | Linux | NetBSD | OSX | illumos | Solaris | iOS | tvOS | MacCatalyst | Android | Browser,
         Any = ~0
     }
 }

--- a/src/tests/Interop/PInvoke/BestFitMapping/Test.cs
+++ b/src/tests/Interop/PInvoke/BestFitMapping/Test.cs
@@ -38,13 +38,13 @@ internal unsafe class Test
         T invalid = data.Invalid;
         if (shouldThrowOnInvalid)
         {
-            Assert.Throws<ArgumentException>(() => funcs.In(invalid));
+            Assert.Throws<ArgumentException>(() => funcs.In(invalid));
 
             invalid = data.Invalid;
-            Assert.Throws<ArgumentException>(() => funcs.InByRef(ref invalid));
+            Assert.Throws<ArgumentException>(() => funcs.InByRef(ref invalid));
 
             invalid = data.Invalid;
-            Assert.Throws<ArgumentException>(() => funcs.InOutByRef(ref invalid));
+            Assert.Throws<ArgumentException>(() => funcs.InOutByRef(ref invalid));
         }
         else
         {


### PR DESCRIPTION
This changes some non-breaking space characters to regular space characters in C# source files. Visual Studio Code flags these as invisible and highlights them as irregular (See [VS Code's release notes][notes]). I don't see why we need to use a non-breaking space in the locations I found, so I changed them to make VS Code stop drawing attention to them.

If we want to allow non-breaking spaces in source files then we can create a `settings.json` for VS Code to allowlist it by adding `editor.unicodeHighlight.allowedCharacters` to it.

[notes]: https://code.visualstudio.com/updates/v1_63#_unicode-highlighting