### PR TITLE
Update zip extraction to never throw any exceptions when the LastWriteTime update fails

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -83,7 +83,7 @@ namespace System.IO.Compression
             {
                 File.SetLastWriteTime(destinationFileName, source.LastWriteTime.DateTime);
             }
-            catch (UnauthorizedAccessException)
+            catch
             {
                 // some OSes like Android (#35374) might not support setting the last write time, the extraction should not fail because of that
             }


### PR DESCRIPTION
This PR is a proposed tweak to the changes added by https://github.com/dotnet/runtime/pull/56370. The tweak is adjusting the try/catch block to catch _all_ exceptions instead of only `UnauthorizedAccessException`.

The reason I would like this change made is because I received an error report from a Windows 11 user that indicates file extraction using the `ExtractToDirectory` extension method is failing with an `IOException`, and the error that wraps is `ERROR_SHARING_VIOLATION`. The reason for the exception is unclear to me - I suspect maybe an anti-virus software has opened the file in the short time between the `FileStream`'s disposal and `File.SetLastWriteTime`. Based on the stack trace I received, the operation is failing at the `File.SetLastWriteTime` line. At that point, the file has been successfully extracted & written to the file system, and the LastWriteTime update is just a bonus. The original intent of https://github.com/dotnet/runtime/pull/56370 was to fix problems like this, but it unfortunately covers 1 exception type, and this PR will cover all of them.

If you agree with the changes, I hope you will consider it for a servicing release because I do not see an easy workaround for the issue that can decisively determine the exception originated from `File.SetLastWriteTime`. This affects my users during an update process and making that as bug-free as possible is a priority.