### PR TITLE
Use IndexOf in StringBuilder.Replace(char, char)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -2063,13 +2063,16 @@ namespace System.Text
                 {
                     int curInChunk = Math.Max(startIndexInChunk, 0);
                     int endInChunk = Math.Min(chunk.m_ChunkLength, endIndexInChunk);
-                    while (curInChunk < endInChunk)
+
+                    Span<char> span = chunk.m_ChunkChars.AsSpan(curInChunk, endInChunk - curInChunk);
+                    int i;
+                    while ((i = span.IndexOf(oldChar)) >= 0)
                     {
-                        if (chunk.m_ChunkChars[curInChunk] == oldChar)
-                            chunk.m_ChunkChars[curInChunk] = newChar;
-                        curInChunk++;
+                        span[i] = newChar;
+                        span = span.Slice(i + 1);
                     }
                 }
+
                 if (startIndexInChunk >= 0)
                 {
                     break;


### PR DESCRIPTION
|  Method |         Toolchain | Length | Gap |        Mean |     Error |    StdDev | Ratio |
|-------- |------------------ |------- |---- |------------:|----------:|----------:|------:|
| Replace | \main\corerun.exe |     10 |   5 |    28.74 ns |  0.092 ns |  0.081 ns |  1.00 |
| Replace |   \pr\corerun.exe |     10 |   5 |    29.27 ns |  0.142 ns |  0.132 ns |  1.02 |
|         |                   |        |     |             |           |           |       |
| Replace | \main\corerun.exe |     10 |  50 |    29.60 ns |  0.075 ns |  0.067 ns |  1.00 |
| Replace |   \pr\corerun.exe |     10 |  50 |    18.09 ns |  0.088 ns |  0.078 ns |  0.61 |
|         |                   |        |     |             |           |           |       |
| Replace | \main\corerun.exe |   1000 |   5 | 2,221.19 ns |  9.383 ns |  8.318 ns |  1.00 |
| Replace |   \pr\corerun.exe |   1000 |   5 | 1,887.47 ns | 13.441 ns | 12.573 ns |  0.85 |
|         |                   |        |     |             |           |           |       |
| Replace | \main\corerun.exe |   1000 |  50 | 2,383.22 ns | 17.205 ns | 14.367 ns |  1.00 |
| Replace |   \pr\corerun.exe |   1000 |  50 |   353.79 ns |  2.230 ns |  2.086 ns |  0.15 |

```C#
using System.Text;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private StringBuilder _sb;

    [Params(10, 1000)]
    public int Length { get; set; }

    [Params(5, 50)]
    public int Gap { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        var sb = new StringBuilder();
        for (int i = 0; i < Length; i++)
        {
            char c = ((i + 1) % Gap) == 0 ? 'b' : 'a';
            sb.Append(c);
        }
        _sb = sb;
    }

    [Benchmark]
    public void Replace()
    {
        _sb.Replace('b', 'c');
        _sb.Replace('c', 'b');
    }
}
```