### PR TITLE
Ignoring leading dot when comparing cookie domains

### DIFF
--- a/src/libraries/Common/src/System/Net/CookieComparer.cs
+++ b/src/libraries/Common/src/System/Net/CookieComparer.cs
@@ -14,7 +14,7 @@ namespace System.Net
                 return result;
             }
 
-            if ((result = string.Compare(left.Domain, right.Domain, StringComparison.OrdinalIgnoreCase)) != 0)
+            if ((result = Cookie.CompareDomain(left.Domain, right.Domain)) != 0)
             {
                 return result;
             }

--- a/src/libraries/Common/src/System/Net/CookieComparer.cs
+++ b/src/libraries/Common/src/System/Net/CookieComparer.cs
@@ -12,7 +12,7 @@ namespace System.Net
                 return false;
             }
 
-            if (!EqualsDomain(left.Domain, right.Domain))
+            if (!EqualDomains(left.Domain, right.Domain))
             {
                 return false;
             }
@@ -22,7 +22,7 @@ namespace System.Net
             return string.Equals(left.Path, right.Path, StringComparison.Ordinal);
         }
 
-        internal static bool EqualsDomain(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+        internal static bool EqualDomains(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
         {
             if (left.Length != 0 && left[0] == '.') left = left.Slice(1);
             if (right.Length != 0 && right[0] == '.') right = right.Slice(1);

--- a/src/libraries/Common/src/System/Net/CookieComparer.cs
+++ b/src/libraries/Common/src/System/Net/CookieComparer.cs
@@ -22,25 +22,12 @@ namespace System.Net
             return string.Equals(left.Path, right.Path, StringComparison.Ordinal);
         }
 
-        internal static bool EqualsDomain(string left, string right)
+        internal static bool EqualsDomain(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
         {
-            if (left.Length == 0)
-            {
-                return right.Length == 0;
-            }
+            if (left.StartsWith(".")) left = left.Slice(1);
+            if (right.StartsWith(".")) right = right.Slice(1);
 
-            int indexLeft = GetComparisonStartIndex(left);
-            int indexRight = GetComparisonStartIndex(right);
-
-            if (left.Length - indexLeft != right.Length - indexRight)
-            {
-                return false;
-            }
-
-            return string.Equals(left.Substring(indexLeft), right.Substring(indexRight), StringComparison.OrdinalIgnoreCase);
+            return left.Equals(right, StringComparison.OrdinalIgnoreCase);
         }
-
-        private static int GetComparisonStartIndex(string domain)
-            => domain.Length != 0 && domain[0] == '.' ? 1 : 0;
     }
 }

--- a/src/libraries/Common/src/System/Net/CookieComparer.cs
+++ b/src/libraries/Common/src/System/Net/CookieComparer.cs
@@ -24,8 +24,8 @@ namespace System.Net
 
         internal static bool EqualsDomain(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
         {
-            if (left.StartsWith(".")) left = left.Slice(1);
-            if (right.StartsWith(".")) right = right.Slice(1);
+            if (left.Length != 0 && left[0] == '.') left = left.Slice(1);
+            if (right.Length != 0 && right[0] == '.') right = right.Slice(1);
 
             return left.Equals(right, StringComparison.OrdinalIgnoreCase);
         }

--- a/src/libraries/Common/src/System/Net/CookieComparer.cs
+++ b/src/libraries/Common/src/System/Net/CookieComparer.cs
@@ -5,23 +5,42 @@ namespace System.Net
 {
     internal static class CookieComparer
     {
-        internal static int Compare(Cookie left, Cookie right)
+        internal static bool Equals(Cookie left, Cookie right)
         {
-            int result;
-
-            if ((result = string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase)) != 0)
+            if (!string.Equals(left.Name, right.Name, StringComparison.OrdinalIgnoreCase))
             {
-                return result;
+                return false;
             }
 
-            if ((result = Cookie.CompareDomain(left.Domain, right.Domain)) != 0)
+            if (!EqualsDomain(left.Domain, right.Domain))
             {
-                return result;
+                return false;
             }
 
             // NB: Only the path is case sensitive as per spec. However, many Windows applications assume
             //     case-insensitivity.
-            return string.Compare(left.Path, right.Path, StringComparison.Ordinal);
+            return string.Equals(left.Path, right.Path, StringComparison.Ordinal);
         }
+
+        internal static bool EqualsDomain(string left, string right)
+        {
+            if (left.Length == 0)
+            {
+                return right.Length == 0;
+            }
+
+            int indexLeft = GetComparisonStartIndex(left);
+            int indexRight = GetComparisonStartIndex(right);
+
+            if (left.Length - indexLeft != right.Length - indexRight)
+            {
+                return false;
+            }
+
+            return string.Equals(left.Substring(indexLeft), right.Substring(indexRight), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int GetComparisonStartIndex(string domain)
+            => domain.Length != 0 && domain[0] == '.' ? 1 : 0;
     }
 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -717,7 +717,7 @@ namespace System.Net
                     && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(Value, other.Value, StringComparison.Ordinal)
                     && string.Equals(Path, other.Path, StringComparison.Ordinal)
-                    && CookieComparer.EqualsDomain(Domain, other.Domain)
+                    && CookieComparer.EqualDomains(Domain, other.Domain)
                     && (Version == other.Version);
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -307,34 +307,6 @@ namespace System.Net
                    (string.Compare(host, 0, domain, 1, host.Length, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
-        internal static int CompareDomain(string? left, string? right)
-        {
-            if (left is null)
-            {
-                return right is null ? 0 : -1;
-            }
-
-            if (right is null)
-            {
-                return 1;
-            }
-
-            int indexLeft = GetComparisonStartIndex(left);
-            int indexRight = GetComparisonStartIndex(right);
-
-            int result;
-
-            if ((result = (left.Length - indexLeft).CompareTo(right.Length - indexRight)) != 0)
-            {
-                return result;
-            }
-
-            return string.Compare(left, indexLeft, right, indexRight, left.Length - indexLeft, StringComparison.OrdinalIgnoreCase);
-        }
-
-        private static int GetComparisonStartIndex(string domain)
-            => domain.Length != 0 && domain[0] == '.' ? 1 : 0;
-
         // According to spec we must assume default values for attributes but still
         // keep in mind that we must not include them into the requests.
         // We also check the validity of all attributes based on the version and variant (read RFC)
@@ -745,7 +717,7 @@ namespace System.Net
                     && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(Value, other.Value, StringComparison.Ordinal)
                     && string.Equals(Path, other.Path, StringComparison.Ordinal)
-                    && CompareDomain(Domain, other.Domain) == 0
+                    && CookieComparer.EqualsDomain(Domain, other.Domain)
                     && (Version == other.Version);
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -307,6 +307,34 @@ namespace System.Net
                    (string.Compare(host, 0, domain, 1, host.Length, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
+        internal static int CompareDomain(string? left, string? right)
+        {
+            if (left is null)
+            {
+                return right is null ? 0 : -1;
+            }
+
+            if (right is null)
+            {
+                return 1;
+            }
+
+            int indexLeft = GetComparisonStartIndex(left);
+            int indexRight = GetComparisonStartIndex(right);
+
+            int result;
+
+            if ((result = (left.Length - indexLeft).CompareTo(right.Length - indexRight)) != 0)
+            {
+                return result;
+            }
+
+            return string.Compare(left, indexLeft, right, indexRight, left.Length - indexLeft, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int GetComparisonStartIndex(string domain)
+            => domain.Length != 0 && domain[0] == '.' ? 1 : 0;
+
         // According to spec we must assume default values for attributes but still
         // keep in mind that we must not include them into the requests.
         // We also check the validity of all attributes based on the version and variant (read RFC)
@@ -717,7 +745,7 @@ namespace System.Net
                     && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(Value, other.Value, StringComparison.Ordinal)
                     && string.Equals(Path, other.Path, StringComparison.Ordinal)
-                    && string.Equals(Domain, other.Domain, StringComparison.OrdinalIgnoreCase)
+                    && CompareDomain(Domain, other.Domain) == 0
                     && (Version == other.Version);
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -203,7 +203,7 @@ namespace System.Net
                 for (int i = 0; i < listCount; i++)
                 {
                     Cookie c = (Cookie)m_list[i]!;
-                    if (CookieComparer.Compare(cookie, c) == 0)
+                    if (CookieComparer.Equals(cookie, c))
                     {
                         ret = 0; // Will replace or reject
 
@@ -237,7 +237,7 @@ namespace System.Net
             int idx = 0;
             foreach (Cookie? c in m_list)
             {
-                if (CookieComparer.Compare(cookie, c!) == 0)
+                if (CookieComparer.Equals(cookie, c!))
                 {
                     return idx;
                 }

--- a/src/libraries/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/UnitTests/CookieContainerTest.cs
@@ -866,6 +866,25 @@ namespace System.Net.Primitives.Unit.Tests
             Assert.Throws<CookieException>(() => container.SetCookies(uri, cookie));
         }
 
+        [Fact]
+        public void SetCookies_DomainCheckSuccess_IgnoresLeadingDot()
+        {
+            var domain = "example.com";
+            var domainWithLeadingDot = '.' + domain;
+            var uri = new Uri($"https://{domain}/", UriKind.Absolute);
+            var container = new CookieContainer();
+
+            // First HTTP response...
+            container.SetCookies(uri, $"foo=bar; Path=/; Domain={domain}");
+
+            // Second HTTP response...
+            container.SetCookies(uri, $"foo=baz; Path=/; Domain={domainWithLeadingDot}");
+
+            CookieCollection acceptedCookies = container.GetCookies(uri);
+            Assert.Equal(1, acceptedCookies.Count);
+            Assert.Equal(domainWithLeadingDot, acceptedCookies[0].Domain);
+        }
+
         // Test default-path calculation as defined in
         // https://tools.ietf.org/html/rfc6265#section-5.1.4
         public static readonly TheoryData<string, string> DefaultPathData = new TheoryData<string, string>()


### PR DESCRIPTION
Fixes #60628 

Domains in cookie should be considered as equal disregarding the leading dot. The leading dots there in `Cookie` class neither added nor removed intentionally. It is trade-off because there is a contradiction between RFC 6265 and browsers' behavior.