### PR TITLE
Fix invalid threading of nodes in rationalization

### DIFF
--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -416,13 +416,10 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
                 }
                 GenTreeSIMD* simdTree =
                     comp->gtNewSIMDNode(simdType, initVal, SIMDIntrinsicInit, simdBaseJitType, genTypeSize(simdType));
-                assignment->AsOp()->gtOp2 = simdTree;
-                value                     = simdTree;
-                initVal->gtNext           = simdTree;
-                simdTree->gtPrev          = initVal;
+                assignment->gtOp2 = simdTree;
+                value             = simdTree;
 
-                simdTree->gtNext = location;
-                location->gtPrev = simdTree;
+                BlockRange().InsertAfter(initVal, simdTree);
             }
         }
 #endif // FEATURE_SIMD


### PR DESCRIPTION
The code in question assumes that the `ASG` will be reversed and thus threads `simdTree` before `location` in the linear order.  That dependency, while valid, because `gtSetEvalOrder` will always reverse `ASG`s with locals on the LHS, is unnecessary and  incorrect from the IR validity point of view.

Fix this by using `InsertAfter` instead of manual node threading.

Side note: this code is fundamentally broken because `SIMDIntrinsicInit` does not follow the semantics of "InitBlkOp" in IR. Fortunately, it appears impossible to get here with anything but a constant zero for the "fill" value...

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1561150&view=ms.vss-build-web.run-extensions-tab) as expected.