### PR TITLE
Add additional loop table asserts

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4636,7 +4636,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // Run an early flow graph simplification pass
         //
         auto earlyUpdateFlowGraphPhase = [this]() {
-            const bool doTailDup = false;
+            constexpr bool doTailDup = false;
             fgUpdateFlowGraph(doTailDup);
         };
         DoPhase(this, PHASE_EARLY_UPDATE_FLOW_GRAPH, earlyUpdateFlowGraphPhase);
@@ -4776,6 +4776,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // Unroll loops
         //
         DoPhase(this, PHASE_UNROLL_LOOPS, &Compiler::optUnrollLoops);
+
+        // Clear loop table info that is not used after this point, and might become invalid.
+        //
+        DoPhase(this, PHASE_CLEAR_LOOP_INFO, &Compiler::optClearLoopIterInfo);
     }
 
 #ifdef DEBUG
@@ -4909,7 +4913,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
                 // update the flowgraph if we modified it during the optimization phase
                 //
                 auto optUpdateFlowGraphPhase = [this]() {
-                    const bool doTailDup = false;
+                    constexpr bool doTailDup = false;
                     fgUpdateFlowGraph(doTailDup);
                 };
                 DoPhase(this, PHASE_OPT_UPDATE_FLOW_GRAPH, optUpdateFlowGraphPhase);
@@ -4966,11 +4970,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_SIMPLE_LOWERING, &Compiler::fgSimpleLowering);
 
-#ifdef DEBUG
-    fgDebugCheckBBlist();
-    fgDebugCheckLinks();
-#endif
-
     // Enable this to gather statistical data such as
     // call and register argument info, flowgraph and loop info, etc.
     compJitStats();
@@ -5020,10 +5019,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     // Copied from rpPredictRegUse()
     SetFullPtrRegMapRequired(codeGen->GetInterruptible() || !codeGen->isFramePointerUsed());
-
-#ifdef DEBUG
-    fgDebugCheckLinks();
-#endif
 
 #if FEATURE_LOOP_ALIGN
     // Place loop alignment instructions

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5945,7 +5945,7 @@ public:
 
     bool fgReorderBlocks();
 
-    void fgDetermineFirstColdBlock();
+    PhaseStatus fgDetermineFirstColdBlock();
 
     bool fgIsForwardBranch(BasicBlock* bJump, BasicBlock* bSrc = nullptr);
 
@@ -6926,7 +6926,7 @@ public:
         }
 
 #ifdef DEBUG
-        void lpValidatePreHeader()
+        void lpValidatePreHeader() const
         {
             // If this is called, we expect there to be a pre-header.
             assert(lpFlags & LPFLG_HAS_PREHEAD);
@@ -6986,6 +6986,8 @@ public:
                        BasicBlock*   bottom,
                        BasicBlock*   exit,
                        unsigned char exitCnt);
+
+    void optClearLoopIterInfo();
 
 #ifdef DEBUG
     void optPrintLoopInfo(unsigned lnum, bool printVerbose = false);

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -5,7 +5,7 @@
 //
 
 //
-// Names of x86 JIT phases, in order.  Assumes that the caller defines CompPhaseNameMacro
+// Names of JIT phases, in order.  Assumes that the caller defines CompPhaseNameMacro
 // in a useful way before including this file, e.g., to define the phase enumeration and the
 // corresponding array of string names of those phases.  This include file undefines CompPhaseNameMacro
 // after the last use.
