### PR TITLE
Trying to fix issue #63788: "NetworkChange.NetworkAddressChanged event leaks threads on Linux

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
@@ -27,15 +27,17 @@ namespace System.Net.NetworkInformation.Tests
             NetworkChange.NetworkAddressChanged -= _addressHandler;
         }
 
-        [PlatformSpecific(TestPlatforms.Linux)]
+        //[PlatformSpecific(TestPlatforms.Linux)]
         //[OuterLoop()] //TODO: add Outer Loop attribute?
-        [ConditionalFact(nameof(SupportsGettingThreadsWithPsCommand))]
-        public void NetworkAddressChanged_AddRemoveMultipleTimes_CheckForLeakingThreads()
+        [ConditionalFact(nameof(SupportsGettingThreadsWithPsCommandOnLinux))]
+        public static void NetworkAddressChanged_AddRemoveMultipleTimes_CheckForLeakingThreads()
         {
+            NetworkAddressChangedEventHandler addressHandler = delegate { };
+
             for (int i = 1; i <= 10; i++)
             {
-                NetworkChange.NetworkAddressChanged += _addressHandler;
-                NetworkChange.NetworkAddressChanged -= _addressHandler;
+                NetworkChange.NetworkAddressChanged += addressHandler;
+                NetworkChange.NetworkAddressChanged -= addressHandler;
             }
 
             Thread.Sleep(2000); //allow some time for threads to exit
@@ -50,6 +52,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.Equal(0, numberOfNetworkAddressChangeThreads); //there should be no threads because there are no event subscribers
         }
 
-        private static bool SupportsGettingThreadsWithPsCommand => TestConfiguration.SupportsGettingThreadsWithPsCommand;
+        private static bool SupportsGettingThreadsWithPsCommandOnLinux
+            => OperatingSystem.IsLinux() && TestConfiguration.SupportsGettingThreadsWithPsCommand;
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace System.Net.NetworkInformation.Tests
 {
@@ -22,6 +25,57 @@ namespace System.Net.NetworkInformation.Tests
         public void NetworkAddressChanged_JustRemove_Success()
         {
             NetworkChange.NetworkAddressChanged -= _addressHandler;
+        }
+
+        [PlatformSpecific(TestPlatforms.Linux)]
+        [Fact]
+        public async void NetworkAddressChanged_AddRemoveMultipleTimes_CheckForLeakingThreads()
+        {
+            static async Task<int> GetNumberOfNetworkAddressChangeThreadsAsync()
+            {
+                int pid = Process.GetCurrentProcess().Id;
+                ProcessStartInfo psi = new ProcessStartInfo("ps", $"-T -p {pid}");
+                psi.RedirectStandardOutput = true;
+
+                using Process process = Process.Start(psi);
+                if (process == null)
+                {
+                    throw new Exception("Could not create process 'ps'");
+                }
+
+                int threadCounter = 0;
+                string output = await process.StandardOutput.ReadToEndAsync();
+                using StringReader sr = new StringReader(output);
+                while (true)
+                {
+                    string? line = await sr.ReadLineAsync();
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    if (line.IndexOf(".NET Network Ad") > 0)
+                    {
+                        //We are searching for threads containing ".NET Network Ad"
+                        //because ps command trims actual thread name ".NET Network Address Change".
+                        //This thread is created in:
+                        //  src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Unix.cs
+                        threadCounter++;
+                    }
+                }
+
+                return threadCounter;
+            }
+
+            for (int i = 1; i <= 10; i++)
+            {
+                NetworkChange.NetworkAddressChanged += _addressHandler;
+                NetworkChange.NetworkAddressChanged -= _addressHandler;
+            }
+
+            await Task.Delay(2000); //allow some time for threads to exit
+            int numberOfNetworkAddressChangeThreads = await GetNumberOfNetworkAddressChangeThreadsAsync();
+            Assert.Equal(0, numberOfNetworkAddressChangeThreads); //there should be no threads because there are no event subscribers
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
@@ -27,17 +27,15 @@ namespace System.Net.NetworkInformation.Tests
             NetworkChange.NetworkAddressChanged -= _addressHandler;
         }
 
-        //[PlatformSpecific(TestPlatforms.Linux)]
+        [PlatformSpecific(TestPlatforms.Linux)]
         //[OuterLoop()] //TODO: add Outer Loop attribute?
-        [ConditionalFact(nameof(SupportsGettingThreadsWithPsCommandOnLinux))]
-        public static void NetworkAddressChanged_AddRemoveMultipleTimes_CheckForLeakingThreads()
+        [ConditionalFact(nameof(SupportsGettingThreadsWithPsCommand))]
+        public void NetworkAddressChanged_AddRemoveMultipleTimes_CheckForLeakingThreads()
         {
-            NetworkAddressChangedEventHandler addressHandler = delegate { };
-
             for (int i = 1; i <= 10; i++)
             {
-                NetworkChange.NetworkAddressChanged += addressHandler;
-                NetworkChange.NetworkAddressChanged -= addressHandler;
+                NetworkChange.NetworkAddressChanged += _addressHandler;
+                NetworkChange.NetworkAddressChanged -= _addressHandler;
             }
 
             Thread.Sleep(2000); //allow some time for threads to exit
@@ -52,7 +50,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.Equal(0, numberOfNetworkAddressChangeThreads); //there should be no threads because there are no event subscribers
         }
 
-        private static bool SupportsGettingThreadsWithPsCommandOnLinux
-            => OperatingSystem.IsLinux() && TestConfiguration.SupportsGettingThreadsWithPsCommand;
+        private static bool SupportsGettingThreadsWithPsCommand
+            => TestConfiguration.SupportsGettingThreadsWithPsCommand;
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkAddressChangedTests.cs
@@ -28,7 +28,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Linux)]
-        //[OuterLoop()] //TODO: add Outer Loop attribute?
+        [OuterLoop("May take several seconds")]
         [ConditionalFact(nameof(SupportsGettingThreadsWithPsCommand))]
         public void NetworkAddressChanged_AddRemoveMultipleTimes_CheckForLeakingThreads()
         {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
@@ -51,7 +51,6 @@ namespace System.Net.NetworkInformation.Tests
                 }
 
                 using StringReader sr = new StringReader(output);
