### PR TITLE
Replace "needs more info" label with "needs-author-action"

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -996,7 +996,7 @@
     "subCapability": "IssueCommentResponder",
     "version": "1.0",
     "config": {
-      "taskName": "Replace `needs more info` label with `needs further triage` label when the author comments on an issue",
+      "taskName": "Replace `needs-author-action` label with `needs further triage` label when the author comments on an issue",
       "conditions": {
         "operator": "and",
         "operands": [
@@ -1017,7 +1017,7 @@
           {
             "name": "hasLabel",
             "parameters": {
-              "label": "needs more info"
+              "label": "needs-author-action"
             }
           },
           {
@@ -1036,7 +1036,7 @@
         {
           "name": "removeLabel",
           "parameters": {
-            "label": "needs more info"
+            "label": "needs-author-action"
           }
         }
       ],
@@ -1575,7 +1575,7 @@
         {
           "name": "hasLabel",
           "parameters": {
-            "label": "needs more info"
+            "label": "needs-author-action"
           }
         },
         {
@@ -5416,7 +5416,7 @@
           {
             "name": "labelAdded",
             "parameters": {
-              "label": "needs more info"
+              "label": "needs-author-action"
             }
           }
         ]
@@ -5426,12 +5426,12 @@
         "issues",
         "project_card"
       ],
-      "taskName": "Needs more info notification",
+      "taskName": "Needs-author-action notification",
       "actions": [
         {
           "name": "addReply",
           "parameters": {
-            "comment": "This issue has been marked `needs more info` since it may be missing important information. Please refer to our [contribution guidelines](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md#writing-a-good-bug-report) for tips on how to report issues effectively."
+            "comment": "This issue has been marked `needs-author-action` since it may be missing important information. Please refer to our [contribution guidelines](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md#writing-a-good-bug-report) for tips on how to report issues effectively."
           }
         }
       ]
@@ -5951,7 +5951,7 @@
               {
                 "name": "labelAdded",
                 "parameters": {
-                  "label": "needs more info"
+                  "label": "needs-author-action"
                 }
               },
               {
@@ -6686,7 +6686,7 @@
               {
                 "name": "labelAdded",
                 "parameters": {
-                  "label": "needs more info"
+                  "label": "needs-author-action"
                 }
               },
               {
@@ -7257,7 +7257,7 @@
               {
                 "name": "labelAdded",
                 "parameters": {
-                  "label": "needs more info"
+                  "label": "needs-author-action"
                 }
               },
               {


### PR DESCRIPTION
This PR proposes the removal of the [`needs more info` label](https://github.com/dotnet/runtime/issues?q=is%3Aopen+is%3Aissue+label%3A%22needs+more+info%22) and relevant automation in issues, to be replaced by the [`needs-author-action`](https://github.com/dotnet/runtime/issues?q=is%3Aopen+is%3Aissue+label%3Aneeds-author-action+) label used in PR automation.

This change is meant to consolidate our usage of labels and addresses concerns from both https://github.com/dotnet/runtime/issues/62032 and https://github.com/dotnet/runtime/issues/62496.

NB before merging this PR, all issues marked `needs more info` need to be bulk marked as `needs-author-action`.

cc @danmoseley @marek-safar @jeffschwMSFT @jkotas @stephentoub for feedback.