### PR TITLE
adding centralized location to disable library tests

### DIFF
--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -1,4 +1,5 @@
 <Project>
+<Import Project="../../../libraries_skip.props" />
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TestResultsName>testResults.xml</TestResultsName>
@@ -13,6 +14,7 @@
     <RunScriptCommand>$(RunScriptCommand) $(TargetFileName)</RunScriptCommand>
     <RunScriptCommand>$(RunScriptCommand) -xml $(TestResultsName)</RunScriptCommand>
     <RunScriptCommand>$(RunScriptCommand) -nologo</RunScriptCommand>
+    <RunScriptCommand>$(RunScriptCommand) -nomethod @(SkipTests, '-nomethod')</RunScriptCommand>
     <RunScriptCommand Condition="'$(ArchiveTests)' == 'true'">$(RunScriptCommand) -nocolor</RunScriptCommand>
     <RunScriptCommand Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TestDisableAppDomain)' == 'true'">$(RunScriptCommand) -noappdomain</RunScriptCommand>
     <RunScriptCommand Condition="'$(TestDisableParallelization)' == 'true'">$(RunScriptCommand) -maxthreads 1</RunScriptCommand>

--- a/libraries_skip.props
+++ b/libraries_skip.props
@@ -1,0 +1,8 @@
+<Project>
+    <!--Contains the Complete Names for each library test to be skipped.-->
+    <ItemGroup>
+        <!--SkipTests Include="Microsoft.CSharp.RuntimeBinder.Tests.DynamicDebuggerProxyTests.Items_Empty" /-->
+
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adding a centralized location will allow the Test Monitor or automation to easily disable any test.
Fixes #61473