### PR TITLE
Respond to feedback in GenerateMultiTargetRoslynComponentTargetsFile

### DIFF
--- a/docs/coding-guidelines/libraries-packaging.md
+++ b/docs/coding-guidelines/libraries-packaging.md
@@ -86,5 +86,12 @@ In the analyzer project make sure to do the following. Ensure it only targets `n
   </PropertyGroup>
 ```
 
+In order to mitigate design-time/build-time performance issues with source generators, we generate build logic to allow the end user to disable the source generator from the package. By default, the MSBuild property an end user can set is named `Disable{PackageId}SourceGenerator`. If a package needs a custom property name, this can be overriden by setting the following property in the project that produces the package
+```xml
+  <PropertyGroup> 
+    <DisableSourceGeneratorPropertyName>CustomPropertyName</DisableSourceGeneratorPropertyName> 
+  </PropertyGroup>
+```
+
 ### .NETFramework RID specific assets
 When targeting .NETFramework, RID specific assets are automatically added to the package if the project contains other compatible RID specific assets, mainly `netstandard2.0-windows`.

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -162,19 +162,18 @@
   </Target>
 
   <Target Name="GenerateMultiTargetRoslynComponentTargetsFile"
-          Inputs="$(MSBuildProjectFullPath);_MultiTargetRoslynComponentTargetsTemplate"
+          Inputs="$(MSBuildProjectFullPath);$(_MultiTargetRoslynComponentTargetsTemplate)"
           Outputs="$(MultiTargetRoslynComponentTargetsFileIntermediatePath)">
     <PropertyGroup>
       <_MultiTargetRoslynComponentTargetPrefix>$(PackageId.Replace('.', '_'))</_MultiTargetRoslynComponentTargetPrefix>
-      <_MultiTargetRoslynComponentDisableSourceGeneratorPropertyName>Disable$(PackageId.Replace('.', ''))SourceGenerator</_MultiTargetRoslynComponentDisableSourceGeneratorPropertyName>
-      <_MultiTargetRoslynComponentDisableSourceGeneratorPropertyName>$(_MultiTargetRoslynComponentDisableSourceGeneratorPropertyName.Replace('Abstractions', ''))</_MultiTargetRoslynComponentDisableSourceGeneratorPropertyName>
+      <DisableSourceGeneratorPropertyName Condition="'$(DisableSourceGeneratorPropertyName)' == ''">Disable$(PackageId.Replace('.', ''))SourceGenerator</DisableSourceGeneratorPropertyName>
     </PropertyGroup>
 
     <WriteLinesToFile File="$(MultiTargetRoslynComponentTargetsFileIntermediatePath)"
                       Lines="$([System.IO.File]::ReadAllText('$(_MultiTargetRoslynComponentTargetsTemplate)')
                                                  .Replace('{TargetPrefix}', '$(_MultiTargetRoslynComponentTargetPrefix)')
                                                  .Replace('{NuGetPackageId}', '$(PackageId)')
-                                                 .Replace('{DisableSourceGeneratorPropertyName}', '$(_MultiTargetRoslynComponentDisableSourceGeneratorPropertyName)'))"
+                                                 .Replace('{DisableSourceGeneratorPropertyName}', '$(DisableSourceGeneratorPropertyName)'))"
                       Overwrite="true" />
   </Target>
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -18,6 +18,7 @@ Microsoft.Extensions.Logging.LogLevel
 Microsoft.Extensions.Logging.Logger&lt;T&gt;
 Microsoft.Extensions.Logging.LoggerMessage
 Microsoft.Extensions.Logging.Abstractions.NullLogger</PackageDescription>
+    <DisableSourceGeneratorPropertyName>DisableMicrosoftExtensionsLoggingSourceGenerator</DisableSourceGeneratorPropertyName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Two small follow up changes from #58446

- Fix a type-o that breaks incremental build. Forgot to use MSBuild property syntax
- Instead of having the infrastructure hard-code removing 'Abstractions', packages can set their own Disable source gen property name.