### PR TITLE
Improve `fgValueNumberBlockAssignment`

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5506,7 +5506,7 @@ public:
     // Does value-numbering for a block assignment.
     void fgValueNumberBlockAssignment(GenTree* tree);
 
-    bool fgValueNumberIsStructReinterpretation(GenTreeLclVarCommon* lhsLclVarTree, GenTreeLclVarCommon* rhsLclVarTree);
+    bool fgValueNumberBlockAssignmentTypeCheck(LclVarDsc* dstVarDsc, FieldSeqNode* dstFldSeq, GenTree* src);
 
     // Does value-numbering for a cast tree.
     void fgValueNumberCastTree(GenTree* tree);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8002,370 +8002,223 @@ void Compiler::fgValueNumberBlockAssignment(GenTree* tree)
     GenTree* lhs = tree->gtGetOp1();
     GenTree* rhs = tree->gtGetOp2();
 
-    if (tree->OperIsInitBlkOp())
+    GenTreeLclVarCommon* lclVarTree;
+    bool                 isEntire;
+    if (tree->DefinesLocal(this, &lclVarTree, &isEntire))
     {
-        GenTreeLclVarCommon* lclVarTree;
-        bool                 isEntire;
+        assert(lclVarTree->gtFlags & GTF_VAR_DEF);
+        // Should not have been recorded as updating the GC heap.
+        assert(!GetMemorySsaMap(GcHeap)->Lookup(tree));
 
-        if (tree->DefinesLocal(this, &lclVarTree, &isEntire))
+        unsigned lhsLclNum    = lclVarTree->GetLclNum();
+        unsigned lclDefSsaNum = GetSsaNumForLocalVarDef(lclVarTree);
+
+        // Ignore vars that we excluded from SSA (for example, because they're address-exposed). They don't have
+        // SSA names in which to store VN's on defs.  We'll yield unique VN's when we read from them.
+        if (lclDefSsaNum != SsaConfig::RESERVED_SSA_NUM)
         {
-            assert(lclVarTree->gtFlags & GTF_VAR_DEF);
-            // Should not have been recorded as updating the GC heap.
-            assert(!GetMemorySsaMap(GcHeap)->Lookup(tree));
+            FieldSeqNode* lhsFldSeq = nullptr;
+            LclVarDsc*    lhsVarDsc = lvaGetDesc(lhsLclNum);
 
-            unsigned lclDefSsaNum = GetSsaNumForLocalVarDef(lclVarTree);
-
-            // Ignore vars that we excluded from SSA (for example, because they're address-exposed). They don't have
-            // SSA names in which to store VN's on defs.  We'll yield unique VN's when we read from them.
-            if (lclDefSsaNum != SsaConfig::RESERVED_SSA_NUM)
+            if (lhs->IsLocalExpr(this, &lclVarTree, &lhsFldSeq))
             {
-                LclVarDsc* lclVarDsc = lvaGetDesc(lclVarTree);
+                noway_assert(lclVarTree->GetLclNum() == lhsLclNum);
+            }
+            else
+            {
+                GenTree* lhsAddr = lhs->AsIndir()->Addr();
 
-                // Should not have been recorded as updating ByrefExposed.
-                assert(!GetMemorySsaMap(ByrefExposed)->Lookup(tree));
+                // For addr-of-local expressions, lib/cons shouldn't matter.
+                assert(lhsAddr->gtVNPair.BothEqual());
+                ValueNum lhsAddrVN = lhsAddr->GetVN(VNK_Liberal);
 
+                // Unpack the PtrToLoc value number of the address.
+                assert(vnStore->IsVNFunc(lhsAddrVN));
+
+                VNFuncApp lhsAddrFuncApp;
+                vnStore->GetVNFunc(lhsAddrVN, &lhsAddrFuncApp);
+
+                assert(lhsAddrFuncApp.m_func == VNF_PtrToLoc);
+                assert(vnStore->IsVNConstant(lhsAddrFuncApp.m_args[0]) &&
+                       vnStore->ConstantValue<unsigned>(lhsAddrFuncApp.m_args[0]) == lhsLclNum);
+
+                lhsFldSeq = vnStore->FieldSeqVNToFieldSeq(lhsAddrFuncApp.m_args[1]);
+            }
+
+            bool         isNewUniq       = false;
+            ValueNumPair newLhsLclVNPair = ValueNumPair();
+            if (tree->OperIsInitBlkOp())
+            {
                 ValueNum lclVarVN = ValueNumStore::NoVN;
                 if (isEntire && rhs->IsIntegralConst(0))
                 {
                     // Note that it is possible to see pretty much any kind of type for the local
                     // (not just TYP_STRUCT) here because of the ASG(BLK(ADDR(LCL_VAR/FLD)), 0) form.
-                    lclVarVN = (lclVarDsc->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(lclVarDsc->GetStructHnd())
-                                                                    : vnStore->VNZeroForType(lclVarDsc->TypeGet());
+                    lclVarVN = (lhsVarDsc->TypeGet() == TYP_STRUCT) ? vnStore->VNForZeroObj(lhsVarDsc->GetStructHnd())
+                                                                    : vnStore->VNZeroForType(lhsVarDsc->TypeGet());
                 }
                 else
                 {
                     // Non-zero block init is very rare so we'll use a simple, unique VN here.
-                    lclVarVN = vnStore->VNForExpr(compCurBB, lclVarDsc->TypeGet());
-                }
-
-                lclVarDsc->GetPerSsaData(lclDefSsaNum)->m_vnPair.SetBoth(lclVarVN);
-#ifdef DEBUG
-                if (verbose)
-                {
-                    printf("Tree ");
-                    Compiler::printTreeID(tree);
-                    printf(" assigned VN to local var V%02u/%d: ", lclVarTree->GetLclNum(), lclDefSsaNum);
-                    vnPrint(lclVarVN, 1);
-                    printf("\n");
-                }
-#endif // DEBUG
-            }
-            else if (lvaVarAddrExposed(lclVarTree->GetLclNum()))
-            {
-                fgMutateAddressExposedLocal(tree DEBUGARG("INITBLK - address-exposed local"));
-            }
-        }
-        else
-        {
-            // For now, arbitrary side effect on GcHeap/ByrefExposed.
-            // TODO-CQ: Why not be complete, and get this case right?
-            fgMutateGcHeap(tree DEBUGARG("INITBLK - non local"));
-        }
-        // Initblock's are of type void.  Give them the void "value" -- they may occur in argument lists, which we
-        // want to be able to give VN's to.
-        tree->gtVNPair.SetBoth(ValueNumStore::VNForVoid());
-    }
-    else
-    {
-        assert(tree->OperIsCopyBlkOp());
-        // TODO-Cleanup: We should factor things so that we uniformly rely on "PtrTo" VN's, and
-        // the memory cases can be shared with assignments.
-        GenTreeLclVarCommon* lclVarTree = nullptr;
-        bool                 isEntire   = false;
-        // Note that we don't care about exceptions here, since we're only using the values
-        // to perform an assignment (which happens after any exceptions are raised...)
-
-        if (tree->DefinesLocal(this, &lclVarTree, &isEntire))
-        {
-            // Should not have been recorded as updating the GC heap.
-            assert(!GetMemorySsaMap(GcHeap)->Lookup(tree));
-
-            unsigned      lhsLclNum    = lclVarTree->GetLclNum();
-            FieldSeqNode* lhsFldSeq    = nullptr;
-            unsigned      lclDefSsaNum = GetSsaNumForLocalVarDef(lclVarTree);
-            LclVarDsc*    lhsVarDsc    = lvaGetDesc(lhsLclNum);
-            // If it's excluded from SSA, don't need to do anything.
-            if (lvaInSsa(lhsLclNum) && lclDefSsaNum != SsaConfig::RESERVED_SSA_NUM)
-            {
-                // Should not have been recorded as updating ByrefExposed.
-                assert(!GetMemorySsaMap(ByrefExposed)->Lookup(tree));
-
-                if (lhs->IsLocalExpr(this, &lclVarTree, &lhsFldSeq))
-                {
-                    noway_assert(lclVarTree->GetLclNum() == lhsLclNum);
-                }
-                else
-                {
-                    GenTree* lhsAddr;
-                    if (lhs->OperIsBlk())
-                    {
-                        lhsAddr = lhs->AsBlk()->Addr();
-                    }
-                    else
-                    {
-                        assert(lhs->OperGet() == GT_IND);
-                        lhsAddr = lhs->AsOp()->gtOp1;
-                    }
-
-                    // For addr-of-local expressions, lib/cons shouldn't matter.
-                    assert(lhsAddr->gtVNPair.BothEqual());
-                    ValueNum lhsAddrVN = lhsAddr->GetVN(VNK_Liberal);
-
-                    // Unpack the PtrToLoc value number of the address.
-                    assert(vnStore->IsVNFunc(lhsAddrVN));
-
-                    VNFuncApp lhsAddrFuncApp;
-                    vnStore->GetVNFunc(lhsAddrVN, &lhsAddrFuncApp);
-
-                    assert(lhsAddrFuncApp.m_func == VNF_PtrToLoc);
-                    assert(vnStore->IsVNConstant(lhsAddrFuncApp.m_args[0]) &&
-                           vnStore->ConstantValue<unsigned>(lhsAddrFuncApp.m_args[0]) == lhsLclNum);
-
-                    lhsFldSeq = vnStore->FieldSeqVNToFieldSeq(lhsAddrFuncApp.m_args[1]);
-                }
-
-                // Now we need to get the proper RHS.
-                GenTreeLclVarCommon* rhsLclVarTree = nullptr;
-                LclVarDsc*           rhsVarDsc     = nullptr;
-                FieldSeqNode*        rhsFldSeq     = nullptr;
-                ValueNumPair         rhsVNPair;
-                bool                 isNewUniq = false;
-                if (!rhs->OperIsIndir())
-                {
-                    if (rhs->IsLocalExpr(this, &rhsLclVarTree, &rhsFldSeq))
-                    {
-                        unsigned rhsLclNum = rhsLclVarTree->GetLclNum();
-                        rhsVarDsc          = lvaGetDesc(rhsLclNum);
-                        if (!lvaInSsa(rhsLclNum) || !rhsLclVarTree->HasSsaName() ||
-                            rhsFldSeq == FieldSeqStore::NotAField())
-                        {
-                            rhsVNPair.SetBoth(vnStore->VNForExpr(compCurBB, rhsLclVarTree->TypeGet()));
-                            isNewUniq = true;
-                        }
-                        else
-                        {
-                            rhsVNPair         = rhsVarDsc->GetPerSsaData(rhsLclVarTree->GetSsaNum())->m_vnPair;
-                            var_types indType = rhsLclVarTree->TypeGet();
-
-                            rhsVNPair = vnStore->VNPairApplySelectors(rhsVNPair, rhsFldSeq, indType);
-                        }
-                    }
-                    else
-                    {
-                        isNewUniq = true;
-                    }
-                }
-                else
-                {
-                    GenTree*  srcAddr = rhs->AsIndir()->Addr();
-                    VNFuncApp srcAddrFuncApp;
-                    if (srcAddr->IsLocalAddrExpr(this, &rhsLclVarTree, &rhsFldSeq))
-                    {
-                        unsigned rhsLclNum = rhsLclVarTree->GetLclNum();
-                        rhsVarDsc          = lvaGetDesc(rhsLclNum);
-                        if (!lvaInSsa(rhsLclNum) || !rhsLclVarTree->HasSsaName() ||
-                            rhsFldSeq == FieldSeqStore::NotAField())
-                        {
-                            isNewUniq = true;
-                        }
-                        else
-                        {
-                            rhsVNPair         = rhsVarDsc->GetPerSsaData(rhsLclVarTree->GetSsaNum())->m_vnPair;
-                            var_types indType = rhsLclVarTree->TypeGet();
-
-                            rhsVNPair = vnStore->VNPairApplySelectors(rhsVNPair, rhsFldSeq, indType);
-                        }
-                    }
-                    else if (vnStore->GetVNFunc(vnStore->VNLiberalNormalValue(srcAddr->gtVNPair), &srcAddrFuncApp))
-                    {
-                        if (srcAddrFuncApp.m_func == VNF_PtrToStatic)
-                        {
-                            var_types     indType            = lclVarTree->TypeGet();
-                            ValueNum      fieldSeqVN         = srcAddrFuncApp.m_args[1];
-                            FieldSeqNode* fldSeqForStaticVar = vnStore->FieldSeqVNToFieldSeq(fieldSeqVN);
-#ifdef DEBUG
-                            FieldSeqNode* zeroOffsetFldSeq = nullptr;
-                            if (GetZeroOffsetFieldMap()->Lookup(srcAddr, &zeroOffsetFldSeq))
-                            {
-                                // Check that the zero offset field seq was attached for `srcAddr`.
-                                assert(fldSeqForStaticVar->GetTail() == zeroOffsetFldSeq);
-                            }
-#endif
-                            if (fldSeqForStaticVar != FieldSeqStore::NotAField())
-                            {
-                                assert(fldSeqForStaticVar != nullptr);
-
-                                // We model statics as indices into GcHeap (which is a subset of ByrefExposed).
-                                ValueNum selectedStaticVar;
-                                size_t   structSize = 0;
-                                selectedStaticVar   = vnStore->VNApplySelectors(VNK_Liberal, fgCurMemoryVN[GcHeap],
-                                                                              fldSeqForStaticVar, &structSize);
-                                selectedStaticVar =
-                                    vnStore->VNApplySelectorsTypeCheck(selectedStaticVar, indType, structSize);
-
-                                rhsVNPair.SetLiberal(selectedStaticVar);
-                                rhsVNPair.SetConservative(vnStore->VNForExpr(compCurBB, indType));
-                            }
-                            else
-                            {
-                                JITDUMP("    *** Missing field sequence info for Src/RHS of COPYBLK\n");
-                                isNewUniq = true;
-                            }
-                        }
-                        else if (srcAddrFuncApp.m_func == VNF_PtrToArrElem)
-                        {
-                            ValueNum elemLib =
-                                fgValueNumberArrIndexVal(nullptr, &srcAddrFuncApp, vnStore->VNPForEmptyExcSet());
-                            rhsVNPair.SetLiberal(elemLib);
-                            rhsVNPair.SetConservative(vnStore->VNForExpr(compCurBB, lclVarTree->TypeGet()));
-                        }
-                        else
-                        {
-                            isNewUniq = true;
-                        }
-                    }
-                    else
-                    {
-                        isNewUniq = true;
-                    }
-                }
-
-                if (lhsFldSeq == FieldSeqStore::NotAField())
-                {
-                    // We don't have proper field sequence information for the lhs
-                    //
-                    JITDUMP("    *** Missing field sequence info for Dst/LHS of COPYBLK\n");
+                    lclVarVN  = vnStore->VNForExpr(compCurBB, lhsVarDsc->TypeGet());
                     isNewUniq = true;
                 }
 
-                if (!isNewUniq && (lclVarTree != nullptr) && (rhsLclVarTree != nullptr))
-                {
-                    isNewUniq = fgValueNumberIsStructReinterpretation(lclVarTree, rhsLclVarTree);
-                }
-
-                if (isNewUniq)
-                {
-                    rhsVNPair.SetBoth(vnStore->VNForExpr(compCurBB, lclVarTree->TypeGet()));
-                }
-                else // We will assign rhsVNPair into a map[lhsFldSeq]
-                {
-                    if (lhsFldSeq != nullptr && isEntire)
-                    {
-                        // This can occur for structs with one field, itself of a struct type.
-                        // We are assigning the one field and it is also the entire enclosing struct.
-                        //
-                        // Use an unique value number for the old map, as this is an an entire assignment
-                        // and we won't have any other values in the map
-                        ValueNumPair uniqueMap;
-                        uniqueMap.SetBoth(vnStore->VNForExpr(compCurBB, lclVarTree->TypeGet()));
-                        rhsVNPair =
-                            vnStore->VNPairApplySelectorsAssign(uniqueMap, lhsFldSeq, rhsVNPair, lclVarTree->TypeGet());
-                    }
-                    else
-                    {
-                        ValueNumPair oldLhsVNPair = lhsVarDsc->GetPerSsaData(lclVarTree->GetSsaNum())->m_vnPair;
-                        rhsVNPair = vnStore->VNPairApplySelectorsAssign(oldLhsVNPair, lhsFldSeq, rhsVNPair,
-                                                                        lclVarTree->TypeGet());
-                    }
-                }
-
-                lhsVarDsc->GetPerSsaData(lclDefSsaNum)->m_vnPair = vnStore->VNPNormalPair(rhsVNPair);
-
-#ifdef DEBUG
-                if (verbose)
-                {
-                    printf("Tree ");
-                    Compiler::printTreeID(tree);
-                    printf(" assigned VN to local var V%02u/%d: ", lhsLclNum, lclDefSsaNum);
-                    if (isNewUniq)
-                    {
-                        printf("new uniq ");
-                    }
-                    vnpPrint(rhsVNPair, 1);
-                    printf("\n");
-                }
-#endif // DEBUG
-            }
-            else if (lvaVarAddrExposed(lhsLclNum))
-            {
-                fgMutateAddressExposedLocal(tree DEBUGARG("COPYBLK - address-exposed local"));
+                newLhsLclVNPair.SetBoth(lclVarVN);
             }
             else
             {
-                JITDUMP("LHS V%02u not in ssa at [%06u], so no VN assigned\n", lhsLclNum, dspTreeID(lclVarTree));
+                assert(tree->OperIsCopyBlkOp());
+
+                if (fgValueNumberBlockAssignmentTypeCheck(lhsVarDsc, lhsFldSeq, rhs))
+                {
+                    ValueNumPair rhsVNPair       = vnStore->VNPNormalPair(rhs->gtVNPair);
+                    ValueNumPair oldLhsLclVNPair = lhsVarDsc->GetPerSsaData(lclVarTree->GetSsaNum())->m_vnPair;
+                    newLhsLclVNPair =
+                        vnStore->VNPairApplySelectorsAssign(oldLhsLclVNPair, lhsFldSeq, rhsVNPair, lhs->TypeGet());
+                }
+                else
+                {
+                    newLhsLclVNPair.SetBoth(vnStore->VNForExpr(compCurBB, lhsVarDsc->TypeGet()));
+                    isNewUniq = true;
+                }
             }
+
+            lhsVarDsc->GetPerSsaData(lclDefSsaNum)->m_vnPair = newLhsLclVNPair;
+
+#ifdef DEBUG
+            if (verbose)
+            {
+                printf("Tree ");
+                Compiler::printTreeID(tree);
+                printf(" assigned VN to local var V%02u/%d: ", lhsLclNum, lclDefSsaNum);
+                if (isNewUniq)
+                {
+                    printf("new uniq ");
+                }
+                vnpPrint(newLhsLclVNPair, 1);
+                printf("\n");
+            }
+#endif // DEBUG
+        }
+        else if (lvaVarAddrExposed(lhsLclNum))
+        {
+            fgMutateAddressExposedLocal(tree DEBUGARG("INITBLK/COPYBLK - address-exposed local"));
         }
         else
         {
-            // For now, arbitrary side effect on GcHeap/ByrefExposed.
-            // TODO-CQ: Why not be complete, and get this case right?
-            fgMutateGcHeap(tree DEBUGARG("COPYBLK - non local"));
+            JITDUMP("LHS V%02u not in ssa at [%06u], so no VN assigned\n", lhsLclNum, dspTreeID(lclVarTree));
         }
-        // Copyblock's are of type void.  Give them the void "value" -- they may occur in argument lists, which we want
-        // to be able to give VN's to.
-        tree->gtVNPair.SetBoth(ValueNumStore::VNForVoid());
     }
+    else
+    {
+        // For now, arbitrary side effect on GcHeap/ByrefExposed.
+        // TODO-CQ: Why not be complete, and get this case right?
+        fgMutateGcHeap(tree DEBUGARG("INITBLK/COPYBLK - non local"));
+    }
+
+    // Assignments produce no values so we give them the "Void" VN.
+    tree->gtVNPair = vnStore->VNPForVoid();
 }
 
 //------------------------------------------------------------------------
