### PR TITLE
Performance: Fix Browser Wasm job not being found for dependent jobs

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -148,390 +148,390 @@ jobs:
           archiveType: zip
           archiveExtension: .zip
 
-  ## build mono for AOT
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: AOT
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: AOT Mono Artifacts
-  #        artifactName: LinuxMonoAOTx64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono for AOT
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AOT
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: AOT Mono Artifacts
+          artifactName: LinuxMonoAOTx64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  ## build mono Android scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Android_arm64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: AndroidMono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: Android Mono Artifacts
-  #        artifactName: AndroidMonoarm64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono Android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AndroidMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: Android Mono Artifacts
+          artifactName: AndroidMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
     
-  ## build mono iOS scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - iOS_arm64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: iOSMono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: iOS Mono Artifacts
-  #        artifactName: iOSMonoarm64
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build mono iOS scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - iOS_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: iOSMono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: iOS Mono Artifacts
+          artifactName: iOSMonoarm64
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz
 
-  ## build mono
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-  #    runtimeFlavor: mono
-  #    buildConfig: release
-  #    platforms:
-  #    - Linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - Linux_x64
 
-  ## run mono and maui android scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: AndroidMono
-  #      projectFile: android_scenarios.proj
-  #      runKind: android_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
+  # run mono and maui android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: AndroidMono
+        projectFile: android_scenarios.proj
+        runKind: android_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
 
-  ## run mono iOS scenarios and maui iOS scenarios
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: iOSMono
-  #      projectFile: ios_scenarios.proj
-  #      runKind: ios_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
-  #      iosLlvmBuild: False
+  # run mono iOS scenarios and maui iOS scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
+        iosLlvmBuild: False
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #      - Windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      runtimeType: iOSMono
-  #      projectFile: ios_scenarios.proj
-  #      runKind: ios_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perfpixel4a'
-  #      iosLlvmBuild: True
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - Windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: iOSMono
+        projectFile: ios_scenarios.proj
+        runKind: ios_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
+        iosLlvmBuild: True
 
-  ## run mono microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono interpreter perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      codeGenType: 'Interpreter'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono wasm interpreter (default) microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildConfig: release
-  #    runtimeFlavor: wasm
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: wasm
-  #      codeGenType: 'wasm'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      javascriptEngine: 'v8'
+  # run mono wasm interpreter (default) microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        codeGenType: 'wasm'
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-  ##run mono wasm aot microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildconfig: release
-  #    runtimeflavor: wasm
-  #    platforms:
-  #    - linux_x64
-  #    jobparameters:
-  #      testgroup: perf
-  #      livelibrariesbuildconfig: Release
-  #      runtimetype: wasm
-  #      codegentype: 'aot'
-  #      projectfile: microbenchmarks.proj
-  #      runkind: micro
-  #      runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      javascriptEngine: 'v8'
+  #run mono wasm aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildconfig: release
+      runtimeflavor: wasm
+      platforms:
+      - linux_x64
+      jobparameters:
+        testgroup: perf
+        livelibrariesbuildconfig: Release
+        runtimetype: wasm
+        codegentype: 'aot'
+        projectfile: microbenchmarks.proj
+        runkind: micro
+        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        javascriptEngine: 'v8'
 
-  ## run mono aot microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #    buildConfig: release
-  #    runtimeFlavor: aot
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: mono
-  #      codeGenType: 'AOT'
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro_mono
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run coreclr perftiger microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    - Linux_musl_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      - Linux_musl_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run coreclr perftiger microbenchmarks pgo perf jobs
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -NoPgo
+  # run coreclr perftiger microbenchmarks pgo perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -NoPgo
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -DynamicPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -DynamicPgo
 
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perftiger'
-  #      pgoRunType: -FullPgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -FullPgo
 
-  ## run coreclr perfowl microbenchmarks perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: microbenchmarks.proj
-  #      runKind: micro
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #      logicalmachine: 'perfowl'
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perfowl'
 
-  ## run coreclr crossgen perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: coreclr
-  #    platforms:
-  #    - Linux_x64
-  #    - windows_x64
-  #    - windows_x86
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      projectFile: crossgen_perf.proj
-  #      runKind: crossgen_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      logicalmachine: 'perftiger'
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - Linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: crossgen_perf.proj
+        runKind: crossgen_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perftiger'
 
