### PR TITLE
[wasm] Improve NodeJs + ESM workaround for require function

### DIFF
--- a/src/mono/sample/wasm/browser-nextjs/components/deepThought.js
+++ b/src/mono/sample/wasm/browser-nextjs/components/deepThought.js
@@ -11,7 +11,9 @@ async function createRuntime() {
         return createDotnetRuntime({
             configSrc: "./mono-config.json",
             disableDotnet6Compatibility: true,
-            scriptDirectory: "/",
+            locateFile: (path, prefix) => {
+                return '/' + path;
+            },
             instantiateWasm: async (imports, successCallback) => {
                 try {
                     const arrayBufferResult = await WebAssembly.instantiate(arrayBuffer, imports);

--- a/src/mono/sample/wasm/browser-webpack/app.js
+++ b/src/mono/sample/wasm/browser-webpack/app.js
@@ -5,7 +5,6 @@ async function dotnetMeaning() {
     try {
         const { BINDING } = await createDotnetRuntime({
             configSrc: "./mono-config.json",
-            scriptDirectory: "./",
         });
         const meaningFunction = BINDING.bind_static_method("[Wasm.Browser.WebPack.Sample] Sample.Test:Main");
         return meaningFunction();

--- a/src/mono/sample/wasm/console-node-es6/main.mjs
+++ b/src/mono/sample/wasm/console-node-es6/main.mjs
@@ -1,15 +1,6 @@
-import { createRequire } from 'module';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
 import createDotnetRuntime from './dotnet.js'
 
 const { MONO } = await createDotnetRuntime(() => ({
-    imports: {
-        //TODO internalize into dotnet.js if possible
-        require: createRequire(import.meta.url)
-    },
-    //TODO internalize into dotnet.js if possible
-    scriptDirectory: dirname(fileURLToPath(import.meta.url)) + '/',
     disableDotnet6Compatibility: true,
     configSrc: "./mono-config.json",
 }));

--- a/src/mono/sample/wasm/console-node-ts/main.ts
+++ b/src/mono/sample/wasm/console-node-ts/main.ts
@@ -1,15 +1,6 @@
-import { createRequire } from 'module';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
 import createDotnetRuntime from '@microsoft/dotnet-runtime'
 
 const { MONO } = await createDotnetRuntime(() => ({
-    imports: {
-        //TODO internalize into dotnet.js if possible
-        require: createRequire(import.meta.url)
-    },
-    //TODO internalize into dotnet.js if possible
-    scriptDirectory: dirname(fileURLToPath(import.meta.url)) + '/',
     disableDotnet6Compatibility: true,
     configSrc: "./mono-config.json",
 }));

--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
@@ -7,21 +7,17 @@
 const DotnetSupportLib = {
     $DOTNET: {},
     // these lines will be placed early on emscripten runtime creation, passing import and export objects into __dotnet_runtime IFFE
+    // we replace implementation of readAsync and fetch
+    // replacement of require is there for consistency with ES6 code
     $DOTNET__postset: `
-let __dotnet_replacements = {scriptDirectory, readAsync, fetch: globalThis.fetch, require};
+let __dotnet_replacements = {readAsync, fetch: globalThis.fetch, require};
 let __dotnet_exportedAPI = __dotnet_runtime.__initializeImportsAndExports(
-    { isES6:false, isGlobal:ENVIRONMENT_IS_GLOBAL, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile, quit_ }, 
+    { isESM:false, isGlobal:ENVIRONMENT_IS_GLOBAL, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile, quit_, requirePromise:Promise.resolve(require)}, 
     { mono:MONO, binding:BINDING, internal:INTERNAL, module:Module },
     __dotnet_replacements);
-
-// here we replace things which are not exposed in another way
-scriptDirectory = __dotnet_replacements.scriptDirectory;
 readAsync = __dotnet_replacements.readAsync;
 var fetch = __dotnet_replacements.fetch;
-if (ENVIRONMENT_IS_NODE) { 
-    __dirname = __dotnet_replacements.scriptDirectory; 
-    require = __dotnet_replacements.require;
-}
+require = __dotnet_replacements.requireOut;
 `,
 };
 

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -196,7 +196,6 @@ declare type DotnetModuleConfig = {
     disableDotnet6Compatibility?: boolean;
     config?: MonoConfig | MonoConfigError;
     configSrc?: string;
-    scriptDirectory?: string;
     onConfigLoaded?: (config: MonoConfig) => Promise<void>;
     onDotnetReady?: () => void;
     imports?: DotnetModuleConfigImports;

--- a/src/mono/wasm/runtime/imports.ts
+++ b/src/mono/wasm/runtime/imports.ts
@@ -14,28 +14,30 @@ export let BINDING: any;
 export let INTERNAL: any;
 
 // these are imported and re-exported from emscripten internals
-export let ENVIRONMENT_IS_GLOBAL: boolean;
+export let ENVIRONMENT_IS_ESM: boolean;
 export let ENVIRONMENT_IS_NODE: boolean;
 export let ENVIRONMENT_IS_SHELL: boolean;
 export let ENVIRONMENT_IS_WEB: boolean;
 export let locateFile: Function;
 export let quit: Function;
+export let requirePromise: Promise<Function>;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function setImportsAndExports(
-    imports: { isGlobal: boolean, isNode: boolean, isShell: boolean, isWeb: boolean, locateFile: Function, quit_: Function },
+    imports: { isESM: boolean, isNode: boolean, isShell: boolean, isWeb: boolean, locateFile: Function, quit_: Function, requirePromise: Promise<Function> },
     exports: { mono: any, binding: any, internal: any, module: any },
 ): void {
     MONO = exports.mono;
     BINDING = exports.binding;
     INTERNAL = exports.internal;
     Module = exports.module;
-    ENVIRONMENT_IS_GLOBAL = imports.isGlobal;
+    ENVIRONMENT_IS_ESM = imports.isESM;
     ENVIRONMENT_IS_NODE = imports.isNode;
     ENVIRONMENT_IS_SHELL = imports.isShell;
     ENVIRONMENT_IS_WEB = imports.isWeb;
     locateFile = imports.locateFile;
     quit = imports.quit_;
+    requirePromise = imports.requirePromise;
 }
 
 let monoConfig: MonoConfig;

--- a/src/mono/wasm/runtime/polyfills.ts
+++ b/src/mono/wasm/runtime/polyfills.ts
@@ -1,4 +1,7 @@
-import { ENVIRONMENT_IS_NODE, Module } from "./imports";
+import { ENVIRONMENT_IS_NODE, Module, requirePromise } from "./imports";
+
+let node_fs: any | undefined = undefined;
+let node_url: any | undefined = undefined;
 
 export async function fetch_like(url: string): Promise<Response> {
     try {
@@ -6,8 +9,11 @@ export async function fetch_like(url: string): Promise<Response> {
             return globalThis.fetch(url, { credentials: "same-origin" });
         }
         else if (ENVIRONMENT_IS_NODE) {
-            const node_fs = Module.imports!.require!("fs");
-            const node_url = Module.imports!.require!("url");
+            if (!node_fs) {
+                const node_require = await requirePromise;
+                node_url = node_require("url");
+                node_fs = node_require("fs");
+            }
             if (url.startsWith("file://")) {
                 url = node_url.fileURLToPath(url);
             }

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { AllAssetEntryTypes, assert, AssetEntry, CharPtrNull, DotnetModule, GlobalizationMode, MonoConfig, MonoConfigError, wasm_type_symbol } from "./types";
-import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, locateFile, Module, MONO, runtimeHelpers } from "./imports";
+import { ENVIRONMENT_IS_ESM, ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL, INTERNAL, locateFile, Module, MONO, requirePromise, runtimeHelpers } from "./imports";
 import cwraps from "./cwraps";
 import { mono_wasm_raise_debug_event, mono_wasm_runtime_ready } from "./debug";
 import { mono_wasm_globalization_init, mono_wasm_load_icu_data } from "./icu";
@@ -89,6 +89,11 @@ async function mono_wasm_pre_init(): Promise<void> {
     const moduleExt = Module as DotnetModule;
 
     Module.addRunDependency("mono_wasm_pre_init");
+
+    // wait for locateFile setup on NodeJs
+    if (ENVIRONMENT_IS_NODE && ENVIRONMENT_IS_ESM) {
+        await requirePromise;
+    }
 
     if (moduleExt.configSrc) {
         try {

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -162,7 +162,6 @@ export type DotnetModuleConfig = {
 
     config?: MonoConfig | MonoConfigError,
     configSrc?: string,
-    scriptDirectory?: string,
     onConfigLoaded?: (config: MonoConfig) => Promise<void>;
     onDotnetReady?: () => void;
 


### PR DESCRIPTION
Emscripten uses `require` function for NodeJS even in ES6 module :-(
We need https://nodejs.org/api/module.html#modulecreaterequirefilename

- In this PR I use dynamic `import` because there is no "module" module in the browser. 
- Correct `locateFile` and therefore `scriptDirectory` also depends on it on NodeJS + ESM
