### PR TITLE
MemoryMappedFile: don't check for file existence if there is no need

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -148,7 +148,12 @@ namespace System.IO.MemoryMappedFiles
                 throw new ArgumentException(SR.Argument_NewMMFWriteAccessNotAllowed, nameof(access));
             }
 
-            bool existed = File.Exists(path);
+            bool existed = mode switch
+            {
+                FileMode.Open => true, // if it's not true, the line below is going to throw
+                FileMode.CreateNew => false,
+                _ => File.Exists(path)
+            };
             FileStream fileStream = new FileStream(path, mode, GetFileAccess(access), FileShare.Read, 0x1000, FileOptions.None);
 
             if (capacity == 0 && fileStream.Length == 0)

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -150,7 +150,7 @@ namespace System.IO.MemoryMappedFiles
 
             bool existed = mode switch
             {
-                FileMode.Open => true, // if it's not true, the line below is going to throw
+                FileMode.Open => true, // FileStream ctor will throw if the file doesn't exist
                 FileMode.CreateNew => false,
                 _ => File.Exists(path)
             };


### PR DESCRIPTION
Specyfing `FileMode.Open` for `MemoryMappedFile.CreateFromFile` is quite common (https://github.com/dotnet/runtime/issues/62768#issuecomment-993428790), moreover it's the default value for `MemoryMappedFile.CreateFromFile(string path)`:

https://github.com/dotnet/runtime/blob/ec0c7f3a91b9fc47f7a867f0b997ba34560302e7/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs#L97

Since opening a file with `FileMode.Open` fails if it does not exist, we can avoid calling `File.Exists` in such case. Same goes for `FileMode.CreateNew` which fails if the file already exists.

Windows 11 numbers for the [following benchmarks](https://github.com/dotnet/performance/blob/8add5a29c24bd3572c257c12f8dd37afe2c553c7/src/benchmarks/micro/libraries/System.IO.MemoryMappedFiles/Perf.MemoryMappedFile.cs#L30-L38):

|         Method |           Toolchain | capacity |     Mean | Ratio |
|--------------- |-------------------- |--------- |---------:|------:|
| CreateFromFile | \exists\corerun.exe |    10000 | 42.69 us |  0.69 |
| CreateFromFile |   \main\corerun.exe |    10000 | 61.98 us |  1.00 |
|                |                     |          |          |       |
| CreateFromFile | \exists\corerun.exe |   100000 | 43.25 us |  0.69 |
| CreateFromFile |   \main\corerun.exe |   100000 | 62.63 us |  1.00 |
|                |                     |          |          |       |
| CreateFromFile | \exists\corerun.exe |  1000000 | 46.48 us |  0.72 |
| CreateFromFile |   \main\corerun.exe |  1000000 | 64.65 us |  1.00 |
|                |                     |          |          |       |
| CreateFromFile | \exists\corerun.exe | 10000000 | 57.51 us |  0.76 |
| CreateFromFile |   \main\corerun.exe | 10000000 | 75.82 us |  1.00 |


Contributes to #62768