### PR TITLE
Extra tests for assembly name parser.

### DIFF
--- a/src/coreclr/binder/inc/assemblyidentity.hpp
+++ b/src/coreclr/binder/inc/assemblyidentity.hpp
@@ -30,7 +30,6 @@ namespace BINDER_SPACE
             IDENTITY_FLAG_PUBLIC_KEY_TOKEN       = 0x004,
             IDENTITY_FLAG_PUBLIC_KEY             = 0x008,
             IDENTITY_FLAG_CULTURE                = 0x010,
-            IDENTITY_FLAG_LANGUAGE               = 0x020,
             IDENTITY_FLAG_PROCESSOR_ARCHITECTURE = 0x040,
             IDENTITY_FLAG_RETARGETABLE           = 0x080,
             IDENTITY_FLAG_PUBLIC_KEY_TOKEN_NULL  = 0x100,

--- a/src/coreclr/binder/inc/assemblyidentity.hpp
+++ b/src/coreclr/binder/inc/assemblyidentity.hpp
@@ -33,8 +33,6 @@ namespace BINDER_SPACE
             IDENTITY_FLAG_PROCESSOR_ARCHITECTURE = 0x040,
             IDENTITY_FLAG_RETARGETABLE           = 0x080,
             IDENTITY_FLAG_PUBLIC_KEY_TOKEN_NULL  = 0x100,
-            IDENTITY_FLAG_CUSTOM                 = 0x200,
-            IDENTITY_FLAG_CUSTOM_NULL            = 0x400,
             IDENTITY_FLAG_CONTENT_TYPE           = 0x800,
             IDENTITY_FLAG_FULL_NAME              = (IDENTITY_FLAG_SIMPLE_NAME |
                                                     IDENTITY_FLAG_VERSION)
@@ -49,7 +47,6 @@ namespace BINDER_SPACE
             // Need to pre-populate SBuffers because of bogus asserts
             static const BYTE byteArr[] = { 0 };
             m_publicKeyOrTokenBLOB.SetImmutable(byteArr, sizeof(byteArr));
-            m_customBLOB.SetImmutable(byteArr, sizeof(byteArr));
         }
         ~AssemblyIdentity()
         {
@@ -82,7 +79,6 @@ namespace BINDER_SPACE
         SBuffer             m_publicKeyOrTokenBLOB;
         PEKIND              m_kProcessorArchitecture;
         AssemblyContentType m_kContentType;
-        SBuffer             m_customBLOB;
         DWORD               m_dwIdentityFlags;
     };
 

--- a/src/coreclr/binder/inc/stringlexer.hpp
+++ b/src/coreclr/binder/inc/stringlexer.hpp
@@ -55,7 +55,7 @@ namespace BINDER_SPACE
         inline StringLexer();
         inline ~StringLexer();
 
-        inline void Init(SString &inputString, BOOL fSupportEscaping);
+        inline void Init(SString &inputString);
 
         static inline BOOL IsWhitespace(WCHAR wcChar);
         static inline BOOL IsEOS(WCHAR wcChar);
@@ -67,7 +67,7 @@ namespace BINDER_SPACE
     protected:
         static const WCHAR INVALID_CHARACTER = -1;
 
-        LEXEME_TYPE GetNextLexeme(SString &currentString, BOOL fPermitUnescapedQuotes = FALSE);
+        LEXEME_TYPE GetNextLexeme(SString &currentString);
 
         inline WCHAR PopCharacter(BOOL *pfIsEscaped);
         inline void PushCharacter(WCHAR wcCurrentChar,
@@ -79,8 +79,7 @@ namespace BINDER_SPACE
         inline WCHAR GetNextCharacter(BOOL *pfIsEscaped);
 
         inline WCHAR ParseUnicode();
-        LEXEME_TYPE ParseString(SString &currentString,
-                                BOOL     fPermitUnescapeQuotes);
+        LEXEME_TYPE ParseString(SString &currentString);
 
         void TrimTrailingWhiteSpaces(SString &currentString);
 
@@ -89,7 +88,6 @@ namespace BINDER_SPACE
 
         WCHAR m_wcCurrentChar;
         BOOL m_fCurrentCharIsEscaped;
-        BOOL m_fSupportEscaping;
         BOOL m_fReadRawCharacter;
     };
 

--- a/src/coreclr/binder/inc/stringlexer.hpp
+++ b/src/coreclr/binder/inc/stringlexer.hpp
@@ -61,8 +61,8 @@ namespace BINDER_SPACE
         static inline BOOL IsEOS(WCHAR wcChar);
         static inline BOOL IsQuoteCharacter(WCHAR wcChar);
 
