### PR TITLE
Split CheckNotDisposed to allow inlining

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -646,6 +646,12 @@ namespace System.Text.Json
         {
             throw GetInvalidOperationException("char", tokenType);
         }
+
+        [DoesNotReturn]
+        public static void ThrowObjectDisposedException_Utf8JsonWriter()
+        {
+            throw new ObjectDisposedException(nameof(Utf8JsonWriter));
+        }
     }
 
     internal enum ExceptionResource

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -238,10 +238,12 @@ namespace System.Text.Json
                 // The conditions are ordered with stream first as that would be the most common mode
                 if (_output == null)
                 {
-                    throw new ObjectDisposedException(nameof(Utf8JsonWriter));
+                    ThrowObjectDisposedException();
                 }
             }
         }
+
+        private void ThrowObjectDisposedException() => throw new ObjectDisposedException(nameof(Utf8JsonWriter));
 
         /// <summary>
         /// Commits the JSON text written so far which makes it visible to the output destination.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -238,12 +238,10 @@ namespace System.Text.Json
                 // The conditions are ordered with stream first as that would be the most common mode
                 if (_output == null)
                 {
-                    ThrowObjectDisposedException();
+                    ThrowHelper.ThrowObjectDisposedException_Utf8JsonWriter();
                 }
             }
         }
-
-        private void ThrowObjectDisposedException() => throw new ObjectDisposedException(nameof(Utf8JsonWriter));
 
         /// <summary>
         /// Commits the JSON text written so far which makes it visible to the output destination.


### PR DESCRIPTION
`CheckNotDisposed` is not getting inlined because RyuJIT thinks it's not profitable (ldstr/newobj/throw is expensive). If we extract the rare path into a separate method, it changes the profitability math and allows inlining to happen.