### PR TITLE
Do not hoist constants if they will not be CSEed

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7395,6 +7395,8 @@ protected:
 
     bool optIsCSEcandidate(GenTree* tree);
 
+    bool optIsIntegralConstCSEcandidate(GenTreeIntConCommon* tree);
+
     // lclNumIsTrueCSE returns true if the LclVar was introduced by the CSE phase of the compiler
     //
     bool lclNumIsTrueCSE(unsigned lclNum) const

--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -74,7 +74,7 @@
 #else // !UNIX_AMD64_ABI
   #define ETW_EBP_FRAMED           0       // if 1 we cannot use EBP as a scratch register and must create EBP based frames for most methods
 #endif // !UNIX_AMD64_ABI
-  #define CSE_CONSTS               1       // Enable if we want to CSE constants
+  #define CSE_INTEGRAL_CONSTS      0       // Do we *want* to CSE integral constants?
 
   #define RBM_ALLFLOAT            (RBM_XMM0 | RBM_XMM1 | RBM_XMM2 | RBM_XMM3 | RBM_XMM4 | RBM_XMM5 | RBM_XMM6 | RBM_XMM7 | RBM_XMM8 | RBM_XMM9 | RBM_XMM10 | RBM_XMM11 | RBM_XMM12 | RBM_XMM13 | RBM_XMM14 | RBM_XMM15)
   #define RBM_ALLDOUBLE            RBM_ALLFLOAT

--- a/src/coreclr/jit/targetarm.h
+++ b/src/coreclr/jit/targetarm.h
@@ -44,7 +44,7 @@
   #define FEATURE_EH               1       // To aid platform bring-up, eliminate exceptional EH clauses (catch, filter, filter-handler, fault) and directly execute 'finally' clauses.
   #define FEATURE_EH_CALLFINALLY_THUNKS 0  // Generate call-to-finally code in "thunks" in the enclosing EH region, protected by "cloned finally" clauses.
   #define ETW_EBP_FRAMED           1       // if 1 we cannot use REG_FP as a scratch register and must setup the frame pointer for most methods
-  #define CSE_CONSTS               1       // Enable if we want to CSE constants
+  #define CSE_INTEGRAL_CONSTS      0       // Do we *want* to CSE integral constants?
 
   #define REG_FP_FIRST             REG_F0
   #define REG_FP_LAST              REG_F31

--- a/src/coreclr/jit/targetarm64.h
+++ b/src/coreclr/jit/targetarm64.h
@@ -49,7 +49,7 @@
   #define FEATURE_EH               1       // To aid platform bring-up, eliminate exceptional EH clauses (catch, filter, filter-handler, fault) and directly execute 'finally' clauses.
   #define FEATURE_EH_CALLFINALLY_THUNKS 1  // Generate call-to-finally code in "thunks" in the enclosing EH region, protected by "cloned finally" clauses.
   #define ETW_EBP_FRAMED           1       // if 1 we cannot use REG_FP as a scratch register and must setup the frame pointer for most methods
-  #define CSE_CONSTS               1       // Enable if we want to CSE constants
+  #define CSE_INTEGRAL_CONSTS      1       // Do we *want* to CSE integral constants?
 
   #define REG_FP_FIRST             REG_V0
   #define REG_FP_LAST              REG_V31

--- a/src/coreclr/jit/targetx86.h
+++ b/src/coreclr/jit/targetx86.h
@@ -61,7 +61,7 @@
                                            // protected by "cloned finally" clauses.
   #define ETW_EBP_FRAMED           1       // if 1 we cannot use EBP as a scratch register and must create EBP based
                                            // frames for most methods
-  #define CSE_CONSTS               1       // Enable if we want to CSE constants
+  #define CSE_INTEGRAL_CONSTS      0       // Do we *want* to CSE integral constants?
 
   // The following defines are useful for iterating a regNumber
   #define REG_FIRST                REG_EAX


### PR DESCRIPTION
We can sometimes see cases where hoisting decides to hoist a constant on platforms where CSEing for them is disabled, leading to wasted work.

Fix this by folding the relevant checks into `optIsCSEcandidate` that the hoisting code uses.

Diffs are mixed... it seems we sometimes get better allocation and better flow with the pre-header, even if we don't get anything out of the hoist itself.