### PR TITLE
Add pmi_path argument to superpmi.py script and use it in the superpmi-collect pipeline.

### DIFF
--- a/src/coreclr/scripts/superpmi-collect.proj
+++ b/src/coreclr/scripts/superpmi-collect.proj
@@ -54,7 +54,7 @@
     <OutputMchPath>%HELIX_WORKITEM_UPLOAD_ROOT%</OutputMchPath>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
-    <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll </WorkItemCommand>
+    <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll -pmi_path $(SuperPMIDirectory)\crossgen2</WorkItemCommand>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <Python>$HELIX_PYTHONPATH</Python>
@@ -68,7 +68,7 @@
     <OutputMchPath>$HELIX_WORKITEM_UPLOAD_ROOT</OutputMchPath>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)/artifacts/helixresults</HelixResultsDestinationDir>
-    <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll </WorkItemCommand>
+    <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll -pmi_path $(SuperPMIDirectory)/crossgen2</WorkItemCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WorkItemCommand)' != ''">

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -834,9 +834,12 @@ class SuperPMICollect:
                 pmi_complus_env["JitName"] = self.collection_shim_name
 
                 if self.coreclr_args.pmi_path is not None:
-                    root_env["PMIPATH"] = ";".join(self.coreclr_args.pmi_path)
+                    pmi_root_env = root_env.copy()
+                    pmi_root_env["PMIPATH"] = ";".join(self.coreclr_args.pmi_path)
+                else:
+                    pmi_root_env = root_env
 
-                set_and_report_env(pmi_command_env, root_env, pmi_complus_env)
+                set_and_report_env(pmi_command_env, pmi_root_env, pmi_complus_env)
 
                 old_env = os.environ.copy()
                 os.environ.update(pmi_command_env)

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -597,10 +597,6 @@ class SuperPMICollect:
         if coreclr_args.pmi:
             self.pmi_location = determine_pmi_location(coreclr_args)
             self.corerun = os.path.join(self.core_root, self.corerun_tool_name)
-            if coreclr_args.pmi_path is None:
-                self.pmi_path_directories = []
-            else:
-                self.pmi_path_directories = coreclr_args.pmi_path
         else:
             if coreclr_args.pmi_path is not None:
                 logging.warning("Warning: -pmi_path is set but --pmi is not.")
@@ -729,9 +725,6 @@ class SuperPMICollect:
             root_env["SuperPMIShimLogPath"] = self.temp_location
             root_env["SuperPMIShimPath"] = self.jit_path
 
-            if self.coreclr_args.pmi and self.pmi_path_directories:
-                root_env["PMIPATH"] = ";".join(self.pmi_path_directories)
-
             complus_env = {}
             complus_env["EnableExtraSuperPmiQueries"] = "1"
 
@@ -844,6 +837,10 @@ class SuperPMICollect:
                 pmi_command_env = env_copy.copy()
                 pmi_complus_env = complus_env.copy()
                 pmi_complus_env["JitName"] = self.collection_shim_name
+
+                if self.coreclr_args.pmi_path is not None:
+                    root_env["PMIPATH"] = ";".join(self.coreclr_args.pmi_path)
+
                 set_and_report_env(pmi_command_env, root_env, pmi_complus_env)
 
                 old_env = os.environ.copy()

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -597,11 +597,6 @@ class SuperPMICollect:
         if coreclr_args.pmi:
             self.pmi_location = determine_pmi_location(coreclr_args)
             self.corerun = os.path.join(self.core_root, self.corerun_tool_name)
-        else:
-            if coreclr_args.pmi_path is not None:
-                logging.warning("Warning: -pmi_path is set but --pmi is not.")
-            if coreclr_args.pmi_location is not None:
-                logging.warning("Warning: -pmi_location is set but --pmi is not.")
 
         if coreclr_args.crossgen2:
             self.corerun = os.path.join(self.core_root, self.corerun_tool_name)
@@ -3135,6 +3130,12 @@ def setup_args(args):
         if ((args.pmi is True) or (args.crossgen2 is True)) and (len(args.assemblies) == 0):
             print("Specify `-assemblies` if `--pmi` or `--crossgen2` is given")
             sys.exit(1)
+
+        if not args.pmi:
+            if args.pmi_path is not None:
+                logging.warning("Warning: -pmi_path is set but --pmi is not.")
+            if args.pmi_location is not None:
+                logging.warning("Warning: -pmi_location is set but --pmi is not.")
 
         if args.collection_command is None and args.merge_mch_files is not True:
             assert args.collection_args is None

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -601,6 +601,11 @@ class SuperPMICollect:
                 self.pmi_path_directories = []
             else:
                 self.pmi_path_directories = coreclr_args.pmi_path
+        else:
+            if coreclr_args.pmi_path is not None:
+                logging.warning("Warning: -pmi_path is set but --pmi is not.")
+            if coreclr_args.pmi_location is not None:
+                logging.warning("Warning: -pmi_location is set but --pmi is not.")
 
         if coreclr_args.crossgen2:
             self.corerun = os.path.join(self.core_root, self.corerun_tool_name)


### PR DESCRIPTION
This is to fix an issue with superpmi-collect pipeline when an assembly in one partition depends on an assemblies in a different partition. 

For example, `ILCompiler.ReadyToRun.dll` in partition 0 depends on `ILCompiler.DependencyAnalysisFramework.dll` in partition 1
```
DRIVEALL: Invoking C:\h\w\B2DD0947\p\superpmi\corerun.exe C:\h\w\B2DD0947\p\superpmi\pmi.dll PREPALL C:\h\w\B2DD0947\w\A3C808ED\u\binaries\crossgen2\ILCompiler.ReadyToRun.dll 0
ReflectionTypeLoadException ILCompiler.ReadyToRun
ReflectionTypeLoadException ILCompiler.ReadyToRun   ex: Could not load file or assembly 'ILCompiler.DependencyAnalysisFramework, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
ReflectionTypeLoadException ILCompiler.ReadyToRun   ex: Could not load file or assembly 'ILCompiler.DependencyAnalysisFramework, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
ReflectionTypeLoadException ILCompiler.ReadyToRun   ex: Could not load file or assembly 'ILCompiler.DependencyAnalysisFramework, Version=7.0.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
```
Since the second assembly is not located next to either `ILCompiler.ReadyToRun.dll` or `corerun.exe` the pmi.dll run could not load it. 

As Bruce suggested, the PR adds functionality to set `PMIPATH` to find dependent assemblies.