-                List<string> lstThreads = new List<string>();
 
                 while (true)
                 {
@@ -61,10 +60,8 @@ namespace System.Net.NetworkInformation.Tests
                         break;
                     }
 
-                    lstThreads.Add(line);
+                    yield return line;
                 }
-
-                return lstThreads;
             }
             finally
             {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Net.NetworkInformation.Tests
+{
+    internal static class ProcessUtil
+    {
+        public static IEnumerable<string> GetProcessThreadsWithPsCommand(int pid)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo("ps", $"-T --no-headers -p {pid}");
+            psi.RedirectStandardOutput = true;
+
+            using Process process = Process.Start(psi);
+            if (process == null)
+            {
+                throw new Exception("Could not create process 'ps'");
+            }
+
+            string output = process.StandardOutput.ReadToEnd();
+            if (process.ExitCode != 0)
+            {
+                throw new Exception($"Process 'ps' returned exit code {process.ExitCode}");
+            }
+
+            using StringReader sr = new StringReader(output);
+
+            while (true)
+            {
+                string? line = sr.ReadLine();
+                if (line == null)
+                {
+                    break;
+                }
+
+                yield return line;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
@@ -22,7 +22,7 @@ namespace System.Net.NetworkInformation.Tests
             }
             catch (Exception ex)
             {
-                throw new Exception($"Exception while trying to run 'ps' command for user '{Environment.UserName}'", ex);
+                throw new Exception($"Exception while trying to run 'ps' command", ex);
             }
 
             if (process == null)
@@ -51,6 +51,7 @@ namespace System.Net.NetworkInformation.Tests
                 }
 
                 using StringReader sr = new StringReader(output);
+                List<string> lstThreads = new List<string>();
 
                 while (true)
                 {
@@ -60,8 +61,10 @@ namespace System.Net.NetworkInformation.Tests
                         break;
                     }
 
-                    yield return line;
+                    lstThreads.Add(line);
                 }
+
+                return lstThreads;
             }
             finally
             {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ProcessUtil.cs
@@ -9,34 +9,63 @@ namespace System.Net.NetworkInformation.Tests
 {
     internal static class ProcessUtil
     {
-        public static IEnumerable<string> GetProcessThreadsWithPsCommand(int pid)
+        public static IEnumerable<string> GetProcessThreadsWithPsCommand(int pid, int? timeoutInMilliseconds = null)
         {
             ProcessStartInfo psi = new ProcessStartInfo("ps", $"-T --no-headers -p {pid}");
             psi.RedirectStandardOutput = true;
 
-            using Process process = Process.Start(psi);
+            Process? process;
+
+            try
+            {
+                process = Process.Start(psi);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Exception while trying to run 'ps' command for user '{Environment.UserName}'", ex);
+            }
+
             if (process == null)
             {
                 throw new Exception("Could not create process 'ps'");
             }
 
-            string output = process.StandardOutput.ReadToEnd();
-            if (process.ExitCode != 0)
+            try
             {
-                throw new Exception($"Process 'ps' returned exit code {process.ExitCode}");
-            }
-
-            using StringReader sr = new StringReader(output);
-
-            while (true)
-            {
-                string? line = sr.ReadLine();
-                if (line == null)
+                if (timeoutInMilliseconds.HasValue)
                 {
-                    break;
+                    if (!process.WaitForExit(timeoutInMilliseconds.Value))
+                    {
+                        throw new Exception($"Process 'ps' did not exit after {timeoutInMilliseconds} milliseconds");
+                    }
+                }
+                else
+                {
+                    process.WaitForExit();
                 }
 
-                yield return line;
+                string output = process.StandardOutput.ReadToEnd();
+                if (process.ExitCode != 0)
+                {
+                    throw new Exception($"Process 'ps' returned exit code {process.ExitCode}");
+                }
+
+                using StringReader sr = new StringReader(output);
+
+                while (true)
+                {
+                    string? line = sr.ReadLine();
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    yield return line;
+                }
+            }
+            finally
+            {
+                process.Dispose();
             }
         }
     }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -40,6 +40,8 @@
     <Compile Include="PhysicalAddressTest.cs" />
     <Compile Include="ConnectionsParsingTests.cs" />
     <Compile Include="StatisticsParsingTests.cs" />
+    <Compile Include="ProcessUtil.cs" />
+    <Compile Include="TestConfiguration.cs" />
     <!-- Common test files -->
     <Compile Include="$(CommonTestPath)System\Net\Http\TestHelper.cs"
              Link="Common\System\Net\Http\TestHelper.cs" />

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/TestConfiguration.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Net.NetworkInformation.Tests
+{
+    internal static class TestConfiguration
+    {
+        public static bool SupportsGettingThreadsWithPsCommand { get { return s_supportsGettingThreadsWithPsCommand.Value; } }
+
+        private static Lazy<bool> s_supportsGettingThreadsWithPsCommand = new Lazy<bool>(() =>
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return false;
+            }
+
+            // On other platforms we will try it.
+            try
+            {
+                _ = ProcessUtil.GetProcessThreadsWithPsCommand(Process.GetCurrentProcess().Id);
+                return true;
+            }
+            catch { return false; }
+        });
+    }
+}

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/TestConfiguration.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Linq;
 
 namespace System.Net.NetworkInformation.Tests
 {
@@ -19,7 +20,7 @@ namespace System.Net.NetworkInformation.Tests
             // On other platforms we will try it.
             try
             {
-                _ = ProcessUtil.GetProcessThreadsWithPsCommand(Process.GetCurrentProcess().Id);
+                _ = ProcessUtil.GetProcessThreadsWithPsCommand(Process.GetCurrentProcess().Id).ToArray();
                 return true;
             }
             catch { return false; }

--- a/src/native/libs/System.Native/pal_networkchange.c
+++ b/src/native/libs/System.Native/pal_networkchange.c
@@ -35,14 +35,14 @@ Error SystemNative_CreateNetworkChangeListenerSocket(int32_t* retSocket)
     sa.nl_family = AF_NETLINK;
     sa.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_ROUTE;
     int32_t sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
-	
-	// Added receive timeout to prevent recvmsg method in SystemNative_ReadEvents to block thread indefinitely.
-	// This allows method SystemNative_ReadEvents to periodically exit and allows .NET thread to exit if needed.
-	struct timeval tv;
-	tv.tv_sec = 1; //timeout in seconds
-	tv.tv_usec = 0;
-	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv);
-	
+
+    // Added receive timeout to prevent recvmsg method in SystemNative_ReadEvents to block thread indefinitely.
+    // This allows method SystemNative_ReadEvents to periodically exit and allows .NET thread to exit if needed.
+    struct timeval tv;
+    tv.tv_sec = 1; //timeout in seconds
+    tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv);
+
 #elif HAVE_RT_MSGHDR
     int32_t sock = socket(PF_ROUTE, SOCK_RAW, 0);
 #endif

