### PR TITLE
Revert "Temporarily disable coredumps during library testing on macOS (#63742)"

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -132,8 +132,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   # files already in /cores/ at this point. This is being done to prevent
   # inadvertently flooding the CI machines with dumps.
   if [[ ! -d "/cores" || ! "$(ls -A /cores)" ]]; then
-    # FIXME: temporarily disable core dumps
-    ulimit -c 0
+    ulimit -c unlimited
   fi
 
 elif [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
This reverts commit 2c28e63f9360280011a3b03c1ca6dc0edce1fae4.

Fixes #63761