### PR TITLE
Begin using the xplat hardware intrinsics in BitArray

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -353,43 +353,24 @@ namespace System.Collections
             }
 
             uint i = 0;
-            if (Avx2.IsSupported)
+
+            ref int left = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
+            ref int right = ref MemoryMarshal.GetArrayDataReference<int>(valueArray);
+
+            if (Vector256.IsHardwareAccelerated)
             {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
+                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
                 {
-                    for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
-                    {
-                        Vector256<int> leftVec = Avx.LoadVector256(leftPtr + i);
-                        Vector256<int> rightVec = Avx.LoadVector256(rightPtr + i);
-                        Avx.Store(leftPtr + i, Avx2.And(leftVec, rightVec));
-                    }
+                    Vector256<int> result = Vector256.LoadUnsafe(ref left, i) & Vector256.LoadUnsafe(ref right, i);
+                    result.StoreUnsafe(ref left, i);
                 }
             }
-            else if (Sse2.IsSupported)
+            else if (Vector128.IsHardwareAccelerated)
             {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
+                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
                 {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> leftVec = Sse2.LoadVector128(leftPtr + i);
-                        Vector128<int> rightVec = Sse2.LoadVector128(rightPtr + i);
-                        Sse2.Store(leftPtr + i, Sse2.And(leftVec, rightVec));
-                    }
-                }
-            }
-            else if (AdvSimd.IsSupported)
-            {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
-                {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> leftVec = AdvSimd.LoadVector128(leftPtr + i);
-                        Vector128<int> rightVec = AdvSimd.LoadVector128(rightPtr + i);
-                        AdvSimd.Store(leftPtr + i, AdvSimd.And(leftVec, rightVec));
-                    }
+                    Vector128<int> result = Vector128.LoadUnsafe(ref left, i) & Vector128.LoadUnsafe(ref right, i);
+                    result.StoreUnsafe(ref left, i);
                 }
             }
 
@@ -439,43 +420,24 @@ namespace System.Collections
             }
 
             uint i = 0;
-            if (Avx2.IsSupported)
+
+            ref int left = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
+            ref int right = ref MemoryMarshal.GetArrayDataReference<int>(valueArray);
+
+            if (Vector256.IsHardwareAccelerated)
             {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
+                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
                 {
-                    for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
-                    {
-                        Vector256<int> leftVec = Avx.LoadVector256(leftPtr + i);
-                        Vector256<int> rightVec = Avx.LoadVector256(rightPtr + i);
-                        Avx.Store(leftPtr + i, Avx2.Or(leftVec, rightVec));
-                    }
+                    Vector256<int> result = Vector256.LoadUnsafe(ref left, i) | Vector256.LoadUnsafe(ref right, i);
+                    result.StoreUnsafe(ref left, i);
                 }
             }
-            else if (Sse2.IsSupported)
+            else if (Vector128.IsHardwareAccelerated)
             {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
+                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
                 {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> leftVec = Sse2.LoadVector128(leftPtr + i);
-                        Vector128<int> rightVec = Sse2.LoadVector128(rightPtr + i);
-                        Sse2.Store(leftPtr + i, Sse2.Or(leftVec, rightVec));
-                    }
-                }
-            }
-            else if (AdvSimd.IsSupported)
-            {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
-                {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> leftVec = AdvSimd.LoadVector128(leftPtr + i);
-                        Vector128<int> rightVec = AdvSimd.LoadVector128(rightPtr + i);
-                        AdvSimd.Store(leftPtr + i, AdvSimd.Or(leftVec, rightVec));
-                    }
+                    Vector128<int> result = Vector128.LoadUnsafe(ref left, i) | Vector128.LoadUnsafe(ref right, i);
+                    result.StoreUnsafe(ref left, i);
                 }
             }
 
@@ -525,43 +487,24 @@ namespace System.Collections
             }
 
             uint i = 0;
-            if (Avx2.IsSupported)
+
+            ref int left = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
+            ref int right = ref MemoryMarshal.GetArrayDataReference<int>(valueArray);
+
+            if (Vector256.IsHardwareAccelerated)
             {
-                fixed (int* leftPtr = m_array)
-                fixed (int* rightPtr = value.m_array)
+                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
                 {
-                    for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
-                    {
-                        Vector256<int> leftVec = Avx.LoadVector256(leftPtr + i);
-                        Vector256<int> rightVec = Avx.LoadVector256(rightPtr + i);
-                        Avx.Store(leftPtr + i, Avx2.Xor(leftVec, rightVec));
-                    }
+                    Vector256<int> result = Vector256.LoadUnsafe(ref left, i) ^ Vector256.LoadUnsafe(ref right, i);
+                    result.StoreUnsafe(ref left, i);
                 }
             }
