### PR TITLE
Unify reading from procfs to get network related information

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
+
 namespace System.Net.NetworkInformation
 {
     internal static class NetworkFiles

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkFiles.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
-
 namespace System.Net.NetworkInformation
 {
     internal static class NetworkFiles

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
@@ -86,7 +86,7 @@ namespace System.Net.NetworkInformation
             {
                 if (File.Exists(filePath)) // avoid an exception in most cases if path doesn't already exist
                 {
-                    string fileContents = File.ReadAllText(filePath);
+                    string fileContents = ReadAllText(filePath);
                     int leaseIndex = -1;
                     int secondBrace = -1;
                     while ((leaseIndex = fileContents.IndexOf("lease", leaseIndex + 1, StringComparison.Ordinal)) != -1)
@@ -128,7 +128,7 @@ namespace System.Net.NetworkInformation
             {
                 if (File.Exists(smbConfFilePath)) // avoid an exception in most cases if path doesn't already exist
                 {
-                    string fileContents = File.ReadAllText(smbConfFilePath);
+                    string fileContents = ReadAllText(smbConfFilePath);
                     string label = "wins server = ";
                     int labelIndex = fileContents.IndexOf(label);
                     int labelLineStart = fileContents.LastIndexOf(Environment.NewLine, labelIndex, StringComparison.Ordinal);

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -13,13 +13,8 @@ namespace System.Net.NetworkInformation
 
         internal static int ParseNumSocketConnections(string filePath, string protocolName)
         {
-            if (!File.Exists(filePath))
-            {
-                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-            }
-
             // Parse the number of active connections out of /proc/net/sockstat
-            string sockstatFile = File.ReadAllText(filePath);
+            string sockstatFile = ReadAllText(filePath);
             int indexOfTcp = sockstatFile.IndexOf(protocolName, StringComparison.Ordinal);
             int endOfTcpLine = sockstatFile.IndexOf(Environment.NewLine, indexOfTcp + 1, StringComparison.Ordinal);
             string tcpLineData = sockstatFile.Substring(indexOfTcp, endOfTcpLine - indexOfTcp);
@@ -31,15 +26,10 @@ namespace System.Net.NetworkInformation
 
         internal static TcpConnectionInformation[] ParseActiveTcpConnectionsFromFiles(string tcp4ConnectionsFile, string tcp6ConnectionsFile)
         {
-            if (!File.Exists(tcp4ConnectionsFile) || !File.Exists(tcp6ConnectionsFile))
-            {
-                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-            }
-
-            string tcp4FileContents = File.ReadAllText(tcp4ConnectionsFile);
+            string tcp4FileContents = ReadAllText(tcp4ConnectionsFile);
             string[] v4connections = tcp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-            string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
+            string tcp6FileContents = ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
             // First line is header in each file. On WSL, this file may be empty.
@@ -99,15 +89,10 @@ namespace System.Net.NetworkInformation
 
         internal static IPEndPoint[] ParseActiveTcpListenersFromFiles(string tcp4ConnectionsFile, string tcp6ConnectionsFile)
         {
-            if (!File.Exists(tcp4ConnectionsFile) || !File.Exists(tcp6ConnectionsFile))
-            {
-                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-            }
-
-            string tcp4FileContents = File.ReadAllText(tcp4ConnectionsFile);
+            string tcp4FileContents = ReadAllText(tcp4ConnectionsFile);
             string[] v4connections = tcp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-            string tcp6FileContents = File.ReadAllText(tcp6ConnectionsFile);
+            string tcp6FileContents = ReadAllText(tcp6ConnectionsFile);
             string[] v6connections = tcp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
             // First line is header in each file. On WSL, this file may be empty.
@@ -167,15 +152,10 @@ namespace System.Net.NetworkInformation
 
         public static IPEndPoint[] ParseActiveUdpListenersFromFiles(string udp4File, string udp6File)
         {
-            if (!File.Exists(udp4File) || !File.Exists(udp6File))
-            {
-                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
-            }
-
-            string udp4FileContents = File.ReadAllText(udp4File);
+            string udp4FileContents = ReadAllText(udp4File);
             string[] v4connections = udp4FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-            string udp6FileContents = File.ReadAllText(udp6File);
+            string udp6FileContents = ReadAllText(udp6File);
             string[] v6connections = udp6FileContents.Split(s_newLineSeparator, StringSplitOptions.RemoveEmptyEntries);
 
             // First line is header in each file. On WSL, this file may be empty.

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Misc.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Misc.cs
@@ -8,9 +8,50 @@ namespace System.Net.NetworkInformation
 {
     internal static partial class StringParsingHelpers
     {
+        // in some environments (restricted docker container, shared hosting etc.),
+        // procfs is not accessible and we get UnauthorizedAccessException while the
+        // inner exception is set to IOException.
+
+        internal static string[] ReadAllLines(string filePath)
+        {
+            try
+            {
+                return File.ReadAllLines(filePath);
+            }
+            catch (Exception e)
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform, e);
+            }
+        }
+
+        internal static string ReadAllText(string filePath)
+        {
+            try
+            {
+                return File.ReadAllText(filePath);
+            }
+            catch (Exception e)
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform, e);
+            }
+        }
+
+
+        internal static StreamReader OpenStreamReader(string filePath)
+        {
+            try
+            {
+                return new StreamReader(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false));
+            }
+            catch (Exception e)
+            {
+                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform, e);
+            }
+        }
+
         internal static int ParseNumRoutesFromRouteFile(string filePath)
         {
-            string routeFile = File.ReadAllText(filePath);
+            string routeFile = ReadAllText(filePath);
             return CountOccurrences(Environment.NewLine, routeFile) - 1; // File includes one-line header
         }
 
@@ -34,7 +75,7 @@ namespace System.Net.NetworkInformation
         internal static int ParseDefaultTtlFromFile(string filePath)
         {
             // snmp6 does not include Default TTL info. Read it from snmp.
-            string snmp4FileContents = File.ReadAllText(filePath);
+            string snmp4FileContents = ReadAllText(filePath);
             int firstIpHeader = snmp4FileContents.IndexOf("Ip:", StringComparison.Ordinal);
             int secondIpHeader = snmp4FileContents.IndexOf("Ip:", firstIpHeader + 1, StringComparison.Ordinal);
             int endOfSecondLine = snmp4FileContents.IndexOf(Environment.NewLine, secondIpHeader, StringComparison.Ordinal);
@@ -49,7 +90,7 @@ namespace System.Net.NetworkInformation
         internal static int ParseRawIntFile(string filePath)
         {
             int ret;
-            if (!int.TryParse(File.ReadAllText(filePath).Trim(), out ret))
+            if (!int.TryParse(ReadAllText(filePath).Trim(), out ret))
             {
                 throw ExceptionHelper.CreateForParseFailure();
             }
@@ -60,7 +101,7 @@ namespace System.Net.NetworkInformation
         internal static long ParseRawLongFile(string filePath)
         {
             long ret;
-            if (!long.TryParse(File.ReadAllText(filePath).Trim(), out ret))
+            if (!long.TryParse(ReadAllText(filePath).Trim(), out ret))
             {
                 throw ExceptionHelper.CreateForParseFailure();
             }
@@ -70,7 +111,7 @@ namespace System.Net.NetworkInformation
 
         internal static int ParseRawHexFileAsInt(string filePath)
         {
-            return Convert.ToInt32(File.ReadAllText(filePath).Trim(), 16);
+            return Convert.ToInt32(ReadAllText(filePath).Trim(), 16);
         }
 
         private static int CountOccurrences(string value, string candidate)

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Misc.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Misc.cs
@@ -20,7 +20,7 @@ namespace System.Net.NetworkInformation
             }
             catch (Exception e)
             {
-                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform, e);
+                throw CreateNetworkInformationException(e);
             }
         }
 
@@ -32,7 +32,7 @@ namespace System.Net.NetworkInformation
             }
             catch (Exception e)
             {
-                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform, e);
+                throw CreateNetworkInformationException(e);
             }
         }
 
@@ -45,8 +45,19 @@ namespace System.Net.NetworkInformation
             }
             catch (Exception e)
             {
-                throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform, e);
+                throw CreateNetworkInformationException(e);
             }
+        }
+
+        internal static NetworkInformationException CreateNetworkInformationException(Exception inner)
+        {
+            // Overload accepting message and inner exception is internal and thus inaccessible in
+            // the unit test project
+#if NETWORKINFORMATION_TEST
+            return new NetworkInformationException();
+#else
+            return new NetworkInformationException(SR.net_PInvokeError, inner);
+#endif
         }
 
         internal static int ParseNumRoutesFromRouteFile(string filePath)

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -175,7 +175,7 @@ namespace System.Net.NetworkInformation
         // Parses ICMP v4 statistics from /proc/net/snmp
         public static Icmpv4StatisticsTable ParseIcmpv4FromSnmpFile(string filePath)
         {
-            string fileContents = File.ReadAllText(filePath);
+            string fileContents = ReadAllText(filePath);
             int firstIpHeader = fileContents.IndexOf("Icmp:", StringComparison.Ordinal);
             int secondIpHeader = fileContents.IndexOf("Icmp:", firstIpHeader + 1, StringComparison.Ordinal);
             int inCsumErrorsIdx = fileContents.IndexOf("InCsumErrors", firstIpHeader + 1, StringComparison.Ordinal);
@@ -219,7 +219,7 @@ namespace System.Net.NetworkInformation
 
         public static Icmpv6StatisticsTable ParseIcmpv6FromSnmp6File(string filePath)
         {
-            string fileContents = File.ReadAllText(filePath);
+            string fileContents = ReadAllText(filePath);
             RowConfigReader reader = new RowConfigReader(fileContents);
             bool hasIcmp6OutErrors = fileContents.Contains("Icmp6OutErrors");
 
@@ -262,7 +262,7 @@ namespace System.Net.NetworkInformation
 
         public static IPGlobalStatisticsTable ParseIPv4GlobalStatisticsFromSnmpFile(string filePath)
         {
-            string fileContents = File.ReadAllText(filePath);
+            string fileContents = ReadAllText(filePath);
 
             int firstIpHeader = fileContents.IndexOf("Ip:", StringComparison.Ordinal);
             int secondIpHeader = fileContents.IndexOf("Ip:", firstIpHeader + 1, StringComparison.Ordinal);
@@ -300,7 +300,7 @@ namespace System.Net.NetworkInformation
         internal static IPGlobalStatisticsTable ParseIPv6GlobalStatisticsFromSnmp6File(string filePath)
         {
             // Read the remainder of statistics from snmp6.
-            string fileContents = File.ReadAllText(filePath);
+            string fileContents = ReadAllText(filePath);
             RowConfigReader reader = new RowConfigReader(fileContents);
 
             return new IPGlobalStatisticsTable()
@@ -329,7 +329,7 @@ namespace System.Net.NetworkInformation
         {
             // NOTE: There is no information in the snmp6 file regarding TCP statistics,
             // so the statistics are always pulled from /proc/net/snmp.
-            string fileContents = File.ReadAllText(filePath);
+            string fileContents = ReadAllText(filePath);
             int firstTcpHeader = fileContents.IndexOf("Tcp:", StringComparison.Ordinal);
             int secondTcpHeader = fileContents.IndexOf("Tcp:", firstTcpHeader + 1, StringComparison.Ordinal);
             int inCsumErrorsIdx = fileContents.IndexOf("InCsumErrors", firstTcpHeader + 1, StringComparison.Ordinal);
@@ -361,7 +361,7 @@ namespace System.Net.NetworkInformation
 
         internal static UdpGlobalStatisticsTable ParseUdpv4GlobalStatisticsFromSnmpFile(string filePath)
         {
-            string fileContents = File.ReadAllText(filePath);
+            string fileContents = ReadAllText(filePath);
             int firstUdpHeader = fileContents.IndexOf("Udp:", StringComparison.Ordinal);
             int secondUdpHeader = fileContents.IndexOf("Udp:", firstUdpHeader + 1, StringComparison.Ordinal);
             int inCsumErrorsIdx = fileContents.IndexOf("InCsumErrors", firstUdpHeader + 1, StringComparison.Ordinal);
@@ -385,7 +385,7 @@ namespace System.Net.NetworkInformation
 
         internal static UdpGlobalStatisticsTable ParseUdpv6GlobalStatisticsFromSnmp6File(string filePath)
         {
-            string fileContents = File.ReadAllText(filePath);
+            string fileContents = ReadAllText(filePath);
             RowConfigReader reader = new RowConfigReader(fileContents);
             bool hasUdp6Errors = fileContents.Contains("Udp6SndbufErrors");
 
@@ -403,7 +403,7 @@ namespace System.Net.NetworkInformation
 
         internal static IPInterfaceStatisticsTable ParseInterfaceStatisticsTableFromFile(string filePath, string name)
         {
-            using (StreamReader sr = new StreamReader(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false)))
+            using (StreamReader sr = OpenStreamReader(filePath))
             {
                 sr.ReadLine();
                 sr.ReadLine();

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
+    <DefineConstants>$(DefineConstants);NETWORKINFORMATION_TEST</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />


### PR DESCRIPTION
This PR makes sure undocumented exceptions like `UnauthorizedAccessException` does not bubble to user code when querying network interface information.

We will throw `NetworkInformationException` with the message "An error was encountered while querying information from the operating system." and pass the inner exception along. It seems more appropriate than `PlatformNotSupportedException` (which is currently thrown when the files do not exist).

Fixes #62513