### PR TITLE
[release/6.0] Fix crash when VS4Mac is debugging VS4Mac arm64

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5469,6 +5469,11 @@ GENERICS_TYPE_TOKEN DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD     
 
     if (dwExactGenericArgsTokenIndex == 0)
     {
+        // In a rare case of VS4Mac debugging VS4Mac ARM64 optimized code we get a null token for certain stack frame variables 
+        if (rawToken == 0)
+        {
+            return rawToken;
+        }
         // In this case the real generics type token is the MethodTable of the "this" object.
         // Note that we want the target address here.
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5469,7 +5469,8 @@ GENERICS_TYPE_TOKEN DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD     
 
     if (dwExactGenericArgsTokenIndex == 0)
     {
-        // In a rare case of VS4Mac debugging VS4Mac ARM64 optimized code we get a null token for certain stack frame variables 
+        // In a rare case of VS4Mac debugging VS4Mac ARM64 optimized code we get a null generics argument token. This workaround
+        // should only cause us to degrade generic types from exact type parameters to approximate or canonical type parameters.
         if (rawToken == 0)
         {
             return rawToken;


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/64011

# Customer Impact

VS4Mac crashes when debugging VS4Mac.

# Testing

VS4Mac team verified that it no longer crashes.

# Risk

Low.