### PR TITLE
Unify string.{Last}IndexOfAny and span.{Last}IndexOfAny

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -46,7 +46,7 @@ namespace System.Reflection.Emit
             while (true)
             {
                 i = typeName.LastIndexOf('+', i);
-                if (i == -1)
+                if (i < 0)
                 {
                     break;
                 }
@@ -626,7 +626,7 @@ namespace System.Reflection.Emit
             {
                 // Are there any possible special characters left?
                 int i = className.AsSpan(startIndex).IndexOfAny('[', '*', '&');
-                if (i == -1)
+                if (i < 0)
                 {
                     // No, type name is simple.
                     baseName = className;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -527,7 +527,7 @@ namespace System.Reflection.Emit
             }
 
             int iLast = fullname.LastIndexOf('.');
-            if (iLast == -1 || iLast == 0)
+            if (iLast <= 0)
             {
                 // no name space
                 m_strNameSpace = string.Empty;

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -523,7 +523,7 @@ namespace System.Reflection
 
                 int i = s.LastIndexOf(System.IO.Path.DirectorySeparatorChar);
 
-                if (i == -1)
+                if (i < 0)
                     return s;
 
                 return s.Substring(i + 1);

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1992,8 +1992,8 @@ namespace System
                 return;
 
             // Get namespace
-            int nsDelimiter = fullname.LastIndexOf(".", StringComparison.Ordinal);
-            if (nsDelimiter != -1)
+            int nsDelimiter = fullname.LastIndexOf('.');
+            if (nsDelimiter >= 0)
             {
                 ns = fullname.Substring(0, nsDelimiter);
                 int nameLength = fullname.Length - ns.Length - 1;

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -184,7 +184,7 @@ namespace System.StubHelpers
         internal static unsafe string ConvertFixedToManaged(IntPtr cstr, int length)
         {
             int end = SpanHelpers.IndexOf(ref *(byte*)cstr, 0, length);
-            if (end != -1)
+            if (end >= 0)
             {
                 length = end;
             }
@@ -512,7 +512,7 @@ namespace System.StubHelpers
         internal static unsafe string ConvertToManaged(IntPtr nativeHome, int length)
         {
             int end = SpanHelpers.IndexOf(ref *(char*)nativeHome, '\0', length);
-            if (end != -1)
+            if (end >= 0)
             {
                 length = end;
             }

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -532,6 +532,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\PasteArguments.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\PlatformID.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\PlatformNotSupportedException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\ProbabilisticMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Progress.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Random.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Random.ImplBase.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/ArraySegment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ArraySegment.cs
@@ -197,7 +197,7 @@ namespace System
 
             int index = System.Array.IndexOf<T>(_array!, item, _offset, _count);
 
-            Debug.Assert(index == -1 ||
+            Debug.Assert(index < 0 ||
                             (index >= _offset && index < _offset + _count));
 
             return index >= 0 ? index - _offset : -1;
@@ -238,7 +238,7 @@ namespace System
 
             int index = System.Array.IndexOf<T>(_array!, item, _offset, _count);
 
-            Debug.Assert(index == -1 ||
+            Debug.Assert(index < 0 ||
                             (index >= _offset && index < _offset + _count));
 
             return index >= 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -318,7 +318,7 @@ namespace System.Collections.Generic
             // via EqualityComparer<T>.Default.Equals, we
             // only make one virtual call to EqualityComparer.IndexOf.
 
-            return _size != 0 && IndexOf(item) != -1;
+            return _size != 0 && IndexOf(item) >= 0;
         }
 
         bool IList.Contains(object? item)

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -951,7 +951,7 @@ namespace System
                 // Find the next separator.
                 ReadOnlySpan<char> subvalue;
                 int endIndex = value.IndexOf(EnumSeparatorChar);
-                if (endIndex == -1)
+                if (endIndex < 0)
                 {
                     // No next separator; use the remainder as the next value.
                     subvalue = value.Trim();

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Unix.cs
@@ -20,7 +20,7 @@ namespace System
             {
                 string hostName = Interop.Sys.GetHostName();
                 int dotPos = hostName.IndexOf('.');
-                return dotPos == -1 ? hostName : hostName.Substring(0, dotPos);
+                return dotPos < 0 ? hostName : hostName.Substring(0, dotPos);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Win32.cs
@@ -123,7 +123,7 @@ namespace System
 
                 ReadOnlySpan<char> name = builder.AsSpan();
                 int index = name.IndexOf('\\');
-                if (index != -1)
+                if (index >= 0)
                 {
                     // In the form of DOMAIN\User, cut off DOMAIN\
                     name = name.Slice(index + 1);
@@ -164,7 +164,7 @@ namespace System
 
                 ReadOnlySpan<char> name = builder.AsSpan();
                 int index = name.IndexOf('\\');
-                if (index != -1)
+                if (index >= 0)
                 {
                     // In the form of DOMAIN\User, cut off \User and return
                     builder.Length = index;

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -195,7 +195,7 @@ namespace System
 
                 // Strip optional suffixes
                 int separatorIndex = versionSpan.IndexOfAny('-', '+', ' ');
-                if (separatorIndex != -1)
+                if (separatorIndex >= 0)
                     versionSpan = versionSpan.Slice(0, separatorIndex);
 
                 // Return zeros rather then failing if the version string fails to parse

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2094,7 +2094,7 @@ namespace System.Globalization
         private static int IndexOfTimePart(string format, int startIndex, string timeParts)
         {
             Debug.Assert(startIndex >= 0, "startIndex cannot be negative");
-            Debug.Assert(timeParts.IndexOfAny(new char[] { '\'', '\\' }) == -1, "timeParts cannot include quote characters");
+            Debug.Assert(timeParts.IndexOfAny(new char[] { '\'', '\\' }) < 0, "timeParts cannot include quote characters");
             bool inQuote = false;
             for (int i = startIndex; i < format.Length; ++i)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -5461,7 +5461,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 int targetPosition = 0;                 // Where we are in the target string
                 int thisPosition = Index;         // Where we are in this string
                 int wsIndex = target.IndexOfAny(WhiteSpaceChecks, targetPosition);
-                if (wsIndex == -1)
+                if (wsIndex < 0)
                 {
                     return false;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -434,7 +434,7 @@ namespace System
             // We continue to support these but expect them to be incredibly rare.  As such, we
             // optimize for correctly formed strings where all the digits are valid hex, and only
             // fall back to supporting these other forms if parsing fails.
-            if (guidString.IndexOfAny('X', 'x', '+') != -1 && TryCompatParsing(guidString, ref result))
+            if (guidString.IndexOfAny('X', 'x', '+') >= 0 && TryCompatParsing(guidString, ref result))
             {
                 return true;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
@@ -76,7 +76,7 @@ namespace System.IO.Enumeration
                     }
                     else
                     {
-                        if (Path.DirectorySeparatorChar != '\\' && expression.IndexOfAny(s_unixEscapeChars) != -1)
+                        if (Path.DirectorySeparatorChar != '\\' && expression.IndexOfAny(s_unixEscapeChars) >= 0)
                         {
                             // Backslash isn't the default separator, need to escape (e.g. Unix)
                             expression = expression.Replace("\\", "\\\\");

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
@@ -161,7 +161,7 @@ namespace System.IO.Enumeration
                     return true;
 
                 ReadOnlySpan<char> expressionEnd = expression.Slice(1);
-                if (expressionEnd.IndexOfAny(useExtendedWildcards ? s_wildcardChars : s_simpleWildcardChars) == -1)
+                if (expressionEnd.IndexOfAny(useExtendedWildcards ? s_wildcardChars : s_simpleWildcardChars) < 0)
                 {
                     // Handle the special case of a single starting *, which essentially means "ends with"
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -226,7 +226,7 @@ namespace System.IO
         {
             ReadOnlySpan<char> fileName = GetFileName(path);
             int lastPeriod = fileName.LastIndexOf('.');
-            return lastPeriod == -1 ?
+            return lastPeriod < 0 ?
                 fileName : // No extension was found
                 fileName.Slice(0, lastPeriod);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -755,61 +755,90 @@ namespace System
 
                 if (Unsafe.SizeOf<T>() == sizeof(char))
                 {
+                    ref char spanRef = ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span));
                     ref char valueRef = ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values));
-                    if (values.Length == 5)
+                    switch (values.Length)
                     {
-                        // Length 5 is a common length for FileSystemName expression (", <, >, *, ?) and in preference to 2 as it has an explicit overload
-                        return SpanHelpers.IndexOfAny(
-                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                            valueRef,
-                            Unsafe.Add(ref valueRef, 1),
-                            Unsafe.Add(ref valueRef, 2),
-                            Unsafe.Add(ref valueRef, 3),
-                            Unsafe.Add(ref valueRef, 4),
-                            span.Length);
-                    }
-                    else if (values.Length == 2)
-                    {
-                        // Length 2 is a common length for simple wildcards (*, ?),  directory separators (/, \), quotes (", '), brackets, etc
-                        return SpanHelpers.IndexOfAny(
-                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                            valueRef,
-                            Unsafe.Add(ref valueRef, 1),
-                            span.Length);
-                    }
-                    else if (values.Length == 4)
-                    {
-                        // Length 4 before 3 as 3 has an explicit overload
-                        return SpanHelpers.IndexOfAny(
-                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                            valueRef,
-                            Unsafe.Add(ref valueRef, 1),
-                            Unsafe.Add(ref valueRef, 2),
-                            Unsafe.Add(ref valueRef, 3),
-                            span.Length);
-                    }
-                    else if (values.Length == 3)
-                    {
-                        return SpanHelpers.IndexOfAny(
-                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                            valueRef,
-                            Unsafe.Add(ref valueRef, 1),
-                            Unsafe.Add(ref valueRef, 2),
-                            span.Length);
-                    }
-                    else if (values.Length == 1)
-                    {
-                        // Length 1 last, as ctoring a ReadOnlySpan to call this overload for a single value
-                        // is already throwing away a bunch of performance vs just calling IndexOf
-                        return SpanHelpers.IndexOf(
-                            ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
-                            valueRef,
-                            span.Length);
+                        case 0:
+                            return -1;
+
+                        case 1:
+                            return SpanHelpers.IndexOf(
+                                ref spanRef,
+                                valueRef,
+                                span.Length);
+
+                        case 2:
+                            return SpanHelpers.IndexOfAny(
+                                ref spanRef,
+                                valueRef,
+                                Unsafe.Add(ref valueRef, 1),
+                                span.Length);
+
+                        case 3:
+                            return SpanHelpers.IndexOfAny(
+                                ref spanRef,
+                                valueRef,
+                                Unsafe.Add(ref valueRef, 1),
+                                Unsafe.Add(ref valueRef, 2),
+                                span.Length);
+
+                        case 4:
+                            return SpanHelpers.IndexOfAny(
+                                ref spanRef,
+                                valueRef,
+                                Unsafe.Add(ref valueRef, 1),
+                                Unsafe.Add(ref valueRef, 2),
+                                Unsafe.Add(ref valueRef, 3),
+                                span.Length);
+
+                        case 5:
+                            return SpanHelpers.IndexOfAny(
+                                ref spanRef,
+                                valueRef,
+                                Unsafe.Add(ref valueRef, 1),
+                                Unsafe.Add(ref valueRef, 2),
+                                Unsafe.Add(ref valueRef, 3),
+                                Unsafe.Add(ref valueRef, 4),
+                                span.Length);
+
+                        default:
+                            return IndexOfAnyProbabilistic(ref spanRef, span.Length, ref valueRef, values.Length);
                     }
                 }
             }
 
             return SpanHelpers.IndexOfAny(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(values), values.Length);
+        }
+
+        /// <summary>Searches for the first index of any of the specified values using a <see cref="ProbabilisticMap"/>.</summary>
+        private static unsafe int IndexOfAnyProbabilistic(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valuesLength >= 0);
+
+            ReadOnlySpan<char> valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
+            ProbabilisticMap map = default;
+
+            uint* charMap = (uint*)&map;
+            ProbabilisticMap.InitializeProbabilisticMap(charMap, valuesSpan);
+
+            ref char cur = ref searchSpace;
+            while (searchSpaceLength != 0)
+            {
+                int ch = cur;
+                if (ProbabilisticMap.IsCharBitSet(charMap, (byte)ch) &&
+                    ProbabilisticMap.IsCharBitSet(charMap, (byte)(ch >> 8)) &&
+                    ProbabilisticMap.SpanContains(valuesSpan, (char)ch))
+                {
+                    return (int)((nint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                }
+
+                searchSpaceLength--;
+                cur = ref Unsafe.Add(ref cur, 1);
+            }
+
+            return -1;
         }
 
         /// <summary>
@@ -918,7 +947,65 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LastIndexOfAny<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> values) where T : IEquatable<T>
         {
+            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            {
+                if (Unsafe.SizeOf<T>() == sizeof(char))
+                {
+                    switch (values.Length)
+                    {
+                        case 0:
+                            return -1;
+
+                        case 1:
+                            return LastIndexOf(span, values[0]);
+
+                        case 2:
+                            return LastIndexOfAny(span, values[0], values[1]);
+
+                        case 3:
+                            return LastIndexOfAny(span, values[0], values[1], values[2]);
+
+                        default:
+                            return LastIndexOfAnyProbabilistic(
+                                ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
+                                span.Length,
+                                ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(values)),
+                                values.Length);
+                    }
+                }
+            }
+
             return SpanHelpers.LastIndexOfAny(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(values), values.Length);
+        }
+
+        /// <summary>Searches for the last index of any of the specified values using a <see cref="ProbabilisticMap"/>.</summary>
+        private static unsafe int LastIndexOfAnyProbabilistic(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+        {
+            Debug.Assert(searchSpaceLength >= 0);
+            Debug.Assert(valuesLength >= 0);
+
+            var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
+            ProbabilisticMap map = default;
+
+            uint* charMap = (uint*)&map;
+            ProbabilisticMap.InitializeProbabilisticMap(charMap, valuesSpan);
+
+            ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength - 1);
+            while (searchSpaceLength != 0)
+            {
+                int ch = cur;
+                if (ProbabilisticMap.IsCharBitSet(charMap, (byte)ch) &&
+                    ProbabilisticMap.IsCharBitSet(charMap, (byte)(ch >> 8)) &&
+                    ProbabilisticMap.SpanContains(valuesSpan, (char)ch))
+                {
+                    return (int)((nint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                }
+
+                searchSpaceLength--;
+                cur = ref Unsafe.Add(ref cur, -1);
+            }
+
+            return -1;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -281,13 +281,13 @@ namespace System
                         span.Length);
 
                 if (Unsafe.SizeOf<T>() == sizeof(int))
-                    return -1 != SpanHelpers.IndexOfValueType(
+                    return 0 <= SpanHelpers.IndexOfValueType(
                         ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, int>(ref value),
                         span.Length);
 
                 if (Unsafe.SizeOf<T>() == sizeof(long))
-                    return -1 != SpanHelpers.IndexOfValueType(
+                    return 0 <= SpanHelpers.IndexOfValueType(
                         ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, long>(ref value),
                         span.Length);
@@ -320,13 +320,13 @@ namespace System
                         span.Length);
 
                 if (Unsafe.SizeOf<T>() == sizeof(int))
-                    return -1 != SpanHelpers.IndexOfValueType(
+                    return 0 <= SpanHelpers.IndexOfValueType(
                         ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, int>(ref value),
                         span.Length);
 
                 if (Unsafe.SizeOf<T>() == sizeof(long))
-                    return -1 != SpanHelpers.IndexOfValueType(
+                    return 0 <= SpanHelpers.IndexOfValueType(
                         ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.As<T, long>(ref value),
                         span.Length);
@@ -821,7 +821,7 @@ namespace System
             ProbabilisticMap map = default;
 
             uint* charMap = (uint*)&map;
-            ProbabilisticMap.InitializeProbabilisticMap(charMap, valuesSpan);
+            ProbabilisticMap.Initialize(charMap, valuesSpan);
 
             ref char cur = ref searchSpace;
             while (searchSpaceLength != 0)
@@ -988,7 +988,7 @@ namespace System
             ProbabilisticMap map = default;
 
             uint* charMap = (uint*)&map;
-            ProbabilisticMap.InitializeProbabilisticMap(charMap, valuesSpan);
+            ProbabilisticMap.Initialize(charMap, valuesSpan);
 
             ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength - 1);
             while (searchSpaceLength != 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -42,7 +42,7 @@ namespace System.Net
 
             // Don't create ValueStringBuilder if we don't have anything to encode
             int index = IndexOfHtmlEncodingChars(valueSpan);
-            if (index == -1)
+            if (index < 0)
             {
                 return value;
             }
@@ -78,7 +78,7 @@ namespace System.Net
 
             // Don't create ValueStringBuilder if we don't have anything to encode
             int index = IndexOfHtmlEncodingChars(valueSpan);
-            if (index == -1)
+            if (index < 0)
             {
                 output.Write(value);
                 return;
@@ -188,7 +188,7 @@ namespace System.Net
             ReadOnlySpan<char> valueSpan = value.AsSpan();
 
             int index = IndexOfHtmlDecodingChars(valueSpan);
-            if (index == -1)
+            if (index < 0)
             {
                 return value;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    /// <summary>Data structure used to optimize checks for whether a char is in a set of chars.</summary>
+    /// <remarks>
+    /// Like a Bloom filter, the idea is to create a bit map of the characters we are
+    /// searching for and use this map as a "cheap" check to decide if the current
+    /// character in the string exists in the array of input characters. There are
+    /// 256 bits in the map, with each character mapped to 2 bits. Every character is
+    /// divided into 2 bytes, and then every byte is mapped to 1 bit. The character map
+    /// is an array of 8 integers acting as map blocks. The 3 lsb in each byte in the
+    /// character is used to index into this map to get the right block, the value of
+    /// the remaining 5 msb are used as the bit position inside this block.
+    /// </remarks>
+    [StructLayout(LayoutKind.Explicit, Size = Size * sizeof(uint))]
+    internal struct ProbabilisticMap
+    {
+        private const int Size = 0x8;
+        private const int IndexMask = 0x7;
+        private const int IndexShift = 0x3;
+
+        /// <summary>Initializes the map based on the specified values.</summary>
+        /// <param name="charMap">A pointer to the beginning of a <see cref="ProbabilisticMap"/>.</param>
+        /// <param name="values">The values to set in the map.</param>
+        public static unsafe void InitializeProbabilisticMap(uint* charMap, ReadOnlySpan<char> values)
+        {
+#if DEBUG
+            for (int i = 0; i < Size; i++)
+            {
+                Debug.Assert(charMap[i] == 0, "Expected charMap to be zero-initialized.");
+            }
+#endif
+            bool hasAscii = false;
+            uint* charMapLocal = charMap; // https://github.com/dotnet/runtime/issues/9040
+
+            for (int i = 0; i < values.Length; ++i)
+            {
+                int c = values[i];
+
+                // Map low bit
+                SetCharBit(charMapLocal, (byte)c);
+
+                // Map high bit
+                c >>= 8;
+
+                if (c == 0)
+                {
+                    hasAscii = true;
+                }
+                else
+                {
+                    SetCharBit(charMapLocal, (byte)c);
+                }
+            }
+
+            if (hasAscii)
+            {
+                // Common to search for ASCII symbols. Just set the high value once.
+                charMapLocal[0] |= 1u;
+            }
+        }
+
+        public static unsafe bool IsCharBitSet(uint* charMap, byte value) =>
+            (charMap[(uint)value & IndexMask] & (1u << (value >> IndexShift))) != 0;
+
+        private static unsafe void SetCharBit(uint* charMap, byte value) =>
+            charMap[(uint)value & IndexMask] |= 1u << (value >> IndexShift);
+
+        /// <summary>Determines whether <paramref name="searchChar"/> is in <paramref name="span"/>.</summary>
+        /// <remarks>
+        /// <see cref="MemoryExtensions.Contains{T}(ReadOnlySpan{T}, T)"/> could be used, but it's optimized
+        /// for longer spans, whereas typical usage here expects a relatively small number of items in the span.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool SpanContains(ReadOnlySpan<char> span, char searchChar)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                if (span[i] == searchChar)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ProbabilisticMap.cs
@@ -28,7 +28,7 @@ namespace System
         /// <summary>Initializes the map based on the specified values.</summary>
         /// <param name="charMap">A pointer to the beginning of a <see cref="ProbabilisticMap"/>.</param>
         /// <param name="values">The values to set in the map.</param>
-        public static unsafe void InitializeProbabilisticMap(uint* charMap, ReadOnlySpan<char> values)
+        public static unsafe void Initialize(uint* charMap, ReadOnlySpan<char> values)
         {
 #if DEBUG
             for (int i = 0; i < Size; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -566,7 +566,7 @@ namespace System.Resources
 
             // First, compare type names
             int comma = asmTypeName.IndexOf(',');
-            if (((comma == -1) ? asmTypeName.Length : comma) != typeName.Length)
+            if (((comma < 0) ? asmTypeName.Length : comma) != typeName.Length)
                 return false;
 
             // case sensitive

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices
 
                     // Strip the git hash if there is one
                     int plusIndex = versionString.IndexOf('+');
-                    if (plusIndex != -1)
+                    if (plusIndex >= 0)
                     {
                         versionString = versionString.Slice(0, plusIndex);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/FrameworkName.cs
@@ -161,7 +161,7 @@ namespace System.Runtime.Versioning
                 string component = components[i];
                 int separatorIndex = component.IndexOf(KeyValueSeparator);
 
-                if (separatorIndex == -1 || separatorIndex != component.LastIndexOf(KeyValueSeparator))
+                if (separatorIndex < 0 || separatorIndex != component.LastIndexOf(KeyValueSeparator))
                 {
                     throw new ArgumentException(SR.Argument_FrameworkNameInvalid, nameof(frameworkName));
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -459,7 +459,7 @@ namespace System
             }
 #endif // FEATURE_COMINTEROP
 
-            if (namedParams != null && Array.IndexOf(namedParams, null!) != -1)
+            if (namedParams != null && Array.IndexOf(namedParams, null!) >= 0)
                 throw new ArgumentException(SR.Arg_NamedParamNull, nameof(namedParams));
 
             int argCnt = (providedArgs != null) ? providedArgs.Length : 0;

--- a/src/libraries/System.Private.CoreLib/src/System/SR.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SR.cs
@@ -51,7 +51,7 @@ namespace System
 
                 // Are we recursively looking up the same resource?  Note - our backout code will set
                 // the ResourceHelper's currentlyLoading stack to null if an exception occurs.
-                if (_currentlyLoading != null && _currentlyLoading.Count > 0 && _currentlyLoading.LastIndexOf(key) != -1)
+                if (_currentlyLoading != null && _currentlyLoading.Count > 0 && _currentlyLoading.LastIndexOf(key) >= 0)
                 {
                     // We can start infinitely recursing for one resource lookup,
                     // then during our failure reporting, start infinitely recursing again.

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
@@ -303,7 +303,7 @@ namespace System.Security
             if (tag == null)
                 return false;
 
-            return tag.IndexOfAny(s_tagIllegalCharacters) == -1;
+            return tag.IndexOfAny(s_tagIllegalCharacters) < 0;
         }
 
         public static bool IsValidText([NotNullWhen(true)] string? text)
@@ -311,7 +311,7 @@ namespace System.Security
             if (text == null)
                 return false;
 
-            return text.IndexOfAny(s_textIllegalCharacters) == -1;
+            return text.IndexOfAny(s_textIllegalCharacters) < 0;
         }
 
         public static bool IsValidAttributeName([NotNullWhen(true)] string? name)
@@ -324,7 +324,7 @@ namespace System.Security
             if (value == null)
                 return false;
 
-            return value.IndexOfAny(s_valueIllegalCharacters) == -1;
+            return value.IndexOfAny(s_valueIllegalCharacters) < 0;
         }
 
         private static string GetEscapeSequence(char c)
@@ -361,7 +361,7 @@ namespace System.Security
             {
                 index = str.IndexOfAny(s_escapeChars, newIndex);
 
-                if (index == -1)
+                if (index < 0)
                 {
                     if (sb == null)
                         return str;
@@ -425,7 +425,7 @@ namespace System.Security
             {
                 index = str.IndexOf('&', newIndex);
 
-                if (index == -1)
+                if (index < 0)
                 {
                     if (sb == null)
                         return str;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -32,7 +32,7 @@ namespace System
             {
                 // Do a quick search for the first element of "value".
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, offset), valueHead, remainingSearchSpaceLength);
-                if (relativeIndex == -1)
+                if (relativeIndex < 0)
                     break;
 
                 remainingSearchSpaceLength -= relativeIndex;
@@ -430,7 +430,7 @@ namespace System
 
                 // Do a quick search for the first element of "value".
                 int relativeIndex = LastIndexOf(ref searchSpace, valueHead, remainingSearchSpaceLength);
-                if (relativeIndex == -1)
+                if (relativeIndex < 0)
                     break;
 
                 // Found the first element of "value". See if the tail matches.

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -32,7 +32,7 @@ namespace System
             {
                 // Do a quick search for the first element of "value".
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
-                if (relativeIndex == -1)
+                if (relativeIndex < 0)
                     break;
 
                 remainingSearchSpaceLength -= relativeIndex;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -208,7 +208,7 @@ namespace System
 
                 // Do a quick search for the first element of "value".
                 int relativeIndex = IndexOf(ref Unsafe.Add(ref searchSpace, index), valueHead, remainingSearchSpaceLength);
-                if (relativeIndex == -1)
+                if (relativeIndex < 0)
                     break;
                 index += relativeIndex;
 
@@ -788,7 +788,7 @@ namespace System
 
                 // Do a quick search for the first element of "value".
                 int relativeIndex = LastIndexOf(ref searchSpace, valueHead, remainingSearchSpaceLength);
-                if (relativeIndex == -1)
+                if (relativeIndex < 0)
                     break;
 
                 // Found the first element of "value". See if the tail matches.

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1087,7 +1087,7 @@ namespace System
                 while (true)
                 {
                     int pos = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, i), c, Length - i);
-                    if (pos == -1)
+                    if (pos < 0)
                     {
                         break;
                     }
@@ -1102,7 +1102,7 @@ namespace System
                 while (true)
                 {
                     int pos = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, i), Length - i, ref oldValue._firstChar, oldValue.Length);
-                    if (pos == -1)
+                    if (pos < 0)
                     {
                         break;
                     }
@@ -1683,7 +1683,7 @@ namespace System
                 {
                     ProbabilisticMap map = default;
                     uint* charMap = (uint*)&map;
-                    ProbabilisticMap.InitializeProbabilisticMap(charMap, separators);
+                    ProbabilisticMap.Initialize(charMap, separators);
 
                     for (int i = 0; i < Length; i++)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1683,12 +1683,13 @@ namespace System
                 {
                     ProbabilisticMap map = default;
                     uint* charMap = (uint*)&map;
-                    InitializeProbabilisticMap(charMap, separators);
+                    ProbabilisticMap.InitializeProbabilisticMap(charMap, separators);
 
                     for (int i = 0; i < Length; i++)
                     {
                         char c = this[i];
-                        if (IsCharBitSet(charMap, (byte)c) && IsCharBitSet(charMap, (byte)(c >> 8)) &&
+                        if (ProbabilisticMap.IsCharBitSet(charMap, (byte)c) &&
+                            ProbabilisticMap.IsCharBitSet(charMap, (byte)(c >> 8)) &&
                             separators.Contains(c))
                         {
                             sepListBuilder.Append(i);

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -81,7 +81,7 @@ namespace System
 
             int result = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, startIndex), value, count);
 
-            return result == -1 ? result : result + startIndex;
+            return result < 0 ? result : result + startIndex;
         }
 
         // Returns the index of the first occurrence of any specified character in the current instance.
@@ -121,7 +121,7 @@ namespace System
 
             int result = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, startIndex), count).IndexOfAny(anyOf);
 
-            return result == -1 ? result : result + startIndex;
+            return result < 0 ? result : result + startIndex;
         }
 
        /*
@@ -291,7 +291,7 @@ namespace System
             int startSearchAt = startIndex + 1 - count;
             int result = SpanHelpers.LastIndexOf(ref Unsafe.Add(ref _firstChar, startSearchAt), value, count);
 
-            return result == -1 ? result : result + startSearchAt;
+            return result < 0 ? result : result + startSearchAt;
         }
 
         // Returns the index of the last occurrence of any specified character in the current instance.
@@ -339,7 +339,7 @@ namespace System
             int startSearchAt = startIndex + 1 - count;
             int result = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, startSearchAt), count).LastIndexOfAny(anyOf);
 
-            return result == -1 ? result : result + startSearchAt;
+            return result < 0 ? result : result + startSearchAt;
         }
 
         // Returns the index of the last occurrence of any character in value in the current instance.

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 namespace System
@@ -42,7 +41,7 @@ namespace System
 
         public int IndexOf(char value, int startIndex)
         {
-            return IndexOf(value, startIndex, this.Length - startIndex);
+            return IndexOf(value, startIndex, Length - startIndex);
         }
 
         public int IndexOf(char value, StringComparison comparisonType)
@@ -71,10 +70,14 @@ namespace System
         public unsafe int IndexOf(char value, int startIndex, int count)
         {
             if ((uint)startIndex > (uint)Length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+            }
 
             if ((uint)count > (uint)(Length - startIndex))
-                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+            }
 
             int result = SpanHelpers.IndexOf(ref Unsafe.Add(ref _firstChar, startIndex), value, count);
 
@@ -86,138 +89,39 @@ namespace System
         //
         public int IndexOfAny(char[] anyOf)
         {
-            return IndexOfAny(anyOf, 0, this.Length);
+            if (anyOf is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.anyOf);
+            }
+
+            return new ReadOnlySpan<char>(ref _firstChar, Length).IndexOfAny(anyOf);
         }
 
         public int IndexOfAny(char[] anyOf, int startIndex)
         {
-            return IndexOfAny(anyOf, startIndex, this.Length - startIndex);
+            return IndexOfAny(anyOf, startIndex, Length - startIndex);
         }
 
         public int IndexOfAny(char[] anyOf, int startIndex, int count)
         {
-            if (anyOf == null)
-                throw new ArgumentNullException(nameof(anyOf));
+            if (anyOf is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.anyOf);
+            }
 
             if ((uint)startIndex > (uint)Length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+            }
 
             if ((uint)count > (uint)(Length - startIndex))
-                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
-
-            if (anyOf.Length > 0 && anyOf.Length <= 5)
             {
-                // The ReadOnlySpan.IndexOfAny extension is vectorized for values of 1 - 5 in length
-                int result = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, startIndex), count).IndexOfAny(anyOf);
-                return result == -1 ? result : result + startIndex;
-            }
-            else if (anyOf.Length > 5)
-            {
-                // Use Probabilistic Map
-                return IndexOfCharArray(anyOf, startIndex, count);
-            }
-            else // anyOf.Length == 0
-            {
-                return -1;
-            }
-        }
-
-        private unsafe int IndexOfCharArray(char[] anyOf, int startIndex, int count)
-        {
-            // use probabilistic map, see InitializeProbabilisticMap
-            ProbabilisticMap map = default;
-            uint* charMap = (uint*)&map;
-
-            InitializeProbabilisticMap(charMap, anyOf);
-
-            fixed (char* pChars = &_firstChar)
-            {
-                char* pCh = pChars + startIndex;
-
-                while (count > 0)
-                {
-                    int thisChar = *pCh;
-
-                    if (IsCharBitSet(charMap, (byte)thisChar) &&
-                        IsCharBitSet(charMap, (byte)(thisChar >> 8)) &&
-                        ArrayContains((char)thisChar, anyOf))
-                    {
-                        return (int)(pCh - pChars);
-                    }
-
-                    count--;
-                    pCh++;
-                }
-
-                return -1;
-            }
-        }
-
-        private const int PROBABILISTICMAP_BLOCK_INDEX_MASK = 0x7;
-        private const int PROBABILISTICMAP_BLOCK_INDEX_SHIFT = 0x3;
-        private const int PROBABILISTICMAP_SIZE = 0x8;
-
-        // A probabilistic map is an optimization that is used in IndexOfAny/
-        // LastIndexOfAny methods. The idea is to create a bit map of the characters we
-        // are searching for and use this map as a "cheap" check to decide if the
-        // current character in the string exists in the array of input characters.
-        // There are 256 bits in the map, with each character mapped to 2 bits. Every
-        // character is divided into 2 bytes, and then every byte is mapped to 1 bit.
-        // The character map is an array of 8 integers acting as map blocks. The 3 lsb
-        // in each byte in the character is used to index into this map to get the
-        // right block, the value of the remaining 5 msb are used as the bit position
-        // inside this block.
-        private static unsafe void InitializeProbabilisticMap(uint* charMap, ReadOnlySpan<char> anyOf)
-        {
-            bool hasAscii = false;
-            uint* charMapLocal = charMap; // https://github.com/dotnet/runtime/issues/9040
-
-            for (int i = 0; i < anyOf.Length; ++i)
-            {
-                int c = anyOf[i];
-
-                // Map low bit
-                SetCharBit(charMapLocal, (byte)c);
-
-                // Map high bit
-                c >>= 8;
-
-                if (c == 0)
-                {
-                    hasAscii = true;
-                }
-                else
-                {
-                    SetCharBit(charMapLocal, (byte)c);
-                }
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
             }
 
-            if (hasAscii)
-            {
-                // Common to search for ASCII symbols. Just set the high value once.
-                charMapLocal[0] |= 1u;
-            }
-        }
+            int result = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, startIndex), count).IndexOfAny(anyOf);
 
-        private static bool ArrayContains(char searchChar, char[] anyOf)
-        {
-            for (int i = 0; i < anyOf.Length; i++)
-            {
-                if (anyOf[i] == searchChar)
-                    return true;
-            }
-
-            return false;
-        }
-
-        private static unsafe bool IsCharBitSet(uint* charMap, byte value)
-        {
-            return (charMap[(uint)value & PROBABILISTICMAP_BLOCK_INDEX_MASK] & (1u << (value >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT))) != 0;
-        }
-
-        private static unsafe void SetCharBit(uint* charMap, byte value)
-        {
-            charMap[(uint)value & PROBABILISTICMAP_BLOCK_INDEX_MASK] |= 1u << (value >> PROBABILISTICMAP_BLOCK_INDEX_SHIFT);
+            return result == -1 ? result : result + startIndex;
         }
 
        /*
@@ -322,12 +226,12 @@ namespace System
 
         public int IndexOf(string value, StringComparison comparisonType)
         {
-            return IndexOf(value, 0, this.Length, comparisonType);
+            return IndexOf(value, 0, Length, comparisonType);
         }
 
         public int IndexOf(string value, int startIndex, StringComparison comparisonType)
         {
-            return IndexOf(value, startIndex, this.Length - startIndex, comparisonType);
+            return IndexOf(value, startIndex, Length - startIndex, comparisonType);
         }
 
         public int IndexOf(string value, int startIndex, int count, StringComparison comparisonType)
@@ -370,13 +274,19 @@ namespace System
         public unsafe int LastIndexOf(char value, int startIndex, int count)
         {
             if (Length == 0)
+            {
                 return -1;
+            }
 
             if ((uint)startIndex >= (uint)Length)
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
+            }
 
             if ((uint)count > (uint)startIndex + 1)
-                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+            }
 
             int startSearchAt = startIndex + 1 - count;
             int result = SpanHelpers.LastIndexOf(ref Unsafe.Add(ref _firstChar, startSearchAt), value, count);
@@ -391,7 +301,12 @@ namespace System
         //
         public int LastIndexOfAny(char[] anyOf)
         {
-            return LastIndexOfAny(anyOf, this.Length - 1, this.Length);
+            if (anyOf is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.anyOf);
+            }
+
+            return new ReadOnlySpan<char>(ref _firstChar, Length).LastIndexOfAny(anyOf);
         }
 
         public int LastIndexOfAny(char[] anyOf, int startIndex)
@@ -401,65 +316,30 @@ namespace System
 
         public unsafe int LastIndexOfAny(char[] anyOf, int startIndex, int count)
         {
-            if (anyOf == null)
-                throw new ArgumentNullException(nameof(anyOf));
+            if (anyOf is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.anyOf);
+            }
 
             if (Length == 0)
+            {
                 return -1;
+            }
 
             if ((uint)startIndex >= (uint)Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_Index);
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_Index);
             }
 
             if ((count < 0) || ((count - 1) > startIndex))
             {
-                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Count);
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
             }
 
-            if (anyOf.Length > 1)
-            {
-                return LastIndexOfCharArray(anyOf, startIndex, count);
-            }
-            else if (anyOf.Length == 1)
-            {
-                return LastIndexOf(anyOf[0], startIndex, count);
-            }
-            else // anyOf.Length == 0
-            {
-                return -1;
-            }
-        }
+            int startSearchAt = startIndex + 1 - count;
+            int result = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, startSearchAt), count).LastIndexOfAny(anyOf);
 
-        private unsafe int LastIndexOfCharArray(char[] anyOf, int startIndex, int count)
-        {
-            // use probabilistic map, see InitializeProbabilisticMap
-            ProbabilisticMap map = default;
-            uint* charMap = (uint*)&map;
-
-            InitializeProbabilisticMap(charMap, anyOf);
-
-            fixed (char* pChars = &_firstChar)
-            {
-                char* pCh = pChars + startIndex;
-
-                while (count > 0)
-                {
-                    int thisChar = *pCh;
-
-                    if (IsCharBitSet(charMap, (byte)thisChar) &&
-                        IsCharBitSet(charMap, (byte)(thisChar >> 8)) &&
-                        ArrayContains((char)thisChar, anyOf))
-                    {
-                        return (int)(pCh - pChars);
-                    }
-
-                    count--;
-                    pCh--;
-                }
-
-                return -1;
-            }
+            return result == -1 ? result : result + startSearchAt;
         }
 
         // Returns the index of the last occurrence of any character in value in the current instance.
@@ -469,7 +349,7 @@ namespace System
         //
         public int LastIndexOf(string value)
         {
-            return LastIndexOf(value, this.Length - 1, this.Length, StringComparison.CurrentCulture);
+            return LastIndexOf(value, Length - 1, Length, StringComparison.CurrentCulture);
         }
 
         public int LastIndexOf(string value, int startIndex)
@@ -484,7 +364,7 @@ namespace System
 
         public int LastIndexOf(string value, StringComparison comparisonType)
         {
-            return LastIndexOf(value, this.Length - 1, this.Length, comparisonType);
+            return LastIndexOf(value, Length - 1, Length, comparisonType);
         }
 
         public int LastIndexOf(string value, int startIndex, StringComparison comparisonType)
@@ -516,8 +396,5 @@ namespace System
                         : new ArgumentException(SR.NotSupported_StringComparison, nameof(comparisonType));
             }
         }
-
-        [StructLayout(LayoutKind.Explicit, Size = PROBABILISTICMAP_SIZE * sizeof(uint))]
-        private struct ProbabilisticMap { }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WaitThread.cs
@@ -442,9 +442,9 @@ namespace System.Threading
                 try
                 {
                     // If this handle is not already pending removal and hasn't already been removed
-                    if (Array.IndexOf(_registeredWaits, handle) != -1)
+                    if (Array.IndexOf(_registeredWaits, handle) >= 0)
                     {
-                        if (Array.IndexOf(_pendingRemoves, handle) == -1)
+                        if (Array.IndexOf(_pendingRemoves, handle) < 0)
                         {
                             _pendingRemoves[_numPendingRemoves++] = handle;
                             _changeHandlesEvent.Set(); // Tell the wait thread that there are changes pending.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -4552,7 +4552,7 @@ namespace System.Threading.Tasks
                     // Find continuationObject in the continuation list
                     int index = continuationsLocalListRef.IndexOf(continuationObject);
 
-                    if (index != -1)
+                    if (index >= 0)
                     {
                         // null out that TaskContinuation entry, which will be interpreted as "to be cleaned up"
                         continuationsLocalListRef[index] = null;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -39,7 +39,7 @@ namespace System.Threading
                 while (true)
                 {
                     WorkStealingQueue[] oldQueues = _queues;
-                    Debug.Assert(Array.IndexOf(oldQueues, queue) == -1);
+                    Debug.Assert(Array.IndexOf(oldQueues, queue) < 0);
 
                     var newQueues = new WorkStealingQueue[oldQueues.Length + 1];
                     Array.Copy(oldQueues, newQueues, oldQueues.Length);
@@ -63,7 +63,7 @@ namespace System.Threading
                     }
 
                     int pos = Array.IndexOf(oldQueues, queue);
-                    if (pos == -1)
+                    if (pos < 0)
                     {
                         Debug.Fail("Should have found the queue");
                         return;

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -852,6 +852,8 @@ namespace System
                     return "offset";
                 case ExceptionArgument.stream:
                     return "stream";
+                case ExceptionArgument.anyOf:
+                    return "anyOf";
                 default:
                     Debug.Fail("The enum value is not defined, please check the ExceptionArgument Enum.");
                     return "";
@@ -1119,7 +1121,8 @@ namespace System
         buffer,
         buffers,
         offset,
-        stream
+        stream,
+        anyOf,
     }
 
     //

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.NonAndroid.cs
@@ -89,15 +89,15 @@ namespace System
                             // the format of the line is "country-code \t coordinates \t TimeZone Id \t comments"
 
                             int firstTabIndex = zoneTabFileLine.IndexOf('\t');
-                            if (firstTabIndex != -1)
+                            if (firstTabIndex >= 0)
                             {
                                 int secondTabIndex = zoneTabFileLine.IndexOf('\t', firstTabIndex + 1);
-                                if (secondTabIndex != -1)
+                                if (secondTabIndex >= 0)
                                 {
                                     string timeZoneId;
                                     int startIndex = secondTabIndex + 1;
                                     int thirdTabIndex = zoneTabFileLine.IndexOf('\t', startIndex);
-                                    if (thirdTabIndex != -1)
+                                    if (thirdTabIndex >= 0)
                                     {
                                         int length = thirdTabIndex - startIndex;
                                         timeZoneId = zoneTabFileLine.Substring(startIndex, length);

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -304,11 +304,11 @@ namespace System
             // We musn't have any separators after build.
             int buildEnd = -1;
             int minorEnd = input.Slice(majorEnd + 1).IndexOf('.');
-            if (minorEnd != -1)
+            if (minorEnd >= 0)
             {
                 minorEnd += (majorEnd + 1);
                 buildEnd = input.Slice(minorEnd + 1).IndexOf('.');
-                if (buildEnd != -1)
+                if (buildEnd >= 0)
                 {
                     buildEnd += (minorEnd + 1);
                     if (input.Slice(buildEnd + 1).Contains('.'))


### PR DESCRIPTION
Currently, string.IndexOfAny delegates to span.IndexOfAny (MemoryExtensions) for 1 through 5 values, and for more than it, it falls back to its own "probabilistic map"-based implementation, which tries to avoid looping through each value character for each character in the input.  span.IndexOfAny doesn't do that, instead always looping through every char for every input char.  This PR moves the logic from string into MemoryExtensions and then has string unconditionally delegate to span.

string.LastIndexOfAny in contrast would only delegate to span's implementation if the values list actually only had a single character in it; otherwise, it would again fall back to its own "probabilistic map"-based implementation.  This PR again moves that fallback into MemoryExtensions, with string unconditionally delegating to it.  MemoryExtensions also has LastIndexOf overloads for 2 and 3 items, so rather than using the probabilistic path for those, it delegates to the existing overloads.

Fixes https://github.com/dotnet/runtime/issues/60864

As an example, the MemoryExtensions.EnumerateLines introduced in .NET 6 uses MemoryExtensions.IndexOfAny with more than 5 values.
```C#
using System;
using System.Linq;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    const string Input = @"Shall I compare thee to a summer’s day?
Thou art more lovely and more temperate:
Rough winds do shake the darling buds of May,
And summer’s lease hath all too short a date;
Sometime too hot the eye of heaven shines,
And often is his gold complexion dimm'd;
And every fair from fair sometime declines,
By chance or nature’s changing course untrimm'd;
But thy eternal summer shall not fade,
Nor lose possession of that fair thou ow’st;
Nor shall death brag thou wander’st in his shade,
When in eternal lines to time thou grow’st:
So long as men can breathe or eyes can see,
So long lives this, and this gives life to thee.";

    [Benchmark]
    public void ParseLines()
    {
        ReadOnlySpan<char> span = Input;
        foreach (ReadOnlySpan<char> line in span.EnumerateLines()) ;
    }
}
```

|     Method |         Toolchain |     Mean | Ratio |
|----------- |------------------ |---------:|------:|
| ParseLines | \main\corerun.exe | 1.622 us |  1.00 |
| ParseLines |   \pr\corerun.exe | 1.223 us |  0.76 |

And a more complete set of microbenchmarks:
```C#
using System;
using System.Linq;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    const string Input = @"Shall I compare thee to a summer’s day?
Thou art more lovely and more temperate:
Rough winds do shake the darling buds of May,
And summer’s lease hath all too short a date;
Sometime too hot the eye of heaven shines,
And often is his gold complexion dimm'd;
And every fair from fair sometime declines,
By chance or nature’s changing course untrimm'd;
But thy eternal summer shall not fade,
Nor lose possession of that fair thou ow’st;
Nor shall death brag thou wander’st in his shade,
When in eternal lines to time thou grow’st:
So long as men can breathe or eyes can see,
So long lives this, and this gives life to thee.";

    [Params(5, 633)] public int InputLength { get; set; }
    [Params(1, 2, 3, 4, 5, 6, 7)] public int ValuesLength { get; set; }

    private string _input;
    private char[] _values;

    [GlobalSetup]
    public void Setup()
    {
        _input = Input.Substring(0, Math.Min(InputLength, Input.Length));
        _values = Enumerable.Range(0, ValuesLength).Select(i => (char)('1' + i)).ToArray();
    }

    [Benchmark] public int StringIndexOfAny() => _input.IndexOfAny(_values);
    [Benchmark] public int SpanIndexOfAny() => ((ReadOnlySpan<char>)_input).IndexOfAny(_values);
    [Benchmark] public int StringLastIndexOfAny() => _input.LastIndexOfAny(_values);
    [Benchmark] public int SpanLastIndexOfAny() => ((ReadOnlySpan<char>)_input).LastIndexOfAny(_values);
}
```
There are some small regressions here and there, but typically just a couple of nanoseconds when dealing with a small input string.

|               Method |         Toolchain | InputLength | ValuesLength |         Mean |      Error | Ratio |
|--------------------- |------------------ |------------ |------------- |-------------:|-----------:|------:|
|     StringIndexOfAny | \main\corerun.exe |           5 |            1 |     6.249 ns |  0.0372 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |           5 |            1 |     5.003 ns |  0.0504 ns |  0.80 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |           5 |            1 |     4.803 ns |  0.0245 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |           5 |            1 |     4.444 ns |  0.0701 ns |  0.93 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |           5 |            1 |     8.176 ns |  0.0180 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |           5 |            1 |     5.414 ns |  0.1334 ns |  0.67 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |           5 |            1 |     5.798 ns |  0.0322 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |           5 |            1 |     4.792 ns |  0.0148 ns |  0.83 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |           5 |            2 |     5.402 ns |  0.0246 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |           5 |            2 |     4.854 ns |  0.0863 ns |  0.90 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |           5 |            2 |     4.408 ns |  0.0256 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |           5 |            2 |     4.801 ns |  0.0810 ns |  1.09 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |           5 |            2 |    11.516 ns |  0.0646 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |           5 |            2 |     4.894 ns |  0.0709 ns |  0.42 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |           5 |            2 |     8.254 ns |  0.1038 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |           5 |            2 |     5.116 ns |  0.0226 ns |  0.62 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |           5 |            3 |     8.210 ns |  0.0521 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |           5 |            3 |     6.524 ns |  0.0253 ns |  0.79 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |           5 |            3 |     6.932 ns |  0.0831 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |           5 |            3 |     6.695 ns |  0.0450 ns |  0.97 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |           5 |            3 |    12.244 ns |  0.0774 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |           5 |            3 |     6.746 ns |  0.0543 ns |  0.55 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |           5 |            3 |     9.645 ns |  0.0561 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |           5 |            3 |     6.506 ns |  0.0623 ns |  0.67 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |           5 |            4 |     8.839 ns |  0.0415 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |           5 |            4 |     8.178 ns |  0.0226 ns |  0.93 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |           5 |            4 |     8.159 ns |  0.0672 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |           5 |            4 |     8.679 ns |  0.1988 ns |  1.09 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |           5 |            4 |    12.837 ns |  0.1069 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |           5 |            4 |    12.798 ns |  0.2512 ns |  1.00 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |           5 |            4 |    10.985 ns |  0.0915 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |           5 |            4 |    13.359 ns |  0.2286 ns |  1.22 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |           5 |            5 |     9.889 ns |  0.2227 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |           5 |            5 |     9.607 ns |  0.0639 ns |  0.97 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |           5 |            5 |     9.312 ns |  0.0899 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |           5 |            5 |    10.030 ns |  0.0813 ns |  1.08 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |           5 |            5 |    13.772 ns |  0.1095 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |           5 |            5 |    14.801 ns |  0.0647 ns |  1.07 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |           5 |            5 |    14.091 ns |  0.1369 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |           5 |            5 |    14.414 ns |  0.0863 ns |  1.02 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |           5 |            6 |    14.728 ns |  0.0862 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |           5 |            6 |    17.797 ns |  0.0539 ns |  1.21 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |           5 |            6 |    15.194 ns |  0.1128 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |           5 |            6 |    17.562 ns |  0.2942 ns |  1.16 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |           5 |            6 |    15.229 ns |  0.1195 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |           5 |            6 |    16.197 ns |  0.0570 ns |  1.06 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |           5 |            6 |    13.563 ns |  0.2548 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |           5 |            6 |    15.354 ns |  0.0580 ns |  1.13 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |           5 |            7 |    15.784 ns |  0.0804 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |           5 |            7 |    18.953 ns |  0.0476 ns |  1.20 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |           5 |            7 |    16.941 ns |  0.0648 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |           5 |            7 |    18.560 ns |  0.0997 ns |  1.10 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |           5 |            7 |    15.936 ns |  0.0061 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |           5 |            7 |    17.403 ns |  0.0528 ns |  1.09 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |           5 |            7 |    15.955 ns |  0.0989 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |           5 |            7 |    16.896 ns |  0.0835 ns |  1.06 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |         633 |            1 |    28.042 ns |  0.4862 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |         633 |            1 |    27.140 ns |  0.0650 ns |  0.97 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |         633 |            1 |    25.624 ns |  0.0351 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |         633 |            1 |    28.144 ns |  0.5964 ns |  1.10 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |         633 |            1 |    42.008 ns |  0.8431 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |         633 |            1 |    38.872 ns |  0.0686 ns |  0.93 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |         633 |            1 |   600.692 ns |  2.1052 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |         633 |            1 |    36.339 ns |  0.0948 ns |  0.06 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |         633 |            2 |    25.267 ns |  0.0462 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |         633 |            2 |    24.816 ns |  0.0774 ns |  0.98 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |         633 |            2 |    24.597 ns |  0.0545 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |         633 |            2 |    23.384 ns |  0.0331 ns |  0.95 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |         633 |            2 |   607.367 ns |  1.0757 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |         633 |            2 |   322.809 ns |  0.3263 ns |  0.53 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |         633 |            2 |   903.389 ns |  5.3103 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |         633 |            2 |   323.466 ns |  0.2158 ns |  0.36 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |         633 |            3 |    38.261 ns |  0.0281 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |         633 |            3 |    38.782 ns |  0.0593 ns |  1.01 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |         633 |            3 |    38.083 ns |  0.0390 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |         633 |            3 |    36.442 ns |  0.0338 ns |  0.96 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |         633 |            3 |   608.062 ns |  2.2131 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |         633 |            3 |   398.454 ns |  0.9846 ns |  0.66 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |         633 |            3 | 1,056.265 ns |  5.0746 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |         633 |            3 |   399.266 ns |  1.0481 ns |  0.38 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |         633 |            4 |    48.881 ns |  0.1916 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |         633 |            4 |    47.981 ns |  0.0337 ns |  0.98 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |         633 |            4 |    48.065 ns |  0.4115 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |         633 |            4 |    46.774 ns |  0.1764 ns |  0.97 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |         633 |            4 |   607.845 ns |  0.4039 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |         633 |            4 |   460.225 ns |  0.8522 ns |  0.76 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |         633 |            4 | 1,288.283 ns |  2.6859 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |         633 |            4 |   459.870 ns |  0.5145 ns |  0.36 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |         633 |            5 |    61.307 ns |  0.0595 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |         633 |            5 |    70.306 ns |  1.2055 ns |  1.15 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |         633 |            5 |    60.051 ns |  0.1810 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |         633 |            5 |    59.801 ns |  0.1136 ns |  1.00 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |         633 |            5 |   609.436 ns |  1.3534 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |         633 |            5 |   468.330 ns |  4.9034 ns |  0.77 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |         633 |            5 | 1,788.365 ns |  2.9329 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |         633 |            5 |   462.836 ns |  1.4536 ns |  0.26 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |         633 |            6 |   427.435 ns |  1.5291 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |         633 |            6 |   465.462 ns |  2.8314 ns |  1.09 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |         633 |            6 | 1,498.790 ns |  5.9545 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |         633 |            6 |   610.906 ns |  1.9665 ns |  0.41 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |         633 |            6 |   615.828 ns |  5.0564 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |         633 |            6 |   463.699 ns |  1.5791 ns |  0.75 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |         633 |            6 | 1,500.374 ns |  3.1733 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |         633 |            6 |   463.651 ns |  1.0817 ns |  0.31 |
|                      |                   |             |              |              |            |       |
|     StringIndexOfAny | \main\corerun.exe |         633 |            7 |   427.660 ns |  2.0628 ns |  1.00 |
|     StringIndexOfAny |   \pr\corerun.exe |         633 |            7 |   464.652 ns |  1.0499 ns |  1.09 |
|                      |                   |             |              |              |            |       |
|       SpanIndexOfAny | \main\corerun.exe |         633 |            7 | 1,770.015 ns | 11.4786 ns |  1.00 |
|       SpanIndexOfAny |   \pr\corerun.exe |         633 |            7 |   611.033 ns |  1.1795 ns |  0.35 |
|                      |                   |             |              |              |            |       |
| StringLastIndexOfAny | \main\corerun.exe |         633 |            7 |   610.580 ns |  1.2085 ns |  1.00 |
| StringLastIndexOfAny |   \pr\corerun.exe |         633 |            7 |   466.873 ns |  2.9522 ns |  0.76 |
|                      |                   |             |              |              |            |       |
|   SpanLastIndexOfAny | \main\corerun.exe |         633 |            7 | 1,647.658 ns |  5.2629 ns |  1.00 |
|   SpanLastIndexOfAny |   \pr\corerun.exe |         633 |            7 |   467.234 ns |  1.5278 ns |  0.28 |