### PR TITLE
Fix up warnings from delegate thunks

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -27,6 +27,14 @@ namespace Internal.IL.Stubs
         private readonly MethodDesc _invokeMethod;
         private MethodSignature _signature;         // signature of the native callable marshalling stub
 
+        public MethodDesc InvokeMethod
+        {
+            get
+            {
+                return _invokeMethod;
+            }
+        }
+
         public DelegateMarshallingMethodThunkKind Kind
         {
             get;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
@@ -61,11 +61,23 @@ namespace ILCompiler
             if ((type.IsWellKnownType(WellKnownType.MulticastDelegate)
                     || type == context.GetWellKnownType(WellKnownType.MulticastDelegate).BaseType))
             {
+                // If we hit this p/invoke as part of delegate marshalling (i.e. this is a delegate
+                // that has another delegate in the signature), blame the delegate type, not the marshalling thunk.
+                // This should ideally warn from the use site (e.g. where GetDelegateForFunctionPointer
+                // is called) but it's currently hard to get a warning from those spots and this guarantees
+                // we won't miss a spot (e.g. a p/invoke that has a delegate and that delegate contains
+                // a System.Delegate parameter).
+                MethodDesc reportedMethod = method;
+                if (reportedMethod is Internal.IL.Stubs.DelegateMarshallingMethodThunk delegateThunkMethod)
+                {
+                    reportedMethod = delegateThunkMethod.InvokeMethod;
+                }
+
                 var message = new DiagnosticString(DiagnosticId.CorrectnessOfAbstractDelegatesCannotBeGuaranteed).GetMessage(DiagnosticUtilities.GetMethodSignatureDisplayName(method));
                 _logger.LogWarning(
                     message,
                     (int)DiagnosticId.CorrectnessOfAbstractDelegatesCannotBeGuaranteed,
-                    method,
+                    reportedMethod,
                     MessageSubCategory.AotAnalysis);
             }
 


### PR DESCRIPTION
If we hit a p/invoke with a `System.Delegate` in a delegate marshalling stub, blame the delegate type, not the compiler-generated method. Apparently we marshal System.Delegate in MsQuick interop.