### PR TITLE
Reverse `ASG(CLS_VAR, ...)`

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4181,6 +4181,7 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
 
                 case GT_LCL_VAR:
                 case GT_LCL_FLD:
+                case GT_CLS_VAR:
 
                     // We evaluate op2 before op1
                     bReverseInAssignment = true;


### PR DESCRIPTION
This helps with register allocation. Consider:
```scala
***** BB01
STMT00001 ( 0x000[E-] ... ??? )
N003 ( 18, 10) [000003] -ACXG-------              *  ASG       ref    $c0
N001 (  3,  4) [000002] ----G--N----              +--*  CLS_VAR   ref    Hnd=0x8fec230 Fseq[hackishFieldName]
N002 ( 14,  5) [000000] --CXG-------              \--*  CALL      ref    CscBench.GetMscorlibPathCore $c0
```
The rationalizer will rewrite it to what is effectively:
```scala
***** BB01
STMT00001 ( 0x000[E-] ... ??? )
N004 ( 18, 12) [000003] -ACXG---R---              *  ASG       ref
N003 (  3,  6) [000002] n---G--N----              +--*  IND       ref
N002 (  1,  4) [000006] H-----------              |  \--*  CLS_VAR_ADDR byref  Hnd=0x8fec230
N001 ( 14,  5) [000000] --CXG-------              \--*  CALL      ref    CscBench.GetMscorlibPathCore
```
And the final LIR will look like:
```scala
               [000006] ------------                 IL_OFFSET void   INLRT @ 0x000[E-]
N001 (  3,  4) [000002] ----G--N----         t2 =    CLS_VAR_ADDR byref  Hnd=0x8fec230
N002 ( 14,  5) [000000] --CXG-------         t0 =    CALL      ref    CscBench.GetMscorlibPathCore $c0
                                                  /--*  t2     byref
                                                  +--*  t0     ref
N003 ( 18, 10) [000003] -A-XG-------              *  STOREIND  ref
               [000007] ------------                 IL_OFFSET void   INLRT @ 0x00A[E-]
N001 (  0,  0) [000004] ------------                 RETURN    void   $180
```
Since this store must use a barrier, `CLS_VAR_ADDR` won't be contained and will have to be evaluated
separately. Because its value is live across a call, it'll get spilled and reloaded. Reversing the `ASG`
fixes the problem:
```scala
------------ BB01 [000..00B) (return), preds={} succs={}
               [000006] ------------                 IL_OFFSET void   INLRT @ 0x000[E-]
N001 ( 14,  5) [000000] --CXG-------         t0 =    CALL      ref    CscBench.GetMscorlibPathCore $c0
N002 (  3,  4) [000002] ----G--N----         t2 =    CLS_VAR_ADDR byref  Hnd=0x8fec230
                                                  /--*  t2     byref
                                                  +--*  t0     ref
N003 ( 18, 10) [000003] -A-XG-------              *  STOREIND  ref
               [000007] ------------                 IL_OFFSET void   INLRT @ 0x00A[E-]
N001 (  0,  0) [000004] ------------                 RETURN    void   $180
```

[Diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1559277&view=ms.vss-build-web.run-extensions-tab) - "a few" improvements on Windows x86.

[ARM diffs](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-63957/linux-arm.md) are not as great, with the runtime tests collection regressing due to fewer "reuse reg val" opportunities. I think it is acceptable to let that regression be as it appears specific to test code (`libraries[_tests].pmi` show nice improvements) and will be compensated for by CSEing addresses of statics, once `CLS_VAR` is no more.