### PR TITLE
Fix generating RunTests.sh and RunTests.cmd scripts

### DIFF
--- a/src/tasks/installer.tasks/GenerateRunScript.cs
+++ b/src/tasks/installer.tasks/GenerateRunScript.cs
@@ -121,8 +121,6 @@ namespace Microsoft.DotNet.Build.Tasks
             // Escape backtick and question mark characters to avoid running commands instead of echo'ing them.
             string sanitizedRunCommand = command.Replace("`", "\\`")
                                                     .Replace("?", "\\")
-                                                    .Replace("$", "")
-                                                    .Replace("%", "")
                                                     .Replace("\r","")
                                                     .Replace("\n"," ")
                                                     .Replace("&", "^&")


### PR DESCRIPTION
This fixes issue where generated RunTests.sh in the "To repro directly: "
section contained unevaluated variables like RUNTIME_PATH, which
prevented simple copy-pasting the code into the terminal

The issue was introduced by https://github.com/dotnet/runtime/pull/62779, I just reverted the new addition which removed $ and % characters from the script.