### PR TITLE
Extract SuperPMI into a separate component

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -58,7 +58,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.spmi</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
@@ -112,6 +112,7 @@
     <SubsetName Include="Clr.Hosts" Description="The CoreCLR corerun test host." />
     <SubsetName Include="Clr.Jit" Description="The JIT for the CoreCLR .NET runtime." />
     <SubsetName Include="Clr.AllJits" Description="All of the cross-targeting JIT compilers for the CoreCLR .NET runtime." />
+    <SubsetName Include="Clr.Spmi" Description="SuperPMI, a tool for CoreCLR JIT testing." />
     <SubsetName Include="Clr.CoreLib" Description="The managed System.Private.CoreLib library for CoreCLR." />
     <SubsetName Include="Clr.NativeCoreLib" Description="Run crossgen on System.Private.CoreLib library for CoreCLR." />
     <SubsetName Include="Clr.Tools" Description="Managed tools that support CoreCLR development and testing." />
@@ -204,6 +205,10 @@
 
   <PropertyGroup Condition="$(_subset.Contains('+clr.nativeaotlibs+')) and '$(NativeAotSupported)' == 'true'">
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrNativeAotSubset=true</ClrRuntimeBuildSubsets>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(_subset.Contains('+clr.spmi+'))">
+    <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrSpmiSubset=true</ClrRuntimeBuildSubsets>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.nativeprereqs+'))">

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -107,10 +107,10 @@ jobs:
 
     # Build CoreCLR JIT
     - ${{ if ne(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) -ci $(compilerArg) -component alljits
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) -ci $(compilerArg) -component alljits -component spmi
         displayName: Build CoreCLR JIT
     - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -component alljits
+      - script: set __TestIntermediateDir=int&&$(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci -component alljits -component spmi
         displayName: Build CoreCLR JIT
 
     - ${{ if eq(parameters.uploadAs, 'azureBlob') }}:

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -132,10 +132,10 @@ jobs:
       value: ''
     - ${{ if ne(parameters.testGroup, 'innerloop') }}:
       - name: clrRuntimeComponentsBuildArg
-        value: '-component runtime -component alljits -component paltests -component nativeaot '
+        value: '-component runtime -component alljits -component paltests -component nativeaot -component spmi '
     - ${{ if and(eq(parameters.osGroup, 'Linux'), eq(parameters.archType, 'x86')) }}:
       - name: clrRuntimeComponentsBuildArg
-        value: '-component runtime -component jit -component iltools '
+        value: '-component runtime -component jit -component iltools -component spmi '
 
     - name: pgoInstrumentArg
       value: ''

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -345,6 +345,9 @@ for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
     if not "!string:-nativeaot-=!"=="!string!" (
         set __CMakeTarget=!__CMakeTarget! nativeaot
     )
+    if not "!string:-spmi-=!"=="!string!" (
+        set __CMakeTarget=!__CMakeTarget! spmi
+    )
 )
 if [!__CMakeTarget!] == [] (
     set __CMakeTarget=install
@@ -745,7 +748,7 @@ echo -all: Builds all configurations and platforms.
 echo Build architecture: one of -x64, -x86, -arm, -arm64 ^(default: -x64^).
 echo Build type: one of -Debug, -Checked, -Release ^(default: -Debug^).
 echo -component ^<name^> : specify this option one or more times to limit components built to those specified.
-echo                     Allowed ^<name^>: hosts jit alljits runtime paltests iltools
+echo                     Allowed ^<name^>: hosts jit alljits runtime paltests iltools nativeaot spmi
 echo -enforcepgo: verify after the build that PGO was used for key DLLs, and fail the build if not
 echo -pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.
 echo -cmakeargs: user-settable additional arguments passed to CMake.

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -22,7 +22,7 @@ usage_list+=("-pgodatapath: path to profile guided optimization data.")
 usage_list+=("-pgoinstrument: generate instrumented code for profile guided optimization enabled binaries.")
 usage_list+=("-skipcrossarchnative: Skip building cross-architecture native binaries.")
 usage_list+=("-staticanalyzer: use scan_build static analyzer.")
-usage_list+=("-component: Build individual components instead of the full project. Available options are 'hosts', 'jit', 'runtime', 'paltests', 'alljits', 'iltools', and 'nativeaot'. Can be specified multiple times.")
+usage_list+=("-component: Build individual components instead of the full project. Available options are 'hosts', 'jit', 'runtime', 'paltests', 'alljits', 'iltools', 'nativeaot', and 'spmi'. Can be specified multiple times.")
 
 setup_dirs_local()
 {

--- a/src/coreclr/components.cmake
+++ b/src/coreclr/components.cmake
@@ -6,6 +6,7 @@ add_component(runtime)
 add_component(paltests paltests_install)
 add_component(iltools)
 add_component(nativeaot)
+add_component(spmi)
 
 # Define coreclr_all as the fallback component and make every component depend on this component.
 # iltools and paltests should be minimal subsets, so don't add a dependency on coreclr_misc

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -48,6 +48,7 @@
       <_CoreClrBuildArg Condition="'$(ClrAllJitsSubset)' == 'true'" Include="-component alljits" />
       <_CoreClrBuildArg Condition="'$(ClrILToolsSubset)' == 'true'" Include="-component iltools" />
       <_CoreClrBuildArg Condition="'$(ClrNativeAotSubset)' == 'true'" Include="-component nativeaot" />
+      <_CoreClrBuildArg Condition="'$(ClrSpmiSubset)' == 'true'" Include="-component spmi" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/coreclr/tools/superpmi/mcs/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/mcs/CMakeLists.txt
@@ -68,4 +68,4 @@ else()
 
 endif(CLR_CMAKE_HOST_UNIX)
 
-install_clr(TARGETS mcs DESTINATIONS .)
+install_clr(TARGETS mcs DESTINATIONS . COMPONENT spmi)

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/CMakeLists.txt
@@ -61,4 +61,4 @@ else()
     )
 endif(CLR_CMAKE_HOST_UNIX)
 
-install_clr(TARGETS superpmi-shim-collector DESTINATIONS .)
+install_clr(TARGETS superpmi-shim-collector DESTINATIONS . COMPONENT spmi)

--- a/src/coreclr/tools/superpmi/superpmi-shim-counter/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-counter/CMakeLists.txt
@@ -63,4 +63,4 @@ else()
     )
 endif(CLR_CMAKE_HOST_UNIX)
 
-install_clr(TARGETS superpmi-shim-counter DESTINATIONS .)
+install_clr(TARGETS superpmi-shim-counter DESTINATIONS . COMPONENT spmi)

--- a/src/coreclr/tools/superpmi/superpmi-shim-simple/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi-shim-simple/CMakeLists.txt
@@ -62,4 +62,4 @@ else()
     )
 endif(CLR_CMAKE_HOST_UNIX)
 
-install_clr(TARGETS superpmi-shim-simple DESTINATIONS .)
+install_clr(TARGETS superpmi-shim-simple DESTINATIONS . COMPONENT spmi)

--- a/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/tools/superpmi/superpmi/CMakeLists.txt
@@ -64,4 +64,4 @@ else()
     )
 endif(CLR_CMAKE_HOST_UNIX)
 
-install_clr(TARGETS superpmi DESTINATIONS .)
+install_clr(TARGETS superpmi DESTINATIONS . COMPONENT spmi)


### PR DESCRIPTION
Allows building the runtime without SPMI.

`build.cmd clr` will still build SPMI.
`build.cmd clr.native` will still build SPMI.
`build.cmd clr.runtime` will no longer build SPMI.

This is mostly motivated by NativeAOT subset builds where SPMI contributes to 10% of the native build time (nativeaot CorecLR subset builds pretty quickly compared to full CoreCLR).

Cc @dotnet/jit-contrib 