### PR TITLE
Make ObjectiveC tests in System.Runtime.InteropServices.Tests check exit code for remote execution

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/MessageSendTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/MessageSendTests.cs
@@ -71,6 +71,10 @@ namespace System.Runtime.InteropServices.Tests
                 var (msgSend, func) = msgSendOverrides[0];
                 ObjectiveCMarshal.SetMessageSendCallback(msgSend, func);
                 Assert.Throws<InvalidOperationException>(() => ObjectiveCMarshal.SetMessageSendCallback(msgSend, func));
+
+                // RemoteExecutor only checks the expected exit code if the invoked function returns an int.
+                // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
+                return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
 
@@ -97,6 +101,10 @@ namespace System.Runtime.InteropServices.Tests
                 }
 
                 SetMessageSendCallbackImpl(msgSendArray);
+
+                // RemoteExecutor only checks the expected exit code if the invoked function returns an int.
+                // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
+                return RemoteExecutor.SuccessExitCode;
             }, string.Join(';', funcsToOverride)).Dispose();
         }
 
@@ -150,4 +158,3 @@ namespace System.Runtime.InteropServices.Tests
         }
     }
 }
-

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/MessageSendTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/MessageSendTests.cs
@@ -72,7 +72,8 @@ namespace System.Runtime.InteropServices.Tests
                 ObjectiveCMarshal.SetMessageSendCallback(msgSend, func);
                 Assert.Throws<InvalidOperationException>(() => ObjectiveCMarshal.SetMessageSendCallback(msgSend, func));
 
-                // RemoteExecutor only checks the expected exit code if the invoked function returns an int.
+                // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
+                // RemoteExecutor currently only checks the expected exit code if the invoked function returns an int.
                 // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
@@ -102,7 +103,8 @@ namespace System.Runtime.InteropServices.Tests
 
                 SetMessageSendCallbackImpl(msgSendArray);
 
-                // RemoteExecutor only checks the expected exit code if the invoked function returns an int.
+                // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
+                // RemoteExecutor currently only checks the expected exit code if the invoked function returns an int.
                 // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
                 return RemoteExecutor.SuccessExitCode;
             }, string.Join(';', funcsToOverride)).Dispose();

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/PendingExceptionTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/PendingExceptionTests.cs
@@ -59,6 +59,10 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.True(Enum.IsDefined<MessageSendFunction>(msgSend));
 
                 ValidateSetMessageSendPendingExceptionImpl(msgSend);
+
+                // RemoteExecutor only checks the expected exit code if the invoked function returns an int.
+                // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
+                return RemoteExecutor.SuccessExitCode;
             }, func.ToString()).Dispose();
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/PendingExceptionTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/PendingExceptionTests.cs
@@ -60,7 +60,8 @@ namespace System.Runtime.InteropServices.Tests
 
                 ValidateSetMessageSendPendingExceptionImpl(msgSend);
 
-                // RemoteExecutor only checks the expected exit code if the invoked function returns an int.
+                // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
+                // RemoteExecutor currently only checks the expected exit code if the invoked function returns an int.
                 // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
                 return RemoteExecutor.SuccessExitCode;
             }, func.ToString()).Dispose();


### PR DESCRIPTION
@AaronRobinsonMSFT @jkoritzinsky 