### PR TITLE
Add `UnicodeRange.ArabicExtendedB`

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.cs
+++ b/src/libraries/System.Text.Encodings.Web/ref/System.Text.Encodings.Web.cs
@@ -83,6 +83,7 @@ namespace System.Text.Unicode
         public static System.Text.Unicode.UnicodeRange AlphabeticPresentationForms { get { throw null; } }
         public static System.Text.Unicode.UnicodeRange Arabic { get { throw null; } }
         public static System.Text.Unicode.UnicodeRange ArabicExtendedA { get { throw null; } }
+        public static System.Text.Unicode.UnicodeRange ArabicExtendedB { get { throw null; } }
         public static System.Text.Unicode.UnicodeRange ArabicPresentationFormsA { get { throw null; } }
         public static System.Text.Unicode.UnicodeRange ArabicPresentationFormsB { get { throw null; } }
         public static System.Text.Unicode.UnicodeRange ArabicSupplement { get { throw null; } }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Unicode/UnicodeRanges.generated.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Unicode/UnicodeRanges.generated.cs
@@ -191,6 +191,15 @@ namespace System.Text.Unicode
         private static UnicodeRange? _u0860;
 
         /// <summary>
+        /// A <see cref="UnicodeRange"/> corresponding to the 'Arabic Extended-B' Unicode block (U+0870..U+089F).
+        /// </summary>
+        /// <remarks>
+        /// See https://www.unicode.org/charts/PDF/U0870.pdf for the full set of characters in this block.
+        /// </remarks>
+        public static UnicodeRange ArabicExtendedB => _u0870 ?? CreateRange(ref _u0870, first: '\u0870', last: '\u089F');
+        private static UnicodeRange? _u0870;
+
+        /// <summary>
         /// A <see cref="UnicodeRange"/> corresponding to the 'Arabic Extended-A' Unicode block (U+08A0..U+08FF).
         /// </summary>
         /// <remarks>

--- a/src/libraries/System.Text.Encodings.Web/tests/UnicodeRangesTests.generated.cs
+++ b/src/libraries/System.Text.Encodings.Web/tests/UnicodeRangesTests.generated.cs
@@ -32,6 +32,7 @@ namespace System.Text.Unicode.Tests
             new object[] { '\u0800', '\u083F', nameof(UnicodeRanges.Samaritan) },
             new object[] { '\u0840', '\u085F', nameof(UnicodeRanges.Mandaic) },
             new object[] { '\u0860', '\u086F', nameof(UnicodeRanges.SyriacSupplement) },
+            new object[] { '\u0870', '\u089F', nameof(UnicodeRanges.ArabicExtendedB) },
             new object[] { '\u08A0', '\u08FF', nameof(UnicodeRanges.ArabicExtendedA) },
             new object[] { '\u0900', '\u097F', nameof(UnicodeRanges.Devanagari) },
             new object[] { '\u0980', '\u09FF', nameof(UnicodeRanges.Bengali) },


### PR DESCRIPTION
Fixes #57609

Produced via `dotnet run -- Blocks.txt "..\..\src\System\Text\Unicode\UnicodeRanges.generated.cs" "..\..\tests\UnicodeRangesTests.generated.cs"` with latest UCD Blocks from https://www.unicode.org/Public/UCD/latest/ucd/Blocks.txt.