-        virtual BOOL IsSeparatorChar(WCHAR wcChar) = NULL;
-        virtual LEXEME_TYPE GetLexemeType(WCHAR wcChar) = NULL;
+        BOOL IsSeparatorChar(WCHAR wcChar);
+        LEXEME_TYPE GetLexemeType(WCHAR wcChar);
 
     protected:
         static const WCHAR INVALID_CHARACTER = -1;
@@ -74,7 +74,6 @@ namespace BINDER_SPACE
                                   BOOL fIsEscaped);
 
         inline WCHAR GetRawCharacter();
-        inline void PushRawCharacter();
         inline WCHAR GetNextCharacter(BOOL *pfIsEscaped);
 
         LEXEME_TYPE ParseString(SString &currentString);
@@ -86,7 +85,6 @@ namespace BINDER_SPACE
 
         WCHAR m_wcCurrentChar;
         BOOL m_fCurrentCharIsEscaped;
-        BOOL m_fReadRawCharacter;
     };
 
 #include "stringlexer.inl"

--- a/src/coreclr/binder/inc/stringlexer.hpp
+++ b/src/coreclr/binder/inc/stringlexer.hpp
@@ -75,10 +75,8 @@ namespace BINDER_SPACE
 
         inline WCHAR GetRawCharacter();
         inline void PushRawCharacter();
-        inline WCHAR DecodeUTF16Character();
         inline WCHAR GetNextCharacter(BOOL *pfIsEscaped);
 
-        inline WCHAR ParseUnicode();
         LEXEME_TYPE ParseString(SString &currentString);
 
         void TrimTrailingWhiteSpaces(SString &currentString);

--- a/src/coreclr/binder/inc/stringlexer.inl
+++ b/src/coreclr/binder/inc/stringlexer.inl
@@ -105,7 +105,6 @@ WCHAR StringLexer::GetNextCharacter(BOOL *pfIsEscaped)
         case L'\'':
         case L',':
         case L'\\':
-        case L'/':
         case L'=':
         case L't':
         case L'n':

--- a/src/coreclr/binder/inc/stringlexer.inl
+++ b/src/coreclr/binder/inc/stringlexer.inl
@@ -25,11 +25,10 @@ StringLexer::~StringLexer()
     // Nothing to do here
 }
 
-void StringLexer::Init(SString &inputString, BOOL fSupportEscaping)
+void StringLexer::Init(SString &inputString)
 {
     m_cursor = inputString.Begin();
     m_end = inputString.End();
-    m_fSupportEscaping = fSupportEscaping;
     m_fReadRawCharacter = FALSE;
 }
 
@@ -146,52 +145,34 @@ WCHAR StringLexer::GetNextCharacter(BOOL *pfIsEscaped)
     {
         WCHAR wcTempChar = GetRawCharacter(); // DecodeUTF16Character()
 
-        if (m_fSupportEscaping)
+        // Handle standard escapes
+        switch (wcTempChar)
         {
-            // Handle standard escapes
-            switch (wcTempChar)
-            {
-            case L'"':
-            case L'\'':
-            case L',':
-            case L'\\':
-            case L'/':
-            case L'=':
-                break;
-            case L't':
-                wcTempChar = 9;
-                break;
-            case L'n':
-                wcTempChar = 10;
-                break;
-            case L'r':
-                wcTempChar = 13;
-                break;
-            case L'u':
-                wcTempChar = ParseUnicode();
-                break;
-            default:
-                return INVALID_CHARACTER;
-            }
+        case L'"':
+        case L'\'':
+        case L',':
+        case L'\\':
+        case L'/':
+        case L'=':
+            break;
+        case L't':
+            wcTempChar = 9;
+            break;
+        case L'n':
+            wcTempChar = 10;
+            break;
+        case L'r':
+            wcTempChar = 13;
+            break;
+        case L'u':
+            wcTempChar = ParseUnicode();
+            break;
+        default:
+            return INVALID_CHARACTER;
+        }
 
-            *pfIsEscaped = TRUE;
-            wcCurrentChar = wcTempChar;
-        }
-        else
-        {
-            // Do not handle escapes except for quotes
-            switch (wcTempChar)
-            {
-            case L'"':
-            case L'\'':
-                *pfIsEscaped = TRUE;
-                wcCurrentChar = wcTempChar;
-                break;
-            default:
-                PushRawCharacter();
-                break;
-            }
-        }
+        *pfIsEscaped = TRUE;
+        wcCurrentChar = wcTempChar;
     }
 
     return wcCurrentChar;

--- a/src/coreclr/binder/inc/stringlexer.inl
+++ b/src/coreclr/binder/inc/stringlexer.inl
@@ -29,7 +29,6 @@ void StringLexer::Init(SString &inputString)
 {
     m_cursor = inputString.Begin();
     m_end = inputString.End();
-    m_fReadRawCharacter = FALSE;
 }
 
 BOOL StringLexer::IsWhitespace(WCHAR wcChar)
