### PR TITLE
[metadata] Use MonoDefaults from components without hacks

### DIFF
--- a/src/mono/mono/component/debugger-engine.c
+++ b/src/mono/mono/component/debugger-engine.c
@@ -812,7 +812,7 @@ mono_de_process_single_step (void *tls, gboolean from_signal)
 	 * Stopping in memset makes half-initialized vtypes visible.
 	 * Stopping in memcpy makes half-copied vtypes visible.
 	 */
-	if (method->klass == mdbg_mono_defaults->string_class && (!strcmp (method->name, "memset") || strstr (method->name, "memcpy")))
+	if (method->klass == mono_get_string_class () && (!strcmp (method->name, "memset") || strstr (method->name, "memcpy")))
 		goto exit;
 
 	/*
@@ -1719,7 +1719,7 @@ get_notify_debugger_of_wait_completion_method (void)
 	if (notify_debugger_of_wait_completion_method_cache != NULL)
 		return notify_debugger_of_wait_completion_method_cache;
 	ERROR_DECL (error);
-	MonoClass* task_class = mono_class_load_from_name (mdbg_mono_defaults->corlib, "System.Threading.Tasks", "Task");
+	MonoClass* task_class = mono_class_load_from_name (mono_get_corlib (), "System.Threading.Tasks", "Task");
 	GPtrArray* array = mono_class_get_methods_by_name (task_class, "NotifyDebuggerOfWaitCompletion", 0x24, 1, FALSE, error);
 	mono_error_assert_ok (error);
 	g_assert (array->len == 1);

--- a/src/mono/mono/component/debugger-stub.c
+++ b/src/mono/mono/component/debugger-stub.c
@@ -16,7 +16,7 @@ static void
 stub_debugger_parse_options (char *options);
 
 static void
-stub_debugger_init (MonoDefaults *mono_defaults);
+stub_debugger_init (void);
 
 static void
 stub_debugger_breakpoint_hit (void *sigctx);
@@ -113,7 +113,7 @@ stub_debugger_parse_options (char *options)
 }
 
 static void
-stub_debugger_init (MonoDefaults *mono_defaults)
+stub_debugger_init (void)
 {
 }
 

--- a/src/mono/mono/component/debugger.h
+++ b/src/mono/mono/component/debugger.h
@@ -172,7 +172,7 @@ typedef struct _DebuggerTlsData DebuggerTlsData;
 
 typedef struct MonoComponentDebugger {
 	MonoComponent component;
-	void (*init) (MonoDefaults *mono_defaults);
+	void (*init) (void);
 	void (*user_break) (void);
 	void (*parse_options) (char *options);
 	void (*breakpoint_hit) (void *sigctx);
@@ -198,8 +198,6 @@ typedef struct MonoComponentDebugger {
 
 } MonoComponentDebugger;
 
-
-extern MonoDefaults *mdbg_mono_defaults;
 
 #define DE_ERR_NONE 0
 // WARNING WARNING WARNING

--- a/src/mono/mono/component/mini-wasm-debugger.c
+++ b/src/mono/mono/component/mini-wasm-debugger.c
@@ -141,15 +141,13 @@ mono_wasm_enable_debugging_internal (int debug_level)
 }
 
 static void
-mono_wasm_debugger_init (MonoDefaults *mono_defaults)
+mono_wasm_debugger_init (void)
 {
 	int debug_level = mono_wasm_get_debug_level();
 	mono_wasm_enable_debugging_internal (debug_level);
 
 	if (!debugger_enabled)
 		return;
-
-	mdbg_mono_defaults = mono_defaults;
 
 	DebuggerEngineCallbacks cbs = {
 		.tls_get_restore_state = tls_get_restore_state,
@@ -433,7 +431,7 @@ mono_wasm_breakpoint_hit (void)
 }
 
 static void
-mono_wasm_debugger_init (MonoDefaults *mono_defaults)
+mono_wasm_debugger_init (void)
 {
 }
 

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -984,11 +984,24 @@ typedef struct {
 	MonoClass *appcontext_class;
 } MonoDefaults;
 
+/* If you need a MonoType, use one of the mono_get_*_type () functions in class-inlines.h */
+extern MonoDefaults mono_defaults;
+
 #define GENERATE_GET_CLASS_WITH_CACHE_DECL(shortname) \
 MonoClass* mono_class_get_##shortname##_class (void);
 
 #define GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(shortname) \
 MonoClass* mono_class_try_get_##shortname##_class (void);
