### PR TITLE
Fix a few IL tests using the namespace syntax without an actual namespace

### DIFF
--- a/src/tests/JIT/Methodical/nonvirtualcall/classic.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/classic.il
@@ -30,8 +30,8 @@
 .corflags 0x00000001    //  ILONLY
 
 
-
-.class public abstract auto ansi beforefieldinit Test_classic.Base
+.namespace Test_classic {
+.class public abstract auto ansi beforefieldinit Base
        extends [mscorlib]System.Object
 {
   .method public hidebysig newslot abstract virtual 
@@ -163,7 +163,7 @@
 
 } // end of class Test.Base
 
-.class public auto ansi beforefieldinit Test_classic.Child
+.class public auto ansi beforefieldinit Child
        extends Test_classic.Base
 {
   .method public hidebysig virtual final 
@@ -372,7 +372,7 @@
 
 } // end of class Test.Child
 
-.class public auto ansi beforefieldinit Test_classic.GrandChild
+.class public auto ansi beforefieldinit GrandChild
        extends Test_classic.Child
 {
   .method public hidebysig virtual final 
@@ -559,7 +559,7 @@
 
 } // end of class Test.GrandChild
 
-.class public auto ansi sealed beforefieldinit Test_classic.SealedGrandChild
+.class public auto ansi sealed beforefieldinit SealedGrandChild
        extends Test_classic.GrandChild
 {
   .method public hidebysig specialname rtspecialname 
@@ -573,7 +573,7 @@
 
 } // end of class Test.SealedGrandChild
 
-.class public abstract auto ansi sealed beforefieldinit Test_classic.Program
+.class public abstract auto ansi sealed beforefieldinit Program
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  CallSealedGrandChild() cil managed
@@ -730,7 +730,7 @@
 
 } // end of class Test.Program
 
-.class public abstract auto ansi sealed beforefieldinit Test_classic.Assert
+.class public abstract auto ansi sealed beforefieldinit Assert
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  AreEqual(string left,
@@ -790,6 +790,4 @@
   } // end of method Assert::AreEqual
 
 } // end of class Test.Assert
-
-
-
+}

--- a/src/tests/JIT/Methodical/nonvirtualcall/delegate.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/delegate.il
@@ -30,8 +30,8 @@
 .corflags 0x00000001    //  ILONLY
 
 
-
-.class public abstract auto ansi beforefieldinit Test_delegate.Base
+.namespace Test_delegate {
+.class public abstract auto ansi beforefieldinit Base
        extends [mscorlib]System.Object
 {
   .method public hidebysig newslot abstract virtual 
@@ -163,7 +163,7 @@
 
 } // end of class Test.Base
 
-.class public auto ansi beforefieldinit Test_delegate.Child
+.class public auto ansi beforefieldinit Child
        extends Test_delegate.Base
 {
   .method public hidebysig virtual final 
@@ -275,7 +275,7 @@
 
 } // end of class Test.Child
 
-.class public auto ansi beforefieldinit Test_delegate.GrandChild
+.class public auto ansi beforefieldinit GrandChild
        extends Test_delegate.Child
 {
   .method public hidebysig virtual final 
@@ -373,7 +373,7 @@
 
 } // end of class Test.GrandChild
 
-.class public auto ansi sealed beforefieldinit Test_delegate.SealedGrandChild
+.class public auto ansi sealed beforefieldinit SealedGrandChild
        extends Test_delegate.GrandChild
 {
   .method public hidebysig specialname rtspecialname 
@@ -387,7 +387,7 @@
 
 } // end of class Test.SealedGrandChild
 
-.class public auto ansi sealed Test_delegate.TestMethod
+.class public auto ansi sealed TestMethod
        extends [mscorlib]System.MulticastDelegate
 {
   .method public hidebysig specialname rtspecialname 
@@ -415,7 +415,7 @@
 
 } // end of class Test.TestMethod
 
-.class public abstract auto ansi sealed beforefieldinit Test_delegate.Program
+.class public abstract auto ansi sealed beforefieldinit Program
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  CallDelegateFromSealedGrandChild() cil managed
@@ -613,7 +613,7 @@
 
 } // end of class Test.Program
 
