### PR TITLE
Disable the Runtime_34587 regression test with GH issue #63818

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -832,6 +832,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170/*">
             <Issue>https://github.com/dotnet/runtime/issues/53560</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_34587/Runtime_34587/*">
+            <Issue>https://github.com/dotnet/runtime/issues/63818</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/debugging/poisoning/poison/*">
             <Issue>https://github.com/dotnet/runtime/issues/56148</Issue>
         </ExcludeList>


### PR DESCRIPTION
cf: https://github.com/dotnet/runtime/issues/63818
cc: @dotnet/crossgen-contrib, @dotnet/jit-contrib 