### PR TITLE
Fix Crossgen2 bug #61104 and add regression test

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHashCode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHashCode.cs
@@ -34,10 +34,10 @@ namespace ILCompiler
             byte[] src = Encoding.UTF8.GetBytes(name);
             for (int i = 0; i < src.Length; i += 2)
             {
-                hash1 = unchecked(hash1 + RotateLeft(hash1, 5)) ^ src[i];
+                hash1 = unchecked(hash1 + RotateLeft(hash1, 5)) ^ (int)unchecked((sbyte)src[i]);
                 if (i + 1 < src.Length)
                 {
-                    hash2 = unchecked(hash2 + RotateLeft(hash2, 5)) ^ src[i + 1];
+                    hash2 = unchecked(hash2 + RotateLeft(hash2, 5)) ^ (int)unchecked((sbyte)src[i + 1]);
                 }
                 else
                 {

--- a/src/tests/Regressions/coreclr/GitHub_61104/test61104.cs
+++ b/src/tests/Regressions/coreclr/GitHub_61104/test61104.cs
@@ -1,22 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-Console.WriteLine("Hello, World!");
-
-var type = Type.GetType("AotProblem." + "_测试数据记录仪_Iiİı_åäö_Controller_DataLogger1_log_all_", false);
-
-Console.WriteLine(type?.FullName??"null");
-
+var type = Type.GetType("_测试数据记录仪_Iiİı_åäö_Controller_DataLogger1_log_all_", false);
 var obj = Activator.CreateInstance(type!);
-
 Console.WriteLine(obj?.GetType().Name);
 
 return 100;
 
-namespace AotProblem
+public class _测试数据记录仪_Iiİı_åäö_Controller_DataLogger1_log_all_
 {
-    public class _测试数据记录仪_Iiİı_åäö_Controller_DataLogger1_log_all_
-    {
-
-    }
 }

--- a/src/tests/Regressions/coreclr/GitHub_61104/test61104.cs
+++ b/src/tests/Regressions/coreclr/GitHub_61104/test61104.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+Console.WriteLine("Hello, World!");
+
+var type = Type.GetType("AotProblem." + "_测试数据记录仪_Iiİı_åäö_Controller_DataLogger1_log_all_", false);
+
+Console.WriteLine(type?.FullName??"null");
+
+var obj = Activator.CreateInstance(type!);
+
+Console.WriteLine(obj?.GetType().Name);
+
+return 100;
+
+namespace AotProblem
+{
+    public class _测试数据记录仪_Iiİı_åäö_Controller_DataLogger1_log_all_
+    {
+
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_61104/test61104.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_61104/test61104.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- This is an explicit crossgen test -->
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="test61104.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The issue tracks the runtime regression failure where
Crossgen2-compiled app is unable to locate a type with non-ASCII
characters in its name. The failure was caused by the fact that
Crossgen2 was incorrectly zero-extended the individual characters
when calculating the hash whereas runtime is sign-extending them.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/61104

P.S.: Please let me know if you believe I should initiate the process of backporting this to .NET Core 6 servicing.

/cc @dotnet/crossgen-contrib 

P.P.S.: I have copied the sample class verbatim from the issue. I have no idea how to check that the Asian characters don't contain any swearwords or some such as I have no expertise in this family of languages, please advise how to proceed in this respect.