### PR TITLE
Fixed IsFloatPositiveZero from returning 'true' on non-constant double operands

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7661,7 +7661,12 @@ inline bool GenTree::IsSIMDZero() const
 //
 inline bool GenTree::IsFloatPositiveZero() const
 {
-    return !(IsCnsNonZeroFltOrDbl());
+    if (OperGet() == GT_CNS_DBL)
+    {
+        return !(IsCnsNonZeroFltOrDbl());
+    }
+
+    return false;
 }
 
 //-------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7661,12 +7661,7 @@ inline bool GenTree::IsSIMDZero() const
 //
 inline bool GenTree::IsFloatPositiveZero() const
 {
-    if (OperGet() == GT_CNS_DBL)
-    {
-        return !(IsCnsNonZeroFltOrDbl());
-    }
-
-    return false;
+    return IsCnsFltOrDbl() && !IsCnsNonZeroFltOrDbl();
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
This is a quick bug fix - the logic for `IsFloatPositiveZero` is incorrect as it would return 'true' for operands that are not non-constant doubles.