### PR TITLE
Throw during renegotiation if there is incomplete received TLS frame

### DIFF
--- a/src/libraries/Common/tests/System/Net/ManualChunkingStream.cs
+++ b/src/libraries/Common/tests/System/Net/ManualChunkingStream.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Test.Common
+{
+    // Wrapper stream to manually chop writes. This can be useful for simulating partial network transfers
+    public class ManualChunkingStream : Stream
+    {
+        private readonly Stream _innerStream;
+        private readonly StreamBuffer _writeBuffer = new StreamBuffer();
+        private bool _chunkWrite;
+
+        public ManualChunkingStream(Stream stream, bool chunkWrite)
+        {
+            _innerStream = stream;
+            _chunkWrite = chunkWrite;
+        }
+
+        public int PendingWriteLength => _writeBuffer.ReadBytesAvailable;
+
+        public async ValueTask CommitWriteAsync(int length)
+        {
+            Debug.Assert(length <= PendingWriteLength && length > 0, "length <= PendingWriteLength && length > 0");
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
+
+            int read = await _writeBuffer.ReadAsync(buffer.AsMemory(0, length));
+            Debug.Assert(read == length, "read == length");
+            await _innerStream.WriteAsync(buffer, 0, read);
+            await _innerStream.FlushAsync();
+
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        public void SetWriteChunking(bool chunking)
+        {
+            _chunkWrite = chunking;
+            if (!_chunkWrite && PendingWriteLength > 0)
+            {
+                // flush pending writes
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(PendingWriteLength);
+
+                int read = _writeBuffer.Read(buffer.AsSpan(0, PendingWriteLength));
+                Debug.Assert(PendingWriteLength == 0, "PendingWriteLength == 0");
+                _innerStream.Write(buffer, 0, read);
+                _innerStream.Flush();
+
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        public override bool CanSeek => _innerStream.CanSeek;
+
+        public override bool CanRead => _innerStream.CanRead;
+
+        public override bool CanTimeout => _innerStream.CanTimeout;
+
+        public override bool CanWrite => _innerStream.CanWrite;
+
+        public override long Position
+        {
+            get => _innerStream.Position;
+            set => _innerStream.Position = value;
+        }
+
+        public override void SetLength(long value) => _innerStream.SetLength(value);
+
+        public override long Length => _innerStream.Length;
+
+        public override void Flush() => _innerStream.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => _innerStream.FlushAsync(cancellationToken);
+
+        public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(new Span<byte>(buffer, offset, count));
+
+        public override int Read(Span<byte> buffer) => _innerStream.Read(buffer);
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => ReadAsync(new Memory<byte>(buffer, offset, count)).AsTask();
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => _innerStream.ReadAsync(buffer, cancellationToken);
+
+        public override void Write(byte[] buffer, int offset, int count) => Write(new ReadOnlySpan<byte>(buffer, offset, count));
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            if (_chunkWrite)
+                _writeBuffer.Write(buffer);
+            else
+                _innerStream.Write(buffer);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count)).AsTask();
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => _chunkWrite ? _writeBuffer.WriteAsync(buffer, cancellationToken) : _innerStream.WriteAsync(buffer, cancellationToken);
+    }
+}

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -270,7 +270,7 @@ namespace System.Net.Security
 
             try
             {
-                if (_decryptedBytesCount != 0 || _internalBufferCount != 0)
+                if ((_decryptedBytesCount | _internalBufferCount) != 0)
                 {
                     throw new InvalidOperationException(SR.net_ssl_renegotiate_buffer);
                 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -270,7 +270,7 @@ namespace System.Net.Security
 
             try
             {
-                if (_decryptedBytesCount is not 0)
+                if (_decryptedBytesCount != 0 || _internalBufferCount != 0)
                 {
                     throw new InvalidOperationException(SR.net_ssl_renegotiate_buffer);
                 }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -394,7 +394,7 @@ namespace System.Net.Security.Tests
                 byte[] buffer = new byte[20 * 1024];
 
                 // Send application data instead of Client hello.
-                _ = client.WriteAsync(buffer, cts.Token);
+                await client.WriteAsync(buffer, cts.Token);
                 // Server don't drain all client data (reading 16kB leaves further TLS frames undecrypted)
                 int read = await server.ReadAsync(buffer.AsMemory(0, 16 * 1024), cts.Token);
                 // Fail as it is not allowed to receive non handshake frames during handshake.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -359,16 +359,18 @@ namespace System.Net.Security.Tests
 
         [ConditionalFact(nameof(SupportsRenegotiation))]
         [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
-        public async Task SslStream_NegotiateClientCertificateAsync_ServerDontDrainClientData()
+        public async Task SslStream_NegotiateClientCertificateAsync_IncompleteIncomingTlsFrame_Throws()
         {
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.CancelAfter(TestConfiguration.PassingTestTimeout);
 
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
 
-            // use RandomReadWriteStream in the middle to receive incomplete TLS frames
-            using (SslStream server = new SslStream(new RandomReadWriteSizeStream(serverStream, 4 * 1024)))
-            using (SslStream client = new SslStream(clientStream))
+            // use ManualChunkingStream in the middle to enforce partial TLS frame receive later
+            ManualChunkingStream clientChunkingStream = new ManualChunkingStream(clientStream, false);
+
+            using (SslStream server = new SslStream(serverStream))
+            using (SslStream client = new SslStream(clientChunkingStream))
             {
                 using X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate();
                 using X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate();
@@ -388,31 +390,86 @@ namespace System.Net.Security.Tests
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
                                 client.AuthenticateAsClientAsync(clientOptions, cts.Token),
                                 server.AuthenticateAsServerAsync(serverOptions, cts.Token));
-
                 Assert.Null(server.RemoteCertificate);
 
-                byte[] buffer = new byte[20 * 1024];
+                // manually approve all future writes
+                clientChunkingStream.SetWriteChunking(true);
 
-                // Send application data instead of Client hello.
-                await client.WriteAsync(buffer, cts.Token);
-                // Server don't drain all client data (reading 16kB leaves further TLS frames undecrypted)
-                int read = await server.ReadAsync(buffer.AsMemory(0, 16 * 1024), cts.Token);
-                // Fail as it is not allowed to receive non handshake frames during handshake.
+                // TLS packets are maximum 16 kB, sending 20 kB of data guarantees at least 2 packets to be sent
+                byte[] buffer = new byte[20 * 1024];
+                client.Write(buffer);
+
+                // delay receiving last few B so that only an incomplete TLS frame is received
+                await clientChunkingStream.CommitWriteAsync(clientChunkingStream.PendingWriteLength - 100);
+                int read = await server.ReadAsync(buffer, cts.Token);
+
+                // Fail as there are still some undrained data (incomplete incoming TLS frame)
                 await Assert.ThrowsAsync<InvalidOperationException>(()=>
                     server.NegotiateClientCertificateAsync(cts.Token)
                 );
 
-                // Drain client data.
+                // no more delaying needed, drain client data.
+                clientChunkingStream.SetWriteChunking(false);
                 while (read < buffer.Length)
                 {
                     read += await server.ReadAsync(buffer);
                 }
+
                 // Verify that the session is usable even renego request failed.
                 await TestHelper.PingPong(client, server, cts.Token);
                 await TestHelper.PingPong(server, client, cts.Token);
             }
         }
 
+        [ConditionalFact(nameof(SupportsRenegotiation))]
+        [PlatformSpecific(TestPlatforms.Windows | TestPlatforms.Linux)]
+        public async Task SslStream_NegotiateClientCertificateAsync_PendingDecryptedData_Throws()
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.CancelAfter(TestConfiguration.PassingTestTimeout);
+
+            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
+            using (client)
+            using (server)
+            {
+                using X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate();
+                using X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate();
+
+                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions()
+                {
+                    TargetHost = Guid.NewGuid().ToString("N"),
+                    ClientCertificates = new X509CertificateCollection(new X509Certificate2[] { clientCertificate })
+                };
+                clientOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+
+                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions() { ServerCertificate = serverCertificate };
+                serverOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
+                                client.AuthenticateAsClientAsync(clientOptions, cts.Token),
+                                server.AuthenticateAsServerAsync(serverOptions, cts.Token));
+
+                await TestHelper.PingPong(client, server, cts.Token);
+                Assert.Null(server.RemoteCertificate);
+
+                // This should go out in single TLS frame
+                await client.WriteAsync(new byte[200], cts.Token);
+                byte[] readBuffer = new byte[10];
+                // when we read part of the frame, remaining part should left decrypted
+                int read = await server.ReadAsync(readBuffer, cts.Token);
+
+                await Assert.ThrowsAsync<InvalidOperationException>(() => server.NegotiateClientCertificateAsync(cts.Token));
+
+                while (read < 200)
+                {
+                    read += await server.ReadAsync(readBuffer, cts.Token);
+                }
+
+                // verify that the session is usable with or without client's certificate
+                await TestHelper.PingPong(client, server, cts.Token);
+                await TestHelper.PingPong(server, client, cts.Token);
+            }
+        }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.SupportsTls13))]
         [InlineData(true)]
