### PR TITLE
Serialize SendPacketsAsync tests

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
+    [Collection(nameof(DisableParallelization))]
     public class SendPacketsAsync : IDisposable
     {
         private readonly ITestOutputHelper _log;
@@ -518,10 +519,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        public static bool IsNotWindows11 = !PlatformDetection.IsWindows10Version22000OrGreater;
-
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58898")]
-        [ConditionalFact(nameof(IsNotWindows11))]
+        [Fact]
         public void SendPacketsElement_FileStreamLargeOffset_Throws()
         {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true))
@@ -544,8 +542,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58898")]
-        [ConditionalFact(nameof(IsNotWindows11))]
+        [Fact]
         public void SendPacketsElement_FileStreamWithOptions_Success() {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 var element = new SendPacketsElement(stream, 0, s_testFileSize);
@@ -576,8 +573,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/58898")]
-        [ConditionalFact(nameof(IsNotWindows11))]
+        [Fact]
         public void SendPacketsElement_FileStreamMultiPartMixed_MultipleFileStreams_Success() {
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous))
             using (var stream2 = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous)) {


### PR DESCRIPTION
I believe there is a threading issue that only repros on the CI test machines, and serializing the test execution should workaround it. The change raises total execution time only by 60ms. If this fix works out we should backport it to 6.0 branches so we get clean runs there as well.

Fixes #60017
Fixes #58898
Fixes #62384
Fixes #60267
Fixes #60204

Since the root cause of the issue is not understood, it is still worth an investigation. I recommend to open a single new issue for that if this gets merged.