### PR TITLE
Separate variance information in mangled names

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericCompositionNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericCompositionNode.cs
@@ -36,6 +36,7 @@ namespace ILCompiler.DependencyAnalysis
 
             if (_details.Variance != null)
             {
+                sb.Append("__Variance__");
                 for (int i = 0; i < _details.Variance.Length; i++)
                 {
                     sb.Append('_');


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtimelab/issues/1821.

Eventually we'll need to have a holistic look at how we mangle things.