### PR TITLE
JIT: Fix repeatable failure for max CALLSITE_DEPTH

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -47,7 +47,9 @@ unsigned Compiler::fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo)
             // This inline candidate has the same IL code buffer as an already
             // inlined method does.
             inlineResult->NoteFatal(InlineObservation::CALLSITE_IS_RECURSIVE);
-            break;
+
+            // No need to note CALLSITE_DEPTH we're already rejecting this candidate
+            return depth;
         }
 
         if (depth > InlineStrategy::IMPLEMENTATION_MAX_INLINE_DEPTH)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Found by Antigen
+
+public class Runtime_63942
+{
+    public static int Main()
+    {
+        var _ = 3.14.ToString();
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_63942/Runtime_63942.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_EnableHWIntrinsic=0
+set COMPlus_JITInlineDepth=0
+set COMPlus_TieredCompilation=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_EnableHWIntrinsic=0
+export COMPlus_JITInlineDepth=0
+export COMPlus_TieredCompilation=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix for a debug-only artificial assert 
Closes https://github.com/dotnet/runtime/issues/63942
