### PR TITLE
Add StringSyntax attribute to Regex.pattern field

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -22,6 +22,7 @@ namespace System.Text.RegularExpressions
     {
         internal const int MaxOptionShift = 11;
 
+        [StringSyntax(StringSyntaxAttribute.Regex)]
         protected internal string? pattern;                   // The string pattern provided
         protected internal RegexOptions roptions;             // the top-level options from the options string
         protected internal RegexRunnerFactory? factory;       // Factory used to create runner instances for executing the regex


### PR DESCRIPTION
I missed adding this one in my initial audit.  It'll be exceedingly rare for a developer to manually write code that assigns a string to this protected field, but every source-generated regex does so, and thus any colorization VS provides will benefit looking at the source-generated code.