### PR TITLE
Add the exception set for `ObjGetType`

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5250,7 +5250,7 @@ bool GenTree::OperRequiresCallFlag(Compiler* comp)
 // Return Value:
 //    True if the given node contains an implicit indirection
 //
-// Note that for the GT_HWINTRINSIC node we have to examine the
+// Note that for the [HW]INTRINSIC nodes we have to examine the
 // details of the node to determine its result.
 //
 
@@ -5275,6 +5275,8 @@ bool GenTree::OperIsImplicitIndir() const
         case GT_ARR_ELEM:
         case GT_ARR_OFFSET:
             return true;
+        case GT_INTRINSIC:
+            return AsIntrinsic()->gtIntrinsicName == NI_System_Object_GetType;
 #ifdef FEATURE_SIMD
         case GT_SIMD:
         {
@@ -5331,18 +5333,8 @@ bool GenTree::OperMayThrow(Compiler* comp)
 
         case GT_INTRINSIC:
             // If this is an intrinsic that represents the object.GetType(), it can throw an NullReferenceException.
-            // Report it as may throw.
-            // Note: Some of the rest of the existing intrinsics could potentially throw an exception (for example
-            //       the array and string element access ones). They are handled differently than the GetType intrinsic
-            //       and are not marked with GTF_EXCEPT. If these are revisited at some point to be marked as
-            //       GTF_EXCEPT,
-            //       the code below might need to be specialized to handle them properly.
-            if ((this->gtFlags & GTF_EXCEPT) != 0)
-            {
-                return true;
-            }
-
-            break;
+            // Currently, this is the only intrinsic that can throw an exception.
+            return AsIntrinsic()->gtIntrinsicName == NI_System_Object_GetType;
 
         case GT_CALL:
 

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -4,7 +4,10 @@
 #ifndef _NAMEDINTRINSICLIST_H_
 #define _NAMEDINTRINSICLIST_H_
 
-// Named jit intrinsics
+// Named jit intrinsics.
+
+// When adding a new intrinsic that will use the GT_INTRINSIC node and can throw, make sure
+// to update the "OperMayThrow" and "fgValueNumberAddExceptionSet" methods to account for that.
 
 enum NamedIntrinsic : unsigned short
 {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10979,7 +10979,8 @@ void Compiler::fgValueNumberAddExceptionSet(GenTree* tree)
                 break;
 
             case GT_INTRINSIC:
-                // ToDo: model the exceptions for Intrinsics
+                assert(tree->AsIntrinsic()->gtIntrinsicName == NI_System_Object_GetType);
+                fgValueNumberAddExceptionSetForIndirection(tree, tree->AsIntrinsic()->gtGetOp1());
                 break;
 
             case GT_IND:

--- a/src/tests/JIT/opt/ValueNumbering/ExceptionSets.cs
+++ b/src/tests/JIT/opt/ValueNumbering/ExceptionSets.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+#pragma warning disable CS0253 // Possible unintended reference comparison
+
+class ExceptionSets
+{
+    public static int Main()
+    {
+        try
+        {
+            TestObjGetType(null, 0);
+            return 101;
+        }
+        catch (NullReferenceException) { }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool TestObjGetType(object a, int i)
+    {
+        var fls = false;
+        var c1 = i == 0;
+        var c2 = c1;
+
+        if (((a.GetType() == a) & fls) | (i == 0))
+        {
+            return true;
+        }
+
+        return c2;
+    }
+}

--- a/src/tests/JIT/opt/ValueNumbering/ExceptionSets.csproj
+++ b/src/tests/JIT/opt/ValueNumbering/ExceptionSets.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Also fix `OperMayThrow` and `OperIsImplicitIndir` to check for it.

There are a couple [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1565344&view=ms.vss-build-web.run-extensions-tab), from the `OperMayThrow` change, one from blocked hoisting because of exception reordering, other because the side effect extractor now knows that math intrinsics don't throw.

Fixes #63553.