### PR TITLE
Revert "Enable GC regions by default (#59283)"

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -51,8 +51,8 @@ inline void FATAL_GC_ERROR()
 //
 // This means any empty regions can be freely used for any generation. For
 // Server GC we will balance regions between heaps.
-// For now disable regions StandAlone GC builds
-#if defined (HOST_64BIT) && !defined (BUILD_AS_STANDALONE)
+// For now disable regions outside of StandAlone GC builds
+#if defined (HOST_64BIT) && defined (BUILD_AS_STANDALONE)
 #define USE_REGIONS
 #endif //HOST_64BIT && BUILD_AS_STANDALONE
 


### PR DESCRIPTION
This reverts commit cf91716becf05b255ab9e201d3ff32cfb43230e0.

This looks to be creating a lot of crashes in a lot of different unit tests on Mac. Reverting seems to halt the Mac failures (see https://dev.azure.com/dnceng/public/_build/results?buildId=1557880)

Fixes https://github.com/dotnet/runtime/issues/63439