### PR TITLE
Re-enable long path test to get exception message [NO MERGE]

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -264,7 +264,6 @@ namespace System.IO.Tests
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64019")]
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsException()


### PR DESCRIPTION

This reverts commit a7aff062a07f6a52fdfe69854dd28cf1c5f539a9.

Get the string provided by the logging added in https://github.com/dotnet/runtime/commit/e2da32c1f327b586dfcbda173f720d2c68726a2f

Not to be merged.

cc @MattGal 