### PR TITLE
Fixes a few issues for dprintf on OSX

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -27448,7 +27448,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         _sort (&mark_list[0], mark_list_index - 1, 0);
 #endif //USE_VXSORT
 
-        dprintf (3, ("using mark list at GC #%d", (size_t)settings.gc_index));
+        dprintf (3, ("using mark list at GC #%Id", (size_t)settings.gc_index));
         //verify_qsort_array (&mark_list[0], mark_list_index-1);
 #endif //!MULTIPLE_HEAPS
         use_mark_list = TRUE;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -27448,7 +27448,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         _sort (&mark_list[0], mark_list_index - 1, 0);
 #endif //USE_VXSORT
 
-        dprintf (3, ("using mark list at GC #%d", settings.gc_index));
+        dprintf (3, ("using mark list at GC #%d", (size_t)settings.gc_index));
         //verify_qsort_array (&mark_list[0], mark_list_index-1);
 #endif //!MULTIPLE_HEAPS
         use_mark_list = TRUE;
@@ -36650,7 +36650,7 @@ go_through_refs:
             hpt->heap_number, heap_number, n_eph, n_gen, n_card_set, total_cards_cleared,
             (n_eph ? (int)(((float)n_gen / (float)n_eph) * 100) : 0)));
         dprintf (3, ("h%d marking h%d Msoh: total cross %Id, useful: %Id, running ratio: %d",
-            hpt->heap_number, heap_number, n_eph_soh, n_gen_soh,
+            hpt->heap_number, heap_number, (size_t)n_eph_soh, (size_t)n_gen_soh,
             (n_eph_soh ? (int)(((float)n_gen_soh / (float)n_eph_soh) * 100) : 0)));
 #else
         generation_skip_ratio = ((n_eph > MIN_SOH_CROSS_GEN_REFS) ? (int)(((float)n_gen / (float)n_eph) * 100) : 100);
@@ -41398,7 +41398,7 @@ go_through_refs:
             hpt->heap_number, heap_number, n_eph, n_gen, n_card_set, total_cards_cleared,
             (n_eph ? (int)(((float)n_gen / (float)n_eph) * 100) : 0)));
         dprintf (3, ("h%d marking h%d Mloh: total cross %Id, useful: %Id, running ratio: %d",
-            hpt->heap_number, heap_number, n_eph_loh, n_gen_loh,
+            hpt->heap_number, heap_number, (size_t)n_eph_loh, (size_t)n_gen_loh,
             (n_eph_loh ? (int)(((float)n_gen_loh / (float)n_eph_loh) * 100) : 0)));
 #else
         generation_skip_ratio = min (((n_eph > MIN_LOH_CROSS_GEN_REFS) ?

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -345,6 +345,12 @@ void StressLog::AddModule(uint8_t* moduleBase)
     }
 #endif //MEMORY_MAPPED_STRESSLOG
     theLog.modules[moduleIndex].size = PAL_CopyModuleData(moduleBase, destination, destination_end);
+#ifdef MEMORY_MAPPED_STRESSLOG
+    if (hdr != nullptr)
+    {
+        hdr->modules[moduleIndex].size = theLog.modules[moduleIndex].size;
+    }
+#endif //MEMORY_MAPPED_STRESSLOG
 #endif //HOST_WINDOWS
 }
 
@@ -884,7 +890,6 @@ void StressLog::LogMsg(unsigned level, unsigned facility, const StressLogMsg &ms
 
     if (InlinedStressLogOn(facility, level))
     {
-#ifdef HOST_WINDOWS // On Linux, this cast: (va_list)msg.m_args gives a compile error
        ThreadStressLog* msgs = t_pCurrentThreadLog;
 
         if (msgs == 0)
@@ -894,7 +899,15 @@ void StressLog::LogMsg(unsigned level, unsigned facility, const StressLogMsg &ms
             if (msgs == 0)
                 return;
         }
+#ifdef HOST_WINDOWS 
+        // On Linux, this cast: (va_list)msg.m_args gives a compile error
         msgs->LogMsg(facility, msg.m_cArgs, msg.m_format, (va_list)msg.m_args);
+#else
+        msgs->LogMsg(facility, msg.m_cArgs, msg.m_format, 
+        msg.m_args[0], msg.m_args[1], msg.m_args[2], msg.m_args[3], 
+        msg.m_args[4], msg.m_args[5], msg.m_args[6], msg.m_args[7], 
+        msg.m_args[8], msg.m_args[9], msg.m_args[10], msg.m_args[11], 
+        msg.m_args[12], msg.m_args[13], msg.m_args[14], msg.m_args[15]);
 #endif //HOST_WINDOWS
     }
 


### PR DESCRIPTION
This change fixes a few issues with `dprintf` on OSX.

1. The `gc.cpp` changes allow the `dprintf` to compile clean on OSX. The values that I casted are `Volatile<size_t>` and implicit type conversion is not happening there.
2. The change in `StressLog::LogMsg` avoid skipping the logging of messages on platforms other than Windows when `STRESS_LOG_VA` is used (which is used exclusively by `dprintf` right now)
3. The change in `StressLog::AddModule` was to make sure `hdr->module[].size` is populated. If it isn't, the 0 default size would lead to the later decoding of string literal arguments (i.e. all `%s` (`dprintf` or not) was failing `CorClrData::ReadVirtual`).

With these changes, I am capable to read `dprintf` on OSX using the `StressLogAnalyzer` now.