+
+static inline MonoImage *
+mono_class_generate_get_corlib_impl (void)
+{
+#ifdef COMPILING_COMPONENT_DYNAMIC
+  return mono_get_corlib ();
+#else
+  return mono_defaults.corlib;
+#endif
+}
 
 // GENERATE_GET_CLASS_WITH_CACHE attempts mono_class_load_from_name whenever
 // its cache is null. i.e. potentially repeatedly, though it is expected to succeed
@@ -1001,7 +1014,7 @@ mono_class_get_##shortname##_class (void)	\
 	static MonoClass *tmp_class;	\
 	MonoClass *klass = tmp_class;	\
 	if (!klass) {	\
-		klass = mono_class_load_from_name (mono_defaults.corlib, name_space, name);	\
+	  klass = mono_class_load_from_name (mono_class_generate_get_corlib_impl (), name_space, name); \
 		mono_memory_barrier ();	/* FIXME excessive? */ \
 		tmp_class = klass;	\
 	}	\
@@ -1023,7 +1036,7 @@ mono_class_try_get_##shortname##_class (void)	\
 	MonoClass *klass = (MonoClass *)tmp_class;	\
 	mono_memory_barrier ();	\
 	if (!inited) {	\
-		klass = mono_class_try_load_from_name (mono_defaults.corlib, name_space, name);	\
+		klass = mono_class_try_load_from_name (mono_class_generate_get_corlib_impl (), name_space, name);	\
 		tmp_class = klass;	\
 		mono_memory_barrier ();	\
 		inited = TRUE;	\
@@ -1054,9 +1067,6 @@ GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL(handleref)
 
 GENERATE_GET_CLASS_WITH_CACHE_DECL (assembly_load_context)
 GENERATE_GET_CLASS_WITH_CACHE_DECL (native_library)
-
-/* If you need a MonoType, use one of the mono_get_*_type () functions in class-inlines.h */
-extern MonoDefaults mono_defaults;
 
 void
 mono_loader_init           (void);

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -987,6 +987,10 @@ typedef struct {
 /* If you need a MonoType, use one of the mono_get_*_type () functions in class-inlines.h */
 extern MonoDefaults mono_defaults;
 
+MONO_COMPONENT_API
+MonoDefaults *
+mono_get_defaults (void);
+
 #define GENERATE_GET_CLASS_WITH_CACHE_DECL(shortname) \
 MonoClass* mono_class_get_##shortname##_class (void);
 

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -107,6 +107,12 @@ mono_loader_init ()
 	}
 }
 
+MonoDefaults *
+mono_get_defaults (void)
+{
+	return &mono_defaults;
+}
+
 void
 mono_global_loader_data_lock (void)
 {

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4522,7 +4522,7 @@ mini_init (const char *filename, const char *runtime_version)
 	if (default_opt & MONO_OPT_AOT)
 		mono_aot_init ();
 
-	mono_component_debugger ()->init (&mono_defaults);
+	mono_component_debugger ()->init ();
 
 #ifdef MONO_ARCH_GSHARED_SUPPORTED
 	mono_set_generic_sharing_supported (TRUE);


### PR DESCRIPTION
1. Add `mono_get_defaults ()` to get a `MonoDefaults*` in components without initialization hacks.
2.  Change `GENERATE_GET_CLASS_WITH_CACHE` to be usable in components by calling a component API function to get corlib when building a dynamic component, otherwise use mono_defaults directly as before.

Update the debugger component to use the new mechanisms