### PR TITLE
Fix DNS cancellation deadlock

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -431,7 +431,7 @@ namespace System.Net
 
             public CancellationToken UnregisterAndGetCancellationToken()
             {
-                Interlocked.Exchange(ref _cancellationContextPtr, IntPtr.Zero);
+                Volatile.Write(ref _cancellationContextPtr, IntPtr.Zero);
 
                 // We should not wait for pending cancellation callbacks with CTR.Dispose(),
                 // since we are in a completion routine and GetAddrInfoExCancel may get blocked until it's finished.

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -8,6 +8,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Net
 {
@@ -138,17 +139,14 @@ namespace System.Net
         {
             Interop.Winsock.EnsureInitialized();
 
-            GetAddrInfoExContext* context = GetAddrInfoExContext.AllocateContext();
-
-            GetAddrInfoExState state;
+            GetAddrInfoExState? state = null;
             try
             {
-                state = new GetAddrInfoExState(context, hostName, justAddresses);
-                context->QueryStateHandle = state.CreateHandle();
+                state = new GetAddrInfoExState(hostName, justAddresses);
             }
             catch
             {
-                GetAddrInfoExContext.FreeContext(context);
+                state?.Dispose();
                 throw;
             }
 
@@ -157,6 +155,8 @@ namespace System.Net
             {
                 hints.ai_flags = AddressInfoHints.AI_CANONNAME;
             }
+
+            GetAddrInfoExContext* context = state.Context;
 
             SocketError errorCode = (SocketError)Interop.Winsock.GetAddrInfoExW(
                 hostName, null, Interop.Winsock.NS_ALL, IntPtr.Zero, &hints, &context->Result, IntPtr.Zero, &context->Overlapped, &GetAddressInfoExCallback, &context->CancelHandle);
@@ -172,7 +172,7 @@ namespace System.Net
                 // and final result would be posted via overlapped IO.
                 // synchronous failure here may signal issue when GetAddrInfoExW does not work from
                 // impersonated context. Windows 8 and Server 2012 fail for same reason with different errorCode.
-                GetAddrInfoExContext.FreeContext(context);
+                state.Dispose();
                 return null;
             }
             else
@@ -194,10 +194,10 @@ namespace System.Net
 
         private static unsafe void ProcessResult(SocketError errorCode, GetAddrInfoExContext* context)
         {
+            GetAddrInfoExState state = GetAddrInfoExState.FromHandleAndFree(context->QueryStateHandle);
+
             try
             {
-                GetAddrInfoExState state = GetAddrInfoExState.FromHandleAndFree(context->QueryStateHandle);
-
                 CancellationToken cancellationToken = state.UnregisterAndGetCancellationToken();
 
                 if (errorCode == SocketError.Success)
@@ -222,7 +222,7 @@ namespace System.Net
             }
             finally
             {
-                GetAddrInfoExContext.FreeContext(context);
+                state.Dispose();
             }
         }
 
@@ -360,18 +360,21 @@ namespace System.Net
             return new IPAddress(address, scope);
         }
 
-        private sealed unsafe class GetAddrInfoExState : IThreadPoolWorkItem
+        // GetAddrInfoExState is a SafeHandle that manages the lifetime of GetAddrInfoExContext*
+        // to make sure GetAddrInfoExCancel always takes a valid memory address regardless of the race
+        // between cancellation and completion callbacks.
+        private sealed unsafe class GetAddrInfoExState : SafeHandleZeroOrMinusOneIsInvalid, IThreadPoolWorkItem
         {
-            private IntPtr _cancellationContextPtr;
             private CancellationTokenRegistration _cancellationRegistration;
 
             private AsyncTaskMethodBuilder<IPHostEntry> IPHostEntryBuilder;
             private AsyncTaskMethodBuilder<IPAddress[]> IPAddressArrayBuilder;
             private object? _result;
+            private volatile bool _completed;
 
-            public GetAddrInfoExState(GetAddrInfoExContext *context, string hostName, bool justAddresses)
+            public GetAddrInfoExState(string hostName, bool justAddresses)
+                : base(true)
             {
-                _cancellationContextPtr = (IntPtr)context;
                 HostName = hostName;
                 JustAddresses = justAddresses;
                 if (justAddresses)
@@ -384,6 +387,10 @@ namespace System.Net
                     IPHostEntryBuilder = AsyncTaskMethodBuilder<IPHostEntry>.Create();
                     _ = IPHostEntryBuilder.Task; // force initialization
                 }
+
+                GetAddrInfoExContext* context = GetAddrInfoExContext.AllocateContext();
+                context->QueryStateHandle = CreateHandle();
+                SetHandle((IntPtr)context);
             }
 
             public string HostName { get; }
@@ -392,46 +399,58 @@ namespace System.Net
 
             public Task Task => JustAddresses ? (Task)IPAddressArrayBuilder.Task : IPHostEntryBuilder.Task;
 
-            private GetAddrInfoExContext* CancellationContext => (GetAddrInfoExContext*)_cancellationContextPtr;
+            internal GetAddrInfoExContext* Context => (GetAddrInfoExContext*)handle;
 
             public void RegisterForCancellation(CancellationToken cancellationToken)
             {
                 if (!cancellationToken.CanBeCanceled) return;
 
-                lock (this)
+                if (_completed)
                 {
-                    if (CancellationContext == null)
+                    // The operation completed before registration could be done.
+                    return;
+                }
+
+                _cancellationRegistration = cancellationToken.UnsafeRegister(static o =>
+                {
+                    var @this = (GetAddrInfoExState)o!;
+                    if (@this._completed)
                     {
-                        // The operation completed before registration could be done.
+                        // Escape early and avoid ObjectDisposedException in DangerousAddRef
                         return;
                     }
 
-                    _cancellationRegistration = cancellationToken.UnsafeRegister(o =>
+                    bool needRelease = false;
+                    try
                     {
-                        var @this = (GetAddrInfoExState)o!;
-                        int cancelResult = 0;
+                        @this.DangerousAddRef(ref needRelease);
 
-                        GetAddrInfoExContext* context = @this.CancellationContext;
+                        // If DangerousAddRef didn't throw ODE, the handle should contain a valid pointer.
+                        GetAddrInfoExContext* context = @this.Context;
 
-                        if (context != null)
-                        {
-                            // An outstanding operation will be completed with WSA_E_CANCELLED, and GetAddrInfoExCancel will return NO_ERROR.
-                            // If this thread has lost the race between cancellation and completion, this will be a NOP
-                            // with GetAddrInfoExCancel returning WSA_INVALID_HANDLE.
-                            cancelResult = Interop.Winsock.GetAddrInfoExCancel(&context->CancelHandle);
-                        }
-
-                        if (cancelResult != 0 && cancelResult != Interop.Winsock.WSA_INVALID_HANDLE && NetEventSource.Log.IsEnabled())
+                        // An outstanding operation will be completed with WSA_E_CANCELLED, and GetAddrInfoExCancel will return NO_ERROR.
+                        // If this thread has lost the race between cancellation and completion, this will be a NOP
+                        // with GetAddrInfoExCancel returning WSA_INVALID_HANDLE.
+                        int cancelResult = Interop.Winsock.GetAddrInfoExCancel(&context->CancelHandle);
+                        if (cancelResult != Interop.Winsock.WSA_INVALID_HANDLE && NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Info(@this, $"GetAddrInfoExCancel returned error {cancelResult}");
                         }
-                    }, this);
-                }
+                    }
+                    finally
+                    {
+                        if (needRelease)
+                        {
+                            @this.DangerousRelease();
+                        }
+                    }
+
+                }, this);
             }
 
             public CancellationToken UnregisterAndGetCancellationToken()
             {
-                Volatile.Write(ref _cancellationContextPtr, IntPtr.Zero);
+                _completed = true;
 
                 // We should not wait for pending cancellation callbacks with CTR.Dispose(),
                 // since we are in a completion routine and GetAddrInfoExCancel may get blocked until it's finished.
@@ -477,8 +496,6 @@ namespace System.Net
                 }
             }
 
