### PR TITLE
[Android][libs] Enable Internal.Console.Write in System.Private.CoreLib

### DIFF
--- a/docs/workflow/debugging/libraries/debugging-corelib.md
+++ b/docs/workflow/debugging/libraries/debugging-corelib.md
@@ -1,0 +1,7 @@
+Debugging System.Private.CoreLib
+==========================
+
+`System.Console.Write`/`System.Console.WriteLine` cannot be used in `System.Private.CoreLib`. Instead, use `Internal.Console.Write` to log.
+
+### Android
+The logs can be found through the generated Android Debug Bridge log or viewed directly through ADB logcat.

--- a/docs/workflow/debugging/libraries/debugging-corelib.md
+++ b/docs/workflow/debugging/libraries/debugging-corelib.md
@@ -1,7 +1,7 @@
 Debugging System.Private.CoreLib
 ==========================
 
-`System.Console.Write`/`System.Console.WriteLine` cannot be used in `System.Private.CoreLib`. Instead, use `Internal.Console.Write` to log.
+`System.Console.Write`/`System.Console.WriteLine` cannot be used in `System.Private.CoreLib`. Instead, use `Internal.Console.Write` to add temporary logging for printf-style debugging.
 
 ### Android
 The logs can be found through the generated Android Debug Bridge log or viewed directly through ADB logcat.

--- a/docs/workflow/debugging/libraries/mobile-instructions.md
+++ b/docs/workflow/debugging/libraries/mobile-instructions.md
@@ -1,0 +1,6 @@
+Debugging Libraries on Mobile
+==========================
+
+## Debugging System.Private.CoreLib on Android
+
+`System.Console.Write`/`System.Console.WriteLine` cannot be used in `System.Private.CoreLib`. Instead, use `Internal.Console.Write` to log. After running a test or program that utilizes the relevant `System.Private.CoreLib` code, the logs can be found through the generated adb log or viewed directly through adb logcat.

--- a/docs/workflow/debugging/libraries/mobile-instructions.md
+++ b/docs/workflow/debugging/libraries/mobile-instructions.md
@@ -1,6 +1,0 @@
-Debugging Libraries on Mobile
-==========================
-
-## Debugging System.Private.CoreLib on Android
-
-`System.Console.Write`/`System.Console.WriteLine` cannot be used in `System.Private.CoreLib`. Instead, use `Internal.Console.Write` to log. After running a test or program that utilizes the relevant `System.Private.CoreLib` code, the logs can be found through the generated adb log or viewed directly through adb logcat.

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.Android.cs
@@ -10,7 +10,15 @@ namespace Internal
     {
         public static unsafe void Write(string s)
         {
-            Interop.Logcat.AndroidLogPrint(Interop.Logcat.LogLevel.Debug, "DOTNET", s);
+            Interop.Logcat.AndroidLogPrint(Interop.Logcat.LogLevel.Debug, "DOTNET", s ?? string.Empty);
+        }
+
+        public static partial class Error
+        {
+            public static unsafe void Write(string s)
+            {
+                Interop.Logcat.AndroidLogPrint(Interop.Logcat.LogLevel.Error, "DOTNET", s ?? string.Empty);
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Internal/Console.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Console.Android.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Internal
+{
+    public static partial class Console
+    {
+        public static unsafe void Write(string s)
+        {
+            Interop.Logcat.AndroidLogPrint(Interop.Logcat.LogLevel.Debug, "DOTNET", s);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2116,7 +2116,14 @@
     <Compile Include="$(CommonPath)System\IO\PathInternal.Unix.cs">
       <Link>Common\System\IO\PathInternal.Unix.cs</Link>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Unix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Unix.cs" Condition="'$(TargetsAndroid)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Android.cs" Condition="'$(TargetsAndroid)' == 'true'" />
+    <Compile Include="$(CommonPath)Interop\Android\Interop.Logcat.cs" Condition="'$(TargetsAndroid)' == 'true'">
+      <Link>Common\Interop\Android\Interop.Logcat.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)Interop\Android\Interop.Libraries.cs" Condition="'$(TargetsAndroid)' == 'true'">
+      <Link>Common\Interop\Android\Interop.Libraries.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomain.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffer.Unix.cs" />


### PR DESCRIPTION
This PR looks to add logging capabilities in `System.Private.CoreLib` on Android because `System.Console.Write()` cannot be used there.
With these changes, one will be able to use `Internal.Console.Write()` to help debug `System.Private.CoreLib`