### PR TITLE
Disable DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsException

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -264,6 +264,7 @@ namespace System.IO.Tests
             });
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64019")]
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsException()


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/64019