### PR TITLE
[DRAFT] new wasm invoke icall with necessary changes from custom marshalers, but no marshalers

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -59,6 +59,14 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern string CancelPromise(int promiseJSHandle, out int exceptionalResult);
 
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern int InvokeJSFunction(
+            string internedFunctionName, int argumentCount,
+            IntPtr type1, IntPtr arg1,
+            IntPtr type2, IntPtr arg2,
+            IntPtr type3, IntPtr arg3
+        );
+
         // / <summary>
         // / Execute the provided string in the JavaScript context
         // / </summary>

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System.Private.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System.Private.Runtime.InteropServices.JavaScript.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
     <Compile Include="$(CommonPath)Interop\Browser\Interop.Runtime.cs" Link="Common\Interop\Browser\Interop.Runtime.cs" />
+    <Compile Include="System\Runtime\InteropServices\JavaScript\Codegen.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Runtime.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Runtime.CS.Owned.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Runtime.JS.Owned.cs" />
@@ -31,6 +32,7 @@
     <Compile Include="System\Runtime\InteropServices\JavaScript\HostObject.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Function.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSObject.References.cs" />
+    <Compile Include="System\Runtime\InteropServices\JavaScript\Types.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Codegen.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Codegen.cs
@@ -265,7 +265,10 @@ namespace System.Runtime.InteropServices.JavaScript
                     case MarshalType.VT:
                         throw new Exception($"Cannot marshal struct of type {argType}");
                     case MarshalType.OBJECT:
