### PR TITLE
Allow SslStream in ConnectCallback

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1375,7 +1375,18 @@ namespace System.Net.Http
             TransportContext? transportContext = null;
             if (IsSecure)
             {
-                SslStream sslStream = await ConnectHelper.EstablishSslConnectionAsync(GetSslOptionsForRequest(request), request, async, stream, cancellationToken).ConfigureAwait(false);
+                SslStream? sslStream = stream as SslStream;
+                if (sslStream == null)
+                {
+                    sslStream = await ConnectHelper.EstablishSslConnectionAsync(GetSslOptionsForRequest(request), request, async, stream, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    if (NetEventSource.Log.IsEnabled())
+                    {
+                        Trace($"Connected with custom SslStream: alpn='${sslStream.NegotiatedApplicationProtocol.ToString()}'");
+                    }
+                }
                 transportContext = sslStream.TransportContext;
                 stream = sslStream;
             }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2753,6 +2753,140 @@ namespace System.Net.Http.Functional.Tests
             HttpRequestException hre = await Assert.ThrowsAnyAsync<HttpRequestException>(async () => await client.GetAsync($"{(useSsl ? "https" : "http")}://nowhere.invalid/foo"));
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ConnectCallback_SslStream_OK(bool useSslStream)
+        {
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    string[] parts = uri.Authority.Split(':',2);
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                    var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+                    socketsHandler.ConnectCallback = async (context, token) =>
+                    {
+                        TcpClient client = new TcpClient();
+                        await client.ConnectAsync(parts[0], Int32.Parse(parts[1]));
+                        if (useSslStream)
+                        {
+                            SslClientAuthenticationOptions options = new SslClientAuthenticationOptions();
+                            options.RemoteCertificateValidationCallback = (a, b, c, d) => true;
+                            options.TargetHost = parts[0];
+                            if (context.InitialRequestMessage.Version.Major == 2)
+                            {
+                              options.ApplicationProtocols = new List<SslApplicationProtocol>{ SslApplicationProtocol.Http2};
+                            }
+                            var sslStream = new SslStream(client.GetStream());
+                            await sslStream.AuthenticateAsClientAsync(options);
+                            return sslStream;
+                        }
+                        else
+                        {
+                            return client.GetStream();
+                        }
+                    };
+                    using (HttpClient client = CreateHttpClient(handler))
+                    {
+                        HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion);
+                        HttpResponseMessage response = await client.SendAsync(request);
+                        if (PlatformDetection.SupportsAlpn)
+                        {
+                            Assert.Equal(request.Version, response.Version);
+                        }
+                    }
+                },
+                async server =>
+                {
+                    HttpRequestData requestData = await server.HandleRequestAsync();
+                }, options: new GenericLoopbackOptions{UseSsl = true});
+        }
+
+        [Fact]
+        public async Task ConnectCallback_DerivedSslStream_OK()
+        {
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    string[] parts = uri.Authority.Split(':',2);
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.ServerCertificateCustomValidationCallback = (a, b, c, d) => false;
+                    var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+                    socketsHandler.ConnectCallback = async (context, token) =>
+                    {
+                        TcpClient client = new TcpClient();
+                        await client.ConnectAsync(parts[0], Int32.Parse(parts[1]));
+
+                        SslClientAuthenticationOptions options = new SslClientAuthenticationOptions();
+                        options.RemoteCertificateValidationCallback = (a, b, c, d) => true;
+                        options.TargetHost = parts[0];
+                        if (context.InitialRequestMessage.Version.Major == 2)
+                        {
+                            options.ApplicationProtocols = new List<SslApplicationProtocol>{ SslApplicationProtocol.Http2};
+                        }
+
+                        MySsl myStream = new MySsl(client.GetStream());
+                        await myStream.AuthenticateAsClientAsync(options);
+                        return myStream;
+
+                    };
+                    using (HttpClient client = CreateHttpClient(handler))
+                    {
+                        HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion);
+                        HttpResponseMessage response = await client.SendAsync(request);
+                        if (PlatformDetection.SupportsAlpn)
+                        {
+                            Assert.Equal(request.Version, response.Version);
+                        }
+                    }
+                },
+                async server =>
+                {
+                    HttpRequestData requestData = await server.HandleRequestAsync();
+                }, options: new GenericLoopbackOptions{UseSsl = true});
+        }
+
+        [Fact]
+        public async Task ConnectCallback_NoAlpn_OK()
+        {
+            // Create HTTP 1.1 loopback. Http2 should downgrade
+            await LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    string[] parts = uri.Authority.Split(':',2);
+
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.ServerCertificateCustomValidationCallback = (a, b, c, d) => false;
+                    var socketsHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
+                    socketsHandler.ConnectCallback = async (context, token) =>
+                    {
+                        TcpClient client = new TcpClient();
+                        await client.ConnectAsync(parts[0], Int32.Parse(parts[1]));
+
+                        SslClientAuthenticationOptions options = new SslClientAuthenticationOptions();
+                        options.RemoteCertificateValidationCallback = (a, b, c, d) => true;
+                        options.TargetHost = parts[0];
+
+                        SslStream myStream = new SslStream(client.GetStream());
+                        await myStream.AuthenticateAsClientAsync(options);
+                        return myStream;
+
+                    };
+                    using (HttpClient client = CreateHttpClient(handler))
+                    {
+                        HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion);
+                        HttpResponseMessage response = await client.SendAsync(request);
+                        Console.WriteLine(response);
+                        Assert.Equal(1, response.Version.Major);
+                    }
+                },
+                async server =>
+                {
+                    HttpRequestData requestData = await server.HandleRequestAsync();
+                }, options: new LoopbackServer.Options{UseSsl = true});
+        }
+
         private static bool PlatformSupportsUnixDomainSockets => Socket.OSSupportsUnixDomainSockets;
    }
 