@@ -61,6 +61,7 @@ CompPhaseNameMacro(PHASE_ZERO_INITS,             "Redundant zero Inits",        
 CompPhaseNameMacro(PHASE_FIND_LOOPS,             "Find loops",                     "LOOP-FND", false, -1, false)
 CompPhaseNameMacro(PHASE_CLONE_LOOPS,            "Clone loops",                    "LP-CLONE", false, -1, false)
 CompPhaseNameMacro(PHASE_UNROLL_LOOPS,           "Unroll loops",                   "UNROLL",   false, -1, false)
+CompPhaseNameMacro(PHASE_CLEAR_LOOP_INFO,        "Clear loop info",                "LP-CLEAR", false, -1, false)
 CompPhaseNameMacro(PHASE_HOIST_LOOP_CODE,        "Hoist loop code",                "LP-HOIST", false, -1, false)
 CompPhaseNameMacro(PHASE_MARK_LOCAL_VARS,        "Mark local vars",                "MARK-LCL", false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_BOOLS,         "Optimize bools",                 "OPT-BOOL", false, -1, false)
@@ -86,7 +87,6 @@ CompPhaseNameMacro(PHASE_INSERT_GC_POLLS,        "Insert GC Polls",             
 CompPhaseNameMacro(PHASE_DETERMINE_FIRST_COLD_BLOCK, "Determine first cold block", "COLD-BLK", false, -1, true)
 CompPhaseNameMacro(PHASE_RATIONALIZE,            "Rationalize IR",                 "RAT",      false, -1, false)
 CompPhaseNameMacro(PHASE_SIMPLE_LOWERING,        "Do 'simple' lowering",           "SMP-LWR",  false, -1, false)
-CompPhaseNameMacro(PHASE_ALIGN_LOOPS,            "Place 'align' instructions",     "LOOP-ALIGN",  false, -1, false)
 
 CompPhaseNameMacro(PHASE_LCLVARLIVENESS,         "Local var liveness",             "LIVENESS", true, -1, false)
 CompPhaseNameMacro(PHASE_LCLVARLIVENESS_INIT,    "Local var liveness init",        "LIV-INIT", false, PHASE_LCLVARLIVENESS, false)
@@ -100,6 +100,7 @@ CompPhaseNameMacro(PHASE_LINEAR_SCAN,            "Linear scan register alloc",  
 CompPhaseNameMacro(PHASE_LINEAR_SCAN_BUILD,      "LSRA build intervals",           "LSRA-BLD", false, PHASE_LINEAR_SCAN, false)
 CompPhaseNameMacro(PHASE_LINEAR_SCAN_ALLOC,      "LSRA allocate",                  "LSRA-ALL", false, PHASE_LINEAR_SCAN, false)
 CompPhaseNameMacro(PHASE_LINEAR_SCAN_RESOLVE,    "LSRA resolve",                   "LSRA-RES", false, PHASE_LINEAR_SCAN, false)
+CompPhaseNameMacro(PHASE_ALIGN_LOOPS,            "Place 'align' instructions",     "LOOP-ALIGN",  false, -1, false)
 CompPhaseNameMacro(PHASE_GENERATE_CODE,          "Generate code",                  "CODEGEN",  false, -1, false)
 CompPhaseNameMacro(PHASE_EMIT_CODE,              "Emit code",                      "EMIT",     false, -1, false)
 CompPhaseNameMacro(PHASE_EMIT_GCEH,              "Emit GC+EH tables",              "EMT-GCEH", false, -1, false)

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -110,7 +110,7 @@ void Compiler::optCheckFlagsAreSet(unsigned    methodFlag,
     if ((basicBlock->bbFlags & bbFlag) == 0)
     {
         printf("%s is not set on " FMT_BB " but is required because of the following tree \n", bbFlagStr,
-               compCurBB->bbNum);
+               basicBlock->bbNum);
         gtDispTree(tree);
         assert(false);
     }

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4552,7 +4552,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 
     BasicBlock* bPrev = block->bbPrev;
 
-    JITDUMP("fgRemoveBlock " FMT_BB "\n", block->bbNum);
+    JITDUMP("fgRemoveBlock " FMT_BB ", unreachable=%s\n", block->bbNum, dspBool(unreachable));
 
     // If we've cached any mappings from switch blocks to SwitchDesc's (which contain only the
     // *unique* successors of the switch block), invalidate that cache, since an entry in one of
@@ -4575,12 +4575,6 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         PREFIX_ASSUME(bPrev != nullptr);
 
         fgUnreachableBlock(block);
-
-        /* If this is the last basic block update fgLastBB */
-        if (block == fgLastBB)
-        {
-            fgLastBB = bPrev;
-        }
 
 #if defined(FEATURE_EH_FUNCLETS)
         // If block was the fgFirstFuncletBB then set fgFirstFuncletBB to block->bbNext
@@ -4634,7 +4628,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
             leaveBlk->bbRefs  = 0;
             leaveBlk->bbPreds = nullptr;
 
-            fgRemoveBlock(leaveBlk, true);
+            fgRemoveBlock(leaveBlk, /* unreachable */ true);
 
 #if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
             fgClearFinallyTargetBit(leaveBlk->bbJumpDest);

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -175,7 +175,7 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
                 nextBlock = leaveBlock->bbNext;
 
                 leaveBlock->bbFlags &= ~BBF_KEEP_BBJ_ALWAYS;
-                fgRemoveBlock(leaveBlock, true);
+                fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                 // Cleanup the postTryFinallyBlock
                 fgCleanupContinuation(postTryFinallyBlock);
@@ -194,8 +194,8 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
         firstBlock->bbRefs = 0;
 
         // Remove the handler block.
-        const bool unreachable = true;
         firstBlock->bbFlags &= ~BBF_DONT_REMOVE;
+        constexpr bool unreachable = true;
         fgRemoveBlock(firstBlock, unreachable);
 
         // Find enclosing try region for the try, if any, and update
@@ -1181,7 +1181,7 @@ PhaseStatus Compiler::fgCloneFinally()
                         nextBlock = leaveBlock->bbNext;
 
                         leaveBlock->bbFlags &= ~BBF_KEEP_BBJ_ALWAYS;
-                        fgRemoveBlock(leaveBlock, true);
+                        fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                         // Make sure iteration isn't going off the deep end.
                         assert(leaveBlock != endCallFinallyRangeBlock);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1299,6 +1299,10 @@ void LinearScan::doLinearScan()
 
     DBEXEC(VERBOSE, TupleStyleDump(LSRA_DUMP_POST));
 
+#ifdef DEBUG
+    compiler->fgDebugCheckLinks();
+#endif
+
     compiler->compLSRADone = true;
 }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -402,16 +402,14 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
 
     bool removeLoop = false;
 
-    /* If an unreachable block was part of a loop entry or bottom then the loop is unreachable */
-    /* Special case: the block was the head of a loop - or pointing to a loop entry */
+    // If an unreachable block is a loop entry or bottom then the loop is unreachable.
+    // Special case: the block was the head of a loop - or pointing to a loop entry.
 
     for (unsigned loopNum = 0; loopNum < optLoopCount; loopNum++)
     {
         LoopDsc& loop = optLoopTable[loopNum];
 
-        /* Some loops may have been already removed by
-         * loop unrolling or conditional folding */
-
+        // Some loops may have been already removed by loop unrolling or conditional folding.
         if (loop.lpFlags & LPFLG_REMOVED)
         {
             continue;
@@ -454,11 +452,9 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
             continue;
         }
 
-        /* If the loop is still in the table
-         * any block in the loop must be reachable !!! */
+        // If the loop is still in the table any block in the loop must be reachable.
 
-        noway_assert(loop.lpEntry != block);
-        noway_assert(loop.lpBottom != block);
+        noway_assert((loop.lpEntry != block) && (loop.lpBottom != block));
 
         if (loop.lpExit == block)
         {
@@ -468,27 +464,26 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
             loop.lpExit = nullptr;
         }
 
-        /* If this points to the actual entry in the loop
-         * then the whole loop may become unreachable */
+        // If `block` flows to the loop entry then the whole loop will become unreachable if it is the
+        // only non-loop predecessor.
 
         switch (block->bbJumpKind)
         {
             case BBJ_NONE:
-            case BBJ_COND:
                 if (block->bbNext == loop.lpEntry)
                 {
                     removeLoop = true;
-                    break;
                 }
-                if (block->bbJumpKind == BBJ_NONE)
-                {
-                    break;
-                }
+                break;
 
-                FALLTHROUGH;
+            case BBJ_COND:
+                if ((block->bbNext == loop.lpEntry) || (block->bbJumpDest == loop.lpEntry))
+                {
+                    removeLoop = true;
+                }
+                break;
 
             case BBJ_ALWAYS:
-                noway_assert(block->bbJumpDest);
                 if (block->bbJumpDest == loop.lpEntry)
                 {
                     removeLoop = true;
@@ -512,13 +507,12 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
 
         if (removeLoop)
         {
-            /* Check if the entry has other predecessors outside the loop
-             * TODO: Replace this when predecessors are available */
+            // Check if the entry has other predecessors outside the loop.
+            // TODO: Replace this when predecessors are available.
 
             for (BasicBlock* const auxBlock : Blocks())
             {
-                /* Ignore blocks in the loop */
-
+                // Ignore blocks in the loop.
                 if (loop.lpContains(auxBlock))
                 {
                     continue;
@@ -527,21 +521,20 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
                 switch (auxBlock->bbJumpKind)
                 {
                     case BBJ_NONE:
-                    case BBJ_COND:
                         if (auxBlock->bbNext == loop.lpEntry)
                         {
                             removeLoop = false;
-                            break;
                         }
-                        if (auxBlock->bbJumpKind == BBJ_NONE)
-                        {
-                            break;
-                        }
+                        break;
 
-                        FALLTHROUGH;
+                    case BBJ_COND:
+                        if ((auxBlock->bbNext == loop.lpEntry) || (auxBlock->bbJumpDest == loop.lpEntry))
+                        {
+                            removeLoop = false;
+                        }
+                        break;
 
                     case BBJ_ALWAYS:
-                        noway_assert(auxBlock->bbJumpDest);
                         if (auxBlock->bbJumpDest == loop.lpEntry)
                         {
                             removeLoop = false;
@@ -589,6 +582,27 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
         fgReachable(block->bbJumpDest, block))
     {
         optUnmarkLoopBlocks(block->bbJumpDest, block);
+    }
+}
+
+//------------------------------------------------------------------------
+// optClearLoopIterInfo: Clear the info related to LPFLG_ITER loops in the loop table.
+// The various fields related to iterators is known to be valid for loop cloning and unrolling,
+// but becomes invalid afterwards. Clear the info that might be used incorrectly afterwards
+// in JitDump or by subsequent phases.
+//
+void Compiler::optClearLoopIterInfo()
+{
+    for (unsigned lnum = 0; lnum < optLoopCount; lnum++)
+    {
+        LoopDsc& loop = optLoopTable[lnum];
+        loop.lpFlags &= ~(LPFLG_ITER | LPFLG_VAR_INIT | LPFLG_CONST_INIT | LPFLG_SIMD_LIMIT | LPFLG_VAR_LIMIT |
+                          LPFLG_CONST_LIMIT | LPFLG_ARRLEN_LIMIT);
+
+        loop.lpIterTree  = nullptr;
+        loop.lpInitBlock = nullptr;
+        loop.lpConstInit = -1; // union with loop.lpVarInit
+        loop.lpTestTree  = nullptr;
     }
 }
 

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -141,6 +141,8 @@ void Phase::PrePhase()
 //
 void Phase::PostPhase(PhaseStatus status)
 {
+    comp->EndPhase(m_phase);
+
 #ifdef DEBUG
 
     // Don't dump or check post phase unless the phase made changes.
@@ -162,16 +164,32 @@ void Phase::PostPhase(PhaseStatus status)
     // well as the new-style phases that have been updated to return
     // PhaseStatus from their DoPhase methods.
     //
-    static Phases s_allowlist[] = {PHASE_IMPORTATION,      PHASE_IBCINSTR,
-                                   PHASE_IBCPREP,          PHASE_INCPROFILE,
-                                   PHASE_INDXCALL,         PHASE_MORPH_INLINE,
-                                   PHASE_ALLOCATE_OBJECTS, PHASE_EMPTY_TRY,
-                                   PHASE_EMPTY_FINALLY,    PHASE_MERGE_FINALLY_CHAINS,
-                                   PHASE_CLONE_FINALLY,    PHASE_MERGE_THROWS,
-                                   PHASE_MORPH_GLOBAL,     PHASE_INVERT_LOOPS,
-                                   PHASE_OPTIMIZE_LAYOUT,  PHASE_FIND_LOOPS,
-                                   PHASE_BUILD_SSA,        PHASE_RATIONALIZE,
-                                   PHASE_LOWERING,         PHASE_STACK_LEVEL_SETTER};
+    // clang-format off
+
+    static Phases s_allowlist[] = {
+        PHASE_IMPORTATION,
+        PHASE_IBCINSTR,
+        PHASE_IBCPREP,
+        PHASE_INCPROFILE,
+        PHASE_INDXCALL,
+        PHASE_MORPH_INLINE,
+        PHASE_ALLOCATE_OBJECTS,
+        PHASE_EMPTY_TRY,
+        PHASE_EMPTY_FINALLY,
+        PHASE_MERGE_FINALLY_CHAINS,
+        PHASE_CLONE_FINALLY,
+        PHASE_MERGE_THROWS,
+        PHASE_MORPH_GLOBAL,
+        PHASE_INVERT_LOOPS,
+        PHASE_OPTIMIZE_LAYOUT,
+        PHASE_FIND_LOOPS,
+        PHASE_BUILD_SSA,
+        PHASE_INSERT_GC_POLLS,
+        PHASE_RATIONALIZE,
+        PHASE_LOWERING,
+        PHASE_STACK_LEVEL_SETTER};
+
+    // clang-format on
 
     if (madeChanges)
     {
@@ -234,6 +252,4 @@ void Phase::PostPhase(PhaseStatus status)
 #if DUMP_FLOWGRAPHS
     comp->fgDumpFlowGraph(m_phase, Compiler::PhasePosition::PostPhase);
 #endif // DUMP_FLOWGRAPHS
-
-    comp->EndPhase(m_phase);
 }


### PR DESCRIPTION
1. Assert that top-level loops are basic block disjoint
2. Assert LPFLG_ITER related flags are legal

In addition:
1. Create a `optClearLoopIterInfo` phase to clear various bits in the loop
table that are known to no longer be valid, to prevent bad asserts or JitDump
output on their values.
2. Move the EndPhase call in Phase::PostPhase happens early, not late.
This causes any subsequent asserts due to post-phase checking to be
marked with the correct phase, in cases where there was a nested phase
executed (such as liveness re-computation).
3. Convert PHASE_INSERT_GC_POLLS to use EndPhase checking
4. Convert fgDetermineFirstCodeBlock to return a PhaseStatus
5. Some minor cleanup in optUpdateLoopsBeforeRemoveBlock()
(this was extracted from some bigger changes)

No asm diffs