-  ## run mono wasm blazor perf job
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: wasm
-  #    platforms:
-  #    - Linux_x64
-  #    jobParameters:
-  #      testGroup: perf
-  #      liveLibrariesBuildConfig: Release
-  #      runtimeType: wasm
-  #      projectFile: blazor_perf.proj
-  #      runKind: blazor_scenarios
-  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #      additionalSetupParameters: '--latestdotnet'
-  #      logicalmachine: 'perftiger'
+  # run mono wasm blazor perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: wasm
+      platforms:
+      - Linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: wasm
+        projectFile: blazor_perf.proj
+        runKind: blazor_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        additionalSetupParameters: '--latestdotnet'
+        logicalmachine: 'perftiger'
 
-  ## build maui workload packs
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - Android_x86
-  #    - Android_x64
-  #    - Android_arm
-  #    - Android_arm64
-  #    - MacCatalyst_x64
-  #    - iOSSimulator_x64
-  #    jobParameters:
-  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #      nameSuffix: Maui_Packs_Mono
-  #      isOfficialBuild: false
-  #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #      extraStepsParameters:
-  #        name: MonoRuntimePacks
+  # build maui workload packs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - Android_x86
+      - Android_x64
+      - Android_arm
+      - Android_arm64
+      - MacCatalyst_x64
+      - iOSSimulator_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: Maui_Packs_Mono
+        isOfficialBuild: false
+        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+        extraStepsParameters:
+          name: MonoRuntimePacks
   
-  ## build maui app
-  #- template: /eng/pipelines/common/platform-matrix.yml
-  #  parameters:
-  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #    buildConfig: release
-  #    runtimeFlavor: mono
-  #    platforms:
-  #    - iOS_arm64
-  #    jobParameters:
-  #      dependsOn:
-  #        - Build_Android_arm_release_Maui_Packs_Mono
-  #        - Build_Android_arm64_release_Maui_Packs_Mono
-  #        - Build_Android_x86_release_Maui_Packs_Mono
-  #        - Build_Android_x64_release_Maui_Packs_Mono
-  #        - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-  #        - Build_iOSSimulator_x64_release_Maui_Packs_Mono
-  #      buildArgs: -s mono -c $(_BuildConfig)
-  #      nameSuffix: MACiOSAndroidMaui
-  #      isOfficialBuild: false
-  #      pool:
-  #        vmImage: 'macos-11'
-  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
-  #      extraStepsParameters:
-  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #        includeRootFolder: true
-  #        displayName: MAC, iOS, and Android Maui Artifacts
-  #        artifactName: MACiOSAndroidMauiArm
-  #        archiveExtension: '.tar.gz'
-  #        archiveType: tar
-  #        tarCompression: gz
+  # build maui app
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - iOS_arm64
+      jobParameters:
+        dependsOn:
+          - Build_Android_arm_release_Maui_Packs_Mono
+          - Build_Android_arm64_release_Maui_Packs_Mono
+          - Build_Android_x86_release_Maui_Packs_Mono
+          - Build_Android_x64_release_Maui_Packs_Mono
+          - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+          - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+        buildArgs: -s mono -c $(_BuildConfig)
+        nameSuffix: MACiOSAndroidMaui
+        isOfficialBuild: false
+        pool:
+          vmImage: 'macos-11'
+        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+        extraStepsParameters:
+          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+          includeRootFolder: true
+          displayName: MAC, iOS, and Android Maui Artifacts
+          artifactName: MACiOSAndroidMauiArm
+          archiveExtension: '.tar.gz'
+          archiveType: tar
+          tarCompression: gz

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -148,390 +148,390 @@ jobs:
           archiveType: zip
           archiveExtension: .zip
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AOT
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: AOT Mono Artifacts
-          artifactName: LinuxMonoAOTx64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono for AOT
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: AOT
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-artifact-step.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: AOT Mono Artifacts
+  #        artifactName: LinuxMonoAOTx64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: Android Mono Artifacts
-          artifactName: AndroidMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono Android scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Android_arm64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: AndroidMono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: Android Mono Artifacts
+  #        artifactName: AndroidMonoarm64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
     
