### PR TITLE
Spmi replay asmdiffs mac os arm64

### DIFF
--- a/src/coreclr/scripts/superpmi-asmdiffs.proj
+++ b/src/coreclr/scripts/superpmi-asmdiffs.proj
@@ -55,7 +55,8 @@
     <SPMI_Partition Include="win-x64" Platform="windows" Architecture="x64" />
     <SPMI_Partition Include="win-arm64" Platform="windows" Architecture="arm64" />
     <SPMI_Partition Include="unix-x64" Platform="Linux" Architecture="x64" />
-    <SPMI_Partition Include="unix-arm64" Platform="Linux" Architecture="arm64" />
+    <SPMI_Partition Include="linux-arm64" Platform="Linux" Architecture="arm64" />
+    <SPMI_Partition Include="osx-arm64" Platform="OSX" Architecture="arm64" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Architecture)' == 'x86'">

--- a/src/coreclr/scripts/superpmi-collect.proj
+++ b/src/coreclr/scripts/superpmi-collect.proj
@@ -42,6 +42,11 @@
          PmiAssembliesPayload - Path that will be sent to helix machine to run collection on
          PmiAssembliesDirectory - Path on helix machine itself where superpmi.py will discover the sent assemblies.
     -->
+
+  <ItemGroup>
+    <PmiPathDirectories Include="$([System.IO.Directory]::GetDirectories($(SuperPMIDirectory)))" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">
     <Python>%HELIX_PYTHONPATH%</Python>
     <PmiAssembliesPayload>$(WorkItemDirectory)\pmiAssembliesDirectory</PmiAssembliesPayload>
@@ -54,7 +59,7 @@
     <OutputMchPath>%HELIX_WORKITEM_UPLOAD_ROOT%</OutputMchPath>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)\artifacts\helixresults</HelixResultsDestinationDir>
-    <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll -pmi_path $(SuperPMIDirectory)\crossgen2</WorkItemCommand>
+    <WorkItemCommand>$(SuperPMIDirectory)\superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)\pmi.dll -pmi_path @(PmiPathDirectories->'%(FullPath)', ' ')</WorkItemCommand>
   </PropertyGroup>
   <PropertyGroup Condition="'$(AGENT_OS)' != 'Windows_NT'">
     <Python>$HELIX_PYTHONPATH</Python>
@@ -68,7 +73,7 @@
     <OutputMchPath>$HELIX_WORKITEM_UPLOAD_ROOT</OutputMchPath>
     <!-- Workaround until https://github.com/dotnet/arcade/pull/6179 is not available -->
     <HelixResultsDestinationDir>$(BUILD_SOURCESDIRECTORY)/artifacts/helixresults</HelixResultsDestinationDir>
-    <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll -pmi_path $(SuperPMIDirectory)/crossgen2</WorkItemCommand>
+    <WorkItemCommand>$(SuperPMIDirectory)/superpmi.py collect -log_level DEBUG --$(CollectionType) -pmi_location $(SuperPMIDirectory)/pmi.dll -pmi_path @(PmiPathDirectories->'%(FullPath)', ' ')</WorkItemCommand>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(WorkItemCommand)' != ''">

--- a/src/coreclr/scripts/superpmi-replay.proj
+++ b/src/coreclr/scripts/superpmi-replay.proj
@@ -55,7 +55,8 @@
     <SPMI_Partition Include="win-x64" Platform="windows" Architecture="x64" />
     <SPMI_Partition Include="win-arm64" Platform="windows" Architecture="arm64" />
     <SPMI_Partition Include="unix-x64" Platform="Linux" Architecture="x64" />
-    <SPMI_Partition Include="unix-arm64" Platform="Linux" Architecture="arm64" />
+    <SPMI_Partition Include="linux-arm64" Platform="Linux" Architecture="arm64" />
+    <SPMI_Partition Include="osx-arm64" Platform="OSX" Architecture="arm64" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Architecture)' == 'x86'">


### PR DESCRIPTION
Follow up on https://github.com/dotnet/runtime/pull/63691:

Add osx-arm64 in superpmi-replay and superpmi-asmdiffs jobs to use the new osx-arm64 collections. Renamed a corresponding partition from `unix-arm64` to `linux-arm64`


Follow up on https://github.com/dotnet/runtime/pull/63983:

The change has fixed the issue with `ILCompiler.DependencyAnalysisFramework.dll` dependency. However, during the nightly collection run found more issues:

```
DRIVEALL: Invoking C:\h\w\B12209BC\p\superpmi\corerun.exe C:\h\w\B12209BC\p\superpmi\pmi.dll PREPALL C:\h\w\B12209BC\w\B7DE0A0B\u\binaries\R2RTest\Microsoft.Build.dll 0
ReflectionTypeLoadException Microsoft.Build
ReflectionTypeLoadException Microsoft.Build   ex: Could not load file or assembly 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
```

I think it makes to add all subdirectories of `$(SuperPMIDirectory)` to `PMIPATH` 