### PR TITLE
Temporarily disable coredumps during library testing on macOS

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -132,7 +132,9 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # files already in /cores/ at this point. This is being done to prevent
   # inadvertently flooding the CI machines with dumps.
   if [[ ! -d "/cores" || ! "$(ls -A /cores)" ]]; then
-    ulimit -c unlimited
+    # FIXME: temporarily disable core dumps
+    #ulimit -c unlimited
+    true
   fi
 
 elif [[ "$(uname -s)" == "Linux" ]]; then

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -133,8 +133,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # inadvertently flooding the CI machines with dumps.
   if [[ ! -d "/cores" || ! "$(ls -A /cores)" ]]; then
     # FIXME: temporarily disable core dumps
-    #ulimit -c unlimited
-    true
+    ulimit -c 0
   fi
 
 elif [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
System.Runtime.InteropServices.Tests seems to produce >10GB of coredumps which overwhelms CI.