-  # build mono iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: iOSMono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: iOS Mono Artifacts
-          artifactName: iOSMonoarm64
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build mono iOS scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - iOS_arm64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: iOSMono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: iOS Mono Artifacts
+  #        artifactName: iOSMonoarm64
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - Linux_x64
+  ## build mono
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+  #    runtimeFlavor: mono
+  #    buildConfig: release
+  #    platforms:
+  #    - Linux_x64
 
-  # run mono and maui android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
+  ## run mono and maui android scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: AndroidMono
+  #      projectFile: android_scenarios.proj
+  #      runKind: android_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
 
-  # run mono iOS scenarios and maui iOS scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: False
+  ## run mono iOS scenarios and maui iOS scenarios
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: iOSMono
+  #      projectFile: ios_scenarios.proj
+  #      runKind: ios_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
+  #      iosLlvmBuild: False
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - Windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: iOSMono
-        projectFile: ios_scenarios.proj
-        runKind: ios_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
-        iosLlvmBuild: True
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #      - Windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      runtimeType: iOSMono
+  #      projectFile: ios_scenarios.proj
+  #      runKind: ios_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perfpixel4a'
+  #      iosLlvmBuild: True
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono interpreter perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      codeGenType: 'Interpreter'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono wasm interpreter (default) microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        codeGenType: 'wasm'
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+  ## run mono wasm interpreter (default) microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildConfig: release
+  #    runtimeFlavor: wasm
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: wasm
+  #      codeGenType: 'wasm'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      javascriptEngine: 'v8'
 
-  #run mono wasm aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildconfig: release
-      runtimeflavor: wasm
-      platforms:
-      - linux_x64
-      jobparameters:
-        testgroup: perf
-        livelibrariesbuildconfig: Release
-        runtimetype: wasm
-        codegentype: 'aot'
-        projectfile: microbenchmarks.proj
-        runkind: micro
-        runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        javascriptEngine: 'v8'
+  ##run mono wasm aot microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobtemplate: /eng/pipelines/coreclr/templates/perf-job.yml # note: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildconfig: release
+  #    runtimeflavor: wasm
+  #    platforms:
+  #    - linux_x64
+  #    jobparameters:
+  #      testgroup: perf
+  #      livelibrariesbuildconfig: Release
+  #      runtimetype: wasm
+  #      codegentype: 'aot'
+  #      projectfile: microbenchmarks.proj
+  #      runkind: micro
+  #      runjobtemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      javascriptEngine: 'v8'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run mono aot microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #    buildConfig: release
+  #    runtimeFlavor: aot
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: mono
+  #      codeGenType: 'AOT'
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro_mono
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      - Linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  ## run coreclr perftiger microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    - Linux_musl_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoPgo
+  ## run coreclr perftiger microbenchmarks pgo perf jobs
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -NoPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -DynamicPgo
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -DynamicPgo
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -FullPgo
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perftiger'
+  #      pgoRunType: -FullPgo
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+  ## run coreclr perfowl microbenchmarks perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: microbenchmarks.proj
+  #      runKind: micro
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #      logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - Linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger'
+  ## run coreclr crossgen perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: coreclr
+  #    platforms:
+  #    - Linux_x64
+  #    - windows_x64
+  #    - windows_x86
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      projectFile: crossgen_perf.proj
+  #      runKind: crossgen_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      logicalmachine: 'perftiger'
 
-  # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - Linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: blazor_perf.proj
-        runKind: blazor_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        additionalSetupParameters: '--latestdotnet'
-        logicalmachine: 'perftiger'
+  ## run mono wasm blazor perf job
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: wasm
+  #    platforms:
+  #    - Linux_x64
+  #    jobParameters:
+  #      testGroup: perf
+  #      liveLibrariesBuildConfig: Release
+  #      runtimeType: wasm
+  #      projectFile: blazor_perf.proj
+  #      runKind: blazor_scenarios
+  #      runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #      additionalSetupParameters: '--latestdotnet'
+  #      logicalmachine: 'perftiger'
 
