### PR TITLE
Bump Explicit-layout value types with no fields to at minimum 1 byte size.

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -8648,6 +8648,14 @@ MethodTableBuilder::HandleExplicitLayout(
                 BuildMethodTableThrowException(IDS_CLASSLOAD_GENERAL);
             }
         }
+
+        if (!numInstanceFieldBytes.IsOverflow() && numInstanceFieldBytes.Value() == 0)
+        {
+            // If we calculate a 0-byte size here, we should have also calculated a 0-byte size
+            // in the initial layout algorithm.
+            _ASSERTE(GetLayoutInfo()->IsZeroSized());
+            numInstanceFieldBytes = S_UINT32(1);
+        }
     }
 
     // The GC requires that all valuetypes containing orefs be sized to a multiple of TARGET_POINTER_SIZE.

--- a/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
+++ b/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
@@ -52,7 +52,7 @@ public class Test_explicitStruct_empty
 
     [Fact]
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void EmptyExplicitStructCanBeLoadedAndCreatedThroughReflection()
+    public static void EmptyExplicitClassCanBeLoadedAndCreatedThroughReflection()
     {
         object c = Activator.CreateInstance(Type.GetType("C2"));
     }

--- a/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
+++ b/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Explicit)]
+public struct S
+{
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public struct S2
+{
+}
+
+public class Test_explicitStruct_empty
+{
+    // Mark as no-inlining so any test failures will show the right stack trace even after
+    // we consolidate test assemblies.
+    [Fact]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void EmptyExplicitStructCanBeLoadedAndCreated()
+    {
+        S s = new S();
+    }
+
+    [Fact]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void EmptyExplicitStructCanBeLoadedAndCreatedThroughReflection()
+    {
+        object s = Activator.CreateInstance(Type.GetType("S2"));
+    }
+}

--- a/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
+++ b/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [StructLayout(LayoutKind.Explicit)]
 public struct S

--- a/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
+++ b/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.cs
@@ -15,6 +15,16 @@ public struct S2
 {
 }
 
+[StructLayout(LayoutKind.Explicit)]
+public class C
+{
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public class C2
+{
+}
+
 public class Test_explicitStruct_empty
 {
     // Mark as no-inlining so any test failures will show the right stack trace even after
@@ -31,5 +41,19 @@ public class Test_explicitStruct_empty
     public static void EmptyExplicitStructCanBeLoadedAndCreatedThroughReflection()
     {
         object s = Activator.CreateInstance(Type.GetType("S2"));
+    }
+
+    [Fact]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void EmptyExplicitClassCanBeLoadedAndCreated()
+    {
+        C c = new C();
+    }
+
+    [Fact]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void EmptyExplicitStructCanBeLoadedAndCreatedThroughReflection()
+    {
+        object c = Activator.CreateInstance(Type.GetType("C2"));
     }
 }

--- a/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.csproj
+++ b/src/tests/Loader/classloader/explicitlayout/Regressions/empty/explicitStruct_empty.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="explicitStruct_empty.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #63664

cc: @jeffschwMSFT this PR should fix the WPF AppCompat issues.