### PR TITLE
[release/6.0] Serialize SendPacketsAsync tests

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
+    [Collection(nameof(NoParallelTests))]
     public class SendPacketsAsync
     {
         private readonly ITestOutputHelper _log;


### PR DESCRIPTION
Backport of #63702 to `release/6.0`, which is a workaround for `SendPacketsAsync` test failures.

Fixes #63521, #63522, #63523.

# Customer Impact

N/A, this is a test-only change.

# Testing

N/A

# Risk

Low.