@@ -54,6 +53,7 @@ WCHAR StringLexer::PopCharacter(BOOL *pfIsEscaped)
     {
         m_wcCurrentChar = INVALID_CHARACTER;
         *pfIsEscaped = m_fCurrentCharIsEscaped;
+        m_cursor++;
     }
     else
     {
@@ -70,6 +70,7 @@ void StringLexer::PushCharacter(WCHAR wcCurrentChar,
 
     m_wcCurrentChar = wcCurrentChar;
     m_fCurrentCharIsEscaped = fIsEscaped;
+    m_cursor--;
 }
 
 WCHAR StringLexer::GetRawCharacter()
@@ -79,24 +80,13 @@ WCHAR StringLexer::GetRawCharacter()
     if (m_cursor <= m_end)
     {
         wcCurrentChar = m_cursor[0];
-        m_fReadRawCharacter = TRUE;
         m_cursor++;
     }
     else
     {
-        m_fReadRawCharacter = FALSE;
     }
 
     return wcCurrentChar;
-}
-
-void StringLexer::PushRawCharacter()
-{
-    if (m_fReadRawCharacter)
-    {
-        m_cursor--;
-        m_fReadRawCharacter = FALSE;
-    }
 }
 
 WCHAR StringLexer::GetNextCharacter(BOOL *pfIsEscaped)
@@ -117,15 +107,9 @@ WCHAR StringLexer::GetNextCharacter(BOOL *pfIsEscaped)
         case L'\\':
         case L'/':
         case L'=':
-            break;
         case L't':
-            wcTempChar = 9;
-            break;
         case L'n':
-            wcTempChar = 10;
-            break;
         case L'r':
-            wcTempChar = 13;
             break;
         default:
             return INVALID_CHARACTER;

--- a/src/coreclr/binder/inc/stringlexer.inl
+++ b/src/coreclr/binder/inc/stringlexer.inl
@@ -77,13 +77,21 @@ WCHAR StringLexer::GetRawCharacter()
 {
     WCHAR wcCurrentChar = 0;
 
-    if (m_cursor <= m_end)
+    if (m_cursor < m_end)
     {
         wcCurrentChar = m_cursor[0];
         m_cursor++;
+
+        // do not allow \0 anywhere in the string.
+        if (wcCurrentChar == 0)
+        {
+            wcCurrentChar = INVALID_CHARACTER;
+        }
     }
     else
     {
+        // EOS
+        wcCurrentChar = 0;
     }
 
     return wcCurrentChar;

--- a/src/coreclr/binder/inc/textualidentityparser.hpp
+++ b/src/coreclr/binder/inc/textualidentityparser.hpp
@@ -28,11 +28,9 @@ namespace BINDER_SPACE
         TextualIdentityParser(AssemblyIdentity *pAssemblyIdentity);
         ~TextualIdentityParser();
 
-        virtual BOOL IsSeparatorChar(WCHAR wcChar);
-        virtual StringLexer::LEXEME_TYPE GetLexemeType(WCHAR wcChar);
-
         static HRESULT Parse(/* in */  SString           &textualIdentity,
                              /* out */ AssemblyIdentity *pAssemblyIdentity);
+
         static HRESULT ToString(/* in */  AssemblyIdentity *pAssemblyIdentity,
                                 /* in */  DWORD             dwIdentityFlags,
                                 /* out */ SString          &textualIdentity);
@@ -44,6 +42,7 @@ namespace BINDER_SPACE
                               /* in */  BOOL     fValidateHex,
                               /* in */  BOOL     fIsToken,
                               /* out */ SBuffer &publicKeyOrTokenBLOB);
+
         static void BlobToHex(/* in */  SBuffer &publicKeyOrTokenBLOB,
                               /* out */ SString &publicKeyOrToken);
 

--- a/src/coreclr/binder/inc/textualidentityparser.hpp
+++ b/src/coreclr/binder/inc/textualidentityparser.hpp
@@ -32,8 +32,7 @@ namespace BINDER_SPACE
         virtual StringLexer::LEXEME_TYPE GetLexemeType(WCHAR wcChar);
 
         static HRESULT Parse(/* in */  SString           &textualIdentity,
-                             /* out */ AssemblyIdentity *pAssemblyIdentity,
-                             /* in */  BOOL              fPermitUnescapedQuotes = FALSE);
+                             /* out */ AssemblyIdentity *pAssemblyIdentity);
         static HRESULT ToString(/* in */  AssemblyIdentity *pAssemblyIdentity,
                                 /* in */  DWORD             dwIdentityFlags,
                                 /* out */ SString          &textualIdentity);
@@ -52,8 +51,7 @@ namespace BINDER_SPACE
                          /* out */ SString &contentString);
 
     protected:
