### PR TITLE
don't Flush readonly MemoryMappedViewAccessor on disposal

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewAccessor.cs
@@ -34,7 +34,7 @@ namespace System.IO.MemoryMappedFiles
             {
                 // Explicitly flush the changes.  The OS will do this for us anyway, but not until after the
                 // MemoryMappedFile object itself is closed.
-                if (disposing && !_view.IsClosed)
+                if (disposing && !_view.IsClosed && CanWrite)
                 {
                     Flush();
                 }

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedViewStream.cs
@@ -37,7 +37,7 @@ namespace System.IO.MemoryMappedFiles
         {
             try
             {
-                if (disposing && !_view.IsClosed)
+                if (disposing && !_view.IsClosed && CanWrite)
                 {
                     Flush();
                 }


### PR DESCRIPTION
`MemoryMappedViewAccessor` created with readonly access (`MemoryMappedFileAccess.Read`) does not allow for writing to the memory mapped file, hence we don't need to flush it when it's being disposed

Fixes #62768

Benchmark source code: https://github.com/dotnet/performance/pull/2213

Ubuntu results:

|              Method |        Toolchain | capacity |      Mean | Ratio |
|-------------------- |----------------- |--------- |----------:|------:|
| CreateFromFile_Read |    /main/corerun |    10000 | 10.393 us |  1.00 |
| CreateFromFile_Read | /noFlush/corerun |    10000 |  9.601 us |  0.92 |
|                     |                  |          |           |       |
| CreateFromFile_Read |    /main/corerun |   100000 | 10.279 us |  1.00 |
| CreateFromFile_Read | /noFlush/corerun |   100000 |  9.175 us |  0.89 |
|                     |                  |          |           |       |
| CreateFromFile_Read |    /main/corerun |  1000000 | 10.448 us |  1.00 |
| CreateFromFile_Read | /noFlush/corerun |  1000000 |  9.533 us |  0.90 |
|                     |                  |          |           |       |
| CreateFromFile_Read |    /main/corerun | 10000000 | 10.972 us |  1.00 |
| CreateFromFile_Read | /noFlush/corerun | 10000000 |  9.441 us |  0.85 |

Windows results:

|              Method |          Toolchain | capacity | Ratio | 
|-------------------- |------------------- |--------- |------:| 
| CreateFromFile_Read | \flush\corerun.exe |    10000 |  0.94 | 
| CreateFromFile_Read |  \main\corerun.exe |    10000 |  1.00 | 
|                     |                    |          |       | 
| CreateFromFile_Read | \flush\corerun.exe |   100000 |  0.92 | 
| CreateFromFile_Read |  \main\corerun.exe |   100000 |  1.00 | 
|                     |                    |          |       | 
| CreateFromFile_Read | \flush\corerun.exe |  1000000 |  0.91 | 
| CreateFromFile_Read |  \main\corerun.exe |  1000000 |  1.00 | 
|                     |                    |          |       | 
| CreateFromFile_Read | \flush\corerun.exe | 10000000 |  0.73 | 
| CreateFromFile_Read |  \main\corerun.exe | 10000000 |  1.00 | 

Mind that the larger the file, the larger gain.