### PR TITLE
Improve ILLink.targets integration

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -54,6 +54,8 @@
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != ''" Text="NativeLib requires OutputType=Library." />
 
+    <Error Condition="'$(PublishTrimmed)' == 'false'" Text="PublishTrimmed is implied by native compilation and cannot be disabled." />
+
     <!-- Fail with descriptive error message for common unsupported cases. -->
     <Error Condition="'$(DisableUnsupportedError)' != 'true' and '$(OS)' == 'Windows_NT' and !$(RuntimeIdentifier.StartsWith('win'))"
       Text="Cross-OS native compilation is not supported. https://github.com/dotnet/corert/issues/5458" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -31,6 +31,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <!-- Workaround for https://github.com/dotnet/runtimelab/issues/771 -->
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
+    <RunILLink>false</RunILLink>
   </PropertyGroup>
 
   <!-- Set up the defaults for the compatibility mode -->
@@ -39,7 +40,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <IlcGenerateStackTraceData Condition="$(IlcGenerateStackTraceData) == ''">true</IlcGenerateStackTraceData>
     <IlcScanReflection Condition="$(IlcScanReflection) == ''">true</IlcScanReflection>
-    <SuppressTrimAnalysisWarnings Condition="$(SuppressTrimAnalysisWarnings) == ''">true</SuppressTrimAnalysisWarnings>
+    <SuppressTrimAnalysisWarnings Condition="$(SuppressTrimAnalysisWarnings) == '' and $([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '6.0.0'))">true</SuppressTrimAnalysisWarnings>
     <TrimmerDefaultAction Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '6.0.0'))">copyused</TrimmerDefaultAction>
   </PropertyGroup>
 
@@ -304,8 +305,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Command="&quot;$(IlcToolsPath)\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
 
     <!-- Trick ILLinker into not actually running -->
-    <MakeDir Directories="$(IntermediateLinkDir)" />
-    <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" />
+    <MakeDir Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '7.0.0'))" Directories="$(IntermediateLinkDir)" />
+    <Touch Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '7.0.0'))" Files="$(_LinkSemaphore)" AlwaysCreate="true" />
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Windows.props" Condition="'$(TargetOS)' == 'windows'" />


### PR DESCRIPTION
Runtime side of https://github.com/dotnet/sdk/pull/23470 (depends on that getting merged). Skip touching the IL Linker semaphore that tricks the target into not running.