### PR TITLE
FileSystemEntry.Unix: don't make a syscall to check hidden on Linux.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LChflags.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LChflags.cs
@@ -22,5 +22,11 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LChflagsCanSetHiddenFlag")]
         [SuppressGCTransition]
         private static partial int LChflagsCanSetHiddenFlag();
+
+        internal static readonly bool SupportsHiddenFlag = (CanGetHiddenFlag() != 0);
+
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CanGetHiddenFlag")]
+        [SuppressGCTransition]
+        private static partial int CanGetHiddenFlag();
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -145,7 +145,7 @@ namespace System.IO.Enumeration
         public DateTimeOffset CreationTimeUtc => _status.GetCreationTime(FullPath, continueOnError: true);
         public DateTimeOffset LastAccessTimeUtc => _status.GetLastAccessTime(FullPath, continueOnError: true);
         public DateTimeOffset LastWriteTimeUtc => _status.GetLastWriteTime(FullPath, continueOnError: true);
-        public bool IsHidden => _status.IsHidden(FullPath, FileName, continueOnError: true);
+        public bool IsHidden => _status.IsFileSystemEntryHidden(FullPath, FileName);
         internal bool IsReadOnly => _status.IsReadOnly(FullPath, continueOnError: true);
 
         public bool IsDirectory => _status.InitiallyDirectory;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -145,14 +145,20 @@ namespace System.IO
             return HasReadOnlyFlag;
         }
 
-        internal bool IsHidden(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName, bool continueOnError = false)
+        internal bool IsFileSystemEntryHidden(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
         {
-            // Avoid disk hit first
+            // Because this is called for FileSystemEntry we can assume the entry exists and
+            // avoid initialization in some cases.
             if (IsNameHidden(fileName))
             {
                 return true;
             }
-            EnsureCachesInitialized(path, continueOnError);
+            if (!Interop.Sys.SupportsHiddenFlag)
+            {
+                return false;
+            }
+
+            EnsureCachesInitialized(path, continueOnError: true);
             return HasHiddenFlag;
         }
 

--- a/src/native/libs/System.Native/entrypoints.c
+++ b/src/native/libs/System.Native/entrypoints.c
@@ -109,6 +109,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_LockFileRegion)
     DllImportEntry(SystemNative_LChflags)
     DllImportEntry(SystemNative_LChflagsCanSetHiddenFlag)
+    DllImportEntry(SystemNative_CanGetHiddenFlag)
     DllImportEntry(SystemNative_ReadProcessStatusInfo)
     DllImportEntry(SystemNative_Log)
     DllImportEntry(SystemNative_LogError)

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1553,7 +1553,16 @@ int32_t SystemNative_LChflags(const char* path, uint32_t flags)
 
 int32_t SystemNative_LChflagsCanSetHiddenFlag(void)
 {
-#if defined(UF_HIDDEN) && defined(HAVE_STAT_FLAGS) && defined(HAVE_LCHFLAGS)
+#if defined(HAVE_LCHFLAGS)
+    return SystemNative_CanGetHiddenFlag();
+#else
+    return false;
+#endif
+}
+
+int32_t SystemNative_CanGetHiddenFlag(void)
+{
+#if defined(UF_HIDDEN) && defined(HAVE_STAT_FLAGS)
     return true;
 #else
     return false;

--- a/src/native/libs/System.Native/pal_io.h
+++ b/src/native/libs/System.Native/pal_io.h
@@ -745,6 +745,13 @@ PALEXPORT int32_t SystemNative_LChflags(const char* path, uint32_t flags);
 PALEXPORT int32_t SystemNative_LChflagsCanSetHiddenFlag(void);
 
 /**
+ * Determines if the current platform supports getting UF_HIDDEN (0x8000) flag
+ *
+ * Returns true (non-zero) if supported, false (zero) if not.
+ */
+PALEXPORT int32_t SystemNative_CanGetHiddenFlag(void);
+
+/**
  * Reads the psinfo_t struct and converts into ProcessStatus.
  *
  * Returns 1 if the process status was read; otherwise, 0.


### PR DESCRIPTION
Minor perf improvement.