### PR TITLE
Build all packages on source-build even when in servicing

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -23,6 +23,10 @@
                                        '$(PreReleaseVersionLabel)' != 'servicing' and
                                        '$(GitHubRepositoryName)' != 'runtimelab'">true</GeneratePackageOnBuild>
     <GeneratePackageOnBuild Condition="'$(GeneratePackageOnBuild)' != 'true'">false</GeneratePackageOnBuild>
+    <!-- When in source-build we need to generate all packages when building for all configurations even in servicing. -->
+    <GeneratePackageOnBuild Condition="!$(GeneratePackageOnBuild) and
+                                       '$(BuildAllConfigurations)' == 'true' and
+                                       '$(DotNetBuildFromSource)' == 'true'">true</GeneratePackageOnBuild>
     <!-- Search for the documentation file in the intellisense package and otherwise pick up the generated one. -->
     <LibIntellisenseDocumentationFilePath>$(XmlDocFileRoot)1033\$(AssemblyName).xml</LibIntellisenseDocumentationFilePath>
     <UseIntellisenseDocumentationFile Condition="'$(UseIntellisenseDocumentationFile)' == '' and Exists('$(LibIntellisenseDocumentationFilePath)')">true</UseIntellisenseDocumentationFile>
@@ -259,7 +263,7 @@
   </Target>
 
   <Target Name="ValidateServicingVersionIsPropertlySet"
-          Condition="'$(PreReleaseVersionLabel)' == 'servicing'"
+          Condition="'$(PreReleaseVersionLabel)' == 'servicing' and '$(DotNetBuildFromSource)' != 'true'"
           AfterTargets="GenerateNuspec">
     <Error Condition="'$(ServicingVersion)' == '0'" Text="ServicingVersion is set to 0 and it should be an increment of the patch version from the last released package." />
   </Target>


### PR DESCRIPTION
This is the main port for: https://github.com/dotnet/runtime/issues/63451 -- 6.0 change was: https://github.com/dotnet/runtime/pull/63653