-            else if (Sse2.IsSupported)
+            else if (Vector128.IsHardwareAccelerated)
             {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
+                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
                 {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> leftVec = Sse2.LoadVector128(leftPtr + i);
-                        Vector128<int> rightVec = Sse2.LoadVector128(rightPtr + i);
-                        Sse2.Store(leftPtr + i, Sse2.Xor(leftVec, rightVec));
-                    }
-                }
-            }
-            else if (AdvSimd.IsSupported)
-            {
-                fixed (int* leftPtr = thisArray)
-                fixed (int* rightPtr = valueArray)
-                {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> leftVec = AdvSimd.LoadVector128(leftPtr + i);
-                        Vector128<int> rightVec = AdvSimd.LoadVector128(rightPtr + i);
-                        AdvSimd.Store(leftPtr + i, AdvSimd.Xor(leftVec, rightVec));
-                    }
+                    Vector128<int> result = Vector128.LoadUnsafe(ref left, i) ^ Vector128.LoadUnsafe(ref right, i);
+                    result.StoreUnsafe(ref left, i);
                 }
             }
 
@@ -603,39 +546,23 @@ namespace System.Collections
             }
 
             uint i = 0;
-            if (Avx2.IsSupported)
+
+            ref int value = ref MemoryMarshal.GetArrayDataReference<int>(thisArray);
+
+            if (Vector256.IsHardwareAccelerated)
             {
-                Vector256<int> ones = Vector256.Create(-1);
-                fixed (int* ptr = thisArray)
+                for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
                 {
-                    for (; i < (uint)count - (Vector256IntCount - 1u); i += Vector256IntCount)
-                    {
-                        Vector256<int> vec = Avx.LoadVector256(ptr + i);
-                        Avx.Store(ptr + i, Avx2.Xor(vec, ones));
-                    }
+                    Vector256<int> result = ~Vector256.LoadUnsafe(ref value, i);
+                    result.StoreUnsafe(ref value, i);
                 }
             }
-            else if (Sse2.IsSupported)
+            else if (Vector128.IsHardwareAccelerated)
             {
-                Vector128<int> ones = Vector128.Create(-1);
-                fixed (int* ptr = thisArray)
+                for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
                 {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> vec = Sse2.LoadVector128(ptr + i);
-                        Sse2.Store(ptr + i, Sse2.Xor(vec, ones));
-                    }
-                }
-            }
-            else if (AdvSimd.IsSupported)
-            {
-                fixed (int* leftPtr = thisArray)
-                {
-                    for (; i < (uint)count - (Vector128IntCount - 1u); i += Vector128IntCount)
-                    {
-                        Vector128<int> leftVec = AdvSimd.LoadVector128(leftPtr + i);
-                        AdvSimd.Store(leftPtr + i, AdvSimd.Not(leftVec));
-                    }
+                    Vector128<int> result = ~Vector128.LoadUnsafe(ref value, i);
+                    result.StoreUnsafe(ref value, i);
                 }
             }
 


### PR DESCRIPTION
This itself isn't a significant change but it does represent a significant stepping stone for .NET 7 by simplifying some of the existing hardware intrinsic usage to use the "Cross Platform Hardware Intrinsics" as described in https://github.com/dotnet/runtime/issues/49397.

The user story here is that many libraries want to write performant code and the number of platforms that may need to be considered is constantly increasing. A few years ago, RyuJIT only supported x86 and x64 which were similar enough that the same code could support both. However, beginning in .NET 5 we started adding the same SIMD acceleration to ARM64 and the number of platforms expanded. Due to it being a new platform for RyuJIT, many users did not have hardware available on which to test and more so may not have been familiar with some of the intricacies of the platform making providing equivalent support sometimes difficult. This was made worse by the fact that the code paths to support the entire set of x86, x64, and ARM64 were often very similar, generally differing just in ISA (`Sse` on x86/64 vs `AdvSimd` on `Arm64`) or even naming conventions (`Horizontal` on x86/x64 vs `Pairwise` on ARM64). Finally there are potentially even more platforms that will be adding support in the future (such as `WASM`) and even existing platforms that Mono supports which likewise have their own SIMD support.

The cross platform hardware intrinsic helper APIs are the solution. These APIs provide functionality common to all the SIMD supporting platforms on the fixed-size hardware intrinsic ABI types (`Vector64<T>`, `Vector128<T>`, and `Vector256<T>`). This allows users to have a good understanding of the potential performance characteristics and iteration patterns, it allows them to utilize APIs that cannot be easily exposed on existing variable length SIMD types (such as `Vector<T>`), and it allows them to trivially fallback and utilize platform specific intrinsics where that extra bit of perf can be grabbed due to functionality only available to a singular platform since they already are using the types that the platform specific intrinsics require (`Vector64<T>`, `Vector128<T>`, and `Vector256<T>`).

`BitArray` is just the first of the BCL APIs to take advantage of these new helper APIs and it shows how simple supporting accelerated SIMD code on all the target architectures can be.