### PR TITLE
Treat `CLS_VAR_ADDR` as never null

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -967,7 +967,7 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
     {
         return false;
     }
-    else if (addr->OperIs(GT_CNS_STR))
+    else if (addr->OperIs(GT_CNS_STR, GT_CLS_VAR_ADDR))
     {
         return false;
     }


### PR DESCRIPTION
Allows the LIR DCE to remove some indirections that were previously incorrectly thought to be throwing.

Contributes to CLS_VAR deletion (by minimizing the diffs).