-.class public abstract auto ansi sealed beforefieldinit Test_delegate.Assert
+.class public abstract auto ansi sealed beforefieldinit Assert
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  AreEqual(string left,
@@ -687,6 +687,4 @@
   } // end of method Assert::AreEqual
 
 } // end of class Test.Assert
-
-
-
+}

--- a/src/tests/JIT/Methodical/nonvirtualcall/generics.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/generics.il
@@ -30,8 +30,8 @@
 .corflags 0x00000001    //  ILONLY
 
 
-
-.class public abstract auto ansi beforefieldinit Test_generics.Base
+.namespace Test_generics {
+.class public abstract auto ansi beforefieldinit Base
        extends [mscorlib]System.Object
 {
   .method public hidebysig newslot abstract virtual 
@@ -163,7 +163,7 @@
 
 } // end of class Test.Base
 
-.class public auto ansi beforefieldinit Test_generics.Child
+.class public auto ansi beforefieldinit Child
        extends Test_generics.Base
 {
   .method public hidebysig virtual final 
@@ -372,7 +372,7 @@
 
 } // end of class Test.Child
 
-.class public auto ansi beforefieldinit Test_generics.GrandChild
+.class public auto ansi beforefieldinit GrandChild
        extends Test_generics.Child
 {
   .method public hidebysig virtual final 
@@ -571,7 +571,7 @@
 
 } // end of class Test.GrandChild
 
-.class public auto ansi sealed beforefieldinit Test_generics.SealedGrandChild
+.class public auto ansi sealed beforefieldinit SealedGrandChild
        extends Test_generics.GrandChild
 {
   .method public hidebysig specialname rtspecialname 
@@ -585,7 +585,7 @@
 
 } // end of class Test.SealedGrandChild
 
-.class public abstract auto ansi sealed beforefieldinit Test_generics.Program
+.class public abstract auto ansi sealed beforefieldinit Program
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  CallSealedGrandChild() cil managed
@@ -742,7 +742,7 @@
 
 } // end of class Test.Program
 
-.class public abstract auto ansi sealed beforefieldinit Test_generics.Assert
+.class public abstract auto ansi sealed beforefieldinit Assert
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  AreEqual(string left,
@@ -802,6 +802,4 @@
   } // end of method Assert::AreEqual
 
 } // end of class Test.Assert
-
-
-
+}

--- a/src/tests/JIT/Methodical/nonvirtualcall/generics2.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/generics2.il
@@ -33,9 +33,10 @@
 // Image base: 0x000000001AB30000
 
 
+.namespace Test_generics2 {
 // =============== CLASS MEMBERS DECLARATION ===================
 
-.class public abstract auto ansi beforefieldinit Test_generics2.Base`1<K>
+.class public abstract auto ansi beforefieldinit Base`1<K>
        extends [mscorlib]System.Object
 {
   .method public hidebysig newslot abstract virtual 
@@ -175,7 +176,7 @@
 
 } // end of class Test.Base`1
 
-.class public auto ansi beforefieldinit Test_generics2.Child`1<K>
+.class public auto ansi beforefieldinit Child`1<K>
        extends class Test_generics2.Base`1<!K>
 {
   .method public hidebysig virtual final 
@@ -394,7 +395,7 @@
 
 } // end of class Test.Child`1
 
-.class public auto ansi beforefieldinit Test_generics2.GrandChild`1<K>
+.class public auto ansi beforefieldinit GrandChild`1<K>
        extends class Test_generics2.Child`1<!K>
 {
   .method public hidebysig virtual final 
@@ -601,7 +602,7 @@
 
 } // end of class Test.GrandChild`1
 
-.class public auto ansi sealed beforefieldinit Test_generics2.SealedGrandChild`1<K>
+.class public auto ansi sealed beforefieldinit SealedGrandChild`1<K>
        extends class Test_generics2.GrandChild`1<!K>
 {
   .method public hidebysig specialname rtspecialname 
@@ -616,7 +617,7 @@
 
 } // end of class Test.SealedGrandChild`1
 
-.class public abstract auto ansi sealed beforefieldinit Test_generics2.Program
+.class public abstract auto ansi sealed beforefieldinit Program
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  CallSealedGrandChild() cil managed
@@ -777,7 +778,7 @@
 
 } // end of class Test.Program
 