-        BOOL Parse(/* in */  SString &textualIdentity,
-                   /* in */  BOOL     fPermitUnescapedQuotes = FALSE);
+        BOOL Parse(/* in */  SString &textualIdentity);
 
         BOOL PopulateAssemblyIdentity(/* in */ SString &attributeString,
                                       /* in */ SString &valueString);

--- a/src/coreclr/binder/stringlexer.cpp
+++ b/src/coreclr/binder/stringlexer.cpp
@@ -19,7 +19,7 @@
 namespace BINDER_SPACE
 {
     StringLexer::LEXEME_TYPE
-    StringLexer::GetNextLexeme(SString &currentString, BOOL fPermitUnescapedQuotes)
+    StringLexer::GetNextLexeme(SString &currentString)
     {
         BOOL fIsEscaped = FALSE;
         WCHAR wcCurrentChar = INVALID_CHARACTER;
@@ -43,11 +43,11 @@ namespace BINDER_SPACE
 
         // First character of string lexeme; push it back
         PushCharacter(wcCurrentChar, fIsEscaped);
-        return ParseString(currentString, fPermitUnescapedQuotes);
+        return ParseString(currentString);
     }
 
     StringLexer::LEXEME_TYPE
-    StringLexer::ParseString(SString &currentString, BOOL fPermitUnescapedQuotes)
+    StringLexer::ParseString(SString &currentString)
     {
         BOOL fIsFirstCharacter = TRUE;
         WCHAR wcCurrentChar = INVALID_CHARACTER;
@@ -99,7 +99,7 @@ namespace BINDER_SPACE
                 break;
             }
 
-            if (!fPermitUnescapedQuotes && !fIsEscaped && IsQuoteCharacter(wcCurrentChar) && !IsQuoteCharacter(wcOpeningQuote))
+            if (!fIsEscaped && IsQuoteCharacter(wcCurrentChar) && !IsQuoteCharacter(wcOpeningQuote))
             {
                 // Unescaped quotes in the middle of the string are an error
                 return LEXEME_TYPE_INVALID;

--- a/src/coreclr/binder/stringlexer.cpp
+++ b/src/coreclr/binder/stringlexer.cpp
@@ -147,4 +147,24 @@ namespace BINDER_SPACE
             currentString.Truncate(cursor + 1);
         }
     }
+
+    BOOL StringLexer::IsSeparatorChar(WCHAR wcChar)
+    {
+        return ((wcChar == W(',')) || (wcChar == W('=')));
+    }
+
+    StringLexer::LEXEME_TYPE StringLexer::GetLexemeType(WCHAR wcChar)
+    {
+        switch (wcChar)
+        {
+        case W('='):
+            return LEXEME_TYPE_EQUALS;
+        case W(','):
+            return LEXEME_TYPE_COMMA;
+        case 0:
+            return LEXEME_TYPE_END_OF_STREAM;
+        default:
+            return LEXEME_TYPE_STRING;
+        }
+    }
 };