-// fgValueNumberIsStructReinterpretation: Checks if there is a struct reinterpretation that prevent VN propagation.
+// fgValueNumberBlockAssignmentTypeCheck: Checks if there is a struct reinterpretation that prevent VN propagation.
 //
 // Arguments:
-//    lhsLclVarTree - a lcl var tree on the lhs of the asg;
-//    rhsLclVarTree - a lcl var tree on the rhs of the asg;
+//    dstVarDsc - the descriptor for the local being assigned to
+//    dstFldSeq - the sequence of fields used for the assignment
+//    src       - the source of the assignment, i. e. the RHS
 //
 // Return Value:
-//    True if the locals have different struct types and VN can't use rhs VN for lhs VN.
-//    False if locals have the same struct type or if this ASG is not a struct ASG.
+//    Whether "src"'s exact type matches that of the destination location.
 //
-bool Compiler::fgValueNumberIsStructReinterpretation(GenTreeLclVarCommon* lhsLclVarTree,
-                                                     GenTreeLclVarCommon* rhsLclVarTree)
+// Notes:
+//    Currently this method only handles local destinations, it should be expanded to support more
+//    locations (static/instance fields, array elements) once/if "fgValueNumberBlockAssignment"
+//    supports them.
+//
+bool Compiler::fgValueNumberBlockAssignmentTypeCheck(LclVarDsc* dstVarDsc, FieldSeqNode* dstFldSeq, GenTree* src)
 {
-    assert(lhsLclVarTree != nullptr);
-    assert(rhsLclVarTree != nullptr);
-
-    if (rhsLclVarTree->TypeGet() == TYP_STRUCT)
+    if (dstFldSeq == FieldSeqStore::NotAField())
     {
-        if (rhsLclVarTree->TypeGet() == lhsLclVarTree->TypeGet())
+        // We don't have proper field sequence information for the lhs - assume arbitrary aliasing.
+        JITDUMP("    *** Missing field sequence info for Dst/LHS of COPYBLK\n");
+        return false;
+    }
+
+    // With unsafe code or nested structs, we can end up with IR that has
+    // mismatched struct types on the LHS and RHS. We need to maintain the
+    // invariant that a node's VN corresponds exactly to its type. Failure
+    // to do so is a correctness problem. For example:
+    //
+    //    S1 s1 = { ... }; // s1 = map
+    //    S1.F0 = 0;       // s1 = map[F0 := 0]
+    //    S2 s2 = s1;      // s2 = map[F0 := 0] (absent below checks)
+    //    s2.F1 = 1;       // s2 = map[F0 := 0][F1 := 1]
+    //    s1    = s2;      // s1 = map[F0 := 0][F1 := 1]
+    //
+    //    int r = s1.F0;   // map[F0 := 0][F1 := 1][F0] => map[F0 := 0][F0] => 0
+    //
+    // If F1 and F0 physically alias (exist at the same offset, say), the above
+    // represents an incorrect optimization.
+
+    var_types            dstLocationType      = TYP_UNDEF;
+    CORINFO_CLASS_HANDLE dstLocationStructHnd = NO_CLASS_HANDLE;
+    if (dstFldSeq == nullptr)
+    {
+        dstLocationType = dstVarDsc->TypeGet();
+        if (dstLocationType == TYP_STRUCT)
         {
-            if (lhsLclVarTree->isLclField() || rhsLclVarTree->isLclField())
-            {
-                // Jit does not have a real support for `LCL_FLD struct [FldSeq]` because it can't determinate their
-                // size
-                // when the fieldSeq is `NotAField`, but by mistake we could have
-                // `BLK(ADDR byref(LCL_FLD struct Fseq[]))` nowadays in out IR.
-                // Generate a unique VN for now, it currently won't match the other side,
-                // otherwise we would not have 'OBJ struct2 (ADDR(LCL_FLD struct1))` cast.
-                return true;
-            }
-
-            assert(lhsLclVarTree->OperIs(GT_LCL_VAR));
-            assert(rhsLclVarTree->OperIs(GT_LCL_VAR));
-
-            const LclVarDsc* lhsVarDsc = lvaGetDesc(lhsLclVarTree);
-            const LclVarDsc* rhsVarDsc = lvaGetDesc(rhsLclVarTree);
-            assert(rhsVarDsc->TypeGet() == TYP_STRUCT);
-            assert(lhsVarDsc->TypeGet() == TYP_STRUCT);
-
-            CORINFO_CLASS_HANDLE rhsStructHnd = rhsVarDsc->GetStructHnd();
-            CORINFO_CLASS_HANDLE lhsStructHnd = lhsVarDsc->GetStructHnd();
-
-            if (rhsStructHnd != lhsStructHnd)
-            {
-                // This can occur for nested structs or for unsafe casts, when we have IR like
-                // struct1 = struct2.
-                // Use an unique value number for the old map, as we don't have information about
-                // the dst field values using dst FIELD_HANDLE.
-                // Note that other asignments, like struct1 = IND struct(ADDR(LCL_VAR long))
-                // will be handled in `VNPairApplySelectorsAssign`, here we care only about
-                // `LCL_VAR structX = (*)LCL_VAR structY` cases.
-                JITDUMP("    *** Different struct handles for Dst/Src of COPYBLK\n");
-                return true;
-            }
+            dstLocationStructHnd = dstVarDsc->GetStructHnd();
+        }
+    }
+    else
+    {
+        // Have to normalize as "eeGetFieldType" will return TYP_STRUCT for TYP_SIMD.
+        dstLocationType = eeGetFieldType(dstFldSeq->GetTail()->GetFieldHandle(), &dstLocationStructHnd);
+        if (dstLocationType == TYP_STRUCT)
+        {
+            dstLocationType = impNormStructType(dstLocationStructHnd);
         }
     }
 
-    return false;
+    // This method is meant to handle TYP_STRUCT mismatches, bail early for anything else.
+    if (dstLocationType != src->TypeGet())
+    {
+        JITDUMP("    *** Different types for Dst/Src of COPYBLK: %s != %s\n", varTypeName(dstLocationType),
+                varTypeName(src->TypeGet()));
+        return false;
+    }
+
+    // They're equal, and they're primitives. Allow, for now. TYP_SIMD is tentatively
+    // allowed here as well as, currently, there are no two vector types with public
+    // fields both that could reasonably alias each other.
+    if (dstLocationType != TYP_STRUCT)
+    {
+        return true;
+    }
+
+    // Figure out what the source's type really is. Note that this will miss
+    // struct fields of struct locals currently ("src" for them is an IND(struct)).
+    // Note as well that we're relying on the invariant that "node type == node's
+    // VN type" here (it would be expensive to recover the handle from "src"'s VN).
+    CORINFO_CLASS_HANDLE srcValueStructHnd = gtGetStructHandleIfPresent(src);
+    if (srcValueStructHnd == NO_CLASS_HANDLE)
+    {
+        JITDUMP("    *** Missing struct handle for Src of COPYBLK\n");
+        return false;
+    }
+
+    assert((dstLocationStructHnd != NO_CLASS_HANDLE) && (srcValueStructHnd != NO_CLASS_HANDLE));
+
+    if (dstLocationStructHnd != srcValueStructHnd)
+    {
+        JITDUMP("    *** Different struct handles for Dst/Src of COPYBLK: %s != %s\n",
+                eeGetClassName(dstLocationStructHnd), eeGetClassName(srcValueStructHnd));
+        return false;
+    }
+
+    return true;
 }
 
 void Compiler::fgValueNumberTree(GenTree* tree)


### PR DESCRIPTION
`fgValueNumberBlockAssignment` had a very interesting oddity: it re-VNd the source tree of the assignment. This is  unnecessary, and is in fact a pessimization, as it means we will fail to VN assignments from sources it does not understand. This change fixes that, bringing along some positive diffs from numbering stores from field indirections.

`fgValueNumberBlockAssignment` also needs to maintain the invariant that a location's VN will always match its type.
It was failing to do that in cases where the assignment's source was not local. This change fixes that.

Finally, this change unifies the code common to numbering `CopyBlk` and `InitBlk` cases. There is no need for them to be different.

Some positive [diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1565626&view=ms.vss-build-web.run-extensions-tab) from the aforementioned more precise numbering.

Part of #58312.