### PR TITLE
Fix minor things in comments to DllImportGenerator

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Interop
                 // of an array as long as it is non-null, matching the behavior of the built-in interop system
                 // for single-dimensional zero-based arrays.
 
-                // ref <elementType> <byRefIdentifier> = <managedIdentifer> == null ? ref *(<elementType*)0 : ref MemoryMarshal.GetArrayDataReference(<managedIdentifer>);
+                // ref <elementType> <byRefIdentifier> = ref <managedIdentifer> == null ? ref *(<elementType>*)0 : ref MemoryMarshal.GetArrayDataReference(<managedIdentifer>);
                 PrefixUnaryExpressionSyntax nullRef =
                     PrefixUnaryExpression(SyntaxKind.PointerIndirectionExpression,
                         CastExpression(


### PR DESCRIPTION
I was using comments as sample how to implement same pattern in my code, and missing `ref` was puzzle me for a bit.
That was mostly with my unfamiliarity with `ref structs`, but I expect that somebody we will use that as reference can be stuck as well.
I'm not sure if this commit valuable enough to justify editing comments and adding churn.
Feel free to close if this is too much.