-            public IntPtr CreateHandle() => GCHandle.ToIntPtr(GCHandle.Alloc(this, GCHandleType.Normal));
-
             public static GetAddrInfoExState FromHandleAndFree(IntPtr handle)
             {
                 GCHandle gcHandle = GCHandle.FromIntPtr(handle);
@@ -486,6 +503,15 @@ namespace System.Net
                 gcHandle.Free();
                 return state;
             }
+
+            protected override bool ReleaseHandle()
+            {
+                GetAddrInfoExContext.FreeContext(Context);
+
+                return true;
+            }
+
+            private IntPtr CreateHandle() => GCHandle.ToIntPtr(GCHandle.Alloc(this, GCHandleType.Normal));
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -522,12 +522,7 @@ namespace System.Net
             public IntPtr CancelHandle;
             public IntPtr QueryStateHandle;
 
-            public static GetAddrInfoExContext* AllocateContext()
-            {
-                var context = (GetAddrInfoExContext*)Marshal.AllocHGlobal(sizeof(GetAddrInfoExContext));
-                *context = default;
-                return context;
-            }
+            public static GetAddrInfoExContext* AllocateContext() => (GetAddrInfoExContext*)NativeMemory.AllocZeroed((nuint)sizeof(GetAddrInfoExContext));
 
             public static void FreeContext(GetAddrInfoExContext* context)
             {
@@ -535,8 +530,7 @@ namespace System.Net
                 {
                     Interop.Winsock.FreeAddrInfoExW(context->Result);
                 }
-
-                Marshal.FreeHGlobal((IntPtr)context);
+                NativeMemory.Free(context);
             }
         }
     }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -432,6 +432,9 @@ namespace System.Net
             public CancellationToken UnregisterAndGetCancellationToken()
             {
                 Interlocked.Exchange(ref _cancellationContextPtr, IntPtr.Zero);
+
+                // We should not wait for pending cancellation callbacks with CTR.Dispose(),
+                // since we are in a completion routine and GetAddrInfoExCancel may get blocked until it's finished.
                 _cancellationRegistration.Unregister();
                 return _cancellationRegistration.Token;
             }

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -194,6 +194,7 @@ namespace System.Net.NameResolution.Tests
         }
 
         // This is a regression test for https://github.com/dotnet/runtime/issues/63552
