### PR TITLE
ILVerify: Handle readonly references in ldfld

### DIFF
--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -2060,7 +2060,7 @@ namespace Internal.IL
                     actualThis = StackValue.CreateByRef(actualThis.Type);
 
                 var declaredThis = owningType.IsValueType ?
-                    StackValue.CreateByRef(owningType) : StackValue.CreateObjRef(owningType);
+                    StackValue.CreateByRef(owningType, readOnly : true) : StackValue.CreateObjRef(owningType);
 
                 CheckIsAssignable(actualThis, declaredThis);
 

--- a/src/tests/ilverify/ILTests/ValueTypeTests.il
+++ b/src/tests/ilverify/ILTests/ValueTypeTests.il
@@ -31,7 +31,7 @@
 {
     .field public int32 InstanceField
 
-    .method public static int32 CallMethod_Valid(object o) cil managed
+    .method public static int32 ValueType.UnboxLdfld(object o) cil managed
     {
         ldarg.0
         unbox      ValueTypeFieldTests

--- a/src/tests/ilverify/ILTests/ValueTypeTests.il
+++ b/src/tests/ilverify/ILTests/ValueTypeTests.il
@@ -26,3 +26,16 @@
     }
 }
 
+.class public sequential ansi sealed beforefieldinit ValueTypeFieldTests
+       extends [System.Runtime]System.ValueType
+{
+    .field public int32 InstanceField
+
+    .method public static int32 CallMethod_Valid(object o) cil managed
+    {
+        ldarg.0
+        unbox      ValueTypeFieldTests
+        ldfld      int32 ValueTypeFieldTests::InstanceField
+        ret
+    }
+}

--- a/src/tests/ilverify/ILTests/ValueTypeTests.il
+++ b/src/tests/ilverify/ILTests/ValueTypeTests.il
@@ -31,7 +31,7 @@
 {
     .field public int32 InstanceField
 
-    .method public static int32 ValueType.UnboxLdfld(object o) cil managed
+    .method public static int32 ValueType.UnboxLdfld_Valid(object o) cil managed
     {
         ldarg.0
         unbox      ValueTypeFieldTests


### PR DESCRIPTION
Fixes #63953