### PR TITLE
Add support for libraries testing with NativeAOT

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -24,6 +24,9 @@
   <PropertyGroup>
     <CoreCLRSharedFrameworkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'sharedFramework'))</CoreCLRSharedFrameworkDir>
     <CoreCLRCrossgen2Dir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'crossgen2'))</CoreCLRCrossgen2Dir>
+    <CoreCLRILCompilerDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'ilc'))</CoreCLRILCompilerDir>
+    <CoreCLRAotSdkDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'aotsdk'))</CoreCLRAotSdkDir>
+    <CoreCLRBuildIntegrationDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'build'))</CoreCLRBuildIntegrationDir>
 
     <MonoAotCrossDir>$([MSBuild]::NormalizeDirectory('$(MonoArtifactsPath)', 'cross', $(TargetOS.ToLowerInvariant())-$(TargetArchitecture.ToLowerInvariant())))</MonoAotCrossDir>
 

--- a/eng/testing/default.rd.xml
+++ b/eng/testing/default.rd.xml
@@ -1,0 +1,81 @@
+<Directives>
+  <Application>
+    <!-- xunit will reflect on these to process certain InlineDataAttributes -->
+    <Assembly Name="System.Linq">
+      <Type Name="System.Linq.Enumerable">
+        <Method Name="Cast">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Char, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Boolean, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Byte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.SByte, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Int16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.UInt16, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Int32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.UInt32, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Int64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.UInt64, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Single, System.Private.CoreLib" />
+        </Method>
+        <Method Name="Cast">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+        <Method Name="ToArray">
+          <GenericArgument Name="System.Double, System.Private.CoreLib" />
+        </Method>
+      </Type>
+    </Assembly>
+  </Application>
+</Directives>

--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -7,6 +7,7 @@
     <TestDependsOn>$(TestDependsOn);GenerateRunScript;RunTests</TestDependsOn>
     <VSTestNoLogo>true</VSTestNoLogo>
     <ILLinkDescriptorsPath>$(MSBuildThisFileDirectory)ILLinkDescriptors\</ILLinkDescriptorsPath>
+    <TestSingleFile Condition="'$(TestNativeAot)' == 'true'">true</TestSingleFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -25,7 +25,8 @@
     <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
     <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
     <IlcFrameworkPath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkPath>
-    <NoWarn>$(NoWarn);IL3050;IL3052;IL1005</NoWarn>
+    <NoWarn>$(NoWarn);IL3050;IL3052;IL3055;IL1005</NoWarn>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
 
     <!-- Forced by ILLink targets; we should fix the SDK -->
     <SelfContained>true</SelfContained>

--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -12,13 +12,36 @@
     <RunScriptCommand Condition="'$(TargetOS)' != 'windows'">chmod +rwx $(AssemblyName) &amp;&amp; ./$(AssemblyName)</RunScriptCommand>
   </PropertyGroup>
   
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TestNativeAot)' != 'true'">
     <PublishSingleFile>true</PublishSingleFile>
     <UseAppHost>true</UseAppHost>
     <SelfContained>true</SelfContained>
     <SingleFileHostSourcePath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'coreclr', '$(TargetOS).$(TargetArchitecture).$(Configuration)', 'corehost'))/singlefilehost</SingleFileHostSourcePath>
     <SingleFileHostSourcePath Condition="'$(TargetOS)' == 'windows'">$(SingleFileHostSourcePath).exe</SingleFileHostSourcePath>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TestNativeAot)' == 'true'">
+    <IlcToolsPath>$(CoreCLRILCompilerDir)</IlcToolsPath>
+    <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
+    <IlcSdkPath>$(CoreCLRAotSdkDir)</IlcSdkPath>
+    <IlcFrameworkPath>$(NetCoreAppCurrentTestHostSharedFrameworkPath)</IlcFrameworkPath>
+    <NoWarn>$(NoWarn);IL3050;IL3052;IL1005</NoWarn>
+
+    <!-- Forced by ILLink targets; we should fix the SDK -->
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.targets" Condition="'$(TestNativeAot)' == 'true'" />
+
+  <ItemGroup Condition="'$(TestNativeAot)' == 'true'">
+    <RdXmlFile Include="$(MSBuildThisFileDirectory)default.rd.xml" />
+
+    <!-- Tests are doing private reflection. -->
+    <IlcArg Include="--nometadatablocking" />
+
+    <!-- xunit calls MakeGenericType to check if something is IEquatable -->
+    <IlcArg Include="--feature:System.Reflection.IsTypeConstructionEagerlyValidated=false" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(CommonTestPath)SingleFileTestRunner\SingleFileTestRunner.cs"

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -26,7 +26,8 @@
 
   <!-- Setup the testing shared framework host -->
   <Target Name="SetupTestingHost"
-          AfterTargets="AfterResolveReferences">
+          AfterTargets="AfterResolveReferences"
+          Condition="'$(TestNativeAot)' != 'true'">
     <PropertyGroup>
       <UseHardlink>true</UseHardlink>
       <!-- workaround core-setup problem for hardlinking dotnet executable to testhost: core-setup #4742 -->
@@ -75,7 +76,7 @@
   <Target Name="OverrideRuntimeCoreCLR"
           DependsOnTargets="ResolveRuntimeFilesFromLocalBuild"
           AfterTargets="AfterResolveReferences"
-          Condition="'$(RuntimeFlavor)' != 'Mono'">
+          Condition="'$(RuntimeFlavor)' != 'Mono' and '$(TestNativeAot)' != 'true'">
     <ItemGroup>
       <!-- CoreRun is not used for testing anymore, but we still use it for benchmarking and profiling -->
       <RuntimeFiles Include="$(CoreCLRArtifactsPath)\corerun*" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -356,11 +356,19 @@ Roslyn4.0.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Drawing.Common\tests\System.Drawing.Common.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TestSingleFile)' == 'true'">
+  <ItemGroup Condition="'$(TestSingleFile)' == 'true' and '$(TestNativeAot)' != 'true'">
     <!-- Run only a small randomly chosen set of passing test suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.IO.IsolatedStorage\tests\System.IO.IsolatedStorage.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TestNativeAot)' == 'true'">
+    <!-- Run only a small randomly chosen set of passing test suites -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" Condition="'$(TargetOS)' != 'OSX'" />
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" Condition="'$(__DistroRid)' != 'linux-musl-x64'"/>
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunSmokeTestsOnly)' == 'true'">


### PR DESCRIPTION
This adds support for running libraries tests with NativeAOT. It reuses the single file xunit runner since we cannot `LoadFrom` the tests on NativeAOT. The strategy is the same as for single file testing: do a publish. To do the NativeAOT publish, we include the Microsoft.DotNet.ILCompiler.targets.

Not attempting to add this to the CI since the tests are currently hitting #63778.