--- a/src/coreclr/binder/textualidentityparser.cpp
+++ b/src/coreclr/binder/textualidentityparser.cpp
@@ -222,8 +222,7 @@ namespace BINDER_SPACE
 
     /* static */
     HRESULT TextualIdentityParser::Parse(SString          &textualIdentity,
-                                         AssemblyIdentity *pAssemblyIdentity,
-                                         BOOL              fPermitUnescapedQuotes)
+                                         AssemblyIdentity *pAssemblyIdentity)
     {
         HRESULT hr = S_OK;
 
@@ -233,7 +232,7 @@ namespace BINDER_SPACE
         {
             TextualIdentityParser identityParser(pAssemblyIdentity);
 
-            if (!identityParser.Parse(textualIdentity, fPermitUnescapedQuotes))
+            if (!identityParser.Parse(textualIdentity))
             {
                 IF_FAIL_GO(FUSION_E_INVALID_NAME);
             }
@@ -486,19 +485,19 @@ namespace BINDER_SPACE
         publicKeyOrToken.CloseBuffer(cbPublicKeyOrTokenBLOB * 2);
     }
 
-    BOOL TextualIdentityParser::Parse(SString &textualIdentity, BOOL fPermitUnescapedQuotes)
+    BOOL TextualIdentityParser::Parse(SString &textualIdentity)
     {
         BOOL fIsValid = TRUE;
         SString unicodeTextualIdentity;
 
         // Lexer modifies input string
         textualIdentity.ConvertToUnicode(unicodeTextualIdentity);
-        Init(unicodeTextualIdentity, TRUE /* fSupportEscaping */);
+        Init(unicodeTextualIdentity);
 
         SmallStackSString currentString;
 
         // Identity format is simple name (, attr = value)*
-        GO_IF_NOT_EXPECTED(GetNextLexeme(currentString, fPermitUnescapedQuotes), LEXEME_TYPE_STRING);
+        GO_IF_NOT_EXPECTED(GetNextLexeme(currentString), LEXEME_TYPE_STRING);
         m_pAssemblyIdentity->m_simpleName.Set(currentString);
         m_pAssemblyIdentity->m_simpleName.Normalize();
         m_pAssemblyIdentity->SetHave(AssemblyIdentity::IDENTITY_FLAG_SIMPLE_NAME);
@@ -532,7 +531,7 @@ namespace BINDER_SPACE
 
         // Lexer modifies input string
         textualString.ConvertToUnicode(unicodeTextualString);
-        Init(unicodeTextualString, TRUE /* fSupportEscaping */);
+        Init(unicodeTextualString);
 
         SmallStackSString currentString;
         GO_IF_NOT_EXPECTED(GetNextLexeme(currentString), LEXEME_TYPE_STRING);

--- a/src/coreclr/binder/textualidentityparser.cpp
+++ b/src/coreclr/binder/textualidentityparser.cpp
@@ -200,26 +200,6 @@ namespace BINDER_SPACE
         // Nothing to do here
     }
 
-    BOOL TextualIdentityParser::IsSeparatorChar(WCHAR wcChar)
-    {
-        return ((wcChar == W(',')) || (wcChar == W('=')));
-    }
-
-    StringLexer::LEXEME_TYPE TextualIdentityParser::GetLexemeType(WCHAR wcChar)
-    {
-        switch (wcChar)
-        {
-        case W('='):
-            return LEXEME_TYPE_EQUALS;
-        case W(','):
-            return LEXEME_TYPE_COMMA;
-        case 0:
-            return LEXEME_TYPE_END_OF_STREAM;
-        default:
-            return LEXEME_TYPE_STRING;
-        }
-    }
-
     /* static */
     HRESULT TextualIdentityParser::Parse(SString          &textualIdentity,
                                          AssemblyIdentity *pAssemblyIdentity)

--- a/src/coreclr/binder/textualidentityparser.cpp
+++ b/src/coreclr/binder/textualidentityparser.cpp
@@ -552,8 +552,7 @@ namespace BINDER_SPACE
             GO_IF_SEEN(AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY_TOKEN);
             GO_IF_WILDCARD(valueString);
 
-            if (!EqualsCaseInsensitive(valueString, W("null")) &&
-                !EqualsCaseInsensitive(valueString, W("neutral")))
+            if (!EqualsCaseInsensitive(valueString, W("null")))
             {
                 GO_IF_VALIDATE_FAILED(ValidatePublicKeyToken,
                                       AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY_TOKEN);
@@ -572,8 +571,7 @@ namespace BINDER_SPACE
             GO_IF_SEEN(AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY_TOKEN);
             GO_IF_SEEN(AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY);
 
-            if (!EqualsCaseInsensitive(valueString, W("null")) &&
-                !EqualsCaseInsensitive(valueString, W("neutral")))
+            if (!EqualsCaseInsensitive(valueString, W("null")))
             {
                 GO_IF_VALIDATE_FAILED(ValidatePublicKey, AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY);
                 HexToBlob(valueString,

--- a/src/coreclr/binder/textualidentityparser.cpp
+++ b/src/coreclr/binder/textualidentityparser.cpp
@@ -314,18 +314,6 @@ namespace BINDER_SPACE
                 textualIdentity.Append(ContentTypeToString(pAssemblyIdentity->m_kContentType));
             }
 
-            if (AssemblyIdentity::Have(dwIdentityFlags, AssemblyIdentity::IDENTITY_FLAG_CUSTOM))
-            {
-                textualIdentity.Append(W(", Custom="));
-                tmpString.Clear();
-                BlobToHex(pAssemblyIdentity->m_customBLOB, tmpString);
-                textualIdentity.Append(tmpString);
-            }
-            else if (AssemblyIdentity::Have(dwIdentityFlags,
-                                            AssemblyIdentity::IDENTITY_FLAG_CUSTOM_NULL))
-            {
-                textualIdentity.Append(W(", Custom=null"));
-            }
         }
         EX_CATCH_HRESULT(hr);
 
@@ -637,23 +625,6 @@ namespace BINDER_SPACE
             else
             {
                 fIsValid = FALSE;
-            }
-        }
-        else if (EqualsCaseInsensitive(attributeString, W("custom")))
-        {
-            GO_IF_SEEN(AssemblyIdentity::IDENTITY_FLAG_CUSTOM);
-
-            if (EqualsCaseInsensitive(valueString, W("null")))
-            {
-                m_pAssemblyIdentity->SetHave(AssemblyIdentity::IDENTITY_FLAG_CUSTOM_NULL);
-            }
-            else
-            {
-                GO_IF_VALIDATE_FAILED(ValidateHex, AssemblyIdentity::IDENTITY_FLAG_CUSTOM);
-                HexToBlob(valueString,
-                          FALSE /* fValidateHex */,
-                          FALSE /* fIsToken */,
-                          m_pAssemblyIdentity->m_customBLOB);
             }
         }
 

--- a/src/coreclr/binder/textualidentityparser.cpp
+++ b/src/coreclr/binder/textualidentityparser.cpp
@@ -528,8 +528,7 @@ namespace BINDER_SPACE
     {
         BOOL fIsValid = TRUE;
 
-        if (EqualsCaseInsensitive(attributeString, W("culture")) ||
-            EqualsCaseInsensitive(attributeString, W("language")))
+        if (EqualsCaseInsensitive(attributeString, W("culture")))
         {
             GO_IF_SEEN(AssemblyIdentity::IDENTITY_FLAG_CULTURE);
             GO_IF_WILDCARD(valueString);

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -271,6 +271,15 @@ HRESULT AssemblySpec::InitializeSpec(StackingAllocator* alloc, ASSEMBLYNAMEREF* 
         WCHAR* pString;
         int    iString;
         ((STRINGREF) (*pName)->GetSimpleName())->RefInterpretGetStringValuesDangerousForGC(&pString, &iString);
+
+        for (int i = 0; i < iString; i++)
+        {
+            if (pString[i] == 0)
+            {
+                ThrowHR(FUSION_E_INVALID_NAME);
+            }
+        }
+
         DWORD lgth = WszWideCharToMultiByte(CP_UTF8, 0, pString, iString, NULL, 0, NULL, NULL);
         if (lgth + 1 < lgth)
             ThrowHR(E_INVALIDARG);
@@ -290,7 +299,8 @@ HRESULT AssemblySpec::InitializeSpec(StackingAllocator* alloc, ASSEMBLYNAMEREF* 
         SetName(lpName);
     }
 
-    if (fParse) {
+    if (fParse)
+    {
         HRESULT hr = ParseName();
         // Sometimes Fusion flags invalid characters in the name, sometimes it doesn't
         // depending on where the invalid characters are

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -272,13 +272,9 @@ HRESULT AssemblySpec::InitializeSpec(StackingAllocator* alloc, ASSEMBLYNAMEREF* 
         int    iString;
         ((STRINGREF) (*pName)->GetSimpleName())->RefInterpretGetStringValuesDangerousForGC(&pString, &iString);
 
-        for (int i = 0; i < iString; i++)
-        {
-            if (pString[i] == 0)
-            {
-                ThrowHR(FUSION_E_INVALID_NAME);
-            }
-        }
+        // we will not parse names that contain nulls
+        if (fParse && (wcslen(pString) != iString))
+            ThrowHR(FUSION_E_INVALID_NAME);
 
         DWORD lgth = WszWideCharToMultiByte(CP_UTF8, 0, pString, iString, NULL, 0, NULL, NULL);
         if (lgth + 1 < lgth)

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -273,7 +273,7 @@ HRESULT AssemblySpec::InitializeSpec(StackingAllocator* alloc, ASSEMBLYNAMEREF* 
         ((STRINGREF) (*pName)->GetSimpleName())->RefInterpretGetStringValuesDangerousForGC(&pString, &iString);
 
         // we will not parse names that contain nulls
-        if (fParse && (wcslen(pString) != iString))
+        if (fParse && (wcslen(pString) != (size_t)iString))
             ThrowHR(FUSION_E_INVALID_NAME);
 
         DWORD lgth = WszWideCharToMultiByte(CP_UTF8, 0, pString, iString, NULL, 0, NULL, NULL);

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -105,7 +105,7 @@ class AssemblySpec  : public BaseAssemblySpec
     void InitializeSpec(PEAssembly* pPEAssembly);
     HRESULT InitializeSpec(StackingAllocator* alloc,
                         ASSEMBLYNAMEREF* pName,
-                        BOOL fParse = TRUE);
+                        BOOL fParse);
 
     void AssemblyNameInit(ASSEMBLYNAMEREF* pName, PEImage* pImageInfo); //[in,out], [in]
 

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -83,6 +83,8 @@ namespace System.Reflection.Tests
 
         [Theory]
         [InlineData("aaaa, language=en-en", "aaaa")]
+        [InlineData("aaaa, foo=bar, foo=baz", "aaaa")]
+        [InlineData("aaaa, foo = bar, foo = bar", "aaaa")]
         public void Ctor_String_Valid_Legacy(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName(name);

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -83,6 +83,8 @@ namespace System.Reflection.Tests
 
         [Theory]
         [InlineData("name\\u50; ", typeof(FileLoadException))]
+        [InlineData("aa/name ", typeof(FileLoadException))]
+        [InlineData("aa\\/tname", typeof(FileLoadException))]
         public void Ctor_String_Invalid_Legacy(string assemblyName, Type exceptionType)
         {
             Assert.Throws(exceptionType, () => new AssemblyName(assemblyName));

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -100,6 +100,9 @@ namespace System.Reflection.Tests
         [InlineData("aa\\/tname", typeof(FileLoadException))]
         [InlineData("aaaa, publickey=neutral", typeof(FileLoadException))]
         [InlineData("aaaa, publickeytoken=neutral", typeof(FileLoadException))]
+        [InlineData("aaaa\0", typeof(FileLoadException))]
+        [InlineData("aaaa\0potato", typeof(FileLoadException))]
+        [InlineData("aaaa, publickeytoken=null\0,culture=en-en", typeof(FileLoadException))]
         public void Ctor_String_Invalid_Legacy(string assemblyName, Type exceptionType)
         {
             Assert.Throws(exceptionType, () => new AssemblyName(assemblyName));

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -82,6 +82,14 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
+        [InlineData("aaaa, language=en-en", "aaaa")]
+        public void Ctor_String_Valid_Legacy(string name, string expectedName)
+        {
+            AssemblyName assemblyName = new AssemblyName(name);
+            Assert.Equal(expectedName, assemblyName.Name);
+        }
+
+        [Theory]
         [InlineData("name\\u50; ", typeof(FileLoadException))]
         [InlineData("aa/name ", typeof(FileLoadException))]
         [InlineData("aa\\/tname", typeof(FileLoadException))]

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -82,6 +82,13 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
+        [InlineData("name\\u50; ", typeof(FileLoadException))]
+        public void Ctor_String_Invalid_Legacy(string assemblyName, Type exceptionType)
+        {
+            Assert.Throws(exceptionType, () => new AssemblyName(assemblyName));
+        }
+
+        [Theory]
         [InlineData("na,me", typeof(FileLoadException))]
         [InlineData("na=me", typeof(FileLoadException))]
         [InlineData("na\'me", typeof(FileLoadException))]

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -69,6 +69,15 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
+        [InlineData("MyAssemblyName, Version=1.0.0.0, PublicKeyToken=b77a5c561934e089", "MyAssemblyName, Version=1.0.0.0, PublicKeyToken=b77a5c561934e089")]
+        [InlineData("MyAssemblyName, Version=1.0.0.0, PublicKey=00000000000000000400000000000000", "MyAssemblyName, Version=1.0.0.0, PublicKeyToken=b77a5c561934e089")]
+        public void Ctor_String_Public_Key(string name, string expectedName)
+        {
+            AssemblyName assemblyName = new AssemblyName(name);
+            Assert.Equal(expectedName, assemblyName.FullName);
+        }
+
+        [Theory]
         [InlineData(null, typeof(ArgumentNullException))]
         [InlineData("", typeof(ArgumentException))]
         [InlineData("\0", typeof(ArgumentException))]
@@ -76,6 +85,7 @@ namespace System.Reflection.Tests
         [InlineData("/a", typeof(FileLoadException))]
         [InlineData("           ", typeof(FileLoadException))]
         [InlineData("  \t \r \n ", typeof(FileLoadException))]
+        [InlineData("MyAssemblyName, PublicKey=00000000000000000400000000000000, PublicKeyToken=b77a5c561934e089", typeof(FileLoadException))]
         public void Ctor_String_Invalid(string assemblyName, Type exceptionType)
         {
             Assert.Throws(exceptionType, () => new AssemblyName(assemblyName));

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -98,6 +98,8 @@ namespace System.Reflection.Tests
         [InlineData("name\\u50; ", typeof(FileLoadException))]
         [InlineData("aa/name ", typeof(FileLoadException))]
         [InlineData("aa\\/tname", typeof(FileLoadException))]
+        [InlineData("aaaa, publickey=neutral", typeof(FileLoadException))]
+        [InlineData("aaaa, publickeytoken=neutral", typeof(FileLoadException))]
         public void Ctor_String_Invalid_Legacy(string assemblyName, Type exceptionType)
         {
             Assert.Throws(exceptionType, () => new AssemblyName(assemblyName));

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -85,6 +85,7 @@ namespace System.Reflection.Tests
         [InlineData("/a", typeof(FileLoadException))]
         [InlineData("           ", typeof(FileLoadException))]
         [InlineData("  \t \r \n ", typeof(FileLoadException))]
+        [InlineData("aa, culture=en-en, culture=en-en", typeof(FileLoadException))]
         [InlineData("MyAssemblyName, PublicKey=00000000000000000400000000000000, PublicKeyToken=b77a5c561934e089", typeof(FileLoadException))]
         public void Ctor_String_Invalid(string assemblyName, Type exceptionType)
         {

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -85,6 +85,9 @@ namespace System.Reflection.Tests
         [InlineData("aaaa, language=en-en", "aaaa")]
         [InlineData("aaaa, foo=bar, foo=baz", "aaaa")]
         [InlineData("aaaa, foo = bar, foo = bar", "aaaa")]
+        [InlineData("aaaa, custom=10", "aaaa")]
+        [InlineData("aaaa, custom=10, custom=20", "aaaa")]
+        [InlineData("aaaa, custom=lalala", "aaaa")]
         public void Ctor_String_Valid_Legacy(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName(name);

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
@@ -19,6 +19,9 @@ namespace System.Reflection
             if (assemblyName.Length == 0 || assemblyName[0] == '\0')
                 throw new ArgumentException(SR.Format_StringZeroLength);
 
+            if (assemblyName.Contains("\0"))
+                throw new FileLoadException("The assembly name is invalid.");
+
             using (SafeStringMarshal name = RuntimeMarshal.MarshalString(assemblyName))
             {
                 // TODO: Should use CoreRT AssemblyNameParser

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/AssemblyName.Mono.cs
@@ -19,7 +19,7 @@ namespace System.Reflection
             if (assemblyName.Length == 0 || assemblyName[0] == '\0')
                 throw new ArgumentException(SR.Format_StringZeroLength);
 
-            if (assemblyName.Contains("\0"))
+            if (assemblyName.Contains('\0'))
                 throw new FileLoadException("The assembly name is invalid.");
 
             using (SafeStringMarshal name = RuntimeMarshal.MarshalString(assemblyName))

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2672,7 +2672,8 @@ mono_assembly_name_parse_full (const char *name, MonoAssemblyName *aname, gboole
 			continue;
 		}
 
-		goto cleanup_and_fail;
+		// compat: If we got here, the attribute name is unknown to us. Ignore it.
+		tmp++;
 	}
 
 	/* if retargetable flag is set, then we must have a fully qualified name */

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2544,7 +2544,7 @@ mono_assembly_name_parse_full (const char *name, MonoAssemblyName *aname, gboole
 	gchar *key_uq;
 	gchar *retargetable = NULL;
 	gchar *retargetable_uq;
-	gchar *procarch;
+	gchar *procarch = NULL;
 	gchar *procarch_uq;
 	gboolean res;
 	gchar *value, *part_name;
@@ -2590,43 +2590,47 @@ mono_assembly_name_parse_full (const char *name, MonoAssemblyName *aname, gboole
 
 		if (part_name_len == 7 && !g_ascii_strncasecmp (part_name, "Version", part_name_len)) {
 			*is_version_defined = TRUE;
-			version = value;
-			if (strlen (version) == 0) {
+			if (version != NULL || strlen (value) == 0) {
 				goto cleanup_and_fail;
 			}
+			version = value;
 			tmp++;
 			continue;
 		}
 
 		if (part_name_len == 7 && !g_ascii_strncasecmp (part_name, "Culture", part_name_len)) {
-			culture = value;
-			if (strlen (culture) == 0) {
+			if (culture != NULL || strlen (value) == 0) {
 				goto cleanup_and_fail;
 			}
+			culture = value;
 			tmp++;
 			continue;
 		}
 
 		if (part_name_len == 14 && !g_ascii_strncasecmp (part_name, "PublicKeyToken", part_name_len)) {
 			*is_token_defined = TRUE;
-			token = value;
-			if (strlen (token) == 0) {
+			if (token != NULL || key != NULL || strlen (value) == 0) {
 				goto cleanup_and_fail;
 			}
+			token = value;
 			tmp++;
 			continue;
 		}
 
 		if (part_name_len == 9 && !g_ascii_strncasecmp (part_name, "PublicKey", part_name_len)) {
-			key = value;
-			if (strlen (key) == 0) {
+			if (token != NULL || key != NULL || strlen (value) == 0) {
 				goto cleanup_and_fail;
 			}
+			key = value;
 			tmp++;
 			continue;
 		}
 
 		if (part_name_len == 12 && !g_ascii_strncasecmp (part_name, "Retargetable", part_name_len)) {
+			if (retargetable != NULL) {
+				goto cleanup_and_fail;
+			}
+
 			retargetable = value;
 			retargetable_uq = unquote (retargetable);
 			if (retargetable_uq != NULL)
@@ -2645,6 +2649,10 @@ mono_assembly_name_parse_full (const char *name, MonoAssemblyName *aname, gboole
 		}
 
 		if (part_name_len == 21 && !g_ascii_strncasecmp (part_name, "ProcessorArchitecture", part_name_len)) {
+			if (procarch != NULL) {
+				goto cleanup_and_fail;
+			}
+
 			procarch = value;
 			procarch_uq = unquote (procarch);
 			if (procarch_uq != NULL)


### PR DESCRIPTION
Adding tests for various corner cases in assembly name parsing.
Also fixing some undesirable/inconsistent legacy behaviors.

This is a prerequisite PR for https://github.com/dotnet/runtime/pull/62866