### PR TITLE
JIT: fix up switch map for out-of-loop predecessor

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7574,6 +7574,8 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
                         fgAddRefPred(preHead, predBlock);
                     }
                 } while (++jumpTab, --jumpCnt);
+
+                UpdateSwitchTableTarget(predBlock, entry, preHead);
                 break;
 
             default:


### PR DESCRIPTION
If we have a loop where some of the non-loop predecessors are switchs, and
we add pre-header to the loop, we need to update the switch map for those
predecessors.

Fixes #63982.