### PR TITLE
Disable DllImportGenerator.Unit.Tests test suite on macOS+arm64+CoreCLR

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -342,6 +342,11 @@ Roslyn4.0.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' and '$(RuntimeFlavor)' != 'Mono' and '$(RunDisabledAppleSiliconTests)' != 'true'">
+    <!-- Issue: https://github.com/dotnet/runtime/issues/63439 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\DllImportGenerator.UnitTests\DllImportGenerator.Unit.Tests.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetArchitecture)' == 's390x' and '$(RunDisableds390xTests)' != 'true'">
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Drawing.Common\tests\System.Drawing.Common.Tests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This will disable `DllImportGenerator.Unit.Tests` test suite on macOS+arm64+CoreCLR to make the rolling build cleaner. 

https://github.com/dotnet/runtime/issues/63439