### PR TITLE
Revert "Temporarily disable coredumps during library testing on macOS"

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -132,8 +132,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # files already in /cores/ at this point. This is being done to prevent
   # inadvertently flooding the CI machines with dumps.
   if [[ ! -d "/cores" || ! "$(ls -A /cores)" ]]; then
-    # FIXME: temporarily disable core dumps
-    ulimit -c 0
+    ulimit -c unlimited
   fi
 
 elif [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
Reverts dotnet/runtime#63742. The problematic tests were fixed with https://github.com/dotnet/runtime/pull/63769.