@@ -3444,5 +3578,12 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandler_RequestContentLengthMismatchTest_Http3(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;
         protected override QuicImplementationProvider UseQuicImplementationProvider => QuicImplementationProviders.MsQuic;
+    }
+
+    public class MySsl : SslStream
+    {
+        public MySsl(Stream stream) : base(stream)
+        {
+        }
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2774,7 +2774,7 @@ namespace System.Net.Http.Functional.Tests
                             SslClientAuthenticationOptions options = new SslClientAuthenticationOptions();
                             options.RemoteCertificateValidationCallback = (a, b, c, d) => true;
                             options.TargetHost = parts[0];
-                            if (context.InitialRequestMessage.Version.Major == 2)
+                            if (context.InitialRequestMessage.Version.Major == 2 && PlatformDetection.SupportsAlpn)
                             {
                               options.ApplicationProtocols = new List<SslApplicationProtocol>{ SslApplicationProtocol.Http2};
                             }
@@ -2821,7 +2821,7 @@ namespace System.Net.Http.Functional.Tests
                         SslClientAuthenticationOptions options = new SslClientAuthenticationOptions();
                         options.RemoteCertificateValidationCallback = (a, b, c, d) => true;
                         options.TargetHost = parts[0];
-                        if (context.InitialRequestMessage.Version.Major == 2)
+                        if (context.InitialRequestMessage.Version.Major == 2 && PlatformDetection.SupportsAlpn)
                         {
                             options.ApplicationProtocols = new List<SslApplicationProtocol>{ SslApplicationProtocol.Http2};
                         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2753,7 +2753,7 @@ namespace System.Net.Http.Functional.Tests
             HttpRequestException hre = await Assert.ThrowsAnyAsync<HttpRequestException>(async () => await client.GetAsync($"{(useSsl ? "https" : "http")}://nowhere.invalid/foo"));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ConnectCallback_SslStream_OK(bool useSslStream)
@@ -2803,7 +2803,7 @@ namespace System.Net.Http.Functional.Tests
                 }, options: new GenericLoopbackOptions{UseSsl = true});
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
         public async Task ConnectCallback_DerivedSslStream_OK()
         {
             await LoopbackServerFactory.CreateClientAndServerAsync(


### PR DESCRIPTION
This is another attempt to address #42455. It is sitting there for long time and this would be good for for #63663 when implemented. 

This would also solve concerns from #63706 as this allows to track and timeout/log separately TCP and TLS handshakes.
It would also solve old issue (I cannot find any more) when somebody wanted to reuse TCP/TLS to different sites hosted on same server. 

The difference from original PR is that this allows not only SslStream it self but also derived classes (added test for that).
With that somebody can create wrapper or what ever and it would still work as long as we can cast it back to SslStream. 
That should hopefully address https://github.com/dotnet/runtime/issues/42455#issuecomment-695352955 and make @stephentoub happier. 

There were also concerns about options we construct and particular setting. The biggest risk I see is that given stream did not negotiate ALPN for HTTP/2. In that case we should fall-back to HTTP/1 and I don't see  functional problem with that. I added test and trace message to make diagnostic easier. But if somebody is in charge they are also talking responsibility. 
Since the initial request is passed in, `ConnectCallback` _can_ do the right thing. I added test to verify that H/2 can be still negotiated if requested. (and fallback works)

While we may look into more fancy ways how to control connect and SSL, I don't see harm in allowing TLS here. 

fixes #42455