### PR TITLE
Disable annoying warnings in the repro project

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifiers>linux-x64;win-x64;osx-x64</RuntimeIdentifiers>
     <Configurations>Debug;Release;Checked</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>649;169;414</NoWarn>
   </PropertyGroup>
 
   <Target Name="GenerateReproProjectResponseFile"


### PR DESCRIPTION
We have repo-wide WarnAsError that makes this super annoying in a repro project.