+        [OuterLoop]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_ResolveParallelCancelOnFailure_AllCallsReturn()

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -173,6 +173,7 @@ namespace System.Net.NameResolution.Tests
         }
     }
 
+    // Cancellation tests are sequential to reduce the chance of timing issues.
     [Collection(nameof(DisableParallelization))]
     public class GetHostAddressesTest_Cancellation
     {

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -177,7 +177,6 @@ namespace System.Net.NameResolution.Tests
     [Collection(nameof(DisableParallelization))]
     public class GetHostAddressesTest_Cancellation
     {
-        [OuterLoop]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_PostCancelledToken_Throws()
@@ -195,7 +194,6 @@ namespace System.Net.NameResolution.Tests
         }
 
         // This is a regression test for https://github.com/dotnet/runtime/issues/63552
-        [OuterLoop]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_ResolveParallelCancelOnFailure_AllCallsReturn()

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -170,10 +171,13 @@ namespace System.Net.NameResolution.Tests
             OperationCanceledException oce = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Dns.GetHostAddressesAsync(TestSettings.LocalHost, cts.Token));
             Assert.Equal(cts.Token, oce.CancellationToken);
         }
+    }
 
+    [Collection(nameof(DisableParallelization))]
+    public class GetHostAddressesTest_Cancellation
+    {
         [OuterLoop]
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/43816")] // Race condition outlined below.
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         public async Task DnsGetHostAddresses_PostCancelledToken_Throws()
         {
@@ -187,6 +191,36 @@ namespace System.Net.NameResolution.Tests
 
             OperationCanceledException oce = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
             Assert.Equal(cts.Token, oce.CancellationToken);
+        }
+
+        // This is a regression test for https://github.com/dotnet/runtime/issues/63552
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
+        public async Task DnsGetHostAddresses_ResolveParallelCancelOnFailure_AllCallsReturn()
+        {
+            string invalidAddress = TestSettings.UncachedHost;
+            await ResolveManyAsync(invalidAddress);
+            await ResolveManyAsync(invalidAddress, TestSettings.LocalHost)
+                .WaitAsync(TestSettings.PassingTestTimeout);
+
+            static async Task ResolveManyAsync(params string[] addresses)
+            {
+                using CancellationTokenSource cts = new();
+                Task[] resolveTasks = addresses.Select(a => ResolveOneAsync(a, cts)).ToArray();
+                await Task.WhenAll(resolveTasks);
+            }
+
+            static async Task ResolveOneAsync(string address, CancellationTokenSource cancellationTokenSource)
+            {
+                try
+                {
+                    await Dns.GetHostAddressesAsync(address, cancellationTokenSource.Token);
+                }
+                catch (Exception)
+                {
+                    cancellationTokenSource.Cancel();
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -320,6 +320,10 @@ namespace System.Net.NameResolution.Tests
         [Fact]
         public async Task DnsGetHostEntry_PostCancelledToken_Throws()
         {
+            // Windows 7 name resolution is synchronous and does not respect cancellation.
+            if (PlatformDetection.IsWindows7)
+                return;
+
             using var cts = new CancellationTokenSource();
 
             Task task = Dns.GetHostEntryAsync(TestSettings.UncachedHost, cts.Token);

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -311,6 +311,7 @@ namespace System.Net.NameResolution.Tests
         }
     }
 
+    // Cancellation tests are sequential to reduce the chance of timing issues.
     [Collection(nameof(DisableParallelization))]
     public class GetHostEntryTest_Cancellation
     {

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -309,9 +309,12 @@ namespace System.Net.NameResolution.Tests
             OperationCanceledException oce = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Dns.GetHostEntryAsync(TestSettings.LocalHost, cts.Token));
             Assert.Equal(cts.Token, oce.CancellationToken);
         }
+    }
 
+    [Collection(nameof(DisableParallelization))]
+    public class GetHostEntryTest_Cancellation
+    {
         [OuterLoop]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/43816")] // Race condition outlined below.
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33378", TestPlatforms.AnyUnix)] // Cancellation of an outstanding getaddrinfo is not supported on *nix.
         [Fact]
         public async Task DnsGetHostEntry_PostCancelledToken_Throws()


### PR DESCRIPTION
As shown by https://github.com/dotnet/runtime/issues/63552#issuecomment-1008991864, in case the completion triggers before cancellation, `GetAddrInfoExCancel` does not return while the completion routine is running. This results in a deadlock if we are taking the same lock in completion and cancellation callbacks.

It looks to me that the lock is unnecessary, since `GetAddrInfoExContext*` is the only shared state, and pointer access is atomic.

As a prerequisite, I had to address #43816, so we can have reliable cancellation tests. I did this by serializing the tests, which eliminates parallel load as an instability factor causing races between CPU and IO-bound code.

Fixes #63552.
Resolves #43816. (If not, we can reopen.)