-.class public abstract auto ansi sealed beforefieldinit Test_generics2.Assert
+.class public abstract auto ansi sealed beforefieldinit Assert
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  AreEqual(string left,
@@ -838,9 +839,4 @@
   } // end of method Assert::AreEqual
 
 } // end of class Test.Assert
-
-
-// =============================================================
-
-// *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file nonvirtualcalls_generics2.res
+}

--- a/src/tests/JIT/Methodical/nonvirtualcall/tailcall.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/tailcall.il
@@ -22,9 +22,10 @@
 // Image base: 0x000000001AB30000
 
 
+.namespace Test_tailcall {
 // =============== CLASS MEMBERS DECLARATION ===================
 
-.class public abstract auto ansi beforefieldinit Test_tailcall.Base
+.class public abstract auto ansi beforefieldinit Base
        extends [mscorlib]System.Object
 {
   .method public hidebysig newslot abstract virtual 
@@ -164,7 +165,7 @@
 
 } // end of class Test.Base
 
-.class public auto ansi beforefieldinit Test_tailcall.Child
+.class public auto ansi beforefieldinit Child
        extends Test_tailcall.Base
 {
   .method public hidebysig virtual final 
@@ -347,7 +348,7 @@
 
 } // end of class Test.Child
 
-.class public auto ansi beforefieldinit Test_tailcall.GrandChild
+.class public auto ansi beforefieldinit GrandChild
        extends Test_tailcall.Child
 {
   .method public hidebysig virtual final 
@@ -584,7 +585,7 @@
 
 } // end of class Test.GrandChild
 
-.class public abstract auto ansi sealed beforefieldinit Test_tailcall.Program
+.class public abstract auto ansi sealed beforefieldinit Program
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  CallFromInsideGrandChild() cil managed
@@ -646,7 +647,7 @@
 
 } // end of class Test.Program
 
-.class public abstract auto ansi sealed beforefieldinit Test_tailcall.Assert
+.class public abstract auto ansi sealed beforefieldinit Assert
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  AreEqual(string left,
@@ -707,9 +708,4 @@
   } // end of method Assert::AreEqual
 
 } // end of class Test.Assert
-
-
-// =============================================================
-
-// *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file nonvirtualcalls_tailcall.res
+}

--- a/src/tests/JIT/Methodical/nonvirtualcall/valuetype.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/valuetype.il
@@ -32,10 +32,10 @@
 .corflags 0x00000001    //  ILONLY
 // Image base: 0x02EC0000
 
-
+.namespace Test_valuetype {
 // =============== CLASS MEMBERS DECLARATION ===================
 
-.class public sequential ansi sealed beforefieldinit Test_valuetype.Dummy
+.class public sequential ansi sealed beforefieldinit Dummy
        extends [mscorlib]System.ValueType
 {
   .pack 0
@@ -57,7 +57,7 @@
 
 } // end of class Test.Dummy
 
-.class public auto ansi sealed Test_valuetype.TestMethod
+.class public auto ansi sealed TestMethod
        extends [mscorlib]System.MulticastDelegate
 {
   .method public hidebysig specialname rtspecialname 
@@ -85,7 +85,7 @@
 
 } // end of class Test.TestMethod
 
-.class public abstract auto ansi sealed beforefieldinit Test_valuetype.Program
+.class public abstract auto ansi sealed beforefieldinit Program
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  CallDummy() cil managed
@@ -160,7 +160,7 @@
 
 } // end of class Test.Program
 
-.class public abstract auto ansi sealed beforefieldinit Test_valuetype.Assert
+.class public abstract auto ansi sealed beforefieldinit Assert
        extends [mscorlib]System.Object
 {
   .method public hidebysig static void  AreEqual(string left,
@@ -236,9 +236,4 @@
   } // end of method Assert::AreEqual
 
 } // end of class Test.Assert
-
-
-// =============================================================
-
-// *********** DISASSEMBLY COMPLETE ***********************
-// WARNING: Created Win32 resource file valuetype.res
+}


### PR DESCRIPTION
/cc @dotnet/jit-contrib 