### PR TITLE
Update NativeAOT codegen and Crossgen2 for CreateSpan

### DIFF
--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -13,6 +13,7 @@ This is a list of additions and edits to be made in ECMA-335 specifications. It 
 - [Static Interface Methods](#static-interface-methods)
 - [Covariant Return Types](#covariant-return-types)
 - [Unsigned data conversion with overflow detection](#unsigned-data-conversion-with-overflow-detection)
+- [Rules for IL rewriters](#rules-for-il-rewriters)
 
 ## Signatures
 
@@ -948,3 +949,12 @@ Conversions from floating-point numbers to integral values truncate the number t
 on the top of the stack is reinterpreted as an unsigned value before the conversion.
 Note that integer values of less than 4 bytes are extended to int32 (not native int) on the
 evaluation stack.
+
+## Rules for IL Rewriters
+
+There are apis such as `System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<T>(...)` which require that the PE file have a particular structure. In particular, that api requires that the associated RVA of a FieldDef which is used to create a span must be naturally aligned over the data type that `CreateSpan` is instantiated over. There are 2 major concerns.
+
+1. That the RVA be aligned when the PE file is constructed. This may be achieved by whatever means is most convenient for the compiler.
+2. That in the presence of IL rewriters that the RVA remains aligned. This section descibes metadata which will be processed by IL rewriters in order to maintain the required alignment.
+
+In order to maintain alignment, if the field needs alignment to be preserved, the field must be of a type locally defined within the module which has a Pack (§II.10.7) value of the desired alignment. Unlike other uses of the .pack directive, in this circumstance the .pack specifies a minimum alignment.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -143,8 +143,9 @@ namespace ILCompiler
             {
                 // Use the typical field definition in case this is an instantiated generic type
                 field = field.GetTypicalFieldDefinition();
+                int fieldTypePack = (field.FieldType as MetadataType)?.GetClassLayout().PackingSize ?? 1;
                 return NodeFactory.ReadOnlyDataBlob(NameMangler.GetMangledFieldName(field),
-                    ((EcmaField)field).GetFieldRvaData(), NodeFactory.Target.PointerSize);
+                    ((EcmaField)field).GetFieldRvaData(), Math.Max(NodeFactory.Target.PointerSize, fieldTypePack));
             }
         }
 

--- a/src/tests/JIT/Intrinsics/CreateSpan_il.il
+++ b/src/tests/JIT/Intrinsics/CreateSpan_il.il
@@ -100,7 +100,7 @@
   .class explicit ansi sealed nested private '__StaticArrayInitTypeSize=16'
          extends [System.Runtime]System.ValueType
   {
-    .pack 1
+    .pack 4
     .size 16
   } // end of class '__StaticArrayInitTypeSize=16'
 


### PR DESCRIPTION
- Make sure FieldRVA pointers remain aligned as required by the code generator
  - Use the same Packing Size approach as the IL Linker will use (See jbevain/cecil#817 for details)
  - Compilers that generate CreateSpan will need to follow that trick to be compatible with rewriters.
- Provide ECMA spec augment describing packing size detail

Fixes #62316