### PR TITLE
Fix compilation with older gcc

### DIFF
--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -972,7 +972,7 @@ namespace BINDER_SPACE
             {
                 // Search Assembly.ni.dll, then Assembly.dll
                 // The Assembly.ni.dll paths are rare, and intended for supporting managed C++ R2R assemblies.
-                SString candidates[] = { W(".ni.dll"),  W(".dll") };
+                const WCHAR* const candidates[] = { W(".ni.dll"),  W(".dll") };
 
                 // Loop through the binding paths looking for a matching assembly
                 for (int i = 0; i < 2; i++)

--- a/src/coreclr/binder/bindertracing.cpp
+++ b/src/coreclr/binder/bindertracing.cpp
@@ -176,8 +176,8 @@ namespace BinderTracing
 {
     static thread_local bool t_AssemblyLoadStartInProgress = false;
 
-    AssemblyBindOperation::AssemblyBindOperation(AssemblySpec *assemblySpec, const WCHAR *assemblyPath)
-        : m_bindRequest { assemblySpec, nullptr, assemblyPath }
+    AssemblyBindOperation::AssemblyBindOperation(AssemblySpec *assemblySpec, const SString& assemblyPath)
+        : m_bindRequest { assemblySpec, SString::Empty(), assemblyPath }
         , m_populatedBindRequest { false }
         , m_checkedIgnoreBind { false }
         , m_ignoreBind { false }

--- a/src/coreclr/binder/inc/bindertracing.h
+++ b/src/coreclr/binder/inc/bindertracing.h
@@ -27,7 +27,7 @@ namespace BinderTracing
     {
     public:
         // This class assumes the assembly spec will have a longer lifetime than itself
-        AssemblyBindOperation(AssemblySpec *assemblySpec, const WCHAR *assemblyPath = nullptr);
+        AssemblyBindOperation(AssemblySpec *assemblySpec, const SString& assemblyPath = SString::Empty());
         ~AssemblyBindOperation();
 
         void SetResult(PEAssembly *assembly, bool cached = false);

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -28,6 +28,10 @@
 #undef min
 #undef max
 
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) (0)
+#endif
+
 #if __has_cpp_attribute(fallthrough)
 #define FALLTHROUGH [[fallthrough]]
 #else

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1735,7 +1735,7 @@ public:
     // In this case, it must be removed by GenTreeCall::ResetArgInfo.
     bool isNonStandardArgAddedLate() const
     {
-        switch (nonStandardArgKind)
+        switch (static_cast<NonStandardArgKind>(nonStandardArgKind))
         {
             case NonStandardArgKind::None:
             case NonStandardArgKind::PInvokeFrame:

--- a/src/coreclr/pal/inc/rt/sal.h
+++ b/src/coreclr/pal/inc/rt/sal.h
@@ -2862,6 +2862,10 @@ of each annotation, see the advanced annotations section.
 #define __useHeader                          _Use_decl_anno_impl_
 #define __on_failure(annotes)                _On_failure_impl_(annotes _SAL_nop_impl_)
 
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) (0)
+#endif
+
 #ifndef __fallthrough // [
 #if __has_cpp_attribute(fallthrough)
 #define __fallthrough [[fallthrough]]

--- a/src/coreclr/vm/dacenumerablehash.inl
+++ b/src/coreclr/vm/dacenumerablehash.inl
@@ -400,8 +400,8 @@ namespace HashTableDetail
 {
     // Use the C++ detection idiom (https://isocpp.org/blog/2017/09/detection-idiom-a-stopgap-for-concepts-simon-brand) to call the
     // derived table's EnumMemoryRegionsForEntry method if it defines one.
-    template<typename...>
-    using void_t = void;
+    template <class... > struct make_void { using type = void; };
+    template <class... T> using void_t = typename make_void<T...>::type;
 
     template<typename B>
     struct negation : std::integral_constant<bool, !bool(B::value)> { };

--- a/src/native/corehost/fxr/host_context.cpp
+++ b/src/native/corehost/fxr/host_context.cpp
@@ -129,8 +129,8 @@ host_context_t::host_context_t(
     const corehost_context_contract &hostpolicy_context_contract)
     : marker { valid_host_context_marker }
     , type { type }
-    , hostpolicy_contract { hostpolicy_contract }
-    , hostpolicy_context_contract { hostpolicy_context_contract }
+    , hostpolicy_contract (hostpolicy_contract)
+    , hostpolicy_context_contract (hostpolicy_context_contract)
 { }
 
 void host_context_t::initialize_frameworks(const corehost_init_t& init)

--- a/src/native/libs/Common/pal_utilities.h
+++ b/src/native/libs/Common/pal_utilities.h
@@ -43,6 +43,10 @@
 #define CONST_CAST2(TOTYPE, FROMTYPE, X) ((union { FROMTYPE _q; TOTYPE _nq; }){ ._q = (X) }._nq)
 #define CONST_CAST(TYPE, X) CONST_CAST2(TYPE, const TYPE, (X))
 
+#ifndef __has_attribute
+#define __has_attribute(x) (0)
+#endif
+
 #if __has_attribute(fallthrough)
 #define FALLTHROUGH __attribute__((fallthrough))
 #else


### PR DESCRIPTION
Currently gcc 6 onwards can compile the native components in the repo. However, the minimum supported gcc version is 4.9 per:
https://github.com/dotnet/runtime/blob/c7630198c93988fcf2cab2e6e30aadc76328e09a/eng/common/native/init-compiler.sh#L75
which was broken.