@@ -591,46 +648,6 @@ namespace System.Net.Security.Tests
                 {
                     await Assert.ThrowsAsync<NotSupportedException>(() => server.WriteAsync(TestHelper.s_ping).AsTask());
                 }
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public async Task NegotiateClientCertificateAsync_PendingData_Throws()
-        {
-            using CancellationTokenSource cts = new CancellationTokenSource();
-            cts.CancelAfter(TestConfiguration.PassingTestTimeout);
-
-            (SslStream client, SslStream server) = TestHelper.GetConnectedSslStreams();
-            using (client)
-            using (server)
-            using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
-            using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
-            {
-                SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions()
-                {
-                    TargetHost = Guid.NewGuid().ToString("N"),
-                    ClientCertificates = new X509CertificateCollection(new X509Certificate2[] { clientCertificate })
-                };
-                clientOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
-
-                SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions() { ServerCertificate = serverCertificate };
-                serverOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
-
-                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
-                                client.AuthenticateAsClientAsync(clientOptions, cts.Token),
-                                server.AuthenticateAsServerAsync(serverOptions, cts.Token));
-
-                await TestHelper.PingPong(client, server, cts.Token);
-                Assert.Null(server.RemoteCertificate);
-
-                // This should go out in single TLS frame
-                await client.WriteAsync(new byte[200], cts.Token);
-                byte[] readBuffer = new byte[10];
-                // when we read part of the frame, remaining part should left decrypted
-                await server.ReadAsync(readBuffer, cts.Token);
-
-                await Assert.ThrowsAsync<InvalidOperationException>(() => server.NegotiateClientCertificateAsync(cts.Token));
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -52,6 +52,8 @@
              Link="Common\System\Net\SslStreamCertificatePolicy.cs" />
     <Compile Include="$(CommonTestPath)System\Net\RandomReadWriteSizeStream.cs"
              Link="Common\System\Net\RandomReadWriteSizeStream.cs" />
+    <Compile Include="$(CommonTestPath)System\Net\ManualChunkingStream.cs"
+             Link="Common\System\Net\ManualChunkingStream.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.cs"
              Link="Common\System\Net\Configuration.cs" />
     <Compile Include="$(CommonTestPath)System\Net\Configuration.Security.cs"


### PR DESCRIPTION
Fixes [#63662](https://github.com/dotnet/runtime/issues/63662)