--- a/src/native/libs/System.Native/pal_networkchange.c
+++ b/src/native/libs/System.Native/pal_networkchange.c
@@ -35,6 +35,14 @@ Error SystemNative_CreateNetworkChangeListenerSocket(int32_t* retSocket)
     sa.nl_family = AF_NETLINK;
     sa.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_ROUTE;
     int32_t sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	
+	// Added receive timeout to prevent recvmsg method in SystemNative_ReadEvents to block thread indefinitely.
+	// This allows method SystemNative_ReadEvents to periodically exit and allows .NET thread to exit if needed.
+	struct timeval tv;
+	tv.tv_sec = 1; //timeout in seconds
+	tv.tv_usec = 0;
+	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv);
+	
 #elif HAVE_RT_MSGHDR
     int32_t sock = socket(PF_ROUTE, SOCK_RAW, 0);
 #endif

--- a/src/native/libs/System.Native/pal_networkchange.c
+++ b/src/native/libs/System.Native/pal_networkchange.c
@@ -36,13 +36,6 @@ Error SystemNative_CreateNetworkChangeListenerSocket(int32_t* retSocket)
     sa.nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_ROUTE;
     int32_t sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
 
-    // Added receive timeout to prevent recvmsg method in SystemNative_ReadEvents to block thread indefinitely.
-    // This allows method SystemNative_ReadEvents to periodically exit and allows .NET thread to exit if needed.
-    struct timeval tv;
-    tv.tv_sec = 1; //timeout in seconds
-    tv.tv_usec = 0;
-    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv);
-
 #elif HAVE_RT_MSGHDR
     int32_t sock = socket(PF_ROUTE, SOCK_RAW, 0);
 #endif
@@ -50,6 +43,20 @@ Error SystemNative_CreateNetworkChangeListenerSocket(int32_t* retSocket)
     {
         *retSocket = -1;
         return (Error)(SystemNative_ConvertErrorPlatformToPal(errno));
+    }
+
+    // Added receive timeout to prevent recvmsg method in SystemNative_ReadEvents to block thread indefinitely.
+    // This allows method SystemNative_ReadEvents to periodically exit and allows .NET thread to exit if needed.
+    struct timeval tv;
+    tv.tv_sec = 1; //we will wait in SystemNative_ReadEvents method for max one second (TODO: is this good default value?)
+    tv.tv_usec = 0;
+
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv) != 0)
+    {
+        *retSocket = -1;
+        Error palError = (Error)(SystemNative_ConvertErrorPlatformToPal(errno));
+        close(sock);
+        return palError;
     }
 
 #if HAVE_LINUX_RTNETLINK_H


### PR DESCRIPTION
Adding "s_socketCreateContext" counter which changes each time CreateSocket() method is called. Method LoopReadSocket can then use this information to exit thread.

Fixes #63788