### PR TITLE
Fix Failing Globalization Test on OSX

### DIFF
--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -65,7 +65,11 @@ namespace System.Globalization.Tests
                     return PlatformDetection.IsNlsGlobalization ? new int[] { 12 } : new int[] { 9 };
 
                 case "es-BO":
-                    return (PlatformDetection.IsNlsGlobalization && PlatformDetection.WindowsVersion < 10) ? new int[] { 14 } : new int[] { 1 };
+                    return (PlatformDetection.IsNlsGlobalization && PlatformDetection.WindowsVersion < 10) ? 
+                                new int[] { 14 } : 
+                                // Mac OSX used to return 1 which is the format "-$n". OSX Version 12 (Monterey) started
+                                // to return a different value 12 "$ -n". 
+                                PlatformDetection.IsOSX ? new int[] { 1, 12 } : new int[] { 1 };
 
                 case "fr-CA":
                     return PlatformDetection.IsNlsGlobalization ? new int[] { 15 } : new int[] { 8, 15 };


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/58944

Mac OSX 12 (Monterey) has changed the es-BO culture negative currency format from `-$n` to `$ -n` causing the test to fail. This change fixes the test to make it work with different versions of Mac OSX.