### PR TITLE
[release/6.0] Avoid deadlock with ConfigurationManager

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ConfigurationManager.cs
@@ -12,15 +12,20 @@ namespace Microsoft.Extensions.Configuration
 {
     /// <summary>
     /// Configuration is mutable configuration object. It is both an <see cref="IConfigurationBuilder"/> and an <see cref="IConfigurationRoot"/>.
-    /// As sources are added, it updates its current view of configuration. Once Build is called, configuration is frozen.
+    /// As sources are added, it updates its current view of configuration.
     /// </summary>
     public sealed class ConfigurationManager : IConfigurationBuilder, IConfigurationRoot, IDisposable
     {
+        // Concurrently modifying config sources or properties is not thread-safe. However, it is thread-safe to read config while modifying sources or properties.
         private readonly ConfigurationSources _sources;
         private readonly ConfigurationBuilderProperties _properties;
 
-        private readonly object _providerLock = new();
-        private readonly List<IConfigurationProvider> _providers = new();
+        // ReferenceCountedProviderManager manages copy-on-write references to support concurrently reading config while modifying sources.
+        // It waits for readers to unreference the providers before disposing them without blocking on any concurrent operations.
+        private readonly ReferenceCountedProviderManager _providerManager = new();
+
+        // _changeTokenRegistrations is only modified when config sources are modified. It is not referenced by any read operations.
+        // Because modify config sources is not thread-safe, modifying _changeTokenRegistrations does not need to be thread-safe either.
         private readonly List<IDisposable> _changeTokenRegistrations = new();
         private ConfigurationReloadToken _changeToken = new();
 
@@ -43,17 +48,13 @@ namespace Microsoft.Extensions.Configuration
         {
             get
             {
-                lock (_providerLock)
-                {
-                    return ConfigurationRoot.GetConfiguration(_providers, key);
-                }
+                using ReferenceCountedProviders reference = _providerManager.GetReference();
+                return ConfigurationRoot.GetConfiguration(reference.Providers, key);
             }
             set
             {
-                lock (_providerLock)
-                {
-                    ConfigurationRoot.SetConfiguration(_providers, key, value);
-                }
+                using ReferenceCountedProviders reference = _providerManager.GetReference();
+                ConfigurationRoot.SetConfiguration(reference.Providers, key, value);
             }
         }
 
@@ -61,37 +62,22 @@ namespace Microsoft.Extensions.Configuration
         public IConfigurationSection GetSection(string key) => new ConfigurationSection(this, key);
 
         /// <inheritdoc/>
-        public IEnumerable<IConfigurationSection> GetChildren()
-        {
-            lock (_providerLock)
-            {
-                // ToList() to eagerly evaluate inside lock.
-                return this.GetChildrenImplementation(null).ToList();
-            }
-        }
+        public IEnumerable<IConfigurationSection> GetChildren() => this.GetChildrenImplementation(null);
 
         IDictionary<string, object> IConfigurationBuilder.Properties => _properties;
 
         IList<IConfigurationSource> IConfigurationBuilder.Sources => _sources;
 
-        IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers
-        {
-            get
-            {
-                lock (_providerLock)
-                {
-                    return new List<IConfigurationProvider>(_providers);
-                }
-            }
-        }
+        // We cannot track the duration of the reference to the providers if this property is used.
+        // If a configuration source is removed after this is accessed but before it's completely enumerated,
+        // this may allow access to a disposed provider.
+        IEnumerable<IConfigurationProvider> IConfigurationRoot.Providers => _providerManager.NonReferenceCountedProviders;
 
         /// <inheritdoc/>
         public void Dispose()
         {
-            lock (_providerLock)
-            {
-                DisposeRegistrationsAndProvidersUnsynchronized();
-            }
+            DisposeRegistrations();
+            _providerManager.Dispose();
         }
 
         IConfigurationBuilder IConfigurationBuilder.Add(IConfigurationSource source)
@@ -106,9 +92,9 @@ namespace Microsoft.Extensions.Configuration
 
         void IConfigurationRoot.Reload()
         {
-            lock (_providerLock)
+            using (ReferenceCountedProviders reference = _providerManager.GetReference())
             {
-                foreach (var provider in _providers)
+                foreach (IConfigurationProvider provider in reference.Providers)
                 {
                     provider.Load();
                 }
@@ -116,6 +102,8 @@ namespace Microsoft.Extensions.Configuration
 
             RaiseChanged();
         }
+
+        internal ReferenceCountedProviders GetProvidersReference() => _providerManager.GetReference();
 
         private void RaiseChanged()
         {
@@ -126,59 +114,49 @@ namespace Microsoft.Extensions.Configuration
         // Don't rebuild and reload all providers in the common case when a source is simply added to the IList.
         private void AddSource(IConfigurationSource source)
         {
-            lock (_providerLock)
-            {
-                var provider = source.Build(this);
-                _providers.Add(provider);
+            IConfigurationProvider provider = source.Build(this);
 
-                provider.Load();
-                _changeTokenRegistrations.Add(ChangeToken.OnChange(() => provider.GetReloadToken(), () => RaiseChanged()));
-            }
+            provider.Load();
+            _changeTokenRegistrations.Add(ChangeToken.OnChange(() => provider.GetReloadToken(), () => RaiseChanged()));
 
+            _providerManager.AddProvider(provider);
             RaiseChanged();
         }
 
         // Something other than Add was called on IConfigurationBuilder.Sources or IConfigurationBuilder.Properties has changed.
         private void ReloadSources()
         {
-            lock (_providerLock)
+            DisposeRegistrations();
+
+            _changeTokenRegistrations.Clear();
+
+            var newProvidersList = new List<IConfigurationProvider>();
+
+            foreach (IConfigurationSource source in _sources)
             {
-                DisposeRegistrationsAndProvidersUnsynchronized();
-
-                _changeTokenRegistrations.Clear();
-                _providers.Clear();
-
-                foreach (var source in _sources)
-                {
-                    _providers.Add(source.Build(this));
-                }
-
-                foreach (var p in _providers)
-                {
-                    p.Load();
-                    _changeTokenRegistrations.Add(ChangeToken.OnChange(() => p.GetReloadToken(), () => RaiseChanged()));
-                }
+                newProvidersList.Add(source.Build(this));
             }
 
+            foreach (IConfigurationProvider p in newProvidersList)
+            {
+                p.Load();
+                _changeTokenRegistrations.Add(ChangeToken.OnChange(() => p.GetReloadToken(), () => RaiseChanged()));
+            }
+
+            _providerManager.ReplaceProviders(newProvidersList);
             RaiseChanged();
         }
 
-        private void DisposeRegistrationsAndProvidersUnsynchronized()
+        private void DisposeRegistrations()
         {
             // dispose change token registrations
-            foreach (var registration in _changeTokenRegistrations)
+            foreach (IDisposable registration in _changeTokenRegistrations)
             {
                 registration.Dispose();
             }
-
-            // dispose providers
-            foreach (var provider in _providers)
-            {
-                (provider as IDisposable)?.Dispose();
-            }
         }
 
-        private class ConfigurationSources : IList<IConfigurationSource>
+        private sealed class ConfigurationSources : IList<IConfigurationSource>
         {
             private readonly List<IConfigurationSource> _sources = new();
             private readonly ConfigurationManager _config;
@@ -259,7 +237,7 @@ namespace Microsoft.Extensions.Configuration
             }
         }
 
-        private class ConfigurationBuilderProperties : IDictionary<string, object>
+        private sealed class ConfigurationBuilderProperties : IDictionary<string, object>
         {
             private readonly Dictionary<string, object> _properties = new();
             private readonly ConfigurationManager _config;

--- a/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/InternalConfigurationRootExtensions.cs
@@ -20,11 +20,24 @@ namespace Microsoft.Extensions.Configuration
         /// <returns>Immediate children sub-sections of section specified by key.</returns>
         internal static IEnumerable<IConfigurationSection> GetChildrenImplementation(this IConfigurationRoot root, string path)
         {
-            return root.Providers
+            using ReferenceCountedProviders? reference = (root as ConfigurationManager)?.GetProvidersReference();
+            IEnumerable<IConfigurationProvider> providers = reference?.Providers ?? root.Providers;
+
+            IEnumerable<IConfigurationSection> children = providers
                 .Aggregate(Enumerable.Empty<string>(),
                     (seed, source) => source.GetChildKeys(seed, path))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .Select(key => root.GetSection(path == null ? key : ConfigurationPath.Combine(path, key)));
+
+            if (reference is null)
+            {
+                return children;
+            }
+            else
+            {
+                // Eagerly evaluate the IEnumerable before releasing the reference so we don't allow iteration over disposed providers.
+                return children.ToList();
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration/src/Microsoft.Extensions.Configuration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/Microsoft.Extensions.Configuration.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <PackageDescription>Implementation of key-value pair based configuration for Microsoft.Extensions.Configuration. Includes the memory configuration provider.</PackageDescription>
+    <ServicingVersion>1</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ReferenceCountedProviders.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ReferenceCountedProviders.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.Extensions.Configuration
+{
+    // ReferenceCountedProviders is used by ConfigurationManager to wait until all readers unreference it before disposing any providers.
+    internal abstract class ReferenceCountedProviders : IDisposable
+    {
+        public static ReferenceCountedProviders Create(List<IConfigurationProvider> providers) => new ActiveReferenceCountedProviders(providers);
+
+        // If anything references DisposedReferenceCountedProviders, it indicates something is using the ConfigurationManager after it's been disposed.
+        // We could preemptively throw an ODE from ReferenceCountedProviderManager.GetReference() instead of returning this type, but this might
+        // break existing apps that are previously able to continue to read configuration after disposing an ConfigurationManager.
+        public static ReferenceCountedProviders CreateDisposed(List<IConfigurationProvider> providers) => new DisposedReferenceCountedProviders(providers);
+
+        public abstract List<IConfigurationProvider> Providers { get; set; }
+
+        // NonReferenceCountedProviders is only used to:
+        // 1. Support IConfigurationRoot.Providers because we cannot track the lifetime of that reference.
+        // 2. Construct DisposedReferenceCountedProviders because the providers are disposed anyway and no longer reference counted.
+        public abstract List<IConfigurationProvider> NonReferenceCountedProviders { get; }
+
+        public abstract void AddReference();
+        // This is Dispose() rather than RemoveReference() so we can conveniently release a reference at the end of a using block.
+        public abstract void Dispose();
+
+        private sealed class ActiveReferenceCountedProviders : ReferenceCountedProviders
+        {
+            private long _refCount = 1;
+            // volatile is not strictly necessary because the runtime adds a barrier either way, but volatile indicates that this field has
+            // unsynchronized readers meaning the all writes initializing the list must be published before updating the _providers reference.
+            private volatile List<IConfigurationProvider> _providers;
+
+            public ActiveReferenceCountedProviders(List<IConfigurationProvider> providers)
+            {
+                _providers = providers;
+            }
+
+            public override List<IConfigurationProvider> Providers
+            {
+                get
+                {
+                    Debug.Assert(_refCount > 0);
+                    return _providers;
+                }
+                set
+                {
+                    Debug.Assert(_refCount > 0);
+                    _providers = value;
+                }
+            }
+
+            public override List<IConfigurationProvider> NonReferenceCountedProviders => _providers;
+
+            public override void AddReference()
+            {
+                // AddReference() is always called with a lock to ensure _refCount hasn't already decremented to zero.
+                Debug.Assert(_refCount > 0);
+                Interlocked.Increment(ref _refCount);
+            }
+
+            public override void Dispose()
+            {
+                if (Interlocked.Decrement(ref _refCount) == 0)
+                {
+                    foreach (IConfigurationProvider provider in _providers)
+                    {
+                        (provider as IDisposable)?.Dispose();
+                    }
+                }
+            }
+        }
+
+        private sealed class DisposedReferenceCountedProviders : ReferenceCountedProviders
+        {
+            public DisposedReferenceCountedProviders(List<IConfigurationProvider> providers)
+            {
+                Providers = providers;
+            }
+
+            public override List<IConfigurationProvider> Providers { get; set; }
+            public override List<IConfigurationProvider> NonReferenceCountedProviders => Providers;
+
+            public override void AddReference() { }
+            public override void Dispose() { }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration/src/ReferenceCountedProvidersManager.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/src/ReferenceCountedProvidersManager.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.Configuration
+{
+    // ReferenceCountedProviderManager is used by ConfigurationManager to provide copy-on-write references that support concurrently
+    // reading config while modifying sources. It waits for readers to unreference the providers before disposing them
+    // without blocking on any concurrent operations.
+    internal sealed class ReferenceCountedProviderManager : IDisposable
+    {
+        private readonly object _replaceProvidersLock = new object();
+        private ReferenceCountedProviders _refCountedProviders = ReferenceCountedProviders.Create(new List<IConfigurationProvider>());
+        private bool _disposed;
+
+        // This is only used to support IConfigurationRoot.Providers because we cannot track the lifetime of that reference.
+        public IEnumerable<IConfigurationProvider> NonReferenceCountedProviders => _refCountedProviders.NonReferenceCountedProviders;
+
+        public ReferenceCountedProviders GetReference()
+        {
+            // Lock to ensure oldRefCountedProviders.Dispose() in ReplaceProviders() or Dispose() doesn't decrement ref count to zero
+            // before calling _refCountedProviders.AddReference().
+            lock (_replaceProvidersLock)
+            {
+                if (_disposed)
+                {
+                    // Return a non-reference-counting ReferenceCountedProviders instance now that the ConfigurationManager is disposed.
+                    // We could preemptively throw an ODE instead, but this might break existing apps that were previously able to
+                    // continue to read configuration after disposing an ConfigurationManager.
+                    return ReferenceCountedProviders.CreateDisposed(_refCountedProviders.NonReferenceCountedProviders);
+                }
+
+                _refCountedProviders.AddReference();
+                return _refCountedProviders;
+            }
+        }
+
+        // Providers should never be concurrently modified. Reading during modification is allowed.
+        public void ReplaceProviders(List<IConfigurationProvider> providers)
+        {
+            ReferenceCountedProviders oldRefCountedProviders = _refCountedProviders;
+
+            lock (_replaceProvidersLock)
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(ConfigurationManager));
+                }
+
+                _refCountedProviders = ReferenceCountedProviders.Create(providers);
+            }
+
+            // Decrement the reference count to the old providers. If they are being concurrently read from
+            // the actual disposal of the old providers will be delayed until the final reference is released.
+            // Never dispose ReferenceCountedProviders with a lock because this may call into user code.
+            oldRefCountedProviders.Dispose();
+        }
+
+        public void AddProvider(IConfigurationProvider provider)
+        {
+            lock (_replaceProvidersLock)
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(ConfigurationManager));
+                }
+
+                // Maintain existing references, but replace list with copy containing new item.
+                _refCountedProviders.Providers = new List<IConfigurationProvider>(_refCountedProviders.Providers)
+                {
+                    provider
+                };
+            }
+        }
+
+        public void Dispose()
+        {
+            ReferenceCountedProviders oldRefCountedProviders = _refCountedProviders;
+
+            // This lock ensures that we cannot reduce the ref count to zero before GetReference() calls AddReference().
+            // Once _disposed is set, GetReference() stops reference counting.
+            lock (_replaceProvidersLock)
+            {
+                _disposed = true;
+            }
+
+            // Never dispose ReferenceCountedProviders with a lock because this may call into user code.
+            oldRefCountedProviders.Dispose();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationManagerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/ConfigurationManagerTest.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.Primitives;
 using Moq;
@@ -169,6 +171,91 @@ namespace Microsoft.Extensions.Configuration.Test
             Assert.True(provider2.IsDisposed);
             Assert.True(provider4.IsDisposed);
             Assert.True(provider5.IsDisposed);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public async Task ProviderCanBlockLoadWaitingOnConcurrentRead()
+        {
+            using var mre = new ManualResetEventSlim(false);
+            var provider = new BlockLoadOnMREProvider(mre, timeout: TimeSpan.FromSeconds(30));
+
+            var config = new ConfigurationManager();
+            IConfigurationBuilder builder = config;
+
+            // builder.Add(source) will block on provider.Load().
+            var loadTask = Task.Run(() => builder.Add(new TestConfigurationSource(provider)));
+            await provider.LoadStartedTask;
+
+            // Read configuration while provider.Load() is blocked waiting on us.
+            _ = config["key"];
+
+            // Unblock provider.Load()
+            mre.Set();
+
+            // This will throw if provider.Load() timed out instead of unblocking gracefully after the read.
+            await loadTask;
+        }
+
+        public static TheoryData ConcurrentReadActions
+        {
+            get
+            {
+                return new TheoryData<Action<IConfiguration>>
+                {
+                    config => _ = config["key"],
+                    config => config.GetChildren(),
+                    config => config.GetSection("key").GetChildren(),
+                };
+            }
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [MemberData(nameof(ConcurrentReadActions))]
+        public async Task ProviderDisposeDelayedWaitingOnConcurrentRead(Action<IConfiguration> concurrentReadAction)
+        {
+            using var mre = new ManualResetEventSlim(false);
+            var provider = new BlockReadOnMREProvider(mre, timeout: TimeSpan.FromSeconds(30));
+
+            var config = new ConfigurationManager();
+            IConfigurationBuilder builder = config;
+
+            builder.Add(new TestConfigurationSource(provider));
+
+            // Reading configuration will block on provider.TryRead() or profvider.GetChildKeys().
+            var readTask = Task.Run(() => concurrentReadAction(config));
+            await provider.ReadStartedTask;
+
+            // Removing the source normally disposes the provider except when there provider is in use as is the case here.
+            builder.Sources.Clear();
+
+            Assert.False(provider.IsDisposed);
+
+            // Unblock TryRead() or GetChildKeys()
+            mre.Set();
+
+            // This will throw if TryRead() or GetChildKeys() timed out instead of unblocking gracefully after setting the MRE.
+            await readTask;
+
+            // The provider should be disposed when the concurrentReadAction releases the last reference to the provider.
+            Assert.True(provider.IsDisposed);
+        }
+
+        [Fact]
+        public void DisposingConfigurationManagerCausesOnlySourceChangesToThrow()
+        {
+            var config = new ConfigurationManager
+            {
+                ["TestKey"] = "TestValue",
+            };
+
+            config.Dispose();
+
+            Assert.Equal("TestValue", config["TestKey"]);
+            config["TestKey"] = "TestValue2";
+            Assert.Equal("TestValue2", config["TestKey"]);
+
+            Assert.Throws<ObjectDisposedException>(() => config.AddInMemoryCollection());
+            Assert.Throws<ObjectDisposedException>(() => ((IConfigurationBuilder)config).Sources.Clear());
         }
 
         [Fact]
@@ -1126,6 +1213,62 @@ namespace Microsoft.Extensions.Configuration.Test
         {
             public TestConfigurationProvider(string key, string value)
                 => Data.Add(key, value);
+        }
+
+        private class BlockLoadOnMREProvider : ConfigurationProvider
+        {
+            private readonly ManualResetEventSlim _mre;
+            private readonly TimeSpan _timeout;
+
+            private readonly TaskCompletionSource<object> _loadStartedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public BlockLoadOnMREProvider(ManualResetEventSlim mre, TimeSpan timeout)
+            {
+                _mre = mre;
+                _timeout = timeout;
+            }
+
+            public Task LoadStartedTask => _loadStartedTcs.Task;
+
+            public override void Load()
+            {
+                _loadStartedTcs.SetResult(null);
+                Assert.True(_mre.Wait(_timeout), "BlockLoadOnMREProvider.Load() timed out.");
+            }
+        }
+
+        private class BlockReadOnMREProvider : ConfigurationProvider, IDisposable
+        {
+            private readonly ManualResetEventSlim _mre;
+            private readonly TimeSpan _timeout;
+
+            private readonly TaskCompletionSource<object> _readStartedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public BlockReadOnMREProvider(ManualResetEventSlim mre, TimeSpan timeout)
+            {
+                _mre = mre;
+                _timeout = timeout;
+            }
+
+            public Task ReadStartedTask => _readStartedTcs.Task;
+
+            public bool IsDisposed { get; set; }
+
+            public override bool TryGet(string key, out string? value)
+            {
+                _readStartedTcs.SetResult(null);
+                Assert.True(_mre.Wait(_timeout), "BlockReadOnMREProvider.TryGet() timed out.");
+                return base.TryGet(key, out value);
+            }
+
+            public override IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string? parentPath)
+            {
+                _readStartedTcs.SetResult(null);
+                Assert.True(_mre.Wait(_timeout), "BlockReadOnMREProvider.GetChildKeys() timed out.");
+                return base.GetChildKeys(earlierKeys, parentPath);
+            }
+
+            public void Dispose() => IsDisposed = true;
         }
 
         private class DisposableTestConfigurationProvider : ConfigurationProvider, IDisposable


### PR DESCRIPTION
Backport of #62209 to release/6.0

## Customer Impact

The following is from [a comment](https://github.com/dotnet/runtime/issues/61747#issuecomment-972836932) @martincostello who originally reported the issue.

> From a customer/production perspective, this is an example of the behaviour we saw when the issue first arose.
>
> ![image](https://user-images.githubusercontent.com/1439341/142417966-b9b065c5-0f75-4d9a-ac9c-5430fbada95b.png)
>
> The application was in a steady state serving requests (each coloured line is a different HTTP endpoint), then where the red arrow is when the application's configuration was reloaded in each of the 3 AWS EC2 instances that were in service at the time in response to a change made in our remote configuration store.
>
> The application then very quickly went into a state of deadlock in each instance, with health checks eventually also deadlocking, leading to our load-balancer marking the instances all as unhealthy and taking them out of service. Traffic then flatlines until new instances come into service to take up the load.

I'm not sure if any others have run into the issue, but @martincostello's [app](https://github.com/martincostello/ConfigurationManagerDeadlock/blob/8fdf7342d414efd9a0346130f67c469f503eb0db/Program.cs) wasn't doing anything that unusual. Calling `IConfigurationRoot.Reload()`  isn't super common but it is something I've seen in other apps. Adding or removing config sources at runtime is a new capability of `ConfigurationManager` and doing that could have also had similar consequences.

## Testing

Regression tests were added.

## Risk

Medium.

I'm personally confident in the correctness of the change, but I wish it could have been a more surgical fix. The fix removes a lock that was being taken to avoid disposing `IConfigurationProvider`s while they were in use and instead adds reference counting logic to serve the same purpose without needing to lock while calling into arbitrary `IConfigurationProvider` implementations.

`ConfigurationManager` is new in .NET 6 which mitigates the risk somewhat. However, it is used by ASP.NET Core's new `WebApplication` which is now the default host in all the .NET 6 ASP.NET Core project templates, but I think that's all the more reason to fix this deadlock in .NET 6.