### PR TITLE
Reduce number of jump-stubs on ARM64 via smaller preserved space

### DIFF
--- a/src/coreclr/pal/src/include/pal/virtual.h
+++ b/src/coreclr/pal/src/include/pal/virtual.h
@@ -180,21 +180,21 @@ private:
     int32_t GenerateRandomStartOffset();
 
 private:
-#ifdef TARGET_XARCH
+
     // There does not seem to be an easy way find the size of a library on Unix.
     // So this constant represents an approximation of the libcoreclr size (on debug build)
     // that can be used to calculate an approximate location of the memory that
     // is in 2GB range from the coreclr library. In addition, having precise size of libcoreclr
     // is not necessary for the calculations.
-    static const int32_t CoreClrLibrarySize = 100 * 1024 * 1024;
+    static const int32_t CoreClrLibrarySize = 32 * 1024 * 1024;
 
+#ifdef TARGET_XARCH
     // This constant represent the max size of the virtual memory that this allocator
     // will try to reserve during initialization. We want all JIT-ed code and the
     // entire libcoreclr to be located in a 2GB range.
     static const int32_t MaxExecutableMemorySize = 0x7FFF0000;// 2GB - 64KB
 #else
-    // Smaller values for ARM64 where relative calls/jumps only work within 128MB
-    static const int32_t CoreClrLibrarySize = 32 * 1024 * 1024;
+    // Smaller size for ARM64 where relative calls/jumps only work within 128MB
     static const int32_t MaxExecutableMemorySize = 0x7FF0000; // 128MB - 64KB
 #endif
 

--- a/src/coreclr/pal/src/include/pal/virtual.h
+++ b/src/coreclr/pal/src/include/pal/virtual.h
@@ -191,10 +191,11 @@ private:
     // This constant represent the max size of the virtual memory that this allocator
     // will try to reserve during initialization. We want all JIT-ed code and the
     // entire libcoreclr to be located in a 2GB range.
-    static const int32_t MaxExecutableMemorySize = 0x7FFF0000;
+    static const int32_t MaxExecutableMemorySize = 0x7FFF0000;// 2GB - 64KB
 #else
-    static const int32_t CoreClrLibrarySize = 16 * 1024 * 1024;
-    static const int32_t MaxExecutableMemorySize = 128 * 1024 * 1024;
+    // Smaller values for ARM64 where relative calls/jumps only work within 128MB
+    static const int32_t CoreClrLibrarySize = 32 * 1024 * 1024;
+    static const int32_t MaxExecutableMemorySize = 0x7FF0000; // 128MB - 64KB
 #endif
 
     static const int32_t MaxExecutableMemorySizeNearCoreClr = MaxExecutableMemorySize - CoreClrLibrarySize;

--- a/src/coreclr/pal/src/include/pal/virtual.h
+++ b/src/coreclr/pal/src/include/pal/virtual.h
@@ -180,6 +180,7 @@ private:
     int32_t GenerateRandomStartOffset();
 
 private:
+#ifdef TARGET_XARCH
     // There does not seem to be an easy way find the size of a library on Unix.
     // So this constant represents an approximation of the libcoreclr size (on debug build)
     // that can be used to calculate an approximate location of the memory that
@@ -191,6 +192,11 @@ private:
     // will try to reserve during initialization. We want all JIT-ed code and the
     // entire libcoreclr to be located in a 2GB range.
     static const int32_t MaxExecutableMemorySize = 0x7FFF0000;
+#else
+    static const int32_t CoreClrLibrarySize = 16 * 1024 * 1024;
+    static const int32_t MaxExecutableMemorySize = 128 * 1024 * 1024;
+#endif
+
     static const int32_t MaxExecutableMemorySizeNearCoreClr = MaxExecutableMemorySize - CoreClrLibrarySize;
 
     // Start address of the reserved virtual address space

--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -66,7 +66,12 @@ void ExecutableAllocator::InitLazyPreferredRange(size_t base, size_t size, int r
     // to coreclr.dll.  This avoids having to create jump stubs for calls to
     // helpers and R2R images loaded close to coreclr.dll.
     //
+#ifdef TARGET_XARCH
     SIZE_T reach = 0x7FFF0000u;
+#else
+    // Smaller size for ARM64 where relative calls/jumps only work within 128MB
+    SIZE_T reach = 0x7FF0000u;
+#endif
 
     // We will choose the preferred code region based on the address of coreclr.dll. The JIT helpers
     // in coreclr.dll are the most heavily called functions.

--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -66,12 +66,7 @@ void ExecutableAllocator::InitLazyPreferredRange(size_t base, size_t size, int r
     // to coreclr.dll.  This avoids having to create jump stubs for calls to
     // helpers and R2R images loaded close to coreclr.dll.
     //
-#ifdef TARGET_XARCH
     SIZE_T reach = 0x7FFF0000u;
-#else
-    // Smaller size for ARM64 where relative calls/jumps only work within 128MB
-    SIZE_T reach = 0x7FF0000u;
-#endif
 
     // We will choose the preferred code region based on the address of coreclr.dll. The JIT helpers
     // in coreclr.dll are the most heavily called functions.


### PR DESCRIPTION
In https://github.com/dotnet/runtime/issues/62302#issuecomment-1013857967 I realized that all internal calls use jump-stubs (double calls basically) because managed code can't reach them within 128MB distance in memory. 
![image](https://user-images.githubusercontent.com/523221/149663487-6906b520-a7f2-41ec-95d2-8c782956cecd.png)

Even an empty console app emits 35 jump stubs. During investigation, @jakobbotsch suggested to change these limits and it helped! Many micro and macro benchmarks significantly improved:
```csharp
using BenchmarkDotNet.Attributes; 
using BenchmarkDotNet.Running; 
 
BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args); 
 
[Benchmark] 
[Arguments(3.14)] 
public double Test(double d) => Math.Cos(d) * Math.Sin(d) * Math.Tan(d);  // 3 InternalCalls
```
Results on Apple M1 arm64:
```
|  Method |        Job |               Toolchain |    d |      Mean |
|-------- |----------- |------------------------ |----- |----------:|
|    Test | Job-UWEEFQ |   /Core_Root_PR/corerun | 3.14 |  9.884 ns | 3x faster!!
|    Test | Job-HATVTO | /Core_Root_base/corerun | 3.14 | 28.235 ns |
```
Techempower (linux-arm64):
![image](https://user-images.githubusercontent.com/523221/149674801-2d06ceb9-3500-4cbb-9824-067439557b9a.png)

cc @jkotas @jakobbotsch 