### PR TITLE
Make ILStubGenerated event log ModuleID corresponding to that on other events

### DIFF
--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1985,18 +1985,6 @@ public:
         return dac_cast<TADDR>(m_ModuleID);
     }
 
-    SIZE_T *             GetAddrModuleID()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return (SIZE_T*) &m_ModuleID;
-    }
-
-    static SIZE_T       GetOffsetOfModuleID()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return offsetof(Module, m_ModuleID);
-    }
-
     PTR_DomainLocalModule   GetDomainLocalModule();
 
     // LoaderHeap for storing IJW thunks

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -959,7 +959,7 @@ public:
         if (pTargetMD)
         {
             pTargetMD->GetMethodInfoWithNewSig(strNamespaceOrClassName, strMethodName, strMethodSignature);
-            uModuleId = (UINT64)pTargetMD->GetModule()->GetAddrModuleID();
+            uModuleId = (UINT64)(TADDR)pTargetMD->GetModule_NoLogging();
         }
 
         //


### PR DESCRIPTION
The `ILStubGenerated` event was logging the address of the module ID field on `Module` (containing the managed method for which the stub was being generated) as the event's `ModuleID` data. Maybe I'm missing something, but I couldn't see a good way to correlate this to something of use in a collected trace.

Other events (like module load, method load) log the `Module` address as their `ModuleID` - this change makes the `ILStubGenerated` event do the same.

@AaronRobinsonMSFT @jkoritzinsky 