-                        ch = ArgsMarshalCharacter.JSObj;
+                        if (argType.FullName == "System.Uri")
+                            ch = ArgsMarshalCharacter.Uri;
+                        else
+                            ch = ArgsMarshalCharacter.JSObj;
                         break;
                 }
             } else {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Codegen.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Codegen.cs
@@ -1,0 +1,447 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace System.Runtime.InteropServices.JavaScript
+{
+    public static unsafe class Codegen
+    {
+        public static readonly int PointerSize = sizeof(IntPtr);
+        // HACK: Unless we align all the argument values in the heap by this amount,
+        //  certain parameter types will be garbled when received by target C# functions
+        public const int IndirectAddressAlignment = 8;
+
+        private static readonly Dictionary<MarshalType, string> FastUnboxHandlers = new Dictionary<MarshalType, string> {
+            { MarshalType.INT, "getI32(unboxBuffer)" },
+            { MarshalType.POINTER, "getU32(unboxBuffer)" }, // FIXME: Is this right?
+            { MarshalType.UINT32, "getU32(unboxBuffer)" },
+            { MarshalType.FP32, "getF32(unboxBuffer)" },
+            { MarshalType.FP64, "getF64(unboxBuffer)" },
+            { MarshalType.BOOL, "getI32(unboxBuffer) !== 0" },
+            { MarshalType.CHAR, "String.fromCharCode(getI32(unboxBuffer))" },
+        };
+
+        public abstract class BuilderStateBase {
+            public MarshalString MarshalString;
+            public StringBuilder Output = new StringBuilder();
+            public HashSet<string> ClosureReferences = new HashSet<string>();
+        }
+
+        public class MarshalBuilderState : BuilderStateBase {
+            public StringBuilder Phase2 = new StringBuilder();
+            public Dictionary<string, object> Closure = new Dictionary<string, object>();
+            public int ArgIndex, RootIndex, DirectOffset, IndirectOffset;
+
+            public string ArgKey => $"arg{ArgIndex}";
+
+            public MarshalBuilderState () {
+                ClosureReferences = new HashSet<string> {
+                    "_malloc",
+                    "_error",
+                };
+            }
+        }
+
+        public class BoundMethodBuilderState : BuilderStateBase {
+            public string? FriendlyName;
+            public MethodInfo Method;
+
+            public BoundMethodBuilderState (MethodInfo method) {
+                Method = method;
+                ClosureReferences = new HashSet<string> {
+                    "_error",
+                    "mono_wasm_new_root",
+                    "_create_temp_frame",
+                    "_get_args_root_buffer_for_method_call",
+                    "_get_buffer_for_method_call",
+                    "_handle_exception_for_call",
+                    "_teardown_after_call",
+                    "mono_wasm_try_unbox_primitive_and_get_type",
+                    "_unbox_mono_obj_root_with_known_nonprimitive_type",
+                    "invoke_method",
+                    "getI32",
+                    "getU32",
+                    "getF32",
+                    "getF64",
+                };
+            }
+        }
+
+        private static string ToJsBool (bool b) => b ? "true" : "false";
+
+        public static void GenerateSignatureConverter (MarshalBuilderState state) {
+            int length = state.MarshalString.ArgumentCount;
+            var debugName = string.Concat("converter_", state.MarshalString.Key);
+            var variadicName = string.Concat("varConverter_", state.MarshalString.Key);
+
+            // First we generate the individual steps that pack each argument into the buffer and
+            //  place pointers to each argument into the args list that is passed when invoking a method.
+            var output = state.Output;
+            for (int i = 0; i < length; i++) {
+                state.ArgIndex = i;
+                var ch = state.MarshalString[i];
+                EmitMarshalStep(state, ch);
+            }
+
+            // Now we capture that list of steps so we can put stuff above it. Generating the list of
+            //  steps produced valuable information like how large our buffer needs to be.
+            var temp = output.ToString();
+            output.Clear();
+
+            // This special comment assigns a URL to this generated function in browser debuggers
+            output.AppendLine($"//# sourceURL=https://mono-wasm.invalid/signature/{state.MarshalString.Key}");
+            output.AppendLine("\"use strict\";");
+
+            var alignmentMinusOne = IndirectAddressAlignment - 1;
+            // HACK: We have to pad out both buffers to ensure that all addresses will have an alignment of 8
+            // If we don't do this, passing values to C# functions can fail (typically for doubles)
+            var directSize = (state.DirectOffset + alignmentMinusOne) / IndirectAddressAlignment * IndirectAddressAlignment;
+            var indirectSize = (state.IndirectOffset + alignmentMinusOne) / IndirectAddressAlignment * IndirectAddressAlignment;
+            var totalBufferSize = directSize + indirectSize + IndirectAddressAlignment;
+            output.AppendLine($"// '{state.MarshalString.Signature}' {length} argument(s)");
+            output.AppendLine($"// direct buffer {state.DirectOffset} byte(s), indirect {state.IndirectOffset} byte(s)");
+
+            if (length > 0) {
+                // Now we scan through all the closure references that were generated while emitting
+                //  the marshal steps, and pull them out of the closure table into local variables in
+                //  the scope of the outer function. This will make them visible to the two inner
+                //  inner functions we're generating (which are the actual signature converter + its
+                //  variadic wrapper), eliminating any need to do table lookups on every invocation.
+                // FIXME: It's possible to end up with a cyclic dependency between converters this way
+
+                // TODO: Sort this for consistent code
+                foreach (var key in state.ClosureReferences)
+                    output.AppendLine($"const {key} = get_api('{key}');");
+            }
+
+            output.AppendLine("");
+            output.Append($"function {debugName} (buffer, rootBuffer, methodPtr");
+            for (int i = 0; i < length; i++)
+                output.Append($", arg{i}");
+            output.AppendLine(") {");
+
+            if (length > 0) {
+                output.AppendLine("  if (!methodPtr) _error('no method provided');");
+                if (state.RootIndex > 0)
+                    state.Output.AppendLine($"  if (!rootBuffer) _error('no root buffer provided');");
+                // When a signature converter is called it may be passed an existing buffer for reuse, but
+                //  if not it will allocate one on the fly. The caller is responsible for freeing it.
+                output.AppendLine($"  if (!buffer) buffer = _malloc({totalBufferSize});");
+                // FIXME: While we're aligning the size of the direct buffer, it's possible 'buffer' itself is not
+                //  properly aligned, which would mean indirectBuffer will also not be properly aligned.
+                // In my testing emscripten's malloc always produces aligned addresses, but we may want to
+                //  detect and handle this by shifting indirectBuffer forward to align it.
+                output.AppendLine($"  const directBuffer = buffer, indirectBuffer = directBuffer + {directSize};");
+                output.AppendLine(temp);
+
+                // Some marshaling operations need to occur in two phases, so we append the second phase
+                //  code right at the end before returning
+                if (state.Phase2.Length > 0)
+                    output.AppendLine(state.Phase2.ToString());
+
+                output.AppendLine("  return buffer;");
+            } else {
+                output.AppendLine("  return 0;");
+            }
+            output.AppendLine("};");
+
+            // Generate a small dispatcher function that will unpack an arguments array to pass
+            //  the individual arguments to the signature converter. This is much slower than
+            //  taking arguments directly so it is only available as a fallback
+            output.AppendLine("");
+            output.AppendLine($"function {variadicName} (buffer, rootBuffer, methodPtr, args) {{");
+            output.AppendLine($"  if (args.length !== {length}) _error('Expected {length} argument(s)');");
+            if (length > 0) {
+                output.Append($"  return {debugName}(buffer, rootBuffer, methodPtr");
+                for (int i = 0; i < length; i++)
+                    output.Append($", args[{i}]");
+                output.AppendLine(");");
+            } else {
+                output.Append("  return 0;");
+            }
+            output.AppendLine("};");
+
+            var pMethod = state.MarshalString.Method?.MethodHandle.Value ?? IntPtr.Zero;
+            var method = state.MarshalString.ContainsAuto
+                ? pMethod.ToInt32().ToString()
+                : "null";
+
+            // At the end our wrapper function returns the two nested closures along with information
+            //  on the signature they're for, so that the JS bindings layer can store everything away
+            //  and do relevant setup (allocating the correct sized buffer, etc.)
+            output.AppendLine("");
+            output.AppendLine("return {");
+            output.AppendLine($"  arg_count: {length}, ");
+            output.AppendLine($"  args_marshal: '{state.MarshalString.Signature}', ");
+            output.AppendLine($"  compiled_function: {debugName}, ");
+            output.AppendLine($"  compiled_variadic_function: {variadicName}, ");
+            output.AppendLine($"  contains_auto: {ToJsBool(state.MarshalString.ContainsAuto)}, ");
+            output.AppendLine($"  is_result_definitely_unmarshaled: {ToJsBool(state.MarshalString.RawReturnValue)}, ");
+            output.AppendLine($"  method: {method}, ");
+            output.AppendLine($"  name: '{state.MarshalString.Key}', ");
+            output.AppendLine($"  needs_root_buffer: {ToJsBool(state.RootIndex > 0)}, ");
+            output.AppendLine($"  root_buffer_size: {state.RootIndex}, ");
+            output.AppendLine($"  scratchBuffer: 0, ");
+            output.AppendLine($"  scratchRootBuffer: null, ");
+            output.AppendLine($"  size: {totalBufferSize}, ");
+            output.AppendLine("};");
+        }
+
+        public static void EmitPrimitiveMarshalStep (MarshalBuilderState state, string setterName) {
+            state.ClosureReferences.Add(setterName);
+            state.ClosureReferences.Add("setU32");
+            var offsetKey = $"offset{state.ArgIndex}";
+            state.Output.AppendLine($"  let {offsetKey} = indirectBuffer + {state.IndirectOffset};");
+            state.Output.AppendLine($"  {setterName}({offsetKey}, {state.ArgKey});");
+            state.Output.AppendLine($"  setU32(directBuffer + {state.DirectOffset}, {offsetKey});");
+            state.IndirectOffset += IndirectAddressAlignment;
+            state.DirectOffset += PointerSize;
+        }
+
+        public static void EmitRawPointerMarshalStep (MarshalBuilderState state) {
+            state.ClosureReferences.Add("setU32");
+            state.Output.AppendLine($"  setU32(directBuffer + {state.DirectOffset}, {state.ArgKey});");
+            state.DirectOffset += PointerSize;
+        }
+
+        public static void EmitManagedMarshalStep (MarshalBuilderState state, string? converter) {
+            state.ClosureReferences.Add("setU32");
+
+            var key = state.ArgKey;
+            if (converter != null) {
+                key = $"converted{state.ArgIndex}";
+                // Converters can either be a bare function name or raw 'foo(x, ..., y)' JS, where we will replace the '...'
+                var parenIndex = converter.IndexOf('(');
+                if (parenIndex >= 0) {
+                    state.ClosureReferences.Add(converter.Substring(0, parenIndex));
+                    state.Output.AppendLine($"  const {key} = {converter.Replace("...", state.ArgKey)};");
+                } else {
+                    state.ClosureReferences.Add(converter);
+                    state.Output.AppendLine($"  const {key} = {converter}({state.ArgKey});");
+                }
+            }
+
+            state.Output.AppendLine($"  rootBuffer.set({state.RootIndex}, {key});");
+            state.Output.AppendLine($"  setU32(directBuffer + {state.DirectOffset}, {key});");
+            state.RootIndex += 1;
+            state.DirectOffset += PointerSize;
+        }
+
+        public static void EmitMarshalStep (MarshalBuilderState state, ArgsMarshalCharacter ch) {
+            // If this slot in the signature uses the Auto type ('a'), we need to select an
+            //  appropriate type for the parameter based on the target method's type info
+            if (ch == ArgsMarshalCharacter.Auto) {
+                var method = state.MarshalString.Method;
+                if (method == null)
+                    // This either means no method was provided, or we failed to resolve a method
+                    //  from the method handle we were provided (this can happen if it's generic)
+                    throw new Exception("No method provided when compiling converter");
+                var parms = method.GetParameters();
+                if (state.ArgIndex >= parms.Length)
+                    throw new Exception($"Too many signature characters ({state.MarshalString.ArgumentCount}) for method ({parms.Length} args)");
+
+                var parm = parms[state.ArgIndex];
+                var pName = string.IsNullOrEmpty(parm.Name)
+                    ? $"#{state.ArgIndex}"
+                    : parm.Name;
+                var argType = parm.ParameterType;
+                var autoMarshalType = Runtime.GetMarshalTypeFromType(argType);
+
+                state.Output.AppendLine($"// #{state.ArgIndex} Auto {argType} {pName} -> {autoMarshalType}");
+
+                switch (autoMarshalType) {
+                    // For basic types, we can just select an appropriate MarshalType for them, and then
+                    //  use the corresponding signature character as a replacement for the one we're missing
+                    default:
+                        ch = (ArgsMarshalCharacter)(int)Runtime.GetCallSignatureCharacterForMarshalType(autoMarshalType, null);
+                        break;
+                    // If the marshal type selector produced bare ValueType or Object, it needs custom marshaling
+                    case MarshalType.VT:
+                        throw new Exception($"Cannot marshal struct of type {argType}");
+                    case MarshalType.OBJECT:
+                        ch = ArgsMarshalCharacter.JSObj;
+                        break;
+                }
+            } else {
+                state.Output.AppendLine($"// #{state.ArgIndex} {ch}");
+            }
+
+            switch (ch) {
+                case ArgsMarshalCharacter.Int32:
+                    EmitPrimitiveMarshalStep(state, "setI32");
+                    return;
+                case ArgsMarshalCharacter.Int64:
+                    EmitPrimitiveMarshalStep(state, "setI64");
+                    return;
+                case ArgsMarshalCharacter.Float32:
+                    EmitPrimitiveMarshalStep(state, "setF32");
+                    return;
+                case ArgsMarshalCharacter.Float64:
+                    EmitPrimitiveMarshalStep(state, "setF64");
+                    return;
+                case ArgsMarshalCharacter.ByteSpan:
+                    EmitPrimitiveMarshalStep(state, "_setSpan");
+                    return;
+                case ArgsMarshalCharacter.MONOObj:
+                    EmitRawPointerMarshalStep(state);
+                    return;
+                case ArgsMarshalCharacter.String:
+                    EmitManagedMarshalStep(state, "js_string_to_mono_string");
+                    return;
+                case ArgsMarshalCharacter.InternedString:
+                    EmitManagedMarshalStep(state, "js_string_to_mono_string_interned");
+                    return;
+                case ArgsMarshalCharacter.Int32Enum:
+                    state.Output.AppendLine($"  if (typeof({state.ArgKey}) !== 'number') _error(`Expected numeric value for enum argument, got '${{{state.ArgKey}}}'`);");
+                    EmitPrimitiveMarshalStep(state, "setI32");
+                    return;
+                case ArgsMarshalCharacter.JSObj:
+                    EmitManagedMarshalStep(state, "_js_to_mono_obj(false, ...)");
+                    return;
+                case ArgsMarshalCharacter.Uri:
+                    EmitManagedMarshalStep(state, "_js_to_mono_uri(false, ...)");
+                    return;
+                case ArgsMarshalCharacter.Auto:
+                    state.Output.AppendLine($"  _error('Automatic type selection failed');");
+                    return;
+                default:
+                    throw new NotImplementedException(ch.ToString());
+            }
+        }
+
+        private static void GenerateFastUnboxCase (BoundMethodBuilderState state, MarshalType type, string? expression) {
+            var output = state.Output;
+            output.AppendLine($"    case {(int)type}:");
+            output.AppendLine($"        return {expression};");
+        }
+
+        private static void GenerateFastUnboxBlock (BoundMethodBuilderState state) {
+            var output = state.Output;
+            var methodReturnType = Runtime.GetMarshalTypeFromType(state.Method.ReturnType);
+            bool hasPrimitiveType = FastUnboxHandlers.TryGetValue(methodReturnType, out string? fastHandler);
+            // For the common scenario where the return type is a primitive, we want to try and unbox it directly
+            //  into our existing heap allocation and then read it out of the heap. Doing this all in one operation
+            //  means that we only need to enter a gc safe region twice (instead of 3+ times with the normal,
+            //  slower check-type-and-then-unbox flow which has extra checks since unbox verifies the type).
+            if (!hasPrimitiveType) {
+                output.AppendLine("    if (resultRoot.value === 0)");
+                output.AppendLine("      return undefined;");
+            }
+            output.AppendLine( "    let resultType = mono_wasm_try_unbox_primitive_and_get_type(resultRoot.value, unboxBuffer, unboxBufferSize);");
+            output.AppendLine( "    switch (resultType) {");
+            // If we know the return type of this method and it's a primitive, we only need to generate the unbox handler for that type
+            if (hasPrimitiveType) {
+                GenerateFastUnboxCase(state, methodReturnType, fastHandler);
+                // This default case should never be hit, but the runtime is returning a boxed object so it's possible if something horrible happens
+                output.AppendLine( "    default:");
+                output.AppendLine($"        throw new Error('expected method return value to be of type {methodReturnType} but it was ' + resultType);");
+            } else {
+                // The return type is something we can't fast-unbox or is unknown (i.e. object)
+                foreach (var kvp in FastUnboxHandlers)
+                    GenerateFastUnboxCase(state, kvp.Key, kvp.Value);
+                output.AppendLine( "    default:");
+                output.AppendLine( "        return _unbox_mono_obj_root_with_known_nonprimitive_type(resultRoot, resultType, unboxBuffer);");
+            }
+            output.AppendLine( "    }");
+        }
+
+        public static void GenerateBoundMethod (BoundMethodBuilderState state) {
+            // input arguments:
+            // get_api, token
+
+            int length = state.MarshalString.ArgumentCount;
+            var handle = state.Method.MethodHandle.Value;
+            var name = state.FriendlyName ?? $"clr_{handle.ToInt32()}";
+            var output = state.Output;
+
+            // This special comment assigns a URL to this generated function in browser debuggers
+            output.AppendLine($"//# sourceURL=https://mono-wasm.invalid/bound_method/{handle.ToInt32()}");
+            output.AppendLine("\"use strict\";");
+            output.AppendLine($"//{state.Method?.DeclaringType?.FullName}::{state.Method?.Name}");
+
+            // Unpack various closure values into locals in the outer function that returns the actual
+            //  bound method, so that the property lookup doesn't have to occur on every call
+            output.AppendLine("const method = token.method;");
+            output.AppendLine("const converter = token.converter;");
+            output.AppendLine($"const converter_{state.MarshalString.Key} = converter.compiled_function;");
+            output.AppendLine("const unboxBuffer = token.unboxBuffer;");
+            output.AppendLine("const unboxBufferSize = token.unboxBufferSize;");
+            // get_api here will also ensure that every function we reference is available and do
+            //  the check now at construction time instead of later when the bound method is called
+            foreach (var key in state.ClosureReferences)
+                output.AppendLine($"const {key} = get_api('{key}');");
+
+            output.Append($"function {name} (");
+            for (int i = 0; i < length; i++) {
+                if (i < (length - 1))
+                    output.Append($"arg{i}, ");
+                else
+                    output.AppendLine($"arg{i}) {{");
+            }
+            if (length == 0)
+                output.AppendLine(") {");
+
+            output.AppendLine("  _create_temp_frame();");
+            output.AppendLine("  let resultRoot = token.scratchResultRoot;");
+            output.AppendLine("  let exceptionRoot = token.scratchExceptionRoot;");
+            output.AppendLine("  token.scratchResultRoot = null;");
+            output.AppendLine("  token.scratchExceptionRoot = null;");
+            output.AppendLine("  if (resultRoot === null)");
+            output.AppendLine("    resultRoot = mono_wasm_new_root();");
+            output.AppendLine("  if (exceptionRoot === null)");
+            output.AppendLine("    exceptionRoot = mono_wasm_new_root();");
+            output.AppendLine();
+
+            output.AppendLine( "  let argsRootBuffer = _get_args_root_buffer_for_method_call(converter, token);");
+            output.AppendLine( "  let scratchBuffer = _get_buffer_for_method_call(converter, token);");
+            output.AppendLine( "  let buffer = 0;");
+            output.AppendLine( "  let abnormalExit = true;");
+            output.AppendLine( "  try {");
+            output.AppendLine($"    buffer = converter_{state.MarshalString.Key}(");
+            output.AppendLine( "      scratchBuffer, argsRootBuffer, method,");
+            for (int i = 0; i < length; i++) {
+                if (i < (length - 1))
+                    output.AppendLine($"      arg{i},");
+                else
+                    output.AppendLine($"      arg{i}");
+            }
+            output.AppendLine("    );");
+            output.AppendLine();
+
+            output.AppendLine("    resultRoot.value = invoke_method(method, 0, buffer, exceptionRoot.get_address());");
+            output.AppendLine("    _handle_exception_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);");
+            output.AppendLine("    abnormalExit = false;");
+            output.AppendLine();
+
+            if (state.MarshalString.RawReturnValue)
+                output.AppendLine("    return resultRoot.value;");
+            else if ((state.Method?.ReturnType ?? typeof(void)) == typeof(void))
+                output.AppendLine("    return;");
+            else
+                GenerateFastUnboxBlock(state);
+
+            output.AppendLine("  } finally {");
+            // An error can occur during a managed method call, in which case we will hit the finally block without having fully
+            //  cleaned up from the call. In this case, allowing _teardown_after_call to throw a new exception (due to corrupt
+            //  state, etc) would silence the original exception that caused the failure, so we turn it into a log message
+            output.AppendLine("    if (abnormalExit) {");
+            output.AppendLine("      try {");
+            output.AppendLine("        _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);");
+            output.AppendLine("      } catch (exc) {");
+            output.AppendLine("        console.error(`Unhandled error while tearing down after failed managed method call: ${exc}`);");
+            output.AppendLine("      }");
+            output.AppendLine("    } else ");
+            output.AppendLine("      _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);");
+            output.AppendLine("  }");
+            output.AppendLine("};");
+            output.AppendLine();
+            output.AppendLine($"return {name};");
+        }
+    }
+}

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSException.cs
@@ -10,6 +10,12 @@ namespace System.Runtime.InteropServices.JavaScript
     /// </summary>
     public class JSException : Exception
     {
+        public string? Stack;
+
         public JSException(string msg) : base(msg) { }
+
+        public JSException(string msg, string? stack) : base(msg) {
+            Stack = stack;
+        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -1,6 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using Console = System.Diagnostics.Debug;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace System.Runtime.InteropServices.JavaScript
 {
     public interface IJSObject
@@ -15,6 +20,30 @@ namespace System.Runtime.InteropServices.JavaScript
     /// </summary>
     public partial class JSObject : IJSObject, IDisposable
     {
+        [StructLayout(LayoutKind.Sequential)]
+        private struct InvokeRecord {
+            public object?[] Arguments;
+            // FIXME: Make this object? and update Invoke
+            public object Result;
+            public string? ErrorMessage;
+            public string? ErrorStack;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct GetPropertyRecord {
+            public object Value;
+            public string? ErrorMessage;
+            public string? ErrorStack;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SetPropertyRecord {
+            public object? Value;
+            public string? ErrorMessage;
+            public string? ErrorStack;
+            public int CreateIfNotExists;
+        }
+
         /// <summary>
         ///   Invoke a named method of the object, or throws a JSException on error.
         /// </summary>
@@ -34,15 +63,23 @@ namespace System.Runtime.InteropServices.JavaScript
         ///     valuews.
         ///   </para>
         /// </returns>
-        public object Invoke(string method, params object?[] args)
+        // FIXME: This should be object?, but if we correct it lots of stuff breaks
+        public unsafe object Invoke(string method, params object?[] args)
         {
-            AssertNotDisposed();
-
-            object res = Interop.Runtime.InvokeJSWithArgs(JSHandle, method, args, out int exception);
-            if (exception != 0)
-                throw new JSException((string)res);
-            Interop.Runtime.ReleaseInFlight(res);
-            return res;
+            var record = new InvokeRecord {
+                Arguments = args
+            };
+            var pRecord = (IntPtr)Unsafe.AsPointer(ref record);
+            var invokeResult = Runtime.InvokeJSFunctionByName("INTERNAL._JSObject_Invoke", (IntPtr)JSHandle, method, pRecord);
+            if (invokeResult != InvokeJSResult.Success)
+                throw new JSException($"Invoke result was {invokeResult}");
+            else if (record.ErrorMessage != null)
+                throw new JSException(record.ErrorMessage, record.ErrorStack);
+            else {
+                var result = record.Result;
+                Interop.Runtime.ReleaseInFlight(result);
+                return result;
+            }
         }
 
         public struct EventListenerOptions {
@@ -128,15 +165,21 @@ namespace System.Runtime.InteropServices.JavaScript
         ///     valuews.
         ///   </para>
         /// </returns>
-        public object GetObjectProperty(string name)
+        public unsafe object GetObjectProperty(string name)
         {
-            AssertNotDisposed();
-
-            object propertyValue = Interop.Runtime.GetObjectProperty(JSHandle, name, out int exception);
-            if (exception != 0)
-                throw new JSException((string)propertyValue);
-            Interop.Runtime.ReleaseInFlight(propertyValue);
-            return propertyValue;
+            var record = new GetPropertyRecord {
+            };
+            var pRecord = (IntPtr)Unsafe.AsPointer(ref record);
+            var invokeResult = Runtime.InvokeJSFunctionByName("INTERNAL._JSObject_GetProperty", (IntPtr)JSHandle, name, pRecord);
+            if (invokeResult != InvokeJSResult.Success)
+                throw new JSException($"Invoke result was {invokeResult}");
+            else if (record.ErrorMessage != null)
+                throw new JSException(record.ErrorMessage, record.ErrorStack);
+            else {
+                var result = record.Value;
+                Interop.Runtime.ReleaseInFlight(result);
+                return result;
+            }
         }
 
         /// <summary>
@@ -149,14 +192,20 @@ namespace System.Runtime.InteropServices.JavaScript
         /// array that will be surfaced as a typed ArrayBuffer (byte[], sbyte[], short[], ushort[],
         /// float[], double[]) </param>
         /// <param name="createIfNotExists">Defaults to <see langword="true"/> and creates the property on the javascript object if not found, if set to <see langword="false"/> it will not create the property if it does not exist.  If the property exists, the value is updated with the provided value.</param>
-        /// <param name="hasOwnProperty"></param>
-        public void SetObjectProperty(string name, object value, bool createIfNotExists = true, bool hasOwnProperty = false)
+        /// <param name="hasOwnProperty">does nothing</param>
+        // FIXME: hasOwnProperty is unused.
+        public unsafe void SetObjectProperty(string name, object value, bool createIfNotExists = true, bool hasOwnProperty = false)
         {
-            AssertNotDisposed();
-
-            Interop.Runtime.SetObjectProperty(JSHandle, name, value, createIfNotExists, hasOwnProperty, out int exception);
-            if (exception != 0)
-                throw new JSException($"Error setting {name} on (js-obj js '{JSHandle}')");
+            var record = new SetPropertyRecord {
+                Value = value,
+                CreateIfNotExists = createIfNotExists ? 1 : 0
+            };
+            var pRecord = (IntPtr)Unsafe.AsPointer(ref record);
+            var invokeResult = Runtime.InvokeJSFunctionByName("INTERNAL._JSObject_SetProperty", (IntPtr)JSHandle, name, pRecord);
+            if (invokeResult != InvokeJSResult.Success)
+                throw new JSException($"Invoke result was {invokeResult}");
+            else if (record.ErrorMessage != null)
+                throw new JSException(record.ErrorMessage, record.ErrorStack);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -548,5 +548,15 @@ namespace System.Runtime.InteropServices.JavaScript
             Codegen.GenerateBoundMethod(state);
             return state.Output.ToString();
         }
+
+        public static object CreateUriFromStringReflective (string uri) {
+            var type = Type.GetType("System.Uri, System.Private.Uri");
+            if (type == null)
+                throw new WasmInteropException("System.Uri is not available (linked out?)");
+            var ctor = type.GetConstructor(new[] { typeof(string) });
+            if (ctor == null)
+                throw new WasmInteropException("System.Uri's (string) constructor is not available (linked out?)");
+            return ctor.Invoke(new object[] { uri });
+        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Types.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Types.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace System.Runtime.InteropServices.JavaScript
+{
+    // see src/mono/wasm/driver.c MARSHAL_TYPE_xxx
+    public enum MarshalType : int {
+        NULL = 0,
+        INT = 1,
+        FP64 = 2,
+        STRING = 3,
+        VT = 4,
+        DELEGATE = 5,
+        TASK = 6,
+        OBJECT = 7,
+        BOOL = 8,
+        ENUM = 9,
+        URI = 22,
+        SAFEHANDLE = 23,
+        ARRAY_BYTE = 10,
+        ARRAY_UBYTE = 11,
+        ARRAY_UBYTE_C = 12,
+        ARRAY_SHORT = 13,
+        ARRAY_USHORT = 14,
+        ARRAY_INT = 15,
+        ARRAY_UINT = 16,
+        ARRAY_FLOAT = 17,
+        ARRAY_DOUBLE = 18,
+        FP32 = 24,
+        UINT32 = 25,
+        INT64 = 26,
+        UINT64 = 27,
+        CHAR = 28,
+        STRING_INTERNED = 29,
+        VOID = 30,
+        ENUM64 = 31,
+        POINTER = 32,
+        SPAN_BYTE = 33,
+    }
+
+    // see src/mono/wasm/driver.c MARSHAL_ERROR_xxx
+    public enum MarshalError : int {
+        BUFFER_TOO_SMALL = 512,
+        NULL_CLASS_POINTER = 513,
+        NULL_TYPE_POINTER = 514,
+        UNSUPPORTED_TYPE = 515,
+        FIRST = BUFFER_TOO_SMALL
+    }
+
+    public enum ArgsMarshalCharacter {
+        Int32 = 'i', // int32
+        Int32Enum = 'j', // int32 - Enum with underlying type of int32
+        Int64 = 'l', // int64
+        Int64Enum = 'k', // int64 - Enum with underlying type of int64
+        Float32 = 'f', // float
+        Float64 = 'd', // double
+        String = 's', // string
+        InternedString = 'S', // interned string
+        Uri = 'u',
+        JSObj = 'o', // js object will be converted to a C# object (this will box numbers/bool/promises)
+        MONOObj = 'm', // raw mono object. Don't use it unless you know what you're doing
+        Auto = 'a', // the bindings layer will select an appropriate converter based on the C# method signature
+        ByteSpan = 'b', // Span<byte>
+    }
+
+    public enum InvokeJSResult : int {
+        Success = 0,
+        InvalidFunctionName,
+        FunctionNotFound,
+        InvalidArgumentCount,
+        InvalidArgumentType,
+        MissingArgumentType,
+        NullArgumentPointer,
+        FunctionHadReturnValue,
+        FunctionThrewException,
+        InternalError,
+    }
+
+    public struct MarshalString {
+        public string Signature { get; private set; }
+        public string Key { get; private set; }
+        public MethodBase? Method { get; private set; }
+        public int ArgumentCount { get; private set; }
+        public bool RawReturnValue { get; private set; }
+        public bool ContainsAuto { get; private set; }
+
+        public MarshalString (string s, MethodBase? method = null) {
+            Signature = s;
+            Method = method;
+            RawReturnValue = s.EndsWith("!");
+            ArgumentCount = Signature.Length;
+            ContainsAuto = s.Contains((char)(int)ArgsMarshalCharacter.Auto);
+
+            if (RawReturnValue)
+                ArgumentCount -= 1;
+
+            var keySig = Signature.Replace("!", "_result_unmarshaled");
+            if (keySig.Length == 0)
+                keySig = "$void";
+
+            if (ContainsAuto && (Method != null))
+                Key = $"{keySig}_m{Method.MethodHandle.Value.ToInt32()}";
+            else
+                Key = keySig;
+        }
+
+        public ArgsMarshalCharacter this [int index] =>
+            (ArgsMarshalCharacter)(int)Signature[index];
+    }
+
+    public class WasmInteropException : Exception {
+        public WasmInteropException (string message)
+            : base (message) {
+        }
+
+        public WasmInteropException (string message, Exception innerException)
+            : base (message, innerException) {
+        }
+    }
+}

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -107,21 +107,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             return obj;
         }
 
-        internal static DateTime _dateTimeValue;
-        private static void InvokeDateTime(object boxed)
-        {
-            _dateTimeValue = (DateTime)boxed;
-        }
-        private static void InvokeDateTimeOffset(DateTimeOffset dto)
-        {
-            // FIXME
-            _dateTimeValue = dto.DateTime;
-        }
-        private static void InvokeDateTimeByValue(DateTime dt)
-        {
-            _dateTimeValue = dt;
-        }
-
         internal static System.Uri _uriValue;
         private static void InvokeUri(System.Uri uri)
         {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/HelperMarshal.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Runtime.InteropServices.JavaScript.Tests
@@ -12,6 +14,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
     public static class HelperMarshal
     {
         internal const string INTEROP_CLASS = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:";
+
         internal static int _i32Value;
         private static void InvokeI32(int a, int b)
         {
@@ -102,6 +105,27 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             _object2 = obj;
             return obj;
+        }
+
+        internal static DateTime _dateTimeValue;
+        private static void InvokeDateTime(object boxed)
+        {
+            _dateTimeValue = (DateTime)boxed;
+        }
+        private static void InvokeDateTimeOffset(DateTimeOffset dto)
+        {
+            // FIXME
+            _dateTimeValue = dto.DateTime;
+        }
+        private static void InvokeDateTimeByValue(DateTime dt)
+        {
+            _dateTimeValue = dt;
+        }
+
+        internal static System.Uri _uriValue;
+        private static void InvokeUri(System.Uri uri)
+        {
+            _uriValue = uri;
         }
 
         internal static object _marshalledObject;
@@ -642,65 +666,65 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             };
         }
 
-        public static Task SynchronousTask() 
+        public static Task SynchronousTask()
         {
             return Task.CompletedTask;
         }
 
-        public static async Task AsynchronousTask() 
+        public static async Task AsynchronousTask()
         {
             await Task.Yield();
         }
 
-        public static Task<int> SynchronousTaskInt(int i) 
+        public static Task<int> SynchronousTaskInt(int i)
         {
             return Task.FromResult(i);
         }
 
-        public static async Task<int> AsynchronousTaskInt(int i) 
+        public static async Task<int> AsynchronousTaskInt(int i)
         {
             await Task.Yield();
             return i;
         }
 
-        public static Task FailedSynchronousTask() 
+        public static Task FailedSynchronousTask()
         {
             return Task.FromException(new Exception());
         }
 
-        public static async Task FailedAsynchronousTask() 
+        public static async Task FailedAsynchronousTask()
         {
             await Task.Yield();
             throw new Exception();
         }
 
-        public static async ValueTask AsynchronousValueTask() 
+        public static async ValueTask AsynchronousValueTask()
         {
             await Task.Yield();
         }
 
-        public static ValueTask SynchronousValueTask() 
+        public static ValueTask SynchronousValueTask()
         {
             return ValueTask.CompletedTask;
         }
 
-        public static ValueTask<int> SynchronousValueTaskInt(int i) 
+        public static ValueTask<int> SynchronousValueTaskInt(int i)
         {
             return ValueTask.FromResult(i);
         }
 
-        public static async ValueTask<int> AsynchronousValueTaskInt(int i) 
+        public static async ValueTask<int> AsynchronousValueTaskInt(int i)
         {
             await Task.Yield();
             return i;
         }
 
-        public static ValueTask FailedSynchronousValueTask() 
+        public static ValueTask FailedSynchronousValueTask()
         {
             return ValueTask.FromException(new Exception());
         }
 
-        public static async ValueTask FailedAsynchronousValueTask() 
+        public static async ValueTask FailedAsynchronousValueTask()
         {
             await Task.Yield();
             throw new Exception();

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -264,7 +264,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 continue;
             if (item[1] === listener)
                 return;
-        }        
+        }
         this.listeners.push([name, listener, options || null]);
     },
     removeEventListener: function (name, listener, capture) {
@@ -457,40 +457,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             a.Invoke("fireEvent", "test");
             b.Invoke("fireEvent", "test");
             Assert.Equal(3, counter[0]);
-        }
-
-        [Fact]
-        public static void RoundtripCSDate()
-        {
-            var factory = new Function("dummy", @"
-                return {
-                    dummy:dummy,
-                }");
-            var date = new DateTime(2021, 01, 01, 12, 34, 45);
-
-            var obj = (JSObject)factory.Call(null, date);
-            var dummy = (DateTime)obj.GetObjectProperty("dummy");
-            // HACK: JS Dates do not contain timezone information, so date marshaling converts all dates to
-            //  UTC dates.
-            Assert.Equal(date.ToUniversalTime(), dummy.ToUniversalTime());
-        }
-
-        [Fact]
-        public static void RoundtripJSDate()
-        {
-            var factory = new Function(@"
-                var dummy = new Date(2021, 00, 01, 12, 34, 45, 567);
-                return {
-                    dummy:dummy,
-                    check:(value) => {
-                        return value.valueOf()==dummy.valueOf() ? 1 : 0;
-                    },
-                }");
-            var obj = (JSObject)factory.Call();
-
-            var date = (DateTime)obj.GetObjectProperty("dummy");
-            var check = (int)obj.Invoke("check", date);
-            Assert.Equal(1, check);
         }
 
     }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -186,8 +186,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     return rangeIterator;
                 ");
 
-            const int count = 500;
-            for (int attempt = 0; attempt < 100; attempt++)
+            const int count = 500, attemptCount = 100;
+            for (int attempt = 0; attempt < attemptCount; attempt++)
             {
                 int index = 0;
                 try
@@ -226,8 +226,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 {
                     object value = nextResult.GetObjectProperty("value");
                     nextResult.Dispose();
+                    if (value == null)
+                        Console.WriteLine("iter.value was null");
                     yield return value;
                     nextResult = (JSObject)iterrator.Invoke("next");
+                    if (nextResult == null) {
+                        Console.WriteLine("next return value was null");
+                        break;
+                    }
                     done = (bool)nextResult.GetObjectProperty("done");
                 }
             }
@@ -464,7 +470,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             var obj = (JSObject)factory.Call(null, date);
             var dummy = (DateTime)obj.GetObjectProperty("dummy");
-            Assert.Equal(date, dummy);
+            // HACK: JS Dates do not contain timezone information, so date marshaling converts all dates to
+            //  UTC dates.
+            Assert.Equal(date.ToUniversalTime(), dummy.ToUniversalTime());
         }
 
         [Fact]

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -1024,62 +1024,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        public static void MarshalDateTime()
-        {
-            HelperMarshal._dateTimeValue = default(DateTime);
-            Runtime.InvokeJS(
-                $"var dt = new Date('{ExpectedDateString}');\r\n" +
-                "App.call_test_method ('InvokeDateTime', [ dt ], 'o');"
-            );
-            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
-        }
-
-        [Fact]
-        public static void MarshalDateTimeDefault()
-        {
-            HelperMarshal._dateTimeValue = default(DateTime);
-            Runtime.InvokeJS(
-                $"var dt = new Date('{ExpectedDateString}');\r\n" +
-                "App.call_test_method ('InvokeDateTime', [ dt ]);"
-            );
-            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
-        }
-
-        [Fact]
-        public static void MarshalDateTimeAutomatic()
-        {
-            HelperMarshal._dateTimeValue = default(DateTime);
-            Runtime.InvokeJS(
-                $"var dt = new Date('{ExpectedDateString}');\r\n" +
-                "App.call_test_method ('InvokeDateTime', [ dt ], 'a');"
-            );
-            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
-        }
-
-        [Fact]
-        public static void MarshalDateTimeOffsetAutomatic()
-        {
-            HelperMarshal._dateTimeValue = default(DateTime);
-            Runtime.InvokeJS(
-                $"var dt = new Date('{ExpectedDateString}');\r\n" +
-                "App.call_test_method ('InvokeDateTimeOffset', [ dt ], 'a');"
-            );
-            // FIXME
-            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
-        }
-
-        [Fact]
-        public static void MarshalDateTimeByValueAutomatic()
-        {
-            HelperMarshal._dateTimeValue = default(DateTime);
-            Runtime.InvokeJS(
-                $"var dt = new Date('{ExpectedDateString}');\r\n" +
-                "App.call_test_method ('InvokeDateTimeByValue', [ dt.valueOf() ], 'a');"
-            );
-            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
-        }
-
-        [Fact]
         public static void MarshalUri()
         {
             var expected = new System.Uri("https://www.example.com/");

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -69,7 +69,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 for (var i = 0; i < int32View.length; i++) {
                     int32View[i] = i * 2;
                 }
-                App.call_test_method (""MarshalByteBufferToInts"", [ buffer ]);		
+                App.call_test_method (""MarshalByteBufferToInts"", [ buffer ]);
             ");
 
             Assert.Equal(4, HelperMarshal._intBuffer.Length);
@@ -344,7 +344,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             Runtime.InvokeJS(@"
                 var obj = {myInt: 100, myDouble: 4.5, myString: ""Hic Sunt Dracones"", myBoolean: true};
-                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);		
+                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);
             ");
 
             Assert.Equal(100, HelperMarshal._jsProperties[0]);
@@ -358,8 +358,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             Runtime.InvokeJS(@"
                 var obj = {myInt: 200, myDouble: 0, myString: ""foo"", myBoolean: false};
-                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);		
-                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);		
+                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);
+                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);
             ");
 
             Assert.Equal(100, HelperMarshal._jsProperties[0]);
@@ -374,8 +374,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             // This test will not create the properties if they do not already exist
             Runtime.InvokeJS(@"
                 var obj = {myInt: 200};
-                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);		
-                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);		
+                App.call_test_method (""PopulateObjectProperties"", [ obj, false ]);
+                App.call_test_method (""RetrieveObjectProperties"", [ obj ]);
             ");
 
             Assert.Equal(100, HelperMarshal._jsProperties[0]);
@@ -387,7 +387,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void SetObjectPropertiesIfNotExistsTrue()
         {
-            // This test will set the value of the property if it exists and will create and 
+            // This test will set the value of the property if it exists and will create and
             // set the value if it does not exists
             Runtime.InvokeJS(@"
                 var obj = {myInt: 200};
@@ -407,7 +407,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Runtime.InvokeJS(@"
                 var buffer = new ArrayBuffer(16);
                 var uint8View = new Uint8Array(buffer);
-                App.call_test_method (""MarshalByteBuffer"", [ uint8View ]);		
+                App.call_test_method (""MarshalByteBuffer"", [ uint8View ]);
             ");
 
             Assert.Equal(16, HelperMarshal._byteBuffer.Length);
@@ -437,7 +437,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             Runtime.InvokeJS(@"
                 var typedArray = new Float32Array([1, 2.1334, 3, 4.2, 5]);
-                App.call_test_method (""MarshalFloat32Array"", [ typedArray ]);		
+                App.call_test_method (""MarshalFloat32Array"", [ typedArray ]);
             ");
 
             Assert.Equal(1, HelperMarshal._floatBuffer[0]);
@@ -456,7 +456,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 for (var i = 0; i < float32View.length; i++) {
                     float32View[i] = i * 2.5;
                 }
-                App.call_test_method (""MarshalArrayBufferToFloat32Array"", [ buffer ]);		
+                App.call_test_method (""MarshalArrayBufferToFloat32Array"", [ buffer ]);
             ");
 
             Assert.Equal(4, HelperMarshal._floatBuffer.Length);
@@ -471,7 +471,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             Runtime.InvokeJS(@"
 			var typedArray = new Float64Array([1, 2.1334, 3, 4.2, 5]);
-			App.call_test_method (""MarshalFloat64Array"", [ typedArray ]);		
+			App.call_test_method (""MarshalFloat64Array"", [ typedArray ]);
 		");
 
             Assert.Equal(1, HelperMarshal._doubleBuffer[0]);
@@ -490,7 +490,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 for (var i = 0; i < float64View.length; i++) {
                     float64View[i] = i * 2.5;
                 }
-                App.call_test_method (""MarshalByteBufferToDoubles"", [ buffer ]);		
+                App.call_test_method (""MarshalByteBufferToDoubles"", [ buffer ]);
             ");
 
             Assert.Equal(4, HelperMarshal._doubleBuffer.Length);
@@ -509,7 +509,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 for (var i = 0; i < float64View.length; i++) {
                     float64View[i] = i * 2.5;
                 }
-                App.call_test_method (""MarshalArrayBufferToFloat64Array"", [ buffer ]);		
+                App.call_test_method (""MarshalArrayBufferToFloat64Array"", [ buffer ]);
             ");
 
             Assert.Equal(4, HelperMarshal._doubleBuffer.Length);
@@ -621,7 +621,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal(2, HelperMarshal._minValue);
         }
-        
+
         [Fact]
         public static void BoundStaticMethodMissingArgs()
         {
@@ -636,7 +636,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal(0, HelperMarshal._intValue);
         }
-        
+
         [Fact]
         public static void BoundStaticMethodExtraArgs()
         {
@@ -647,7 +647,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal(200, HelperMarshal._intValue);
         }
-        
+
         [Fact]
         public static void BoundStaticMethodArgumentTypeCoercion()
         {
@@ -667,7 +667,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal(400, HelperMarshal._intValue);
         }
-        
+
         [Fact]
         public static void BoundStaticMethodUnpleasantArgumentTypeCoercion()
         {
@@ -697,7 +697,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             Assert.Equal(0xFFFFFFFEu, HelperMarshal._uintValue);
         }
-        
+
         [Fact]
         public static void ReturnUintEnum ()
         {
@@ -711,7 +711,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal((uint)TestEnum.BigValue, HelperMarshal._uintValue);
         }
-        
+
         [Fact]
         public static void PassUintEnumByValue ()
         {
@@ -722,7 +722,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal(TestEnum.BigValue, HelperMarshal._enumValue);
         }
-        
+
         [Fact]
         public static void PassUintEnumByValueMasqueradingAsInt ()
         {
@@ -735,12 +735,12 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             ");
             Assert.Equal(TestEnum.BigValue, HelperMarshal._enumValue);
         }
-        
+
         [Fact]
         public static void PassUintEnumByNameIsNotImplemented ()
         {
             HelperMarshal._enumValue = TestEnum.Zero;
-            var exc = Assert.Throws<JSException>( () => 
+            var exc = Assert.Throws<JSException>( () =>
                 Runtime.InvokeJS(@$"
                     var set_enum = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
                     set_enum (""BigValue"");
@@ -748,11 +748,11 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             );
             Assert.StartsWith("Error: Expected numeric value for enum argument, got 'BigValue'", exc.Message);
         }
-        
+
         [Fact]
         public static void CannotUnboxUint64 ()
         {
-            var exc = Assert.Throws<JSException>( () => 
+            var exc = Assert.Throws<JSException>( () =>
                 Runtime.InvokeJS(@$"
                     var get_u64 = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetUInt64"", """");
                     var u64 = get_u64();
@@ -860,6 +860,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.True(Object.ReferenceEquals(HelperMarshal._stringResource, HelperMarshal._stringResource2));
         }
 
+        const string ExpectedDateString = "1937-07-02T05:35:02.0000000Z";
+        static readonly DateTime ExpectedDateTime = DateTime.Parse(ExpectedDateString).ToUniversalTime();
+
         [Fact]
         public static void InternedStringReturnValuesWork()
         {
@@ -902,16 +905,16 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Null(result);
         }
 
-        private static async Task<bool> MarshalTask(string helperMethodName, string helperMethodArgs = "", string resolvedBody = "") 
+        private static async Task<bool> MarshalTask(string helperMethodName, string helperMethodArgs = "", string resolvedBody = "")
         {
             Runtime.InvokeJS(
                 @"globalThis.__test_promise_completed = false; " +
                 @"globalThis.__test_promise_resolved = false; " +
                 @"globalThis.__test_promise_failed = false; " +
                 $@"var t = App.call_test_method ('{helperMethodName}', [ {helperMethodArgs} ], 'i'); " +
-                "t.then(result => { globalThis.__test_promise_resolved = true; " + resolvedBody + " })" + 
+                "t.then(result => { globalThis.__test_promise_resolved = true; " + resolvedBody + " })" +
                 " .catch(e => { globalThis.__test_promise_failed = true; })" +
-                " .finally(result => { globalThis.__test_promise_completed = true; }); " + 
+                " .finally(result => { globalThis.__test_promise_completed = true; }); " +
                 ""
             );
 
@@ -1018,6 +1021,257 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             bool success = await MarshalTask("FailedAsynchronousValueTask");
             Assert.False(success, "FailedAsynchronousValueTask didn't failed.");
+        }
+
+        [Fact]
+        public static void MarshalDateTime()
+        {
+            HelperMarshal._dateTimeValue = default(DateTime);
+            Runtime.InvokeJS(
+                $"var dt = new Date('{ExpectedDateString}');\r\n" +
+                "App.call_test_method ('InvokeDateTime', [ dt ], 'o');"
+            );
+            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
+        }
+
+        [Fact]
+        public static void MarshalDateTimeDefault()
+        {
+            HelperMarshal._dateTimeValue = default(DateTime);
+            Runtime.InvokeJS(
+                $"var dt = new Date('{ExpectedDateString}');\r\n" +
+                "App.call_test_method ('InvokeDateTime', [ dt ]);"
+            );
+            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
+        }
+
+        [Fact]
+        public static void MarshalDateTimeAutomatic()
+        {
+            HelperMarshal._dateTimeValue = default(DateTime);
+            Runtime.InvokeJS(
+                $"var dt = new Date('{ExpectedDateString}');\r\n" +
+                "App.call_test_method ('InvokeDateTime', [ dt ], 'a');"
+            );
+            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
+        }
+
+        [Fact]
+        public static void MarshalDateTimeOffsetAutomatic()
+        {
+            HelperMarshal._dateTimeValue = default(DateTime);
+            Runtime.InvokeJS(
+                $"var dt = new Date('{ExpectedDateString}');\r\n" +
+                "App.call_test_method ('InvokeDateTimeOffset', [ dt ], 'a');"
+            );
+            // FIXME
+            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
+        }
+
+        [Fact]
+        public static void MarshalDateTimeByValueAutomatic()
+        {
+            HelperMarshal._dateTimeValue = default(DateTime);
+            Runtime.InvokeJS(
+                $"var dt = new Date('{ExpectedDateString}');\r\n" +
+                "App.call_test_method ('InvokeDateTimeByValue', [ dt.valueOf() ], 'a');"
+            );
+            Assert.Equal(ExpectedDateTime, HelperMarshal._dateTimeValue);
+        }
+
+        [Fact]
+        public static void MarshalUri()
+        {
+            var expected = new System.Uri("https://www.example.com/");
+            HelperMarshal._uriValue = default(System.Uri);
+            Runtime.InvokeJS(
+                @"var uri = 'https://www.example.com/';
+                App.call_test_method ('InvokeUri', [ uri ], 'u');"
+            );
+            Assert.Equal(expected, HelperMarshal._uriValue);
+        }
+
+        [Fact]
+        public static void InvokeByNameBasic()
+        {
+            HelperMarshal._stringResource = null;
+            Runtime.InvokeJS("globalThis._test_function = function () { App.call_test_method ('InvokeString', [ 'test' ], 's') }");
+            var result = Runtime.InvokeJSFunctionByName("_test_function");
+            Assert.Equal(InvokeJSResult.Success, result);
+            Assert.Equal("test", HelperMarshal._stringResource);
+        }
+
+        [Fact]
+        public static void InvokeByNameIntArgument()
+        {
+            HelperMarshal._intValue = 0;
+            Runtime.InvokeJS("globalThis._test_function_int = function (i) { App.call_test_method ('InvokeInt', [ i ], 'i') }");
+            var result = Runtime.InvokeJSFunctionByName("_test_function_int", 7);
+            Assert.Equal(InvokeJSResult.Success, result);
+            Assert.Equal(7, HelperMarshal._intValue);
+        }
+
+        [Fact]
+        public static void InvokeByNameIntPtrArgument()
+        {
+            var expected = new IntPtr(42);
+            HelperMarshal._intPtrValue = IntPtr.Zero;
+            Runtime.InvokeJS("globalThis._test_function_intptr = function (i) { App.call_test_method ('InvokeIntPtr', [ i ], 'i') }");
+            var result = Runtime.InvokeJSFunctionByName("_test_function_intptr", expected);
+            Assert.Equal(InvokeJSResult.Success, result);
+            Assert.Equal(expected, HelperMarshal._intPtrValue);
+        }
+
+        [Fact]
+        public static void InvokeByNameStringArgument()
+        {
+            var expected = "hello world";
+            HelperMarshal._stringResource = null;
+            Runtime.InvokeJS("globalThis._test_function_string = function (s) { App.call_test_method ('InvokeString', [ s ], 's') }");
+            var result = Runtime.InvokeJSFunctionByName("_test_function_string", expected);
+            Assert.Equal(InvokeJSResult.Success, result);
+            Assert.Equal(expected, HelperMarshal._stringResource);
+        }
+
+        [Fact]
+        public static void InvokeByNameUriArgument()
+        {
+            var expected = new System.Uri("https://www.example.com/");
+            HelperMarshal._uriValue = default(System.Uri);
+            Runtime.InvokeJS("globalThis._test_function_uri = function (uri) { App.call_test_method ('InvokeUri', [ uri ], 'u') }");
+            var result = Runtime.InvokeJSFunctionByName("_test_function_uri", expected);
+            Assert.Equal(InvokeJSResult.Success, result);
+            Assert.Equal(expected, HelperMarshal._uriValue);
+        }
+
+        [Fact]
+        public static void InvokeByName3Arguments()
+        {
+            int a = 3;
+            double b = 7.31;
+            string c = "hello\0world";
+            HelperMarshal._intValue = 0;
+            HelperMarshal._f64Value = 0;
+            HelperMarshal._stringResource = null;
+            Runtime.InvokeJS("globalThis._test_function_3arg = function (a, b, c) { " +
+                "App.call_test_method ('InvokeInt', [ a ]); " +
+                "App.call_test_method ('InvokeDouble', [ b ]); " +
+                "App.call_test_method ('InvokeString', [ c ]); " +
+            "}");
+            var result = Runtime.InvokeJSFunctionByName("_test_function_3arg", a, b, c);
+            Assert.Equal(InvokeJSResult.Success, result);
+            Assert.Equal(a, HelperMarshal._intValue);
+            Assert.Equal(b, HelperMarshal._f64Value);
+            Assert.Equal(c, HelperMarshal._stringResource);
+        }
+
+        [Fact]
+        public static void InvokeByNameTraversesObjects()
+        {
+            HelperMarshal._intValue = 0;
+            Runtime.InvokeJS("globalThis._foo = { _bar: { _func: function (i) { App.call_test_method ('InvokeInt', [ i ], 'i') } } };");
+            var result = Runtime.InvokeJSFunctionByName("_foo._bar._func", 12);
+            Assert.Equal(InvokeJSResult.Success, result);
+            Assert.Equal(12, HelperMarshal._intValue);
+        }
+
+        [Fact]
+        public static void InvokeByNameRejectsInvalidNames()
+        {
+            // Invalid function names
+            Assert.Equal(InvokeJSResult.InvalidFunctionName, Runtime.InvokeJSFunctionByName(null));
+            Assert.Equal(InvokeJSResult.InvalidFunctionName, Runtime.InvokeJSFunctionByName(""));
+
+            // Function name must be interned
+            var temp = new string('a', 3);
+            Assert.Equal(InvokeJSResult.InvalidFunctionName, Runtime.InvokeJSFunctionByName(temp));
+        }
+
+        [Fact]
+        public static void InvokeByNameCachesValueForName()
+        {
+            Runtime.InvokeJS("globalThis._bar = undefined;");
+            var result = Runtime.InvokeJSFunctionByName("_bar");
+            Assert.Equal(InvokeJSResult.FunctionNotFound, result);
+
+            // The initial value of _bar should be cached, preventing this new one from being found and called
+            Runtime.InvokeJS("globalThis._bar = function () { throw new Error('should not be called'); }");
+            result = Runtime.InvokeJSFunctionByName("_bar");
+            Assert.Equal(InvokeJSResult.FunctionNotFound, result);
+        }
+
+        [Fact]
+        public static void InvokeByNameRejectsMisuse()
+        {
+            Runtime.InvokeJS(
+                // Call target should never return a value (it will be dropped)
+                "globalThis._misbehavior_return_value = function () { return 7; }; " +
+                // Call target should not throw exceptions
+                "globalThis._misbehavior_throw = function () { throw new Error(); }; "
+            );
+
+            Assert.Equal(
+                InvokeJSResult.FunctionHadReturnValue,
+                Runtime.InvokeJSFunctionByName("_misbehavior_return_value")
+            );
+
+            // NOTE: This is not a behavior the consumer should rely on, it exists
+            //  to aid debugging and so that we can potentially remove the
+            //  exception handler entirely if it improves performance
+            Assert.Equal(
+                InvokeJSResult.FunctionThrewException,
+                Runtime.InvokeJSFunctionByName("_misbehavior_throw")
+            );
+        }
+
+        [Fact]
+        public static void InvokeByNameRejectsOutOfRangeArgumentCounts()
+        {
+            Assert.Equal(
+                InvokeJSResult.InvalidArgumentCount,
+                Runtime.InvokeJSFunctionByName(
+                    "nonexistent_function", 4,
+                    null, IntPtr.Zero,
+                    null, IntPtr.Zero,
+                    null, IntPtr.Zero
+                )
+            );
+
+            Assert.Equal(
+                InvokeJSResult.InvalidArgumentCount,
+                Runtime.InvokeJSFunctionByName(
+                    "nonexistent_function", -1,
+                    null, IntPtr.Zero,
+                    null, IntPtr.Zero,
+                    null, IntPtr.Zero
+                )
+            );
+        }
+
+        [Fact]
+        public static void InvokeByNameChecksWhetherArgumentsHaveTypeInfo()
+        {
+            Assert.Equal(
+                InvokeJSResult.MissingArgumentType,
+                Runtime.InvokeJSFunctionByName(
+                    "nonexistent_function", 2,
+                    typeof(string), IntPtr.Zero,
+                    null, IntPtr.Zero,
+                    null, IntPtr.Zero
+                )
+            );
+        }
+
+        [Fact]
+        public static void JSObjectInvokeProperlyRethrowsExceptions() {
+            Runtime.InvokeJS(
+                "globalThis.testObj1 = { throwingMethod: function () { throw new Error('test'); } }; "
+            );
+            var o = (JSObject)Runtime.GetGlobalObject("testObj1");
+            var exc = Assert.Throws<System.Runtime.InteropServices.JavaScript.JSException>(() => {
+                var res = o.Invoke("throwingMethod");
+            });
+            Assert.Equal("test", exc.Message);
         }
     }
 }

--- a/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
+++ b/src/mono/wasm/runtime/cjs/dotnet.cjs.lib.js
@@ -12,7 +12,7 @@ const DotnetSupportLib = {
     $DOTNET__postset: `
 let __dotnet_replacements = {readAsync, fetch: globalThis.fetch, require};
 let __dotnet_exportedAPI = __dotnet_runtime.__initializeImportsAndExports(
-    { isESM:false, isGlobal:ENVIRONMENT_IS_GLOBAL, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile, quit_, requirePromise:Promise.resolve(require)}, 
+    { isESM:false, isGlobal:ENVIRONMENT_IS_GLOBAL, isNode:ENVIRONMENT_IS_NODE, isShell:ENVIRONMENT_IS_SHELL, isWeb:ENVIRONMENT_IS_WEB, locateFile, quit_, requirePromise:Promise.resolve(require)},
     { mono:MONO, binding:BINDING, internal:INTERNAL, module:Module },
     __dotnet_replacements);
 readAsync = __dotnet_replacements.readAsync;
@@ -40,6 +40,9 @@ const linked_functions = [
     "mono_wasm_invoke_js",
     "mono_wasm_invoke_js_blazor",
     "mono_wasm_trace_logger",
+    "mono_wasm_invoke_js_marshalled",
+    "mono_wasm_invoke_js_unmarshalled",
+    "_invoke_js_function_by_qualified_name_impl",
 
     // corebindings.c
     "mono_wasm_invoke_js_with_args",

--- a/src/mono/wasm/runtime/corebindings.ts
+++ b/src/mono/wasm/runtime/corebindings.ts
@@ -26,6 +26,7 @@ const fn_signatures: [jsname: string, csname: string, signature: string][] = [
     ["_is_simple_array", "IsSimpleArray", "m"],
 
     ["make_marshal_signature_info", "MakeMarshalSignatureInfo", "ii"],
+    ["create_uri_from_string_reflective", "CreateUriFromStringReflective", "s!"],
 ];
 
 export interface t_CSwraps {
@@ -51,7 +52,7 @@ export interface t_CSwraps {
 
     make_marshal_signature_info(typePtr: MonoType, methodPtr: MonoMethod): string;
 
-    generate_args_marshaler(signature: string, methodPtr: MonoMethod): string;
+    create_uri_from_string_reflective(uri: string): MonoObject;
 }
 
 const wrapped_cs_functions: t_CSwraps = <any>{};

--- a/src/mono/wasm/runtime/corebindings.ts
+++ b/src/mono/wasm/runtime/corebindings.ts
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { JSHandle, GCHandle, MonoObject } from "./types";
+import { JSHandle, GCHandle, MonoObject, MonoType, MonoMethod } from "./types";
 import { PromiseControl } from "./cancelable-promise";
 import { runtimeHelpers } from "./imports";
 
-const fn_signatures: [jsname: string, csname: string, signature: string/*ArgsMarshalString*/][] = [
+const fn_signatures: [jsname: string, csname: string, signature: string][] = [
     ["_get_cs_owned_object_by_js_handle", "GetCSOwnedObjectByJSHandle", "ii!"],
     ["_get_cs_owned_object_js_handle", "GetCSOwnedObjectJSHandle", "mi"],
     ["_try_get_cs_owned_object_js_handle", "TryGetCSOwnedObjectJSHandle", "mi"],
@@ -23,10 +23,9 @@ const fn_signatures: [jsname: string, csname: string, signature: string/*ArgsMar
     ["_setup_js_cont", "SetupJSContinuation", "mo"],
 
     ["_object_to_string", "ObjectToString", "m"],
-    ["_get_date_value", "GetDateValue", "m"],
-    ["_create_date_time", "CreateDateTime", "d!"],
-    ["_create_uri", "CreateUri", "s!"],
     ["_is_simple_array", "IsSimpleArray", "m"],
+
+    ["make_marshal_signature_info", "MakeMarshalSignatureInfo", "ii"],
 ];
 
 export interface t_CSwraps {
@@ -48,10 +47,11 @@ export interface t_CSwraps {
     _setup_js_cont(task: MonoObject, continuation: PromiseControl): MonoObject
 
     _object_to_string(obj: MonoObject): string;
-    _get_date_value(obj: MonoObject): number;
-    _create_date_time(ticks: number): MonoObject;
-    _create_uri(uri: string): MonoObject;
     _is_simple_array(obj: MonoObject): boolean;
+
+    make_marshal_signature_info(typePtr: MonoType, methodPtr: MonoMethod): string;
+
+    generate_args_marshaler(signature: string, methodPtr: MonoMethod): string;
 }
 
 const wrapped_cs_functions: t_CSwraps = <any>{};

--- a/src/mono/wasm/runtime/cs-to-js.ts
+++ b/src/mono/wasm/runtime/cs-to-js.ts
@@ -83,7 +83,7 @@ function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<a
     }
 }
 
-export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot<any>, type: MarshalType, unbox_buffer: VoidPtr) : any {
+export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot<any>, type: MarshalType, unbox_buffer: VoidPtr): any {
     if (type >= MarshalError.FIRST)
         throw new Error(`Got marshaling error ${type} when attempting to unbox object at address ${root.value} (root located at ${root.get_address()})`);
 
@@ -97,7 +97,7 @@ export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot
     return _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root, type, typePtr, unbox_buffer);
 }
 
-export function _unbox_mono_obj_root(root: WasmRoot<any>) : any {
+export function _unbox_mono_obj_root(root: WasmRoot<any>): any {
     if (root.value === 0)
         return undefined;
 

--- a/src/mono/wasm/runtime/cs-to-js.ts
+++ b/src/mono/wasm/runtime/cs-to-js.ts
@@ -41,8 +41,7 @@ function _unbox_cs_owned_root_as_js_object(root: WasmRoot<any>) {
     return js_obj;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<any>, type: MarshalType, typePtr: MonoType, unbox_buffer: VoidPtr): any {
+function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<any>, type: MarshalType, typePtr: MonoType, unbox_buffer: VoidPtr) : any {
     //See MARSHAL_TYPE_ defines in driver.c
     switch (type) {
         case MarshalType.INT64:
@@ -53,13 +52,13 @@ function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<a
         case MarshalType.STRING_INTERNED:
             return conv_string(root.value);
         case MarshalType.VT:
-            throw new Error("no idea on how to unbox value types");
+            throw new Error("cannot unbox custom value types");
         case MarshalType.DELEGATE:
             return _wrap_delegate_root_as_function(root);
         case MarshalType.TASK:
             return _unbox_task_root_as_promise(root);
         case MarshalType.OBJECT:
-            return _unbox_ref_type_root_as_js_object(root);
+            return _unbox_ref_type_root_as_js_object (root);
         case MarshalType.ARRAY_BYTE:
         case MarshalType.ARRAY_UBYTE:
         case MarshalType.ARRAY_UBYTE_C:
@@ -71,9 +70,8 @@ function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<a
         case MarshalType.ARRAY_DOUBLE:
             throw new Error("Marshalling of primitive arrays are not supported.  Use the corresponding TypedArray instead.");
         case <MarshalType>20: // clr .NET DateTime
-            return new Date(corebindings._get_date_value(root.value));
         case <MarshalType>21: // clr .NET DateTimeOffset
-            return corebindings._object_to_string(root.value);
+            throw new Error("Deprecated type (DATETIME / DATETIMEOFFSET)");
         case MarshalType.URI:
             return corebindings._object_to_string(root.value);
         case MarshalType.SAFEHANDLE:
@@ -85,7 +83,7 @@ function _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root: WasmRoot<a
     }
 }
 
-export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot<any>, type: MarshalType, unbox_buffer: VoidPtr): any {
+export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot<any>, type: MarshalType, unbox_buffer: VoidPtr) : any {
     if (type >= MarshalError.FIRST)
         throw new Error(`Got marshaling error ${type} when attempting to unbox object at address ${root.value} (root located at ${root.get_address()})`);
 
@@ -99,7 +97,7 @@ export function _unbox_mono_obj_root_with_known_nonprimitive_type(root: WasmRoot
     return _unbox_mono_obj_root_with_known_nonprimitive_type_impl(root, type, typePtr, unbox_buffer);
 }
 
-export function _unbox_mono_obj_root(root: WasmRoot<any>): any {
+export function _unbox_mono_obj_root(root: WasmRoot<any>) : any {
     if (root.value === 0)
         return undefined;
 

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -98,7 +98,7 @@ export interface t_Cwraps {
     mono_wasm_find_corlib_type(namespace: string, name: string): MonoType;
     mono_wasm_assembly_find_type(assembly: MonoAssembly, namespace: string, name: string): MonoType;
     mono_wasm_assembly_find_method(klass: MonoClass, name: string, args: number): MonoMethod;
-    mono_wasm_invoke_method(method: MonoMethod, this_arg: MonoObject, params: VoidPtr, out_exc: VoidPtr): MonoObject;
+    mono_wasm_invoke_method(method: MonoMethod, unused_nullptr: MonoObject, params: VoidPtr, out_exc: VoidPtr): MonoObject;
     mono_wasm_string_get_utf8(str: MonoString): CharPtr;
     mono_wasm_string_from_utf16(str: CharPtr, len: number): MonoString;
     mono_wasm_get_obj_type(str: MonoObject): number;

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -57,6 +57,7 @@ const fn_signatures: [ident: string, returnType: string | null, argTypes?: strin
     ["mono_wasm_type_get_class", "number", ["number"]],
     ["mono_wasm_get_type_name", "string", ["number"]],
     ["mono_wasm_get_type_aqn", "string", ["number"]],
+    ["mono_wasm_get_class_for_bind_or_invoke", "number", ["number", "number"]],
     ["mono_wasm_unbox_rooted", "number", ["number"]],
 
     //DOTNET
@@ -117,6 +118,7 @@ export interface t_Cwraps {
     mono_wasm_type_get_class(ty: MonoType): MonoClass;
     mono_wasm_get_type_name(ty: MonoType): string;
     mono_wasm_get_type_aqn(ty: MonoType): string;
+    mono_wasm_get_class_for_bind_or_invoke(this_arg: MonoObject, method: MonoMethod): MonoClass;
     mono_wasm_unbox_rooted(obj: MonoObject): VoidPtr;
 
     //DOTNET

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -3,7 +3,7 @@
 //!
 //! This is generated file, see src/mono/wasm/runtime/rollup.config.js
 
-//! This is not considered public API with backward compatibility guarantees. 
+//! This is not considered public API with backward compatibility guarantees.
 
 declare interface ManagedPointer {
     __brandManagedPointer: "ManagedPointer";
@@ -249,26 +249,26 @@ declare function mono_call_assembly_entry_point(assembly: string, args?: any[], 
 
 declare function mono_wasm_load_bytes_into_heap(bytes: Uint8Array): VoidPtr;
 
-declare type _MemOffset = number | VoidPtr | NativePointer;
-declare type _NumberOrPointer = number | VoidPtr | NativePointer | ManagedPointer;
-declare function setU8(offset: _MemOffset, value: number): void;
-declare function setU16(offset: _MemOffset, value: number): void;
-declare function setU32(offset: _MemOffset, value: _NumberOrPointer): void;
-declare function setI8(offset: _MemOffset, value: number): void;
-declare function setI16(offset: _MemOffset, value: number): void;
-declare function setI32(offset: _MemOffset, value: _NumberOrPointer): void;
-declare function setI64(offset: _MemOffset, value: number): void;
-declare function setF32(offset: _MemOffset, value: number): void;
-declare function setF64(offset: _MemOffset, value: number): void;
-declare function getU8(offset: _MemOffset): number;
-declare function getU16(offset: _MemOffset): number;
-declare function getU32(offset: _MemOffset): number;
-declare function getI8(offset: _MemOffset): number;
-declare function getI16(offset: _MemOffset): number;
-declare function getI32(offset: _MemOffset): number;
-declare function getI64(offset: _MemOffset): number;
-declare function getF32(offset: _MemOffset): number;
-declare function getF64(offset: _MemOffset): number;
+declare type DotnetMemOffset = number | NativePointer;
+declare type DotnetMemValue = number | NativePointer | ManagedPointer;
+declare function setU8(offset: DotnetMemOffset, value: number): void;
+declare function setU16(offset: DotnetMemOffset, value: number): void;
+declare function setU32(offset: DotnetMemOffset, value: DotnetMemValue): void;
+declare function setI8(offset: DotnetMemOffset, value: number): void;
+declare function setI16(offset: DotnetMemOffset, value: number): void;
+declare function setI32(offset: DotnetMemOffset, value: number): void;
+declare function setI64(offset: DotnetMemOffset, value: number): void;
+declare function setF32(offset: DotnetMemOffset, value: number): void;
+declare function setF64(offset: DotnetMemOffset, value: number): void;
+declare function getU8(offset: DotnetMemOffset): number;
+declare function getU16(offset: DotnetMemOffset): number;
+declare function getU32(offset: DotnetMemOffset): number;
+declare function getI8(offset: DotnetMemOffset): number;
+declare function getI16(offset: DotnetMemOffset): number;
+declare function getI32(offset: DotnetMemOffset): number;
+declare function getI64(offset: DotnetMemOffset): number;
+declare function getF32(offset: DotnetMemOffset): number;
+declare function getF64(offset: DotnetMemOffset): number;
 
 declare function mono_run_main_and_exit(main_assembly_name: string, args: string[]): Promise<void>;
 declare function mono_run_main(main_assembly_name: string, args: string[]): Promise<number>;

--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -3,7 +3,7 @@
 //!
 //! This is generated file, see src/mono/wasm/runtime/rollup.config.js
 
-//! This is not considered public API with backward compatibility guarantees.
+//! This is not considered public API with backward compatibility guarantees. 
 
 declare interface ManagedPointer {
     __brandManagedPointer: "ManagedPointer";
@@ -256,7 +256,7 @@ declare function setU16(offset: DotnetMemOffset, value: number): void;
 declare function setU32(offset: DotnetMemOffset, value: DotnetMemValue): void;
 declare function setI8(offset: DotnetMemOffset, value: number): void;
 declare function setI16(offset: DotnetMemOffset, value: number): void;
-declare function setI32(offset: DotnetMemOffset, value: number): void;
+declare function setI32(offset: DotnetMemOffset, value: DotnetMemValue): void;
 declare function setI64(offset: DotnetMemOffset, value: number): void;
 declare function setF32(offset: DotnetMemOffset, value: number): void;
 declare function setF64(offset: DotnetMemOffset, value: number): void;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -35,6 +35,11 @@ extern MonoString* mono_wasm_invoke_js (MonoString *str, int *is_exception);
 // Blazor specific custom routines - see dotnet_support.js for backing code
 extern void* mono_wasm_invoke_js_blazor (MonoString **exceptionMessage, void *callInfo, void* arg0, void* arg1, void* arg2);
 
+extern uint32_t _invoke_js_function_by_qualified_name_impl (
+	MonoString *internedFunctionName, uint32_t argumentCount,
+	int* marshalTypes, MonoType **typeHandles, void **arguments
+);
+
 void mono_wasm_enable_debugging (int);
 
 int mono_wasm_marshal_type_from_mono_type (int mono_type, MonoClass *klass, MonoType *type);
@@ -65,8 +70,6 @@ char *mono_method_get_full_name (MonoMethod *method);
 #define MARSHAL_TYPE_OBJECT 7
 #define MARSHAL_TYPE_BOOL 8
 #define MARSHAL_TYPE_ENUM 9
-#define MARSHAL_TYPE_DATE 20
-#define MARSHAL_TYPE_DATEOFFSET 21
 #define MARSHAL_TYPE_URI 22
 #define MARSHAL_TYPE_SAFEHANDLE 23
 
@@ -90,21 +93,21 @@ char *mono_method_get_full_name (MonoMethod *method);
 #define MARSHAL_TYPE_VOID 30
 #define MARSHAL_TYPE_POINTER 32
 
+// Used for passing spans to C# from the JS bindings. Since spans have type restrictions,
+//  no boxed value will ever have this type and driver.c does not ever produce it
+#define MARSHAL_TYPE_SPAN_BYTE 33
+
 // errors
 #define MARSHAL_ERROR_BUFFER_TOO_SMALL 512
 #define MARSHAL_ERROR_NULL_CLASS_POINTER 513
 #define MARSHAL_ERROR_NULL_TYPE_POINTER 514
 
-static MonoClass* datetime_class;
-static MonoClass* datetimeoffset_class;
 static MonoClass* uri_class;
 static MonoClass* task_class;
 static MonoClass* safehandle_class;
 static MonoClass* voidtaskresult_class;
 
-static int resolved_datetime_class = 0,
-	resolved_datetimeoffset_class = 0,
-	resolved_uri_class = 0,
+static int resolved_uri_class = 0,
 	resolved_task_class = 0,
 	resolved_safehandle_class = 0,
 	resolved_voidtaskresult_class = 0;
@@ -138,6 +141,80 @@ static MonoDomain *root_domain;
 
 extern void mono_wasm_trace_logger (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
 
+#define INVOKERESULT_Success 0
+#define INVOKERESULT_InvalidFunctionName 1 // null/blank name, name not interned, or syntax error
+#define INVOKERESULT_FunctionNotFound 2 // no function found matching this function name
+#define INVOKERESULT_InvalidArgumentCount 3 // argument count outside valid range [0-3]
+#define INVOKERESULT_InvalidArgumentType 4 // an argument was of an unsupported type
+#define INVOKERESULT_MissingArgumentType 5 // an argument value was provided without a type handle
+#define INVOKERESULT_NullArgumentPointer 6 // the pointer to a non-nullable argument value was 0
+#define INVOKERESULT_FunctionHadReturnValue 7
+#define INVOKERESULT_FunctionThrewException 8
+#define INVOKERESULT_InternalError 9 // an unspecified internal error occurred
+
+#define INVOKE_ARGUMENT_BUFFER_SIZE 3
+
+static int32_t
+mono_wasm_invoke_js_function_by_qualified_name (
+	MonoString *internedFunctionName, int32_t argumentCount,
+	MonoType *type1, void *arg1,
+	MonoType *type2, void *arg2,
+	MonoType *type3, void *arg3
+) {
+	if (!internedFunctionName || !mono_string_instance_is_interned (internedFunctionName))
+		return INVOKERESULT_InvalidFunctionName;
+
+	if ((argumentCount < 0) || (argumentCount > INVOKE_ARGUMENT_BUFFER_SIZE))
+		return INVOKERESULT_InvalidArgumentCount;
+
+	int marshalTypes[INVOKE_ARGUMENT_BUFFER_SIZE] = {0};
+	MonoType *typeHandles[INVOKE_ARGUMENT_BUFFER_SIZE] = {0};
+	void *arguments[INVOKE_ARGUMENT_BUFFER_SIZE] = {0};
+
+	if (argumentCount > 0) {
+		typeHandles[0] = type1;
+		arguments[0] = arg1;
+	}
+	if (argumentCount > 1) {
+		typeHandles[1] = type2;
+		arguments[1] = arg2;
+	}
+	if (argumentCount > 2) {
+		typeHandles[2] = type3;
+		arguments[2] = arg3;
+	}
+
+	int32_t result = 0;
+	MonoClass *klass;
+	int mono_type;
+
+	for (int32_t i = 0; i < argumentCount; i++) {
+		if (typeHandles[i] == 0) {
+			result = INVOKERESULT_MissingArgumentType;
+			break;
+		}
+
+		klass = mono_class_from_mono_type (typeHandles[i]);
+		mono_type = mono_type_get_type (typeHandles[i]);
+		marshalTypes[i] = mono_wasm_marshal_type_from_mono_type (mono_type, klass, typeHandles[i]);
+		if (marshalTypes[i] >= MARSHAL_ERROR_BUFFER_TOO_SMALL) {
+			result = INVOKERESULT_InvalidArgumentType;
+			break;
+		}
+
+		// TODO: INVOKERESULT_NullArgumentPointer
+	}
+
+	if (result == 0) {
+		result = _invoke_js_function_by_qualified_name_impl (
+			internedFunctionName, argumentCount,
+			marshalTypes, typeHandles, arguments
+		);
+	}
+
+	return result;
+}
+
 static void
 wasm_trace_logger (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data)
 {
@@ -158,7 +235,7 @@ mono_wasm_register_root (char *start, size_t size, const char *name)
 	return mono_gc_register_root (start, size, (MonoGCDescriptor)NULL, MONO_ROOT_SOURCE_EXTERNAL, NULL, name ? name : "mono_wasm_register_root");
 }
 
-EMSCRIPTEN_KEEPALIVE void 
+EMSCRIPTEN_KEEPALIVE void
 mono_wasm_deregister_root (char *addr)
 {
 	mono_gc_deregister_root (addr);
@@ -407,6 +484,8 @@ void mono_initialize_internals ()
 
 	// Blazor specific custom routines - see dotnet_support.js for backing code
 	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJS", mono_wasm_invoke_js_blazor);
+
+	mono_add_internal_call ("Interop/Runtime::InvokeJSFunction", mono_wasm_invoke_js_function_by_qualified_name);
 
 #ifdef CORE_BINDINGS
 	core_initialize_internals();
@@ -752,14 +831,6 @@ MonoClass* mono_get_uri_class(MonoException** exc)
 
 void mono_wasm_ensure_classes_resolved ()
 {
-	if (!datetime_class && !resolved_datetime_class) {
-		datetime_class = mono_class_from_name (mono_get_corlib(), "System", "DateTime");
-		resolved_datetime_class = 1;
-	}
-	if (!datetimeoffset_class && !resolved_datetimeoffset_class) {
-		datetimeoffset_class = mono_class_from_name (mono_get_corlib(), "System", "DateTimeOffset");
-		resolved_datetimeoffset_class = 1;
-	}
 	if (!uri_class && !resolved_uri_class) {
 		MonoException** exc = NULL;
 		uri_class = mono_get_uri_class(exc);
@@ -811,29 +882,29 @@ mono_wasm_marshal_type_from_mono_type (int mono_type, MonoClass *klass, MonoType
 		return MARSHAL_TYPE_STRING;
 	case MONO_TYPE_SZARRAY:  { // simple zero based one-dim-array
 		if (klass) {
-		MonoClass *eklass = mono_class_get_element_class (klass);
-		MonoType *etype = mono_class_get_type (eklass);
+			MonoClass *eklass = mono_class_get_element_class (klass);
+			MonoType *etype = mono_class_get_type (eklass);
 
-		switch (mono_type_get_type (etype)) {
-			case MONO_TYPE_U1:
-				return MARSHAL_ARRAY_UBYTE;
-			case MONO_TYPE_I1:
-				return MARSHAL_ARRAY_BYTE;
-			case MONO_TYPE_U2:
-				return MARSHAL_ARRAY_USHORT;
-			case MONO_TYPE_I2:
-				return MARSHAL_ARRAY_SHORT;
-			case MONO_TYPE_U4:
-				return MARSHAL_ARRAY_UINT;
-			case MONO_TYPE_I4:
-				return MARSHAL_ARRAY_INT;
-			case MONO_TYPE_R4:
-				return MARSHAL_ARRAY_FLOAT;
-			case MONO_TYPE_R8:
-				return MARSHAL_ARRAY_DOUBLE;
-			default:
-				return MARSHAL_TYPE_OBJECT;
-		}
+			switch (mono_type_get_type (etype)) {
+				case MONO_TYPE_U1:
+					return MARSHAL_ARRAY_UBYTE;
+				case MONO_TYPE_I1:
+					return MARSHAL_ARRAY_BYTE;
+				case MONO_TYPE_U2:
+					return MARSHAL_ARRAY_USHORT;
+				case MONO_TYPE_I2:
+					return MARSHAL_ARRAY_SHORT;
+				case MONO_TYPE_U4:
+					return MARSHAL_ARRAY_UINT;
+				case MONO_TYPE_I4:
+					return MARSHAL_ARRAY_INT;
+				case MONO_TYPE_R4:
+					return MARSHAL_ARRAY_FLOAT;
+				case MONO_TYPE_R8:
+					return MARSHAL_ARRAY_DOUBLE;
+				default:
+					return MARSHAL_TYPE_OBJECT;
+			}
 		} else {
 			return MARSHAL_TYPE_OBJECT;
 		}
@@ -842,24 +913,20 @@ mono_wasm_marshal_type_from_mono_type (int mono_type, MonoClass *klass, MonoType
 		mono_wasm_ensure_classes_resolved ();
 
 		if (klass) {
-		if (klass == datetime_class)
-			return MARSHAL_TYPE_DATE;
-		if (klass == datetimeoffset_class)
-			return MARSHAL_TYPE_DATEOFFSET;
-		if (uri_class && mono_class_is_assignable_from(uri_class, klass))
-			return MARSHAL_TYPE_URI;
-		if (klass == voidtaskresult_class)
-			return MARSHAL_TYPE_VOID;
-		if (mono_class_is_enum (klass))
-			return MARSHAL_TYPE_ENUM;
+			if (uri_class && mono_class_is_assignable_from(uri_class, klass))
+				return MARSHAL_TYPE_URI;
+			if (klass == voidtaskresult_class)
+				return MARSHAL_TYPE_VOID;
+			if (mono_class_is_enum (klass))
+				return MARSHAL_TYPE_ENUM;
 			if (type && !mono_type_is_reference (type)) //vt
-			return MARSHAL_TYPE_VT;
-		if (mono_class_is_delegate (klass))
-			return MARSHAL_TYPE_DELEGATE;
-		if (class_is_task(klass))
-			return MARSHAL_TYPE_TASK;
+				return MARSHAL_TYPE_VT;
+			if (mono_class_is_delegate (klass))
+				return MARSHAL_TYPE_DELEGATE;
+			if (class_is_task(klass))
+				return MARSHAL_TYPE_TASK;
 			if (safehandle_class && (klass == safehandle_class || mono_class_is_subclass_of(klass, safehandle_class, 0)))
-			return MARSHAL_TYPE_SAFEHANDLE;
+				return MARSHAL_TYPE_SAFEHANDLE;
 		}
 
 		return MARSHAL_TYPE_OBJECT;
@@ -952,7 +1019,7 @@ mono_wasm_try_unbox_primitive_and_get_type (MonoObject *obj, void *result, int r
 		if (mono_type_generic_inst_is_valuetype (type))
 			mono_type = MONO_TYPE_VALUETYPE;
 	}
-	
+
 	// FIXME: We would prefer to unbox once here but it will fail if the value isn't unboxable
 
 	switch (mono_type) {
@@ -1155,6 +1222,16 @@ mono_wasm_unbox_rooted (MonoObject *obj)
 	if (!obj)
 		return NULL;
 	return mono_object_unbox (obj);
+}
+
+EMSCRIPTEN_KEEPALIVE MonoClass *
+mono_wasm_get_class_for_bind_or_invoke (MonoObject *this_arg, MonoMethod *method) {
+	if (this_arg)
+		return mono_object_get_class (this_arg);
+	else if (method)
+		return mono_method_get_class (method);
+	else
+		return NULL;
 }
 
 EMSCRIPTEN_KEEPALIVE char *

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -31,7 +31,7 @@ import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
     mono_wasm_load_data_archive, mono_wasm_asm_loaded,
-    configure_emscripten_startup,
+    configure_emscripten_startup
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
@@ -47,7 +47,7 @@ import {
     mono_wasm_get_by_index, mono_wasm_get_global_object, mono_wasm_get_object_property,
     mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
-    mono_wasm_invoke_js_with_args, mono_wasm_set_by_index, mono_wasm_set_object_property,
+    mono_wasm_invoke_js_with_args, mono_wasm_set_by_index, mono_wasm_set_object_property
 } from "./method-calls";
 import { mono_wasm_typed_array_copy_to, mono_wasm_typed_array_from, mono_wasm_typed_array_copy_from, mono_wasm_load_bytes_into_heap } from "./buffers";
 import { mono_wasm_cancel_promise } from "./cancelable-promise";

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -31,7 +31,7 @@ import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
     mono_wasm_load_data_archive, mono_wasm_asm_loaded,
-    configure_emscripten_startup
+    configure_emscripten_startup,
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
@@ -47,7 +47,7 @@ import {
     mono_wasm_get_by_index, mono_wasm_get_global_object, mono_wasm_get_object_property,
     mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
-    mono_wasm_invoke_js_with_args, mono_wasm_set_by_index, mono_wasm_set_object_property
+    mono_wasm_invoke_js_with_args, mono_wasm_set_by_index, mono_wasm_set_object_property,
 } from "./method-calls";
 import { mono_wasm_typed_array_copy_to, mono_wasm_typed_array_from, mono_wasm_typed_array_copy_from, mono_wasm_load_bytes_into_heap } from "./buffers";
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
@@ -65,6 +65,10 @@ import { create_weak_ref } from "./weak-ref";
 import { fetch_like, readAsync_like } from "./polyfills";
 import { EmscriptenModule } from "./types/emscripten";
 import { mono_run_main, mono_run_main_and_exit } from "./run";
+import {
+    _JSObject_Invoke, _JSObject_GetProperty, _JSObject_SetProperty,
+    _invoke_js_function_by_qualified_name_impl
+} from "./invoke-api";
 
 const MONO = {
     // current "public" MONO API
@@ -201,7 +205,7 @@ function initializeImportsAndExports(
         // backward compatibility
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        module.mono_bind_static_method = (fqn: string, signature: string/*ArgsMarshalString*/): Function => {
+        module.mono_bind_static_method = (fqn: string, signature: string): Function => {
             console.warn("Module.mono_bind_static_method is obsolete, please use BINDING.bind_static_method instead");
             return mono_bind_static_method(fqn, signature);
         };
@@ -274,6 +278,7 @@ export const __linker_exports: any = {
     mono_wasm_invoke_js,
     mono_wasm_invoke_js_blazor,
     mono_wasm_trace_logger,
+    _invoke_js_function_by_qualified_name_impl,
 
     // also keep in sync with corebindings.c
     mono_wasm_invoke_js_with_args,
@@ -333,6 +338,32 @@ const INTERNAL: any = {
     mono_wasm_detach_debugger,
     mono_wasm_raise_debug_event,
     mono_wasm_runtime_is_ready: runtimeHelpers.mono_wasm_runtime_is_ready,
+
+    // memory accessors
+    setI8,
+    setI16,
+    setI32,
+    setI64,
+    setU8,
+    setU16,
+    setU32,
+    setF32,
+    setF64,
+    getI8,
+    getI16,
+    getI32,
+    getI64,
+    getU8,
+    getU16,
+    getU32,
+    getF32,
+    getF64,
+
+    // new invoke API
+    _JSObject_Invoke,
+    _JSObject_GetProperty,
+    _JSObject_SetProperty,
+    _invoke_js_function_by_qualified_name_impl,
 };
 
 

--- a/src/mono/wasm/runtime/invoke-api.ts
+++ b/src/mono/wasm/runtime/invoke-api.ts
@@ -9,6 +9,7 @@ import { _js_to_mono_obj } from "./js-to-cs";
 import { conv_string, js_string_to_mono_string_new } from "./strings";
 import { mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
 import { MONO, BINDING, INTERNAL } from "./imports";
+import cswraps from "./corebindings";
 import {
     getI32,
     getF32,
@@ -148,8 +149,7 @@ export function _unbox_function_argument_from_heap_for_invoke (
                 throw new UnboxError(InvokeJSResult.InternalError);
             }
         case MarshalType.URI:
-            console.error("Unbox/convert not implemented for URIs");
-            throw new UnboxError(InvokeJSResult.InvalidArgumentType);
+            return cswraps._object_to_string((<WasmRoot<MonoObject>>root).value);
         case MarshalType.VT:
             console.error("Unbox/convert not implemented for structs");
             throw new UnboxError(InvokeJSResult.InvalidArgumentType);

--- a/src/mono/wasm/runtime/invoke-api.ts
+++ b/src/mono/wasm/runtime/invoke-api.ts
@@ -1,0 +1,399 @@
+import {
+    JSHandle, MonoArray, MonoObject, MarshalType,
+    MonoString, VoidPtrNull, MonoType, MonoTypeNull
+} from "./types";
+import { VoidPtr } from "./types/emscripten";
+import { mono_wasm_new_root, mono_wasm_new_external_root, WasmRoot } from "./roots";
+import { _unbox_mono_obj_root, mono_array_to_js_array, _unbox_mono_obj_root_with_known_nonprimitive_type } from "./cs-to-js";
+import { _js_to_mono_obj } from "./js-to-cs";
+import { conv_string, js_string_to_mono_string_new } from "./strings";
+import { mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
+import { MONO, BINDING, INTERNAL } from "./imports";
+import {
+    getI32,
+    getF32,
+    getU32,
+    getF64,
+    setU32,
+} from "./memory";
+
+// Must match equivalent in Runtime.cs and driver.c
+export enum InvokeJSResult {
+    Success = 0,
+    InvalidFunctionName,
+    FunctionNotFound,
+    InvalidArgumentCount,
+    InvalidArgumentType,
+    MissingArgumentType,
+    NullArgumentPointer,
+    FunctionHadReturnValue,
+    FunctionThrewException,
+    InternalError,
+}
+
+type ResolveJSFunctionSuccessResult = {
+    fn : Function;
+    error? : never;
+};
+
+type ResolveJSFunctionErrorResult = {
+    fn? : never;
+    error : InvokeJSResult;
+};
+
+type ResolveJSFunctionResult = ResolveJSFunctionSuccessResult | ResolveJSFunctionErrorResult;
+
+const _invoke_js_function_cache = new Map<MonoString, ResolveJSFunctionResult>();
+
+export function _resolve_js_function_by_qualified_name (pInternedFunctionName : MonoString) : ResolveJSFunctionResult {
+    let res : ResolveJSFunctionResult | undefined = _invoke_js_function_cache.get(pInternedFunctionName);
+    if (res === undefined) {
+        const str = conv_string(pInternedFunctionName);
+        if (!str)
+            res = { error: InvokeJSResult.InvalidFunctionName };
+        else
+            res = _walk_global_scope_to_find_function(str);
+        _invoke_js_function_cache.set(pInternedFunctionName, res);
+    }
+    return res;
+}
+
+function try_get_special_named_object (name : string) {
+    switch (name) {
+        case "MONO":
+            return MONO;
+        case "BINDING":
+            return BINDING;
+        case "INTERNAL":
+            return INTERNAL;
+        default:
+            return undefined;
+    }
+}
+
+export function _walk_global_scope_to_find_function (str : string) : ResolveJSFunctionResult {
+    let scope : any = globalThis;
+    let fn = scope[str];
+
+    if (typeof (fn) !== "function") {
+        const parts = str.split(".");
+        for (let i = 0; i < parts.length; i++) {
+            if (!scope)
+                return { error: InvokeJSResult.FunctionNotFound };
+
+            const part = parts[i];
+            let newScope = undefined;
+            if (i === 0)
+                newScope = try_get_special_named_object(part);
+            if (!newScope)
+                newScope = scope[parts[i]];
+
+            scope = newScope;
+        }
+
+        fn = scope;
+    }
+
+    if (typeof (fn) !== "function")
+        return { error : InvokeJSResult.FunctionNotFound };
+    else
+        return { fn };
+}
+
+class UnboxError extends Error {
+    errorCode : InvokeJSResult;
+
+    constructor(errorCode : InvokeJSResult) {
+        super();
+        this.errorCode = errorCode;
+    }
+}
+
+export function _unbox_function_argument_from_heap_for_invoke (
+    index : number, pMarshalTypes : VoidPtr, pTypeHandles : VoidPtr, pArguments : VoidPtr,
+    root : WasmRoot<MonoObject> | undefined
+) : any {
+    const typeHandle = <MonoType><any>getU32(<any>pTypeHandles + (index * 4));
+    if (typeHandle === MonoTypeNull)
+        return undefined;
+
+    const marshalType = getU32(<any>pMarshalTypes + (index * 4));
+    const pData = root
+        ? <VoidPtr><any>(root.value)
+        : <VoidPtr><any>getU32(<any>pArguments + (index * 4));
+
+    // console.log(`index=${index}, marshalType=${marshalType}, typeHandle=${typeHandle}, pData=${pData}`);
+
+    switch (marshalType) {
+        case MarshalType.INT:
+            return getI32(pData);
+        case MarshalType.POINTER:
+        case MarshalType.UINT32:
+            return getU32(pData);
+        case MarshalType.FP32:
+            return getF32(pData);
+        case MarshalType.FP64:
+            return getF64(pData);
+        case MarshalType.BOOL:
+            return (getI32(pData) !== 0);
+        case MarshalType.CHAR:
+            return String.fromCharCode(getI32(pData));
+        case MarshalType.DELEGATE:
+        case MarshalType.TASK:
+        case MarshalType.OBJECT:
+            try {
+                return _unbox_mono_obj_root_with_known_nonprimitive_type(<WasmRoot<any>>root, marshalType, VoidPtrNull);
+            } catch (exc : any) {
+                console.error(`Uncaught error when unboxing invoke argument #${index} of type ${marshalType} at address ${(<WasmRoot<MonoObject>>root).value}: ${exc}\r\n${exc.stack}`);
+                throw new UnboxError(InvokeJSResult.InternalError);
+            }
+        case MarshalType.URI:
+            console.error("Unbox/convert not implemented for URIs");
+            throw new UnboxError(InvokeJSResult.InvalidArgumentType);
+        case MarshalType.VT:
+            console.error("Unbox/convert not implemented for structs");
+            throw new UnboxError(InvokeJSResult.InvalidArgumentType);
+        case MarshalType.STRING:
+        case MarshalType.STRING_INTERNED:
+            return conv_string(<MonoString><any>((<WasmRoot<MonoObject>>root).value));
+        default:
+            console.error(`Unbox/convert not implemented for marshal type ${marshalType}`);
+            throw new UnboxError(InvokeJSResult.InvalidArgumentType);
+    }
+}
+
+const marshal_type_needs_root = new Set<MarshalType>(
+    [
+        MarshalType.DELEGATE,
+        MarshalType.TASK,
+        MarshalType.OBJECT,
+        MarshalType.URI,
+        MarshalType.STRING,
+        MarshalType.STRING_INTERNED,
+    ]
+);
+
+function get_object_address_indirect (offset : number) : WasmRoot<MonoObject> {
+    const ptrLocation = getU32(offset);
+    const result = mono_wasm_new_external_root<MonoObject>(<VoidPtr><any>ptrLocation);
+    return result;
+}
+
+function _allocate_root_automatically (index : number, pMarshalTypes : VoidPtr, pArguments : VoidPtr) : WasmRoot<MonoObject> | undefined {
+    return marshal_type_needs_root.has(getU32(<any>pMarshalTypes + (index * 4)))
+        ? get_object_address_indirect(<any>pArguments + (index * 4))
+        : undefined;
+}
+
+function _handle_thunk_error (exc : any) : InvokeJSResult {
+    if (exc instanceof UnboxError)
+        return exc.errorCode;
+    console.error("invoked function threw unhandled error", exc);
+    return InvokeJSResult.FunctionThrewException;
+}
+
+function _invoke_thunk_0 (
+    fn : Function
+) : InvokeJSResult {
+    try {
+        const invokeResult = fn();
+
+        if (typeof (invokeResult) !== "undefined")
+            return InvokeJSResult.FunctionHadReturnValue;
+        else
+            return InvokeJSResult.Success;
+    } catch (exc) {
+        return _handle_thunk_error(exc);
+    }
+}
+
+function _invoke_thunk_1 (
+    fn : Function,
+    pMarshalTypes : VoidPtr, pTypeHandles : VoidPtr, pArguments : VoidPtr
+) : InvokeJSResult {
+    const root0 = _allocate_root_automatically(0, pMarshalTypes, pArguments);
+
+    try {
+        const arg0 = _unbox_function_argument_from_heap_for_invoke(0, pMarshalTypes, pTypeHandles, pArguments, root0);
+
+        const invokeResult = fn(arg0);
+
+        if (typeof (invokeResult) !== "undefined")
+            return InvokeJSResult.FunctionHadReturnValue;
+        else
+            return InvokeJSResult.Success;
+    } catch (exc) {
+        return _handle_thunk_error(exc);
+    } finally {
+        if (root0)
+            root0.release();
+    }
+}
+
+function _invoke_thunk_2 (
+    fn : Function,
+    pMarshalTypes : VoidPtr, pTypeHandles : VoidPtr, pArguments : VoidPtr
+) : InvokeJSResult {
+    const root0 = _allocate_root_automatically(0, pMarshalTypes, pArguments),
+        root1 = _allocate_root_automatically(1, pMarshalTypes, pArguments);
+
+    try {
+        const arg0 = _unbox_function_argument_from_heap_for_invoke(0, pMarshalTypes, pTypeHandles, pArguments, root0),
+            arg1 = _unbox_function_argument_from_heap_for_invoke(1, pMarshalTypes, pTypeHandles, pArguments, root1);
+
+        const invokeResult = fn(arg0, arg1);
+
+        if (typeof (invokeResult) !== "undefined")
+            return InvokeJSResult.FunctionHadReturnValue;
+        else
+            return InvokeJSResult.Success;
+    } catch (exc) {
+        return _handle_thunk_error(exc);
+    } finally {
+        if (root0)
+            root0.release();
+        if (root1)
+            root1.release();
+    }
+}
+
+function _invoke_thunk_3 (
+    fn : Function,
+    pMarshalTypes : VoidPtr, pTypeHandles : VoidPtr, pArguments : VoidPtr
+) : InvokeJSResult {
+    const root0 = _allocate_root_automatically(0, pMarshalTypes, pArguments),
+        root1 = _allocate_root_automatically(1, pMarshalTypes, pArguments),
+        root2 = _allocate_root_automatically(2, pMarshalTypes, pArguments);
+
+    try {
+        const arg0 = _unbox_function_argument_from_heap_for_invoke(0, pMarshalTypes, pTypeHandles, pArguments, root0),
+            arg1 = _unbox_function_argument_from_heap_for_invoke(1, pMarshalTypes, pTypeHandles, pArguments, root1),
+            arg2 = _unbox_function_argument_from_heap_for_invoke(2, pMarshalTypes, pTypeHandles, pArguments, root2);
+
+        const invokeResult = fn(arg0, arg1, arg2);
+
+        if (typeof (invokeResult) !== "undefined")
+            return InvokeJSResult.FunctionHadReturnValue;
+        else
+            return InvokeJSResult.Success;
+    } catch (exc) {
+        return _handle_thunk_error(exc);
+    } finally {
+        if (root0)
+            root0.release();
+        if (root1)
+            root1.release();
+        if (root2)
+            root2.release();
+    }
+}
+
+function _unbox_arguments_and_invoke_js_function (
+    fn : Function, argumentCount : number,
+    pMarshalTypes : VoidPtr, pTypeHandles : VoidPtr, pArguments : VoidPtr
+) : InvokeJSResult {
+    switch (argumentCount) {
+        case 0:
+            return _invoke_thunk_0(fn);
+        case 1:
+            return _invoke_thunk_1(fn, pMarshalTypes, pTypeHandles, pArguments);
+        case 2:
+            return _invoke_thunk_2(fn, pMarshalTypes, pTypeHandles, pArguments);
+        case 3:
+            return _invoke_thunk_3(fn, pMarshalTypes, pTypeHandles, pArguments);
+        default:
+            throw new Error(`Unsupported argument count ${argumentCount} (expected [0 - 3])`);
+    }
+}
+
+export function _invoke_js_function_by_qualified_name_impl (
+    pInternedFunctionName : MonoString, argumentCount : number,
+    pMarshalTypes : VoidPtr, pTypeHandles : VoidPtr, pArguments : VoidPtr
+) : InvokeJSResult | any {
+    const resolved = _resolve_js_function_by_qualified_name(pInternedFunctionName);
+    if (resolved.error)
+        return resolved.error;
+
+    const result = _unbox_arguments_and_invoke_js_function(
+        <Function>resolved.fn, argumentCount,
+        pMarshalTypes, pTypeHandles, pArguments
+    );
+
+    if (typeof (result) !== "number")
+        return InvokeJSResult.InternalError;
+    else
+        return result;
+}
+
+
+export function _JSObject_Invoke (js_handle : JSHandle, method_name : string, pRecord : VoidPtr) : void {
+    const pArguments = pRecord, pResult = <any>pRecord + 4,
+        pErrorMessage = <any>pRecord + 8, pErrorStack = <any>pRecord + 12;
+
+    try {
+        const obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
+        if (!obj)
+            throw new Error(`Invalid js object handle ${js_handle}`);
+
+        const method = obj[method_name];
+        if (typeof (method) !== "function")
+            throw new Error(`Member ${method_name} of object was not a function`);
+
+        const args = mono_array_to_js_array(<MonoArray><any>getU32(pArguments));
+        const jsResult = method.apply(obj, args);
+        const resultPtr = <number><any>_js_to_mono_obj(true, jsResult);
+        setU32(pResult, resultPtr);
+        setU32(pErrorMessage, 0);
+        setU32(pErrorStack, 0);
+    } catch (exc : any) {
+        setU32(pResult, 0);
+        setU32(pErrorMessage, js_string_to_mono_string_new(exc.message));
+        setU32(pErrorStack, js_string_to_mono_string_new(exc.stack));
+    }
+}
+
+export function _JSObject_GetProperty (js_handle : JSHandle, property_name : string, pRecord : VoidPtr) : void {
+    const pResult = <any>pRecord, pErrorMessage = <any>pRecord + 4, pErrorStack = <any>pRecord + 8;
+
+    try {
+        const obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
+        if (!obj)
+            throw new Error(`Invalid js object handle ${js_handle}`);
+
+        const value = obj[property_name];
+        const resultPtr = _js_to_mono_obj(true, value);
+        setU32(pResult, resultPtr);
+        setU32(pErrorMessage, 0);
+        setU32(pErrorStack, 0);
+    } catch (exc : any) {
+        setU32(pResult, 0);
+        setU32(pErrorMessage, <number><any>js_string_to_mono_string_new(exc.message));
+        setU32(pErrorStack, <number><any>js_string_to_mono_string_new(exc.stack));
+    }
+}
+
+export function _JSObject_SetProperty (js_handle : JSHandle, property_name : string, pRecord : VoidPtr) : void {
+    const pValue = pRecord, pErrorMessage = <any>pRecord + 4, pErrorStack = <any>pRecord + 8,
+        pCreate = <any>pRecord + 12;
+
+    const root = mono_wasm_new_root<MonoObject>(<MonoObject><any>getU32(pValue));
+    try {
+        const value = _unbox_mono_obj_root(root);
+
+        const obj = mono_wasm_get_jsobj_from_js_handle(js_handle);
+        if (!obj)
+            throw new Error(`Invalid js object handle ${js_handle}`);
+
+        const createIfNotExist = !!getU32(pCreate);
+        if (createIfNotExist || Object.prototype.hasOwnProperty.call(obj, property_name))
+            obj[property_name] = value;
+
+        setU32(pErrorMessage, 0);
+        setU32(pErrorStack, 0);
+    } catch (exc : any) {
+        setU32(pErrorMessage, js_string_to_mono_string_new(exc.message));
+        setU32(pErrorStack, js_string_to_mono_string_new(exc.stack));
+    } finally {
+        root.release();
+    }
+}

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -9,14 +9,14 @@ import {
 } from "./gc-handles";
 import corebindings from "./corebindings";
 import cwraps from "./cwraps";
-import { mono_wasm_new_root, mono_wasm_release_roots } from "./roots";
+import { mono_wasm_new_root, mono_wasm_release_roots, WasmRoot } from "./roots";
 import { wrap_error } from "./method-calls";
 import { js_string_to_mono_string, js_string_to_mono_string_interned } from "./strings";
 import { isThenable } from "./cancelable-promise";
 import { has_backing_array_buffer } from "./buffers";
 import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, MonoString, wasm_type_symbol } from "./types";
 import { setI32, setU32, setF64 } from "./memory";
-import { Int32Ptr, TypedArray } from "./types/emscripten";
+import { VoidPtr, Int32Ptr, TypedArray } from "./types/emscripten";
 import { find_corlib_type, find_type_in_assembly } from "./class-loader";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -21,7 +21,7 @@ import { find_corlib_type, find_type_in_assembly } from "./class-loader";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function _js_to_mono_uri(should_add_in_flight: boolean, js_obj: any): MonoObject {
-    throw new Error("js_to_mono_uri is no longer supported");
+    return corebindings.create_uri_from_string_reflective(String(js_obj));
 }
 
 // this is only used from Blazor

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -17,19 +17,11 @@ import { has_backing_array_buffer } from "./buffers";
 import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, MonoString, wasm_type_symbol } from "./types";
 import { setI32, setU32, setF64 } from "./memory";
 import { Int32Ptr, TypedArray } from "./types/emscripten";
+import { find_corlib_type, find_type_in_assembly } from "./class-loader";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function _js_to_mono_uri(should_add_in_flight: boolean, js_obj: any): MonoObject {
-    switch (true) {
-        case js_obj === null:
-        case typeof js_obj === "undefined":
-            return MonoObjectNull;
-        case typeof js_obj === "symbol":
-        case typeof js_obj === "string":
-            return corebindings._create_uri(js_obj);
-        default:
-            return _extract_mono_obj(should_add_in_flight, js_obj);
-    }
+    throw new Error("js_to_mono_uri is no longer supported");
 }
 
 // this is only used from Blazor
@@ -69,8 +61,7 @@ export function _js_to_mono_obj(should_add_in_flight: boolean, js_obj: any): Mon
             return task_ptr;
         }
         case js_obj.constructor.name === "Date":
-            // getTime() is always UTC
-            return corebindings._create_date_time(js_obj.getTime());
+            throw new Error("Automatic JS Date conversion is no longer supported");
         default:
             return _extract_mono_obj(should_add_in_flight, js_obj);
     }
@@ -203,7 +194,7 @@ export function _wrap_js_thenable_as_task(thenable: Promise<any>): {
     // ideally, this should be hold alive by lifespan of the resulting C# Task, but this is good cheap aproximation
     const thenable_js_handle = mono_wasm_get_js_handle(thenable);
 
-    // Note that we do not implement promise/task roundtrip. 
+    // Note that we do not implement promise/task roundtrip.
     // With more complexity we could recover original instance when this Task is marshaled back to JS.
     // TODO optimization: return the tcs.Task on this same call instead of _get_tcs_task
     const tcs_gc_handle = corebindings._create_tcs();

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -37,80 +37,80 @@ export function _release_temp_frame(): void {
     alloca_offset = <VoidPtr>alloca_stack.pop();
 }
 
-type _MemOffset = number | VoidPtr | NativePointer;
-type _NumberOrPointer = number | VoidPtr | NativePointer | ManagedPointer;
+type DotnetMemOffset = number | NativePointer;
+type DotnetMemValue = number | NativePointer | ManagedPointer;
 
-export function setU8(offset: _MemOffset, value: number): void {
+export function setU8(offset: DotnetMemOffset, value: number): void {
     Module.HEAPU8[<any>offset] = value;
 }
 
-export function setU16(offset: _MemOffset, value: number): void {
+export function setU16(offset: DotnetMemOffset, value: number): void {
     Module.HEAPU16[<any>offset >>> 1] = value;
 }
 
-export function setU32 (offset: _MemOffset, value: _NumberOrPointer) : void {
+export function setU32 (offset: DotnetMemOffset, value: DotnetMemValue) : void {
     Module.HEAPU32[<any>offset >>> 2] = <number><any>value;
 }
 
-export function setI8(offset: _MemOffset, value: number): void {
+export function setI8(offset: DotnetMemOffset, value: number): void {
     Module.HEAP8[<any>offset] = value;
 }
 
-export function setI16(offset: _MemOffset, value: number): void {
+export function setI16(offset: DotnetMemOffset, value: number): void {
     Module.HEAP16[<any>offset >>> 1] = value;
 }
 
-export function setI32 (offset: _MemOffset, value: _NumberOrPointer) : void {
-    Module.HEAP32[<any>offset >>> 2] = <number><any>value;
+export function setI32(offset: DotnetMemOffset, value: number): void {
+    Module.HEAP32[<any>offset >>> 2] = value;
 }
 
 // NOTE: Accepts a number, not a BigInt, so values over Number.MAX_SAFE_INTEGER will be corrupted
-export function setI64(offset: _MemOffset, value: number): void {
+export function setI64(offset: DotnetMemOffset, value: number): void {
     Module.setValue(<VoidPtr><any>offset, value, "i64");
 }
 
-export function setF32(offset: _MemOffset, value: number): void {
+export function setF32(offset: DotnetMemOffset, value: number): void {
     Module.HEAPF32[<any>offset >>> 2] = value;
 }
 
-export function setF64(offset: _MemOffset, value: number): void {
+export function setF64(offset: DotnetMemOffset, value: number): void {
     Module.HEAPF64[<any>offset >>> 3] = value;
 }
 
 
-export function getU8(offset: _MemOffset): number {
+export function getU8(offset: DotnetMemOffset): number {
     return Module.HEAPU8[<any>offset];
 }
 
-export function getU16(offset: _MemOffset): number {
+export function getU16(offset: DotnetMemOffset): number {
     return Module.HEAPU16[<any>offset >>> 1];
 }
 
-export function getU32(offset: _MemOffset): number {
+export function getU32(offset: DotnetMemOffset): number {
     return Module.HEAPU32[<any>offset >>> 2];
 }
 
-export function getI8(offset: _MemOffset): number {
+export function getI8(offset: DotnetMemOffset): number {
     return Module.HEAP8[<any>offset];
 }
 
-export function getI16(offset: _MemOffset): number {
+export function getI16(offset: DotnetMemOffset): number {
     return Module.HEAP16[<any>offset >>> 1];
 }
 
-export function getI32(offset: _MemOffset): number {
+export function getI32(offset: DotnetMemOffset): number {
     return Module.HEAP32[<any>offset >>> 2];
 }
 
 // NOTE: Returns a number, not a BigInt. This means values over Number.MAX_SAFE_INTEGER will be corrupted
-export function getI64(offset: _MemOffset): number {
+export function getI64(offset: DotnetMemOffset): number {
     return Module.getValue(<number><any>offset, "i64");
 }
 
-export function getF32(offset: _MemOffset): number {
+export function getF32(offset: DotnetMemOffset): number {
     return Module.HEAPF32[<any>offset >>> 2];
 }
 
-export function getF64(offset: _MemOffset): number {
+export function getF64(offset: DotnetMemOffset): number {
     return Module.HEAPF64[<any>offset >>> 3];
 }

--- a/src/mono/wasm/runtime/memory.ts
+++ b/src/mono/wasm/runtime/memory.ts
@@ -60,8 +60,8 @@ export function setI16(offset: DotnetMemOffset, value: number): void {
     Module.HEAP16[<any>offset >>> 1] = value;
 }
 
-export function setI32(offset: DotnetMemOffset, value: number): void {
-    Module.HEAP32[<any>offset >>> 2] = value;
+export function setI32(offset: DotnetMemOffset, value: DotnetMemValue): void {
+    Module.HEAP32[<any>offset >>> 2] = <number><any>value;
 }
 
 // NOTE: Accepts a number, not a BigInt, so values over Number.MAX_SAFE_INTEGER will be corrupted

--- a/src/mono/wasm/runtime/method-binding.ts
+++ b/src/mono/wasm/runtime/method-binding.ts
@@ -313,11 +313,11 @@ export function _compile_converter_for_marshal_string(typePtr: MonoType, method:
     return csFuncResult;
 }
 
-export function mono_bind_method(method: MonoMethod, this_arg: 0 | null, args_marshal: string, friendly_name: string): Function {
+export function mono_bind_method(method: MonoMethod, unused_nullptr: 0 | null, args_marshal: string, friendly_name: string): Function {
     if (typeof (args_marshal) !== "string")
         throw new Error("args_marshal argument invalid, expected string");
 
-    if (this_arg)
+    if (unused_nullptr)
         throw new Error("this_arg must be 0");
 
     // We implement a simple lookup cache here to prevent repeated bind_method calls on the same target

--- a/src/mono/wasm/runtime/method-binding.ts
+++ b/src/mono/wasm/runtime/method-binding.ts
@@ -2,11 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { WasmRoot, WasmRootBuffer, mono_wasm_new_root } from "./roots";
-import { MonoClass, MonoMethod, MonoObject, coerceNull, VoidPtrNull, MonoType, MarshalType } from "./types";
-import { BINDING, Module, runtimeHelpers } from "./imports";
+import { Module, runtimeHelpers } from "./imports";
 import { js_to_mono_enum, _js_to_mono_obj, _js_to_mono_uri } from "./js-to-cs";
-import { js_string_to_mono_string, js_string_to_mono_string_interned } from "./strings";
 import { _unbox_mono_obj_root_with_known_nonprimitive_type } from "./cs-to-js";
+import {
+    MonoClass, MonoMethod, MonoObject, MonoString, MonoObjectNull,
+    VoidPtrNull, MonoType, MarshalSignatureInfo, MonoTypeNull
+} from "./types";
+import { js_string_to_mono_string, js_string_to_mono_string_interned, conv_string } from "./strings";
 import {
     _create_temp_frame,
     getI32, getU32, getF32, getF64,
@@ -14,15 +17,20 @@ import {
 } from "./memory";
 import {
     _get_args_root_buffer_for_method_call, _get_buffer_for_method_call,
-    _handle_exception_for_call, _teardown_after_call
+    _handle_exception_for_call, _teardown_after_call,
+    _convert_exception_for_method_call,
 } from "./method-calls";
 import cwraps from "./cwraps";
 import { VoidPtr } from "./types/emscripten";
+import cswraps from "./corebindings";
 
-const primitiveConverters = new Map<string, Converter>();
-const _signature_converters = new Map<string, Converter>();
+const _signature_converters = new Map<string, SignatureConverter | Map<MonoMethod, SignatureConverter>>();
 const _method_descriptions = new Map<MonoMethod, string>();
+const _method_signature_info_table = new Map<MonoMethod, MarshalSignatureInfo>();
+const _bound_method_cache = new Map<string, Function>();
 
+export const bindings_named_closures = new Map<string, any>();
+let bindings_named_closures_initialized = false;
 
 export function _get_type_name(typePtr: MonoType): string {
     if (!typePtr)
@@ -65,22 +73,13 @@ export function bind_runtime_method(method_name: string, signature: string): Fun
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function _create_named_function(name: string, argumentNames: string[], body: string, closure: any): Function {
-    let result = null;
-    let closureArgumentList: any[] | null = null;
     let closureArgumentNames = null;
 
-    if (closure) {
+    if (closure)
         closureArgumentNames = Object.keys(closure);
-        closureArgumentList = new Array(closureArgumentNames.length);
-        for (let i = 0, l = closureArgumentNames.length; i < l; i++)
-            closureArgumentList[i] = closure[closureArgumentNames[i]];
-    }
 
     const constructor = _create_rebindable_named_function(name, argumentNames, body, closureArgumentNames);
-    // eslint-disable-next-line prefer-spread
-    result = constructor.apply(null, closureArgumentList);
-
-    return result;
+    return constructor(closure);
 }
 
 export function _create_rebindable_named_function(name: string, argumentNames: string[], body: string, closureArgNames: string[] | null): Function {
@@ -94,462 +93,283 @@ export function _create_rebindable_named_function(name: string, argumentNames: s
         escapedFunctionIdentifier = "unnamed";
     }
 
+    let closurePrefix = "";
+    if (closureArgNames) {
+        for (let i = 0; i < closureArgNames.length; i++) {
+            const argName = closureArgNames[i];
+            closurePrefix += `const ${argName} = __closure__.${argName};\r\n`;
+        }
+        closurePrefix += "\r\n";
+    }
+
+
     let rawFunctionText = "function " + escapedFunctionIdentifier + "(" +
         argumentNames.join(", ") +
-        ") {\r\n" +
-        body +
-        "\r\n};\r\n";
+        ") {\r\n";
+
+    rawFunctionText += body + "\r\n";
 
     const lineBreakRE = /\r(\n?)/g;
 
     rawFunctionText =
-        uriPrefix + strictPrefix +
+        uriPrefix + strictPrefix + closurePrefix +
         rawFunctionText.replace(lineBreakRE, "\r\n    ") +
-        `    return ${escapedFunctionIdentifier};\r\n`;
+        `};\r\nreturn ${escapedFunctionIdentifier};\r\n`;
 
-    let result = null, keys = null;
+    /*
+    console.log(rawFunctionText);
+    console.log("");
+    */
 
-    if (closureArgNames) {
-        keys = closureArgNames.concat([rawFunctionText]);
-    } else {
-        keys = [rawFunctionText];
+    return new Function("__closure__", rawFunctionText);
+}
+
+export function get_method_signature_info (typePtr : MonoType, methodPtr : MonoMethod) : MarshalSignatureInfo {
+    if (!methodPtr)
+        throw new Error("Method ptr not provided");
+
+    let result = _method_signature_info_table.get(methodPtr);
+    const classMismatch = !!result && (result.typePtr !== typePtr);
+    if (!result) {
+        const typeName = _get_type_name(typePtr);
+        const json = cswraps.make_marshal_signature_info(typePtr, methodPtr);
+        if (!json)
+            throw new Error(`MakeMarshalSignatureInfo failed for type ${typeName}`);
+
+        result = <MarshalSignatureInfo>JSON.parse(json);
+        result.typePtr = typePtr;
+
+        if (classMismatch)
+            console.log("WARNING: Class ptr mismatch for signature info, so caching is disabled");
+        else
+            _method_signature_info_table.set(methodPtr, result);
     }
-
-    result = Function.apply(Function, keys);
     return result;
 }
 
-export function _create_primitive_converters(): void {
-    const result = primitiveConverters;
-    result.set("m", { steps: [{}], size: 0 });
-    result.set("s", { steps: [{ convert: js_string_to_mono_string.bind(BINDING) }], size: 0, needs_root: true });
-    result.set("S", { steps: [{ convert: js_string_to_mono_string_interned.bind(BINDING) }], size: 0, needs_root: true });
-    // note we also bind first argument to false for both _js_to_mono_obj and _js_to_mono_uri, 
-    // because we will root the reference, so we don't need in-flight reference
-    // also as those are callback arguments and we don't have platform code which would release the in-flight reference on C# end
-    result.set("o", { steps: [{ convert: _js_to_mono_obj.bind(BINDING, false) }], size: 0, needs_root: true });
-    result.set("u", { steps: [{ convert: _js_to_mono_uri.bind(BINDING, false) }], size: 0, needs_root: true });
-
-    // result.set ('k', { steps: [{ convert: js_to_mono_enum.bind (this), indirect: 'i64'}], size: 8});
-    result.set("j", { steps: [{ convert: js_to_mono_enum.bind(BINDING), indirect: "i32" }], size: 8 });
-
-    result.set("i", { steps: [{ indirect: "i32" }], size: 8 });
-    result.set("l", { steps: [{ indirect: "i64" }], size: 8 });
-    result.set("f", { steps: [{ indirect: "float" }], size: 8 });
-    result.set("d", { steps: [{ indirect: "double" }], size: 8 });
-}
-
-function _create_converter_for_marshal_string(args_marshal: string/*ArgsMarshalString*/): Converter {
-    const steps = [];
-    let size = 0;
-    let is_result_definitely_unmarshaled = false,
-        is_result_possibly_unmarshaled = false,
-        result_unmarshaled_if_argc = -1,
-        needs_root_buffer = false;
-
-    for (let i = 0; i < args_marshal.length; ++i) {
-        const key = args_marshal[i];
-
-        if (i === args_marshal.length - 1) {
-            if (key === "!") {
-                is_result_definitely_unmarshaled = true;
-                continue;
-            } else if (key === "m") {
-                is_result_possibly_unmarshaled = true;
-                result_unmarshaled_if_argc = args_marshal.length - 1;
-            }
-        } else if (key === "!")
-            throw new Error("! must be at the end of the signature");
-
-        const conv = primitiveConverters.get(key);
-        if (!conv)
-            throw new Error("Unknown parameter type " + key);
-
-        const localStep = Object.create(conv.steps[0]);
-        localStep.size = conv.size;
-        if (conv.needs_root)
-            needs_root_buffer = true;
-        localStep.needs_root = conv.needs_root;
-        localStep.key = key;
-        steps.push(localStep);
-        size += conv.size;
-    }
-
-    return {
-        steps, size, args_marshal,
-        is_result_definitely_unmarshaled,
-        is_result_possibly_unmarshaled,
-        result_unmarshaled_if_argc,
-        needs_root_buffer
-    };
-}
-
-function _get_converter_for_marshal_string(args_marshal: string/*ArgsMarshalString*/): Converter {
+function _get_converter_for_marshal_string(typePtr: MonoType, method: MonoMethod, args_marshal: string): SignatureConverter | undefined {
     let converter = _signature_converters.get(args_marshal);
-    if (!converter) {
-        converter = _create_converter_for_marshal_string(args_marshal);
-        _signature_converters.set(args_marshal, converter);
+    let map : Map<MonoMethod, SignatureConverter> | null = null;
+    if (converter instanceof Map) {
+        map = converter;
+        converter = map.get(method);
     }
-
     return converter;
 }
 
-export function _compile_converter_for_marshal_string(args_marshal: string/*ArgsMarshalString*/): Converter {
-    const converter = _get_converter_for_marshal_string(args_marshal);
-    if (typeof (converter.args_marshal) !== "string")
-        throw new Error("Corrupt converter for '" + args_marshal + "'");
+function _setSpan (offset : VoidPtr, span : Array<number>) : void {
+    if (!Array.isArray(span) || (span.length !== 2))
+        throw new Error(`Span must be an array of shape [offset, length_in_elements] but was ${span}`);
+    setU32(offset, span[0]);
+    setU32(<any>offset + 4, span[1]);
+}
 
-    if (converter.compiled_function && converter.compiled_variadic_function)
-        return converter;
+function _bindingsError (message : string) : void {
+    throw new Error(message);
+}
 
-    const converterName = args_marshal.replace("!", "_result_unmarshaled");
-    converter.name = converterName;
+function _generate_args_marshaler (typePtr: MonoType, method: MonoMethod, args_marshal: string): string {
+    const argsRoot = mono_wasm_new_root<MonoString>(),
+        resultRoot = mono_wasm_new_root<MonoObject>(),
+        exceptionRoot = mono_wasm_new_root<MonoObject>();
+    const generatorMethod = get_method("GenerateArgsMarshaler");
+    const buffer = <number><any>Module._malloc(64);
 
-    let body = [];
-    let argumentNames = ["buffer", "rootBuffer", "method"];
+    try {
+        argsRoot.value = js_string_to_mono_string(args_marshal);
 
-    // worst-case allocation size instead of allocating dynamically, plus padding
-    const bufferSizeBytes = converter.size + (args_marshal.length * 4) + 16;
+        // Manually assemble an arguments buffer
+        // (RuntimeTypeHandle, RuntimeMethodHandle, string)
+        setU32(buffer + 16, typePtr);
+        setU32(buffer + 32, method);
+        setU32(buffer + 0, buffer + 16);
+        setU32(buffer + 4, buffer + 32);
+        setU32(buffer + 8, argsRoot.value);
 
-    // ensure the indirect values are 8-byte aligned so that aligned loads and stores will work
-    const indirectBaseOffset = ((((args_marshal.length * 4) + 7) / 8) | 0) * 8;
+        // Invoke the managed method
+        resultRoot.value = cwraps.mono_wasm_invoke_method(generatorMethod, MonoObjectNull, <VoidPtr><any>buffer, <VoidPtr><any>exceptionRoot.get_address());
+        // If it threw an exception, this will yield us a JS Error instance to throw
+        const exc = _convert_exception_for_method_call(<MonoString>resultRoot.value, exceptionRoot.value);
+        if (exc)
+            throw exc;
+        // Otherwise it returned a managed String containing the JS for our new function
+        return <string>conv_string(<MonoString>resultRoot.value);
+    } finally {
+        resultRoot.release();
+        exceptionRoot.release();
+        argsRoot.release();
+        Module._free(<VoidPtr><any>buffer);
+    }
+}
 
+function _generate_bound_method (typePtr: MonoType, method: MonoMethod, args_marshal: string, friendly_name: string): string {
+    const argsRoot = mono_wasm_new_root<MonoString>(),
+        nameRoot = mono_wasm_new_root<MonoString>(),
+        resultRoot = mono_wasm_new_root<MonoObject>(),
+        exceptionRoot = mono_wasm_new_root<MonoObject>();
+    const generatorMethod = get_method("GenerateBoundMethod");
+    const buffer = <number><any>Module._malloc(64);
+
+    try {
+        argsRoot.value = js_string_to_mono_string(args_marshal);
+        nameRoot.value = js_string_to_mono_string(friendly_name);
+
+        // Manually assemble an arguments buffer
+        // (RuntimeTypeHandle, RuntimeMethodHandle, string)
+        setU32(buffer + 16, typePtr);
+        setU32(buffer + 32, method);
+        setU32(buffer + 0, buffer + 16);
+        setU32(buffer + 4, buffer + 32);
+        setU32(buffer + 8, argsRoot.value);
+        setU32(buffer + 12, nameRoot.value);
+
+        // Invoke the managed method
+        resultRoot.value = cwraps.mono_wasm_invoke_method(generatorMethod, MonoObjectNull, <VoidPtr><any>buffer, <VoidPtr><any>exceptionRoot.get_address());
+        // If it threw an exception, this will yield us a JS Error instance to throw
+        const exc = _convert_exception_for_method_call(<MonoString>resultRoot.value, exceptionRoot.value);
+        if (exc)
+            throw exc;
+        // Otherwise it returned a managed String containing the JS for our new function
+        return <string>conv_string(<MonoString>resultRoot.value);
+    } finally {
+        resultRoot.release();
+        exceptionRoot.release();
+        nameRoot.release();
+        argsRoot.release();
+        Module._free(<VoidPtr><any>buffer);
+    }
+}
+
+function _initialize_bindings_named_closures () : void {
+    // HACK: Populate the lookup table used by compiled closures
     const closure: any = {
-        Module,
+        _create_temp_frame,
+        _error: _bindingsError,
+        _get_args_root_buffer_for_method_call,
+        _get_buffer_for_method_call,
+        _handle_exception_for_call,
+        _js_to_mono_obj,
+        _js_to_mono_uri,
         _malloc: Module._malloc,
+        _setSpan,
+        _teardown_after_call,
+        _unbox_mono_obj_root_with_known_nonprimitive_type,
+        invoke_method: cwraps.mono_wasm_invoke_method,
+        js_string_to_mono_string_interned,
+        js_string_to_mono_string,
+        js_to_mono_enum,
+        mono_wasm_new_root,
+        mono_wasm_try_unbox_primitive_and_get_type: cwraps.mono_wasm_try_unbox_primitive_and_get_type,
         mono_wasm_unbox_rooted: cwraps.mono_wasm_unbox_rooted,
-        setI32,
-        setU32,
+        getF32,
+        getF64,
+        getI32,
+        getU32,
         setF32,
         setF64,
-        setI64
+        setI32,
+        setI64,
+        setU32,
     };
-    let indirectLocalOffset = 0;
-
-    body.push(
-        "if (!method) throw new Error('no method provided');",
-        `if (!buffer) buffer = _malloc (${bufferSizeBytes});`,
-        `let indirectStart = buffer + ${indirectBaseOffset};`,
-        ""
-    );
-
-    for (let i = 0; i < converter.steps.length; i++) {
-        const step = converter.steps[i];
-        const closureKey = "step" + i;
-        const valueKey = "value" + i;
-
-        const argKey = "arg" + i;
-        argumentNames.push(argKey);
-
-        if (step.convert) {
-            closure[closureKey] = step.convert;
-            body.push(`let ${valueKey} = ${closureKey}(${argKey}, method, ${i});`);
-        } else {
-            body.push(`let ${valueKey} = ${argKey};`);
-        }
-
-        if (step.needs_root) {
-            body.push("if (!rootBuffer) throw new Error('no root buffer provided');");
-            body.push(`rootBuffer.set (${i}, ${valueKey});`);
-        }
-
-        // HACK: needs_unbox indicates that we were passed a pointer to a managed object, and either
-        //  it was already rooted by our caller or (needs_root = true) by us. Now we can unbox it and
-        //  pass the raw address of its boxed value into the callee.
-        // FIXME: I don't think this is GC safe
-        if (step.needs_unbox)
-            body.push(`${valueKey} = mono_wasm_unbox_rooted (${valueKey});`);
-
-        if (step.indirect) {
-            const offsetText = `(indirectStart + ${indirectLocalOffset})`;
-
-            switch (step.indirect) {
-                case "u32":
-                    body.push(`setU32(${offsetText}, ${valueKey});`);
-                    break;
-                case "i32":
-                    body.push(`setI32(${offsetText}, ${valueKey});`);
-                    break;
-                case "float":
-                    body.push(`setF32(${offsetText}, ${valueKey});`);
-                    break;
-                case "double":
-                    body.push(`setF64(${offsetText}, ${valueKey});`);
-                    break;
-                case "i64":
-                    body.push(`setI64(${offsetText}, ${valueKey});`);
-                    break;
-                default:
-                    throw new Error("Unimplemented indirect type: " + step.indirect);
-            }
-
-            body.push(`setU32(buffer + (${i} * 4), ${offsetText});`);
-            indirectLocalOffset += step.size!;
-        } else {
-            body.push(`setI32(buffer + (${i} * 4), ${valueKey});`);
-            indirectLocalOffset += 4;
-        }
-        body.push("");
-    }
-
-    body.push("return buffer;");
-
-    let bodyJs = body.join("\r\n"), compiledFunction = null, compiledVariadicFunction = null;
-    try {
-        compiledFunction = _create_named_function("converter_" + converterName, argumentNames, bodyJs, closure);
-        converter.compiled_function = compiledFunction;
-    } catch (exc) {
-        converter.compiled_function = null;
-        console.warn("compiling converter failed for", bodyJs, "with error", exc);
-        throw exc;
-    }
-
-
-    argumentNames = ["existingBuffer", "rootBuffer", "method", "args"];
-    const variadicClosure = {
-        converter: compiledFunction
-    };
-    body = [
-        "return converter(",
-        "  existingBuffer, rootBuffer, method,"
-    ];
-
-    for (let i = 0; i < converter.steps.length; i++) {
-        body.push(
-            "  args[" + i +
-            (
-                (i == converter.steps.length - 1)
-                    ? "]"
-                    : "], "
-            )
-        );
-    }
-
-    body.push(");");
-
-    bodyJs = body.join("\r\n");
-    try {
-        compiledVariadicFunction = _create_named_function("variadic_converter_" + converterName, argumentNames, bodyJs, variadicClosure);
-        converter.compiled_variadic_function = compiledVariadicFunction;
-    } catch (exc) {
-        converter.compiled_variadic_function = null;
-        console.warn("compiling converter failed for", bodyJs, "with error", exc);
-        throw exc;
-    }
-
-    converter.scratchRootBuffer = null;
-    converter.scratchBuffer = VoidPtrNull;
-
-    return converter;
+    for (const k in closure)
+        bindings_named_closures.set(k, closure[k]);
 }
 
-function _maybe_produce_signature_warning(converter: Converter) {
-    if (converter.has_warned_about_signature)
-        return;
+function _get_api (key: string): Function {
+    if (!bindings_named_closures_initialized) {
+        bindings_named_closures_initialized = true;
+        _initialize_bindings_named_closures();
+    }
 
-    console.warn("MONO_WASM: Deprecated raw return value signature: '" + converter.args_marshal + "'. End the signature with '!' instead of 'm'.");
-    converter.has_warned_about_signature = true;
+    const result = bindings_named_closures.get(key);
+    if (!result || typeof(result) !== "function")
+        throw new Error(`Expected ${key} to be a function but was '${result}'`);
+    return result;
 }
 
-export function _decide_if_result_is_marshaled(converter: Converter, argc: number): boolean {
-    if (!converter)
-        return true;
+export function _compile_converter_for_marshal_string(typePtr: MonoType, method: MonoMethod, args_marshal: string): SignatureConverter {
+    const converter = _get_converter_for_marshal_string(typePtr, method, args_marshal);
+    if (converter && converter.compiled_function && converter.compiled_variadic_function)
+        return converter;
 
-    if (
-        converter.is_result_possibly_unmarshaled &&
-        (argc === converter.result_unmarshaled_if_argc)
-    ) {
-        if (argc < converter.result_unmarshaled_if_argc)
-            throw new Error(`Expected >= ${converter.result_unmarshaled_if_argc} argument(s) but got ${argc} for signature '${converter.args_marshal}'`);
+    let csFuncResult : any = null;
+    // HACK: We invoke this method directly instead of using the cswraps. version, since that wrapper relies on this function
+    const js = _generate_args_marshaler(typePtr, method, args_marshal);
+    const csFunc = new Function("get_api", js);
+    csFuncResult = csFunc(_get_api);
 
-        _maybe_produce_signature_warning(converter);
-        return false;
+    if (csFuncResult.contains_auto) {
+        let map = <Map<MonoMethod, SignatureConverter>>_signature_converters.get(args_marshal);
+        if (!map) {
+            map = new Map();
+            _signature_converters.set(args_marshal, map);
+        }
+
+        map.set(method, csFuncResult);
     } else {
-        if (argc < converter.steps.length)
-            throw new Error(`Expected ${converter.steps.length} argument(s) but got ${argc} for signature '${converter.args_marshal}'`);
-
-        return !converter.is_result_definitely_unmarshaled;
+        _signature_converters.set(args_marshal, csFuncResult);
     }
+
+    return csFuncResult;
 }
 
-export function mono_bind_method(method: MonoMethod, this_arg: MonoObject | null, args_marshal: string/*ArgsMarshalString*/, friendly_name: string): Function {
+export function mono_bind_method(method: MonoMethod, this_arg: 0 | null, args_marshal: string, friendly_name: string): Function {
     if (typeof (args_marshal) !== "string")
         throw new Error("args_marshal argument invalid, expected string");
-    this_arg = coerceNull(this_arg);
 
-    let converter: Converter | null = null;
-    if (typeof (args_marshal) === "string") {
-        converter = _compile_converter_for_marshal_string(args_marshal);
+    if (this_arg)
+        throw new Error("this_arg must be 0");
+
+    // We implement a simple lookup cache here to prevent repeated bind_method calls on the same target
+    //  from exhausting the set of available scratch roots. This is mostly useful for automated tests,
+    //  but it may also save some naive callers from rare runtime failures
+    const cacheKey = `m${method}_a${args_marshal}`;
+    if (_bound_method_cache.has(cacheKey)) {
+        const cacheHit = _bound_method_cache.get(cacheKey);
+        return <Function>cacheHit;
     }
 
     // FIXME
-    const unbox_buffer_size = 8192;
-    const unbox_buffer = Module._malloc(unbox_buffer_size);
+    const unboxBufferSize = 8192;
 
     const token: BoundMethodToken = {
-        friendlyName: friendly_name,
         method,
-        converter,
+        converter: null, // Initialized later
+        unboxBuffer: Module._malloc(unboxBufferSize),
+        unboxBufferSize,
         scratchRootBuffer: null,
         scratchBuffer: VoidPtrNull,
         scratchResultRoot: mono_wasm_new_root(),
         scratchExceptionRoot: mono_wasm_new_root()
     };
-    const closure: any = {
-        Module,
-        mono_wasm_new_root,
-        _create_temp_frame,
-        _get_args_root_buffer_for_method_call,
-        _get_buffer_for_method_call,
-        _handle_exception_for_call,
-        _teardown_after_call,
-        mono_wasm_try_unbox_primitive_and_get_type: cwraps.mono_wasm_try_unbox_primitive_and_get_type,
-        _unbox_mono_obj_root_with_known_nonprimitive_type,
-        invoke_method: cwraps.mono_wasm_invoke_method,
-        method,
-        this_arg,
-        token,
-        unbox_buffer,
-        unbox_buffer_size,
-        getI32,
-        getU32,
-        getF32,
-        getF64
-    };
 
-    const converterKey = converter ? "converter_" + converter.name : "";
-    if (converter)
-        closure[converterKey] = converter;
+    let typePtr : MonoType = MonoTypeNull;
 
-    const argumentNames = [];
-    const body = [
-        "_create_temp_frame();",
-        "let resultRoot = token.scratchResultRoot, exceptionRoot = token.scratchExceptionRoot;",
-        "token.scratchResultRoot = null;",
-        "token.scratchExceptionRoot = null;",
-        "if (resultRoot === null)",
-        "	resultRoot = mono_wasm_new_root ();",
-        "if (exceptionRoot === null)",
-        "	exceptionRoot = mono_wasm_new_root ();",
-        ""
-    ];
-
-    if (converter) {
-        body.push(
-            `let argsRootBuffer = _get_args_root_buffer_for_method_call(${converterKey}, token);`,
-            `let scratchBuffer = _get_buffer_for_method_call(${converterKey}, token);`,
-            `let buffer = ${converterKey}.compiled_function(`,
-            "    scratchBuffer, argsRootBuffer, method,"
-        );
-
-        for (let i = 0; i < converter.steps.length; i++) {
-            const argName = "arg" + i;
-            argumentNames.push(argName);
-            body.push(
-                "    " + argName +
-                (
-                    (i == converter.steps.length - 1)
-                        ? ""
-                        : ", "
-                )
-            );
-        }
-
-        body.push(");");
-
-    } else {
-        body.push("let argsRootBuffer = null, buffer = 0;");
+    let converter: SignatureConverter | null = null;
+    if (typeof (args_marshal) === "string") {
+        const classPtr = cwraps.mono_wasm_get_class_for_bind_or_invoke(MonoObjectNull, method);
+        if (!classPtr)
+            throw new Error(`Could not get class ptr for bind_method with method (${method})`);
+        typePtr = cwraps.mono_wasm_class_get_type(classPtr);
+        converter = _compile_converter_for_marshal_string(typePtr, method, args_marshal);
     }
-
-    if (converter && converter.is_result_definitely_unmarshaled) {
-        body.push("let is_result_marshaled = false;");
-    } else if (converter && converter.is_result_possibly_unmarshaled) {
-        body.push(`let is_result_marshaled = arguments.length !== ${converter.result_unmarshaled_if_argc};`);
-    } else {
-        body.push("let is_result_marshaled = true;");
-    }
-
-    // We inline a bunch of the invoke and marshaling logic here in order to eliminate the GC pressure normally
-    //  created by the unboxing part of the call process. Because unbox_mono_obj(_root) can return non-numeric
-    //  types, v8 and spidermonkey allocate and store its result on the heap (in the nursery, to be fair).
-    // For a bound method however, we know the result will always be the same type because C# methods have known
-    //  return types. Inlining the invoke and marshaling logic means that even though the bound method has logic
-    //  for handling various types, only one path through the method (for its appropriate return type) will ever
-    //  be taken, and the JIT will see that the 'result' local and thus the return value of this function are
-    //  always of the exact same type. All of the branches related to this end up being predicted and low-cost.
-    // The end result is that bound method invocations don't always allocate, so no more nursery GCs. Yay! -kg
-    body.push(
-        "",
-        "resultRoot.value = invoke_method (method, this_arg, buffer, exceptionRoot.get_address ());",
-        `_handle_exception_for_call (${converterKey}, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);`,
-        "",
-        "let resultPtr = resultRoot.value, result = undefined;"
-    );
-
-    if (converter) {
-        if (converter.is_result_possibly_unmarshaled)
-            body.push("if (!is_result_marshaled) ");
-
-        if (converter.is_result_definitely_unmarshaled || converter.is_result_possibly_unmarshaled)
-            body.push("    result = resultPtr;");
-
-        if (!converter.is_result_definitely_unmarshaled)
-            body.push(
-                "if (is_result_marshaled && (resultPtr !== 0)) {",
-                // For the common scenario where the return type is a primitive, we want to try and unbox it directly
-                //  into our existing heap allocation and then read it out of the heap. Doing this all in one operation
-                //  means that we only need to enter a gc safe region twice (instead of 3+ times with the normal,
-                //  slower check-type-and-then-unbox flow which has extra checks since unbox verifies the type).
-                "    let resultType = mono_wasm_try_unbox_primitive_and_get_type (resultPtr, unbox_buffer, unbox_buffer_size);",
-                "    switch (resultType) {",
-                `    case ${MarshalType.INT}:`,
-                "        result = getI32(unbox_buffer); break;",
-                `    case ${MarshalType.POINTER}:`, // FIXME: Is this right?
-                `    case ${MarshalType.UINT32}:`,
-                "        result = getU32(unbox_buffer); break;",
-                `    case ${MarshalType.FP32}:`,
-                "        result = getF32(unbox_buffer); break;",
-                `    case ${MarshalType.FP64}:`,
-                "        result = getF64(unbox_buffer); break;",
-                `    case ${MarshalType.BOOL}:`,
-                "        result = getI32(unbox_buffer) !== 0; break;",
-                `    case ${MarshalType.CHAR}:`,
-                "        result = String.fromCharCode(getI32(unbox_buffer)); break;",
-                "    default:",
-                "        result = _unbox_mono_obj_root_with_known_nonprimitive_type (resultRoot, resultType, unbox_buffer); break;",
-                "    }",
-                "}"
-            );
-    } else {
-        throw new Error("No converter");
-    }
+    token.converter = converter;
 
     if (friendly_name) {
         const escapeRE = /[^A-Za-z0-9_$]/g;
         friendly_name = friendly_name.replace(escapeRE, "_");
     }
 
-    let displayName = friendly_name || ("clr_" + method);
+    const bodyJs = _generate_bound_method(typePtr, method, args_marshal, friendly_name);
+    const ctor = new Function("get_api", "token", bodyJs);
+    const result = ctor(_get_api, token);
 
-    if (this_arg)
-        displayName += "_this" + this_arg;
-
-    body.push(
-        `_teardown_after_call (${converterKey}, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);`,
-        "return result;"
-    );
-
-    const bodyJs = body.join("\r\n");
-
-    const result = _create_named_function(displayName, argumentNames, bodyJs, closure);
+    _bound_method_cache.set(cacheKey, result);
 
     return result;
 }
 
-/*
-We currently don't use these types because it makes typeScript compiler very slow.
-
-declare const enum ArgsMarshal {
+export enum ArgsMarshal {
     Int32 = "i", // int32
     Int32Enum = "j", // int32 - Enum with underlying type of int32
     Int64 = "l", // int64
@@ -557,56 +377,44 @@ declare const enum ArgsMarshal {
     Float32 = "f", // float
     Float64 = "d", // double
     String = "s", // string
-    Char = "s", // interned string
+    InternedString = "S", // interned string
+    Uri = "u",
     JSObj = "o", // js object will be converted to a C# object (this will box numbers/bool/promises)
     MONOObj = "m", // raw mono object. Don't use it unless you know what you're doing
+    Auto = "a", // the bindings layer will select an appropriate converter based on the C# method signature
+    ByteSpan = "b", // Span<byte>
 }
 
-// to suppress marshaling of the return value, place '!' at the end of args_marshal, i.e. 'ii!' instead of 'ii'
-type _ExtraArgsMarshalOperators = "!" | "";
+export type TypeConverter = {
+    needs_unbox: boolean;
+    needs_root: boolean;
+    convert: Function;
+}
 
-export type ArgsMarshalString = ""
-    | `${ArgsMarshal}${_ExtraArgsMarshalOperators}`
-    | `${ArgsMarshal}${ArgsMarshal}${_ExtraArgsMarshalOperators}`
-    | `${ArgsMarshal}${ArgsMarshal}${ArgsMarshal}${_ExtraArgsMarshalOperators}`
-    | `${ArgsMarshal}${ArgsMarshal}${ArgsMarshal}${ArgsMarshal}${_ExtraArgsMarshalOperators}`;
-*/
-
-type ConverterStepIndirects = "u32" | "i32" | "float" | "double" | "i64"
-
-export type Converter = {
-    steps: {
-        convert?: boolean | Function;
-        needs_root?: boolean;
-        needs_unbox?: boolean;
-        indirect?: ConverterStepIndirects;
-        size?: number;
-    }[];
+export type SignatureConverter = {
+    arg_count: number;
     size: number;
-    args_marshal?: string/*ArgsMarshalString*/;
+    args_marshal?: string;
     is_result_definitely_unmarshaled?: boolean;
-    is_result_possibly_unmarshaled?: boolean;
-    result_unmarshaled_if_argc?: number;
     needs_root_buffer?: boolean;
     key?: string;
     name?: string;
-    needs_root?: boolean;
-    needs_unbox?: boolean;
     compiled_variadic_function?: Function | null;
     compiled_function?: Function | null;
     scratchRootBuffer?: WasmRootBuffer | null;
     scratchBuffer?: VoidPtr;
     has_warned_about_signature?: boolean;
-    convert?: Function | null;
     method?: MonoMethod | null;
+    root_buffer_size?: number;
 }
 
 export type BoundMethodToken = {
-    friendlyName: string;
     method: MonoMethod;
-    converter: Converter | null;
+    converter: SignatureConverter | null;
     scratchRootBuffer: WasmRootBuffer | null;
     scratchBuffer: VoidPtr;
+    unboxBuffer: VoidPtr;
+    unboxBufferSize: number;
     scratchResultRoot: WasmRoot<MonoObject>;
     scratchExceptionRoot: WasmRoot<MonoObject>;
 }

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -12,10 +12,9 @@ import { _mono_array_root_to_js_array, _unbox_mono_obj_root } from "./cs-to-js";
 import { get_js_obj, mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
 import { js_array_to_mono_array, _box_js_bool, _js_to_mono_obj } from "./js-to-cs";
 import {
-    mono_bind_method,
-    Converter, _compile_converter_for_marshal_string,
-    _decide_if_result_is_marshaled, find_method,
-    BoundMethodToken
+    mono_bind_method, SignatureConverter,
+    _compile_converter_for_marshal_string,
+    find_method, BoundMethodToken
 } from "./method-binding";
 import { conv_string, js_string_to_mono_string } from "./strings";
 import cwraps from "./cwraps";
@@ -23,7 +22,7 @@ import { bindings_lazy_init } from "./startup";
 import { _create_temp_frame, _release_temp_frame } from "./memory";
 import { VoidPtr, Int32Ptr, EmscriptenModule } from "./types/emscripten";
 
-function _verify_args_for_method_call(args_marshal: string/*ArgsMarshalString*/, args: any) {
+function _verify_args_for_method_call(args_marshal: string, args: any) : boolean {
     const has_args = args && (typeof args === "object") && args.length > 0;
     const has_args_marshal = typeof args_marshal === "string";
 
@@ -37,7 +36,7 @@ function _verify_args_for_method_call(args_marshal: string/*ArgsMarshalString*/,
     return has_args_marshal && has_args;
 }
 
-export function _get_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null): VoidPtr | undefined {
+export function _get_buffer_for_method_call(converter: SignatureConverter, token: BoundMethodToken | null): VoidPtr | undefined {
     if (!converter)
         return VoidPtrNull;
 
@@ -52,7 +51,7 @@ export function _get_buffer_for_method_call(converter: Converter, token: BoundMe
     return result;
 }
 
-export function _get_args_root_buffer_for_method_call(converter: Converter, token: BoundMethodToken | null): WasmRootBuffer | undefined {
+export function _get_args_root_buffer_for_method_call(converter: SignatureConverter, token: BoundMethodToken | null): WasmRootBuffer | undefined {
     if (!converter)
         return undefined;
 
@@ -73,7 +72,7 @@ export function _get_args_root_buffer_for_method_call(converter: Converter, toke
         //  mono_wasm_new_root_buffer_from_pointer instead. Not that important
         //  at present because the scratch buffer will be reused unless we are
         //  recursing through a re-entrant call
-        result = mono_wasm_new_root_buffer(converter.steps.length);
+        result = mono_wasm_new_root_buffer(<number>converter.root_buffer_size);
         // FIXME
         (<any>result).converter = converter;
     }
@@ -82,8 +81,8 @@ export function _get_args_root_buffer_for_method_call(converter: Converter, toke
 }
 
 function _release_args_root_buffer_from_method_call(
-    converter?: Converter, token?: BoundMethodToken | null, argsRootBuffer?: WasmRootBuffer
-) {
+    converter?: SignatureConverter, token?: BoundMethodToken | null, argsRootBuffer?: WasmRootBuffer
+) : void {
     if (!argsRootBuffer || !converter)
         return;
 
@@ -100,8 +99,8 @@ function _release_args_root_buffer_from_method_call(
 }
 
 function _release_buffer_from_method_call(
-    converter: Converter | undefined, token?: BoundMethodToken | null, buffer?: VoidPtr
-) {
+    converter: SignatureConverter | undefined, token?: BoundMethodToken | null, buffer?: VoidPtr
+) : void {
     if (!converter || !buffer)
         return;
 
@@ -113,7 +112,7 @@ function _release_buffer_from_method_call(
         Module._free(buffer);
 }
 
-function _convert_exception_for_method_call(result: MonoString, exception: MonoObject) {
+export function _convert_exception_for_method_call(result: MonoString, exception: MonoObject) : Error | null {
     if (exception === MonoObjectNull)
         return null;
 
@@ -140,7 +139,7 @@ m: raw mono object. Don't use it unless you know what you're doing
 
 to suppress marshaling of the return value, place '!' at the end of args_marshal, i.e. 'ii!' instead of 'ii'
 */
-export function call_method(method: MonoMethod, this_arg: MonoObject | undefined, args_marshal: string/*ArgsMarshalString*/, args: ArrayLike<any>): any {
+export function call_method(method: MonoMethod, this_arg: MonoObject | undefined, args_marshal: string, args: ArrayLike<any>): any {
     // HACK: Sometimes callers pass null or undefined, coerce it to 0 since that's what wasm expects
     this_arg = coerceNull(this_arg);
 
@@ -160,9 +159,14 @@ export function call_method(method: MonoMethod, this_arg: MonoObject | undefined
 
     // check if the method signature needs argument mashalling
     if (needs_converter) {
-        converter = _compile_converter_for_marshal_string(args_marshal);
+        const classPtr = cwraps.mono_wasm_get_class_for_bind_or_invoke(this_arg, method);
+        if (!classPtr)
+            throw new Error (`Could not get class ptr for call_method with this (${this_arg}) and method (${method})`);
 
-        is_result_marshaled = _decide_if_result_is_marshaled(converter, args.length);
+        const typePtr = cwraps.mono_wasm_class_get_type(classPtr);
+        converter = _compile_converter_for_marshal_string(typePtr, method, args_marshal);
+
+        is_result_marshaled = !converter.is_result_definitely_unmarshaled;
 
         argsRootBuffer = _get_args_root_buffer_for_method_call(converter, null);
 
@@ -175,37 +179,39 @@ export function call_method(method: MonoMethod, this_arg: MonoObject | undefined
 
 
 export function _handle_exception_for_call(
-    converter: Converter | undefined, token: BoundMethodToken | null,
-    buffer: VoidPtr, resultRoot: WasmRoot<MonoString>,
+    converter: SignatureConverter | undefined, token: BoundMethodToken | null,
+    buffer: VoidPtr, resultRoot: WasmRoot<MonoObject>,
     exceptionRoot: WasmRoot<MonoObject>, argsRootBuffer?: WasmRootBuffer
 ): void {
-    const exc = _convert_exception_for_method_call(resultRoot.value, exceptionRoot.value);
+    const exc = _convert_exception_for_method_call(<MonoString>resultRoot.value, exceptionRoot.value);
     if (!exc)
         return;
 
-    _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
     throw exc;
 }
 
 function _handle_exception_and_produce_result_for_call(
-    converter: Converter | undefined, token: BoundMethodToken | null,
-    buffer: VoidPtr, resultRoot: WasmRoot<MonoString>,
+    converter: SignatureConverter | undefined, token: BoundMethodToken | null,
+    buffer: VoidPtr, resultRoot: WasmRoot<MonoObject>,
     exceptionRoot: WasmRoot<MonoObject>, argsRootBuffer: WasmRootBuffer | undefined,
     is_result_marshaled: boolean
 ): any {
-    _handle_exception_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
+    try {
+        _handle_exception_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
 
-    let result: any = resultRoot.value;
+        let result: any = resultRoot.value;
 
-    if (is_result_marshaled)
-        result = _unbox_mono_obj_root(resultRoot);
+        if (is_result_marshaled)
+            result = _unbox_mono_obj_root(resultRoot);
 
-    _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
-    return result;
+        return result;
+    } finally {
+        _teardown_after_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer);
+    }
 }
 
 export function _teardown_after_call(
-    converter: Converter | undefined, token: BoundMethodToken | null,
+    converter: SignatureConverter | undefined, token: BoundMethodToken | null,
     buffer: VoidPtr, resultRoot: WasmRoot<any>,
     exceptionRoot: WasmRoot<any>, argsRootBuffer?: WasmRootBuffer
 ): void {
@@ -230,16 +236,16 @@ export function _teardown_after_call(
 }
 
 function _call_method_with_converted_args(
-    method: MonoMethod, this_arg: MonoObject, converter: Converter | undefined,
+    method: MonoMethod, this_arg: MonoObject, converter: SignatureConverter | undefined,
     token: BoundMethodToken | null, buffer: VoidPtr,
     is_result_marshaled: boolean, argsRootBuffer?: WasmRootBuffer
 ): any {
-    const resultRoot = mono_wasm_new_root<MonoString>(), exceptionRoot = mono_wasm_new_root<MonoObject>();
-    resultRoot.value = <any>cwraps.mono_wasm_invoke_method(method, this_arg, buffer, <any>exceptionRoot.get_address());
+    const resultRoot = mono_wasm_new_root<MonoObject>(), exceptionRoot = mono_wasm_new_root<MonoObject>();
+    resultRoot.value = <any>cwraps.mono_wasm_invoke_method(method, this_arg, buffer, <VoidPtr><any>exceptionRoot.get_address());
     return _handle_exception_and_produce_result_for_call(converter, token, buffer, resultRoot, exceptionRoot, argsRootBuffer, is_result_marshaled);
 }
 
-export function call_static_method(fqn: string, args: any[], signature: string/*ArgsMarshalString*/): any {
+export function call_static_method(fqn: string, args: any[], signature: string): any {
     bindings_lazy_init();// TODO remove this once Blazor does better startup
 
     const method = mono_method_resolve(fqn);
@@ -250,7 +256,7 @@ export function call_static_method(fqn: string, args: any[], signature: string/*
     return call_method(method, undefined, signature, args);
 }
 
-export function mono_bind_static_method(fqn: string, signature?: string/*ArgsMarshalString*/): Function {
+export function mono_bind_static_method(fqn: string, signature?: string): Function {
     bindings_lazy_init();// TODO remove this once Blazor does better startup
 
     const method = mono_method_resolve(fqn);
@@ -261,7 +267,7 @@ export function mono_bind_static_method(fqn: string, signature?: string/*ArgsMar
     return mono_bind_method(method, null, signature!, fqn);
 }
 
-export function mono_bind_assembly_entry_point(assembly: string, signature?: string/*ArgsMarshalString*/): Function {
+export function mono_bind_assembly_entry_point(assembly: string, signature?: string): Function {
     bindings_lazy_init();// TODO remove this once Blazor does better startup
 
     const asm = cwraps.mono_wasm_assembly_load(assembly);
@@ -282,7 +288,7 @@ export function mono_bind_assembly_entry_point(assembly: string, signature?: str
     };
 }
 
-export function mono_call_assembly_entry_point(assembly: string, args?: any[], signature?: string/*ArgsMarshalString*/): number {
+export function mono_call_assembly_entry_point(assembly: string, args?: any[], signature?: string): number {
     if (!args) {
         args = [[]];
     }
@@ -471,7 +477,7 @@ export function wrap_error(is_exception: Int32Ptr | null, ex: any): MonoString {
     return js_string_to_mono_string(res)!;
 }
 
-export function mono_method_get_call_signature(method: MonoMethod, mono_obj?: MonoObject): string/*ArgsMarshalString*/ {
+export function mono_method_get_call_signature(method: MonoMethod, mono_obj?: MonoObject): string {
     const instanceRoot = mono_wasm_new_root(mono_obj);
     try {
         return call_method(runtimeHelpers.get_call_sig, undefined, "im", [method, instanceRoot.value]);

--- a/src/mono/wasm/runtime/startup.ts
+++ b/src/mono/wasm/runtime/startup.ts
@@ -9,7 +9,7 @@ import { mono_wasm_globalization_init, mono_wasm_load_icu_data } from "./icu";
 import { toBase64StringImpl } from "./base64";
 import { mono_wasm_init_aot_profiler, mono_wasm_init_coverage_profiler } from "./profiler";
 import { mono_wasm_load_bytes_into_heap } from "./buffers";
-import { bind_runtime_method, get_method, _create_primitive_converters } from "./method-binding";
+import { bind_runtime_method, get_method } from "./method-binding";
 import { find_corlib_class } from "./class-loader";
 import { VoidPtr, CharPtr } from "./types/emscripten";
 import { DotnetPublicAPI } from "./exports";
@@ -42,7 +42,7 @@ export function configure_emscripten_startup(module: DotnetModule, exportedAPI: 
         module.postRun = [module.postRun];
     }
 
-    // when user set configSrc or config, we are running our default startup sequence. 
+    // when user set configSrc or config, we are running our default startup sequence.
     if (module.configSrc || module.config) {
         // execution order == [0] ==
         // - default or user Module.instantiateWasm (will start downloading dotnet.wasm)
@@ -383,8 +383,6 @@ export function bindings_lazy_init(): void {
     runtimeHelpers.get_call_sig = get_method("GetCallSignature");
     if (!runtimeHelpers.get_call_sig)
         throw "Can't find GetCallSignature method";
-
-    _create_primitive_converters();
 }
 
 // Initializes the runtime and loads assemblies, debug information, and other files.

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -62,7 +62,7 @@ export type MonoConfig = {
     runtime_options?: string[], // array of runtime options as strings
     aot_profiler_options?: AOTProfilerOptions, // dictionary-style Object. If omitted, aot profiler will not be initialized.
     coverage_profiler_options?: CoverageProfilerOptions, // dictionary-style Object. If omitted, coverage profiler will not be initialized.
-    ignore_pdb_load_errors?: boolean
+    ignore_pdb_load_errors?: boolean,
 };
 
 export type MonoConfigError = {
@@ -236,4 +236,16 @@ export enum MarshalError {
     NULL_TYPE_POINTER = 514,
     UNSUPPORTED_TYPE = 515,
     FIRST = BUFFER_TOO_SMALL
+}
+
+export type MarshalTypeRecord = {
+    marshalType : MarshalType;
+    typePtr : MonoType;
+    signatureChar : string;
+}
+
+export type MarshalSignatureInfo = {
+    typePtr : MonoType;
+    methodPtr : MonoMethod;
+    parameters : MarshalTypeRecord[];
 }

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -46,18 +46,18 @@ public class WasmAppBuilder : Task
     public bool InvariantGlobalization { get; set; }
     public ITaskItem[]? ExtraFilesToDeploy { get; set; }
 
-    // <summary>
-    // Extra json elements to add to mono-config.json
-    //
-    // Metadata:
-    // - Value: can be a number, bool, quoted string, or json string
-    //
-    // Examples:
-    //      <WasmExtraConfig Include="enable_profiler" Value="true" />
-    //      <WasmExtraConfig Include="json" Value="{ &quot;abc&quot;: 4 }" />
-    //      <WasmExtraConfig Include="string_val" Value="&quot;abc&quot;" />
-    //       <WasmExtraConfig Include="string_with_json" Value="&quot;{ &quot;abc&quot;: 4 }&quot;" />
-    // </summary>
+    /// <summary>
+    /// Extra json elements to add to mono-config.json
+    ///
+    /// Metadata:
+    /// - Value: can be a number, bool, quoted string, or json string
+    ///
+    /// Examples:
+    ///      <WasmExtraConfig Include="enable_profiler" Value="true" />
+    ///      <WasmExtraConfig Include="json" Value="{ &quot;abc&quot;: 4 }" />
+    ///      <WasmExtraConfig Include="string_val" Value="&quot;abc&quot;" />
+    ///      <WasmExtraConfig Include="string_with_json" Value="&quot;{ &quot;abc&quot;: 4 }&quot;" />
+    /// </summary>
     public ITaskItem[]? ExtraConfig { get; set; }
 
     private sealed class WasmAppConfig


### PR DESCRIPTION
This merges together the custom marshalers and new invoke icall pull requests and then removes the custom marshaler support. This also means that support for DateTime and URI is removed, which (as expected) breaks some things, but not too much.