### PR TITLE
Fix case where we incorrectly select a prefix as a FindFirstChar optimization when the pattern includdes an alternation that could lead to different prefixes.

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -200,6 +200,12 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"((\d{2,3}?)){2}", "1234", RegexOptions.None, 0, 4, true, "1234");
                 yield return (@"(abc\d{2,3}?){2}", "abc123abc4567", RegexOptions.None, 0, 12, true, "abc123abc45");
 
+                // Testing selected FindOptimizations finds the right prefix
+                yield return (@"(^|a+)bc", " aabc", RegexOptions.None, 0, 5, true, "aabc");
+                yield return (@"(^|($|a+))bc", " aabc", RegexOptions.None, 0, 5, true, "aabc");
+                yield return (@"yz(^|a+)bc", " yzaabc", RegexOptions.None, 0, 7, true, "yzaabc");
+                yield return (@"(^a|a$) bc", "a bc", RegexOptions.None, 0, 4, true, "a bc");
+
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
                     // Back references not support with NonBacktracking


### PR DESCRIPTION
cc: @stephentoub, @danmoseley @Junjun-zhao 

Fixes #63678 

For 7.0, we added the following logic: When calculating potential optimizations for FindFirstChar method, we try to analyze the expression tree to see if we can find a leading prefix so that we can use IndexOf in order to perform a vectorized search to find the potential candidate of a match. There is one bug with the added code where if the expression contains an alternation, and the first child of the alternation potential match length is zero, then we incorrectly continue looking for the prefix and mark the whole alternation part of the prefix as an empty string. The only possible case where an alternation is used and we still want to try to look for a valid prefix, is if all branches of the alternation would only match the same prefix, which is a rare edge case and we don't expect to find. ( I took a look at all of our test corpus and no patterns are such case) 

This PR is removing some code in order to effectively give up on trying to find a prefix if an alternation is found in the tree as part of the processing. It also adds some tests which were failing before of the code change and are passing now. As part of this change, I also checked the other branches of `FindCaseSensitivePrefix` optimization, and the rest look good now.