### PR TITLE
Tune floating-point CSEs live across a call better

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -2598,17 +2598,18 @@ public:
             cse_use_cost *= slotCount;
         }
 
-        // If this CSE is live across a call then we may need to spill an additional caller save register
+        // If this CSE is live across a call then we may have additional costs
         //
         if (candidate->LiveAcrossCall())
         {
-            if (candidate->Expr()->IsCnsFltOrDbl() && (CNT_CALLEE_SAVED_FLOAT == 0) &&
-                (candidate->CseDsc()->csdUseWtCnt <= 4))
+            // If we have a floating-point CSE that is both live across a call and there
+            // are no callee-saved FP registers available, the RA will have to spill at
+            // the def site and reload at the (first) use site, if the variable is a register
+            // candidate. Account for that.
+            if (varTypeIsFloating(candidate->Expr()) && (CNT_CALLEE_SAVED_FLOAT == 0) && !candidate->IsConservative())
             {
-                // Floating point constants are expected to be contained, so unless there are more than 4 uses
-                // we better not to CSE them, especially on platforms without callee-saved registers
-                // for values living across calls
-                return false;
+                cse_def_cost += 1;
+                cse_use_cost += 1;
             }
 
             // If we don't have a lot of variables to enregister or we have a floating point type


### PR DESCRIPTION
The problem was that the comparison of a weighted refcount, which usually has the order of hundreds or tens, with a small digit like "4" was too weak and missed some cases where we were still trying to CSE cheap floats across calls and ending up with lots of stack shuffling.

Fix this by using different tuning parameters, namely the costs estimated for the uses and defs (increase them to account for the spills and reloads).

Quite some diffs, practically all are positive, but there is one type of regression that's real. Consider:
```cs
var flt1 = 1.1;

Call(flt1);

var flt2 = /* complex expression */; // Evaluates to 1.1
```
We will (now) fail to CSE `1.1` no matter how "expensive" `flt2` is because we use the following formula for determining the "cost of all trees that make up the CSE candidate":
```
Our calculation is based on the following cost estimate formula

Existing costs are:

(def + use) * cost
```
Essentially, we assume the costs are evenly distributed, and the first tree we find for the candidate is representative of this "average" (seems like an assumption inherited from lexical CSE...?).

However, I think it is fine to leave this be, as there are no such regressions in user code, only tests.

This change will unblock #63845.