### PR TITLE
Enable some browser legs on the extra-platforms pipeline

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -141,7 +141,7 @@ jobs:
           df -h
         displayName: Disk Usage before Build
 
-    - ${{ if contains(parameters.nameSuffix, 'Windows_wasm') }}:
+    - ${{ if eq(parameters.platform, 'Browser_wasm_win') }}:
       # Update machine certs
       - task: PowerShell@2
         displayName: Update machine certs

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -21,6 +21,7 @@ jobs:
     archType: ${{ parameters.archType }}
     container: ${{ parameters.container }}
     pool: ${{ parameters.pool }}
+    platform: ${{ parameters.platform }}
     shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths}}
     runtimeFlavorDisplayName: ${{ parameters.runtimeFlavorDisplayName }}

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -21,6 +21,7 @@ jobs:
     archType: ${{ parameters.archType }}
     container: ${{ parameters.container }}
     pool: ${{ parameters.pool }}
+    platform: ${{ parameters.platform }}
     shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths}}
     runtimeFlavorDisplayName: ${{ parameters.runtimeFlavorDisplayName }}

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -568,8 +568,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_wasmdebuggertests.containsChange'], true),
-          eq(variables['isManualOrIsNotPR'], true),
-          eq(variables['isFullMatrix'], true))
+          eq(variables['isRollingBuild'], true))
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:

--- a/eng/pipelines/runtime-extra-platforms.yml
+++ b/eng/pipelines/runtime-extra-platforms.yml
@@ -130,8 +130,7 @@ jobs:
     platforms:
     # BuildWasmApps should only happen on the extra platforms build as we already have coverage for this build on PRs.
     - Browser_wasm
-    # disable until https://github.com/dotnet/runtime/issues/63987 is fixed
-    # - Browser_wasm_win
+    - Browser_wasm_win
     variables:
       # map dependencies variables to local variables
       - name: wasmbuildtestsContainsChange
@@ -169,8 +168,7 @@ jobs:
     buildConfig: release
     runtimeFlavor: mono
     platforms:
-    # disable until https://github.com/dotnet/runtime/issues/63987 is fixed
-    # - Browser_wasm_win
+    - Browser_wasm_win
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -257,8 +255,7 @@ jobs:
     runtimeFlavor: mono
     platforms:
     - Browser_wasm
-    # disable until https://github.com/dotnet/runtime/issues/63987 is fixed
-    # - Browser_wasm_win
+    - Browser_wasm_win
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -541,8 +538,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_wasmdebuggertests.containsChange'], true),
-          eq(variables['isManualOrIsNotPR'], true),
-          eq(variables['isFullMatrix'], true))
+          eq(variables['isRollingBuild'], true))
       # extra steps, run tests
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:
@@ -559,8 +555,7 @@ jobs:
     buildConfig: Release
     runtimeFlavor: mono
     platforms:
-    # disable until https://github.com/dotnet/runtime/issues/63987 is fixed
-    # - Browser_wasm_win
+    - Browser_wasm_win
     variables:
       # map dependencies variables to local variables
       - name: wasmdebuggertestsContainsChange


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/63987

The condition for the debugger tests was wrong so it is not running on Rolling.

Change the condition to install the windows certs to be based on platform rather than name suffix, that way it makes it more resilient for future additions and to be able to share the same template reference for windows and non windows if needed to add this platform to an existing template reference scenario.