### PR TITLE
[release/6.0] Fix ReadyToRun loading on Apple Silicon

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6960,7 +6960,9 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
     //
     CLANG_FORMAT_COMMENT_ANCHOR;
 
+#ifndef OSX_ARM64_ABI
     if (!opts.IsReadyToRun() || IsTargetAbi(CORINFO_CORERT_ABI))
+#endif // !OSX_ARM64_ABI
     {
 
         // Reuse the temp used to pass the array dimensions to avoid bloating
@@ -7017,6 +7019,7 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
 
         node = gtNewHelperCallNode(CORINFO_HELP_NEW_MDARR_NONVARARG, TYP_REF, args);
     }
+#ifndef OSX_ARM64_ABI
     else
     {
         //
@@ -7046,6 +7049,7 @@ void Compiler::impImportNewObjArray(CORINFO_RESOLVED_TOKEN* pResolvedToken, CORI
         }
 #endif
     }
+#endif // !OSX_ARM64_ABI
 
     for (GenTreeCall::Use& use : node->AsCall()->Args())
     {

--- a/src/coreclr/pal/src/map/map.cpp
+++ b/src/coreclr/pal/src/map/map.cpp
@@ -2047,9 +2047,9 @@ MAPmmapAndRecord(
 
         // Set the requested mapping with forced PROT_WRITE to ensure data from the file can be read there,
         // read the data in and finally remove the forced PROT_WRITE
-        if ((mprotect(pvBaseAddress, len + adjust, prot | PROT_WRITE) == -1) ||
+        if ((mprotect(pvBaseAddress, len + adjust, PROT_WRITE) == -1) ||
             (pread(fd, pvBaseAddress, len + adjust, offset - adjust) == -1) ||
-            (((prot & PROT_WRITE) == 0) && mprotect(pvBaseAddress, len + adjust, prot) == -1))
+            (mprotect(pvBaseAddress, len + adjust, prot) == -1))
         {
             palError = FILEGetLastErrorFromErrno();
         }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14200,6 +14200,13 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
             CorInfoHelpFunc corInfoHelpFunc = MapReadyToRunHelper((ReadyToRunHelper)helperNum);
             if (corInfoHelpFunc != CORINFO_HELP_UNDEF)
             {
+#ifdef OSX_ARM64_ABI
+                if (corInfoHelpFunc == CORINFO_HELP_NEW_MDARR)
+                {
+                    STRESS_LOG(LF_ZAP, LL_WARNING, "CORINFO_HELP_NEW_MDARR is not supported on osx-arm64\n");
+                    return FALSE;
+                }
+#endif // OSX_ARM64_ABI
                 result = (size_t)CEEJitInfo::getHelperFtnStatic(corInfoHelpFunc);
             }
             else

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -235,14 +235,14 @@ void PEImageLayout::ApplyBaseRelocations()
             if (((pSection->Characteristics & VAL32(IMAGE_SCN_MEM_WRITE)) == 0))
             {
                 DWORD dwNewProtection = PAGE_READWRITE;
-#if defined(TARGET_UNIX) && !defined(CROSSGEN_COMPILE)
+#if defined(TARGET_UNIX) && !defined(CROSSGEN_COMPILE) && !defined(__APPLE__)
                 if (((pSection->Characteristics & VAL32(IMAGE_SCN_MEM_EXECUTE)) != 0))
                 {
                     // On SELinux, we cannot change protection that doesn't have execute access rights
                     // to one that has it, so we need to set the protection to RWX instead of RW
                     dwNewProtection = PAGE_EXECUTE_READWRITE;
                 }
-#endif // TARGET_UNIX && !CROSSGEN_COMPILE
+#endif // TARGET_UNIX && !CROSSGEN_COMPILE && !__APPLE__
                 if (!ClrVirtualProtect(pWriteableRegion, cbWriteableRegion,
                                        dwNewProtection, &dwOldProtection))
                     ThrowLastError();


### PR DESCRIPTION
## Customer Impact
Slow startup of .NET applications on Apple Silicon. ReadyToRun images are not loaded correctly on Apple Silicon. All methods are JITed during startup. 

For reference, compiling a medium-size project like [ILGPU](https://github.com/m4rs-mt/ILGPU) takes ~17s on a Mac Mini M1 before this change, and ~13s after this change (about 30% faster).

## Testing
crossgen2 outerloop tests. Manually verified that the ReadyToRun images are loaded correctly on Apple Silicon.

## Risk
Low risk. These fixes have been in dotnet/runtime:main for more than a month, however there is a risk of discovering latent Apple Silicon specific bugs in ReadyToRun with this fix.

---

Fixes #64103.

This PR aims at backporting a subset of the changes introduced in #61938 and #62855. The rationale behind this change is explained in more details in #64103. I believe that this change would be limited to `osx-arm64` and introduce a substantial performance gain by enabling ReadyToRun on Apple Silicon, which I imagine was supposed to work in .NET 6 in the first place.

For reference, compiling a medium-size project like [ILGPU](https://github.com/m4rs-mt/ILGPU) takes ~17s on a Mac Mini M1 before this change, and ~13s after this change (about 30% faster). Given the focus on performance in .NET 6, I would argue that this has to be fixed in .NET 6.