### PR TITLE
Fix OpenSSL version check in GetAlpnSupport

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -216,7 +216,12 @@ namespace System
 
             if (IsOpenSslSupported)
             {
-                return OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2);
+                if (OpenSslVersion.Major >= 3)
+                {
+                    return true;
+                }
+                
+                return OpenSslVersion.Major == 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2);
             }
 
             if (IsAndroid)


### PR DESCRIPTION
The previous check failed 3.0.0 because the Minor was 0 and Build was 0.

It could probably be rewritten to be `>= new Version(1, 0, 2)`, but that'd require more thinking.

Fixes #63624.