-  # build maui workload packs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - Android_x86
-      - Android_x64
-      - Android_arm
-      - Android_arm64
-      - MacCatalyst_x64
-      - iOSSimulator_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: Maui_Packs_Mono
-        isOfficialBuild: false
-        extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-        extraStepsParameters:
-          name: MonoRuntimePacks
+  ## build maui workload packs
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - Android_x86
+  #    - Android_x64
+  #    - Android_arm
+  #    - Android_arm64
+  #    - MacCatalyst_x64
+  #    - iOSSimulator_x64
+  #    jobParameters:
+  #      buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #      nameSuffix: Maui_Packs_Mono
+  #      isOfficialBuild: false
+  #      extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+  #      extraStepsParameters:
+  #        name: MonoRuntimePacks
   
-  # build maui app
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - iOS_arm64
-      jobParameters:
-        dependsOn:
-          - Build_Android_arm_release_Maui_Packs_Mono
-          - Build_Android_arm64_release_Maui_Packs_Mono
-          - Build_Android_x86_release_Maui_Packs_Mono
-          - Build_Android_x64_release_Maui_Packs_Mono
-          - Build_MacCatalyst_x64_release_Maui_Packs_Mono
-          - Build_iOSSimulator_x64_release_Maui_Packs_Mono
-        buildArgs: -s mono -c $(_BuildConfig)
-        nameSuffix: MACiOSAndroidMaui
-        isOfficialBuild: false
-        pool:
-          vmImage: 'macos-11'
-        extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
-        extraStepsParameters:
-          rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-          includeRootFolder: true
-          displayName: MAC, iOS, and Android Maui Artifacts
-          artifactName: MACiOSAndroidMauiArm
-          archiveExtension: '.tar.gz'
-          archiveType: tar
-          tarCompression: gz
+  ## build maui app
+  #- template: /eng/pipelines/common/platform-matrix.yml
+  #  parameters:
+  #    jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #    buildConfig: release
+  #    runtimeFlavor: mono
+  #    platforms:
+  #    - iOS_arm64
+  #    jobParameters:
+  #      dependsOn:
+  #        - Build_Android_arm_release_Maui_Packs_Mono
+  #        - Build_Android_arm64_release_Maui_Packs_Mono
+  #        - Build_Android_x86_release_Maui_Packs_Mono
+  #        - Build_Android_x64_release_Maui_Packs_Mono
+  #        - Build_MacCatalyst_x64_release_Maui_Packs_Mono
+  #        - Build_iOSSimulator_x64_release_Maui_Packs_Mono
+  #      buildArgs: -s mono -c $(_BuildConfig)
+  #      nameSuffix: MACiOSAndroidMaui
+  #      isOfficialBuild: false
+  #      pool:
+  #        vmImage: 'macos-11'
+  #      extraStepsTemplate: /eng/pipelines/coreclr/templates/build-perf-maui-apps.yml
+  #      extraStepsParameters:
+  #        rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #        includeRootFolder: true
+  #        displayName: MAC, iOS, and Android Maui Artifacts
+  #        artifactName: MACiOSAndroidMauiArm
+  #        archiveExtension: '.tar.gz'
+  #        archiveType: tar
+  #        tarCompression: gz

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -57,7 +57,7 @@ jobs:
     - ${{ if and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')) }}:
       - ${{ format('mono_{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
     - ${{ if eq(parameters.runtimeType, 'wasm')}}:
-      - ${{ format('build_{0}{1}_{2}_{3}_{4}', 'Browser', '', 'wasm', parameters.buildConfig, parameters.runtimeType) }}
+      - ${{ format('build_{0}{1}_{2}_{3}_{4}_{5}', 'Browser', '', 'wasm', 'Linux', parameters.buildConfig, parameters.runtimeType) }}
     - ${{ if and(eq(parameters.codeGenType, 'AOT'), ne(parameters.runtimeType, 'wasm'))}}:
       - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.codeGenType) }}
     - ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:


### PR DESCRIPTION
Performance runtime performance pipeline is failing because the browser wasm job name changed without the dependson parameter for dependent jobs was updated. This brings the rename to the where the dependson parameter is set.

Comparison with the breaking change:
https://github.com/dotnet/runtime/compare/6f8d8b20..a618086f#diff-724222d1e4fee270f9528b05a761ae1973370747771423cdf62c8271b67f749cR39-R44