### PR TITLE
Add test coverage for frozen objects and GC interaction

### DIFF
--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -40,6 +40,7 @@ internal class Program
         TestDrawCircle.Run();
         TestValueTypeDup.Run();
         TestFunctionPointers.Run();
+        TestGCInteraction.Run();
 #else
         Console.WriteLine("Preinitialization is disabled in multimodule builds for now. Skipping test.");
 #endif
@@ -831,6 +832,39 @@ unsafe class TestFunctionPointers
     {
         Assert.IsLazyInitialized(typeof(WithFunctionPointer));
         Assert.AreEqual(WithFunctionPointer.s_foo.Ptr, (delegate*<void>)&WithFunctionPointer.X);
+    }
+}
+
+class TestGCInteraction
+{
+    class WithFrozenObjects
+    {
+        internal readonly static string s_someStringLiteral = "Some string literal";
+        internal readonly static object s_someObject = new object();
+    }
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(WithFrozenObjects));
+
+        var holder = new object[]
+        {
+            WithFrozenObjects.s_someStringLiteral,
+            WithFrozenObjects.s_someObject,
+        };
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Assert.AreSame(holder[0], WithFrozenObjects.s_someStringLiteral);
+        Assert.AreSame(holder[1], WithFrozenObjects.s_someObject);
+
+        // This will try to make a dependent handle for the frozen object
+        lock (WithFrozenObjects.s_someObject)
+        {
+            Console.WriteLine("Now under lock");
+        }
     }
 }
 

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime;
 using System.Runtime.InteropServices;
 
 using BindingFlags = System.Reflection.BindingFlags;
@@ -853,6 +854,9 @@ class TestGCInteraction
             WithFrozenObjects.s_someObject,
         };
 
+        var h1 = new DependentHandle(WithFrozenObjects.s_someObject, WithFrozenObjects.s_someStringLiteral);
+        var h2 = new DependentHandle(WithFrozenObjects.s_someStringLiteral, WithFrozenObjects.s_someObject);
+
         GC.Collect();
         GC.WaitForPendingFinalizers();
         GC.Collect();
@@ -860,11 +864,8 @@ class TestGCInteraction
         Assert.AreSame(holder[0], WithFrozenObjects.s_someStringLiteral);
         Assert.AreSame(holder[1], WithFrozenObjects.s_someObject);
 
-        // This will try to make a dependent handle for the frozen object
-        lock (WithFrozenObjects.s_someObject)
-        {
-            Console.WriteLine("Now under lock");
-        }
+        h1.Dispose();
+        h2.Dispose();
     }
 }
 


### PR DESCRIPTION
Force GC to see the frozen objects. This should hit both paths that were problematic this week.

The `readonly static` fields are converted to frozen objects (the string literal would be frozen either way, but adding both string and object in case we change our mind on how string literals are done).

Cc @dotnet/gc 