### PR TITLE
Re-enable failing long path test

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -271,8 +271,10 @@ namespace System.IO.Tests
         {
             var paths = IOInputs.GetPathsLongerThanMaxLongPath(GetTestFilePath(), useExtendedSyntax: true);
 
+            // Ideally this should be PathTooLongException or DirectoryNotFoundException but on some machines
+            // windows gives us ERROR_INVALID_NAME, producing IOException.
             Assert.All(paths, path =>
-                AssertExtensions.ThrowsAny<PathTooLongException, DirectoryNotFoundException>(() => Create(path)));
+                AssertExtensions.ThrowsAny<PathTooLongException, DirectoryNotFoundException, IOException>(() => Create(path)));
         }
 
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]

--- a/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/CreateDirectory.cs
@@ -264,7 +264,6 @@ namespace System.IO.Tests
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64019")]
         [ConditionalFact(nameof(LongPathsAreNotBlocked), nameof(UsingNewNormalization))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void DirectoryLongerThanMaxLongPathWithExtendedSyntax_ThrowsException()


### PR DESCRIPTION
Fix #64019
Reenable test, tolerant of the new error code.