### PR TITLE
Make sure Encoding.GetChars for Debug.Assert is not called in release builds

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -529,13 +529,14 @@ namespace System
                 return Empty;
 
             string s = FastAllocateString(stringLength);
+#if DEBUG
             fixed (char* pTempChars = &s._firstChar)
             {
                 int doubleCheck = encoding.GetChars(bytes, byteLength, pTempChars, stringLength);
                 Debug.Assert(stringLength == doubleCheck,
                     "Expected encoding.GetChars to return same length as encoding.GetCharCount");
             }
-
+#endif
             return s;
         }
 


### PR DESCRIPTION
Encoding.GetChars here is only intended to be used in Debug.Assert but is still performed in release builds.
Fixes #63871 