### PR TITLE
[CodeSpace] Install v8 and Prebuild wasm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,12 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         build-essential python curl git lldb-6.0 liblldb-6.0-dev \
         libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev \
         libssl-dev libnuma-dev libkrb5-dev zlib1g-dev ninja-build
+
+# Install V8 Engine
+SHELL ["/bin/bash", "-c"]
+
+RUN curl -sSL "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/linux/chromium-v8/v8-linux64-rel-8.5.183.zip" -o ./v8.zip \
+    && unzip ./v8.zip -d /usr/local/v8 \
+    && echo $'#!/usr/bin/env bash\n\
+"/usr/local/v8/d8" --snapshot_blob="/usr/local/v8/snapshot_blob.bin" "$@"\n' > /usr/local/bin/v8 \
+    && chmod +x /usr/local/bin/v8

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -7,5 +7,10 @@ set -e
 # restore libs tests so that the project is ready to be loaded by OmniSharp
 ./build.sh libs.tests -restore
 
+# prebuild for WASM, so it is ready for wasm development
+make -C src/mono/wasm provision-wasm
+export EMSDK_PATH=$PWD/src/mono/wasm/emsdk
+./build.sh mono+libs -os Browser -c release
+
 # save the commit hash of the currently built assemblies, so developers know which version was built
 git rev-parse HEAD > ./artifacts/prebuild.sha


### PR DESCRIPTION
This PR enables WASM developers to develop using a prebuilt CodeSpace. You are ready to develop or run tests with the repo right away.