### PR TITLE
[mono] Optimize generic sharing for generic methods.

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Roslyn3.11.Unit.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/System.Text.Json.SourceGeneration.Roslyn3.11.Unit.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <HighAotMemoryUsageAssembly Include="Microsoft.CodeAnalysis.dll" />
     <HighAotMemoryUsageAssembly Include="Microsoft.CodeAnalysis.CSharp.dll" />
   </ItemGroup>
 

--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -316,6 +316,7 @@ MONO_JIT_ICALL (mono_value_copy_internal) \
 MONO_JIT_ICALL (mono_x86_start_gsharedvt_call)	\
 MONO_JIT_ICALL (mono_x86_throw_corlib_exception)	\
 MONO_JIT_ICALL (mono_x86_throw_exception)	\
+MONO_JIT_ICALL (mini_init_method_rgctx)		\
 MONO_JIT_ICALL (native_to_interp_trampoline)	\
 MONO_JIT_ICALL (personality) \
 MONO_JIT_ICALL (pthread_getspecific) \

--- a/src/mono/mono/metadata/object-offsets.h
+++ b/src/mono/mono/metadata/object-offsets.h
@@ -163,6 +163,8 @@ DECL_OFFSET(MonoMethodILState, il_offset)
 DECL_OFFSET(MonoMethodILState, data)
 
 DECL_OFFSET(MonoMethodRuntimeGenericContext, class_vtable)
+DECL_OFFSET(MonoMethodRuntimeGenericContext, entries)
+DECL_OFFSET(MonoMethodRuntimeGenericContext, infos)
 
 DECL_OFFSET(MonoJitTlsData, lmf)
 DECL_OFFSET(MonoJitTlsData, class_cast_from)

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1658,3 +1658,30 @@ void
 mono_dummy_jit_icall_val (gpointer val)
 {
 }
+
+void
+mini_init_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, MonoGSharedMethodInfo *info)
+{
+	if (G_LIKELY (mrgctx->entries))
+		return;
+
+	MonoMethod *m = mrgctx->method;
+	int ninline = mono_class_rgctx_get_array_size (0, TRUE);
+
+	// The +1 is for the NULL check at the beginning
+	// FIXME: memory management
+	gpointer *entries = mono_mem_manager_alloc0 (get_default_mem_manager (), (sizeof (gpointer) * (info->num_entries + 1)));
+	for (int i = 0; i < info->num_entries; ++i) {
+		gpointer data = mini_instantiate_gshared_info (&info->entries [i],
+													   mono_method_get_context (m), m->klass);
+		g_assert (data);
+
+		/* The first few entries are stored inline, the rest are stored in mrgctx->entries */
+		if (i < ninline)
+			mrgctx->infos [i] = data;
+		else
+			entries [i - ninline] = data;
+	}
+	mono_memory_barrier ();
+	mrgctx->entries = entries;
+}

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -233,4 +233,6 @@ ICALL_EXPORT void mono_dummy_jit_icall (void);
 
 ICALL_EXPORT void mono_dummy_jit_icall_val (gpointer ptr);
 
+ICALL_EXPORT void mini_init_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, MonoGSharedMethodInfo *info);
+
 #endif /* __MONO_JIT_ICALLS_H__ */

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -853,11 +853,8 @@ mono_get_generic_info_from_stack_frame (MonoJitInfo *ji, MonoContext *ctx)
 	}
 
 	method = jinfo_get_method (ji);
-	if (mono_method_get_context (method)->method_inst || mini_method_is_default_method (method)) {
+	if (mono_method_get_context (method)->method_inst || m_method_is_static (method) || m_class_is_valuetype (method->klass) || mini_method_is_default_method (method)) {
 		/* A MonoMethodRuntimeGenericContext* */
-		return info;
-	} else if ((method->flags & METHOD_ATTRIBUTE_STATIC) || m_class_is_valuetype (method->klass)) {
-		/* A MonoVTable* */
 		return info;
 	} else {
 		/* Avoid returning a managed object */
@@ -881,13 +878,11 @@ mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_inf
 
 	method = jinfo_get_method (ji);
 	g_assert (method->is_inflated);
-	if (mono_method_get_context (method)->method_inst || mini_method_is_default_method (method)) {
+	if (mono_method_get_context (method)->method_inst || mini_method_is_default_method (method) || m_method_is_static (method) || m_class_is_valuetype (method->klass)) {
 		MonoMethodRuntimeGenericContext *mrgctx = (MonoMethodRuntimeGenericContext *)generic_info;
 
 		klass = mrgctx->class_vtable->klass;
 		context.method_inst = mrgctx->method_inst;
-		if (!mini_method_is_default_method (method))
-			g_assert (context.method_inst);
 	} else {
 		MonoVTable *vtable = (MonoVTable *)generic_info;
 

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -3962,6 +3962,8 @@ mini_method_needs_mrgctx (MonoMethod *m)
 {
 	if (mono_class_is_ginst (m->klass) && mini_method_is_default_method (m))
 		return TRUE;
+	if (m->flags & METHOD_ATTRIBUTE_STATIC || m_class_is_valuetype (m->klass))
+		return TRUE;
 	return (mini_method_get_context (m) && mini_method_get_context (m)->method_inst);
 }
 

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -2586,6 +2586,19 @@ instantiate_info (MonoMemoryManager *mem_manager, MonoRuntimeGenericContextInfoT
 	return NULL;
 }
 
+gpointer
+mini_instantiate_gshared_info (MonoRuntimeGenericContextInfoTemplate *oti,
+							   MonoGenericContext *context, MonoClass *klass)
+{
+	ERROR_DECL (error);
+	// FIXME:
+	MonoJitMemoryManager *jit_mm = jit_mm_for_class (klass);
+
+	gpointer res = instantiate_info (jit_mm->mem_manager, oti, context, klass, error);
+	mono_error_assert_ok (error);
+	return res;
+}
+
 /*
  * LOCKING: loader lock
  */
@@ -2784,6 +2797,7 @@ info_equal (gpointer data1, gpointer data2, MonoRgctxInfoType info_type)
  * mini_rgctx_info_type_to_patch_info_type:
  *
  *   Return the type of the runtime object referred to by INFO_TYPE.
+ * The types are identified by MONO_PATCH_INFO_ values.
  */
 MonoJumpInfoType
 mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
@@ -2816,7 +2830,19 @@ mini_rgctx_info_type_to_patch_info_type (MonoRgctxInfoType info_type)
 	case MONO_RGCTX_INFO_GSHAREDVT_OUT_WRAPPER:
 	case MONO_RGCTX_INFO_INTERP_METHOD:
 	case MONO_RGCTX_INFO_LLVMONLY_INTERP_ENTRY:
+	case MONO_RGCTX_INFO_GENERIC_METHOD_CODE:
+	case MONO_RGCTX_INFO_METHOD_DELEGATE_CODE:
 		return MONO_PATCH_INFO_METHOD;
+	case MONO_RGCTX_INFO_DELEGATE_TRAMP_INFO:
+		return MONO_PATCH_INFO_DELEGATE_TRAMPOLINE;
+	case MONO_RGCTX_INFO_VIRT_METHOD_CODE:
+	case MONO_RGCTX_INFO_VIRT_METHOD_BOX_TYPE:
+		return MONO_PATCH_INFO_VIRT_METHOD;
+	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_INFO:
+		return MONO_PATCH_INFO_GSHAREDVT_METHOD;
+	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE:
+	case MONO_RGCTX_INFO_METHOD_GSHAREDVT_OUT_TRAMPOLINE_VIRT:
+		return MONO_PATCH_INFO_GSHAREDVT_CALL;
 	default:
 		printf ("%d\n", info_type);
 		g_assert_not_reached ();
@@ -2941,7 +2967,12 @@ mono_class_rgctx_get_array_size (int n, gboolean mrgctx)
 static gpointer*
 alloc_rgctx_array (MonoMemoryManager *mem_manager, int n, gboolean is_mrgctx)
 {
-	gint32 size = mono_class_rgctx_get_array_size (n, is_mrgctx) * sizeof (gpointer);
+	int size;
+
+	if (is_mrgctx && n == 0)
+		size = sizeof (MonoMethodRuntimeGenericContext) + (mono_class_rgctx_get_array_size (n, is_mrgctx) * sizeof (gpointer));
+	else
+		size = mono_class_rgctx_get_array_size (n, is_mrgctx) * sizeof (gpointer);
 	gpointer *array = (gpointer *)mono_mem_manager_alloc0 (mem_manager, size);
 
 	if (is_mrgctx) {
@@ -3153,24 +3184,6 @@ mono_method_fill_runtime_generic_context (MonoMethodRuntimeGenericContext *mrgct
 	return info;
 }
 
-static guint
-mrgctx_hash_func (gconstpointer key)
-{
-	const MonoMethodRuntimeGenericContext *mrgctx = (const MonoMethodRuntimeGenericContext *)key;
-
-	return mono_aligned_addr_hash (mrgctx->class_vtable) ^ mono_metadata_generic_inst_hash (mrgctx->method_inst);
-}
-
-static gboolean
-mrgctx_equal_func (gconstpointer a, gconstpointer b)
-{
-	const MonoMethodRuntimeGenericContext *mrgctx1 = (const MonoMethodRuntimeGenericContext *)a;
-	const MonoMethodRuntimeGenericContext *mrgctx2 = (const MonoMethodRuntimeGenericContext *)b;
-
-	return mrgctx1->class_vtable == mrgctx2->class_vtable &&
-		mono_metadata_generic_inst_equal (mrgctx1->method_inst, mrgctx2->method_inst);
-}
-
 /*
  * mini_method_get_mrgctx:
  * @class_vtable: a vtable
@@ -3183,7 +3196,6 @@ static MonoMethodRuntimeGenericContext*
 mini_method_get_mrgctx (MonoVTable *class_vtable, MonoMethod *method)
 {
 	MonoMethodRuntimeGenericContext *mrgctx;
-	MonoMethodRuntimeGenericContext key;
 	MonoGenericInst *method_inst = mini_method_get_context (method)->method_inst;
 	MonoJitMemoryManager *jit_mm;
 
@@ -3191,38 +3203,22 @@ mini_method_get_mrgctx (MonoVTable *class_vtable, MonoMethod *method)
 
 	jit_mm = jit_mm_for_method (method);
 
-	if (!method_inst) {
-		g_assert (mini_method_is_default_method (method));
-
-		jit_mm_lock (jit_mm);
-		if (!jit_mm->mrgctx_hash)
-			jit_mm->mrgctx_hash = g_hash_table_new (NULL, NULL);
-		mrgctx = (MonoMethodRuntimeGenericContext*)g_hash_table_lookup (jit_mm->mrgctx_hash, method);
-		jit_mm_unlock (jit_mm);
-	} else {
-		g_assert (!method_inst->is_open);
-
-		jit_mm_lock (jit_mm);
-		if (!jit_mm->method_rgctx_hash)
-			jit_mm->method_rgctx_hash = g_hash_table_new (mrgctx_hash_func, mrgctx_equal_func);
-
-		key.class_vtable = class_vtable;
-		key.method_inst = method_inst;
-
-		mrgctx = (MonoMethodRuntimeGenericContext *)g_hash_table_lookup (jit_mm->method_rgctx_hash, &key);
-		jit_mm_unlock (jit_mm);
-	}
+	jit_mm_lock (jit_mm);
+	if (!jit_mm->mrgctx_hash)
+		jit_mm->mrgctx_hash = g_hash_table_new (NULL, NULL);
+	mrgctx = (MonoMethodRuntimeGenericContext*)g_hash_table_lookup (jit_mm->mrgctx_hash, method);
+	jit_mm_unlock (jit_mm);
 
 	if (!mrgctx) {
 		mrgctx = (MonoMethodRuntimeGenericContext*)alloc_rgctx_array (jit_mm->mem_manager, 0, TRUE);
 		mrgctx->class_vtable = class_vtable;
 		mrgctx->method_inst = method_inst;
+		mrgctx->method = method;
+
+		//printf ("MRGCTX: %s -> %p\n", mono_method_get_full_name (method), mrgctx);
 
 		jit_mm_lock (jit_mm);
-		if (!method_inst)
-			g_hash_table_insert (jit_mm->mrgctx_hash, method, mrgctx);
-		else
-			g_hash_table_insert (jit_mm->method_rgctx_hash, mrgctx, mrgctx);
+		g_hash_table_insert (jit_mm->mrgctx_hash, method, mrgctx);
 		jit_mm_unlock (jit_mm);
 
 		/*

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -3660,10 +3660,6 @@ emit_method_init (EmitContext *ctx)
 			subtype = AOT_INIT_METHOD_GSHARED_THIS;
 		}
 		break;
-	case MONO_RGCTX_ACCESS_VTABLE:
-		args [nargs ++] = convert (ctx, ctx->rgctx_arg, IntPtrType ());
-		subtype = AOT_INIT_METHOD_GSHARED_VTABLE;
-		break;
 	case MONO_RGCTX_ACCESS_THIS:
 		args [nargs ++] = convert (ctx, ctx->this_arg, ObjRefType ());
 		subtype = AOT_INIT_METHOD_GSHARED_THIS;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2831,7 +2831,9 @@ static gpointer
 get_ftnptr_for_method (MonoMethod *method, MonoError *error)
 {
 	if (!mono_llvm_only) {
-		return mono_jit_compile_method (method, error);
+		gpointer res = mono_jit_compile_method (method, error);
+		res = mini_add_method_trampoline (method, res, mono_method_needs_static_rgctx_invoke (method, TRUE), FALSE);
+		return res;
 	} else {
 		return mini_llvmonly_load_method_ftndesc (method, FALSE, FALSE, error);
 	}

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1229,6 +1229,7 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_METHOD_CODE_SLOT:
 	case MONO_PATCH_INFO_AOT_JIT_INFO:
 	case MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE:
+	case MONO_PATCH_INFO_GSHARED_METHOD_INFO:
 		return hash | (gssize)ji->data.target;
 	case MONO_PATCH_INFO_GSHAREDVT_CALL:
 		return hash | (gssize)ji->data.gsharedvt->method;
@@ -1357,6 +1358,63 @@ mono_patch_info_equal (gconstpointer ka, gconstpointer kb)
 	}
 
 	return ji1->data.target == ji2->data.target;
+}
+
+/* Make a copy of MonoGSharedMethodInfo and all its nested data into MEM_MANAGER */
+MonoGSharedMethodInfo *
+mini_gshared_method_info_dup (MonoMemoryManager *mem_manager, MonoGSharedMethodInfo *info)
+{
+	MonoGSharedMethodInfo *res = (MonoGSharedMethodInfo *)mono_mem_manager_alloc0 (mem_manager, sizeof (MonoGSharedMethodInfo));
+	memcpy (res, info, sizeof (MonoGSharedMethodInfo));
+
+	MonoRuntimeGenericContextInfoTemplate *oentries = info->entries;
+	res->entries = (MonoRuntimeGenericContextInfoTemplate *)mono_mem_manager_alloc0 (mem_manager, sizeof (MonoRuntimeGenericContextInfoTemplate) * info->num_entries);
+	memcpy (res->entries, oentries, sizeof (MonoRuntimeGenericContextInfoTemplate) * info->num_entries);
+
+	for (int i = 0; i < info->num_entries; ++i) {
+		MonoRuntimeGenericContextInfoTemplate *entry = &info->entries [i];
+		MonoRuntimeGenericContextInfoTemplate *new_entry = &res->entries [i];
+		switch (mini_rgctx_info_type_to_patch_info_type (entry->info_type)) {
+		case MONO_PATCH_INFO_DELEGATE_TRAMPOLINE: {
+			MonoDelegateClassMethodPair *old_info = (MonoDelegateClassMethodPair*)entry->data;
+			MonoDelegateClassMethodPair *new_info = mono_mem_manager_alloc0 (mem_manager, sizeof (MonoDelegateClassMethodPair));
+			memcpy (new_info, old_info, sizeof (MonoDelegateClassMethodPair));
+			new_entry->data = new_info;
+			break;
+		}
+		case MONO_PATCH_INFO_VIRT_METHOD: {
+			MonoJumpInfoVirtMethod *old_info = (MonoJumpInfoVirtMethod *)entry->data;
+			MonoJumpInfoVirtMethod *new_info = (MonoJumpInfoVirtMethod *)mono_mem_manager_alloc0 (mem_manager, sizeof (MonoJumpInfoVirtMethod));
+			memcpy (new_info, old_info, sizeof (MonoJumpInfoVirtMethod));
+			new_entry->data = new_info;
+			break;
+		}
+		case MONO_PATCH_INFO_GSHAREDVT_METHOD: {
+			MonoGSharedVtMethodInfo *old_info = (MonoGSharedVtMethodInfo*)entry->data;
+			MonoGSharedVtMethodInfo *new_info = (MonoGSharedVtMethodInfo*)mono_mem_manager_alloc0 (mem_manager, sizeof (MonoGSharedVtMethodInfo));
+			memcpy (new_info, old_info, sizeof (MonoGSharedVtMethodInfo));
+
+			MonoRuntimeGenericContextInfoTemplate *old_entries = old_info->entries;
+			MonoRuntimeGenericContextInfoTemplate *new_entries = (MonoRuntimeGenericContextInfoTemplate *)mono_mem_manager_alloc0 (mem_manager, sizeof (MonoRuntimeGenericContextInfoTemplate) * old_info->count_entries);
+			memcpy (new_entries, old_entries, sizeof (MonoRuntimeGenericContextInfoTemplate) * old_info->count_entries);
+			new_info->entries = new_entries;
+
+			new_entry->data = new_info;
+			break;
+		}
+		case MONO_PATCH_INFO_GSHAREDVT_CALL: {
+			MonoJumpInfoGSharedVtCall *old_info = (MonoJumpInfoGSharedVtCall*)entry->data;
+			MonoJumpInfoGSharedVtCall *new_info = (MonoJumpInfoGSharedVtCall*)mono_mem_manager_alloc0 (mem_manager, sizeof (MonoJumpInfoGSharedVtCall));
+			memcpy (new_info, old_info, sizeof (MonoJumpInfoGSharedVtCall));
+			new_entry->data = new_info;
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	return res;
 }
 
 gpointer
@@ -1694,6 +1752,9 @@ mono_resolve_patch_target_ext (MonoMemoryManager *mem_manager, MonoMethod *metho
 		target = NULL;
 		break;
 	}
+	case MONO_PATCH_INFO_GSHARED_METHOD_INFO:
+		target = mini_gshared_method_info_dup (mem_manager, (MonoGSharedMethodInfo*)patch_info->data.target);
+		break;
 	default:
 		g_assert_not_reached ();
 	}
@@ -4265,7 +4326,6 @@ free_jit_mem_manager (MonoMemoryManager *mem_manager)
 	g_hash_table_destroy (info->delegate_trampoline_hash);
 	g_hash_table_destroy (info->static_rgctx_trampoline_hash);
 	g_hash_table_destroy (info->mrgctx_hash);
-	g_hash_table_destroy (info->method_rgctx_hash);
 	g_hash_table_destroy (info->interp_method_pointer_hash);
 	mono_conc_hashtable_destroy (info->runtime_invoke_hash);
 	g_hash_table_destroy (info->seq_points);
@@ -4902,6 +4962,7 @@ register_icalls (void)
 	register_icall (mono_throw_invalid_program, mono_icall_sig_void_ptr, FALSE);
 	register_icall_no_wrapper (mono_dummy_jit_icall, mono_icall_sig_void);
 	//register_icall_no_wrapper (mono_dummy_jit_icall_val, mono_icall_sig_void_ptr);
+	register_icall_no_wrapper (mini_init_method_rgctx, mono_icall_sig_void_ptr_ptr);
 
 	register_icall_with_wrapper (mono_monitor_enter_internal, mono_icall_sig_int32_obj);
 	register_icall_with_wrapper (mono_monitor_enter_v4_internal, mono_icall_sig_void_obj_ptr);

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -54,7 +54,6 @@ typedef struct {
 	MonoInternalHashTable interp_code_hash;
 	/* Maps MonoMethod -> 	MonoMethodRuntimeGenericContext */
 	GHashTable *mrgctx_hash;
-	GHashTable *method_rgctx_hash;
 	/* Maps gpointer -> InterpMethod */
 	GHashTable *interp_method_pointer_hash;
 	/* Protected by 'jit_code_hash_lock' */
@@ -567,6 +566,7 @@ gint  mono_patch_info_equal (gconstpointer ka, gconstpointer kb);
 MonoJumpInfo *mono_patch_info_list_prepend  (MonoJumpInfo *list, int ip, MonoJumpInfoType type, gconstpointer target);
 MonoJumpInfoToken* mono_jump_info_token_new (MonoMemPool *mp, MonoImage *image, guint32 token);
 MonoJumpInfoToken* mono_jump_info_token_new2 (MonoMemPool *mp, MonoImage *image, guint32 token, MonoGenericContext *context);
+MonoGSharedMethodInfo* mini_gshared_method_info_dup (MonoMemoryManager *mem_manager, MonoGSharedMethodInfo *info);
 gpointer  mono_resolve_patch_target         (MonoMethod *method, guint8 *code, MonoJumpInfo *patch_info, gboolean run_cctors, MonoError *error);
 gpointer  mono_resolve_patch_target_ext     (MonoMemoryManager *mem_manager, MonoMethod *method, guint8 *code, MonoJumpInfo *patch_info, gboolean run_cctors, MonoError *error);
 void mini_register_jump_site                (MonoMethod *method, gpointer ip);

--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -558,9 +558,15 @@ common_call_trampoline (host_mgreg_t *regs, guint8 *code, MonoMethod *m, MonoVTa
 			klass = mrgctx->class_vtable->klass;
 			method_inst = mrgctx->method_inst;
 		} else if ((m->flags & METHOD_ATTRIBUTE_STATIC) || m_class_is_valuetype (m->klass)) {
+			MonoMethodRuntimeGenericContext *mrgctx = (MonoMethodRuntimeGenericContext*)mono_arch_find_static_call_vtable (regs, code);
+
+			klass = mrgctx->class_vtable->klass;
+			method_inst = mrgctx->method_inst;
+			/*
 			MonoVTable *vtable = mono_arch_find_static_call_vtable (regs, code);
 
 			klass = vtable->klass;
+			*/
 		} else {
 			MonoObject *this_argument = (MonoObject *)mono_arch_get_this_arg_from_call (regs, code);
 

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3752,6 +3752,13 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 		mono_cfg_dump_ir (cfg, "decompose_array_access_opts");
 	}
 
+	/* Eliminate the mrgctx init call if the method has no mrgctx entries */
+	if (cfg->gshared_info && !cfg->gshared_info->num_entries) {
+		NULLIFY_INS (cfg->init_method_rgctx_ins);
+		/* Needed by the assert in get_gshared_info_slot () */
+		cfg->init_method_rgctx_ins = NULL;
+	}
+
 	if (cfg->got_var) {
 #ifndef MONO_ARCH_GOT_REG
 		GList *regs;
@@ -3839,6 +3846,13 @@ mini_method_compile (MonoMethod *method, guint32 opts, JitFlags flags, int parts
 	}
 
 	mono_insert_branches_between_bblocks (cfg);
+
+	if (cfg->gshared_info) {
+		MonoGSharedMethodInfo *info = mini_gshared_method_info_dup (cfg->mem_manager, cfg->gshared_info);
+
+		/* cfg->gshared_info is already allocated from permanent memory, so change only the entries */
+		cfg->gshared_info->entries = info->entries;
+	}
 
 	if (COMPILE_LLVM (cfg)) {
 #ifdef ENABLE_LLVM

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -3055,7 +3055,7 @@ mini_get_rgctx_access_for_method (MonoMethod *method)
 		return MONO_RGCTX_ACCESS_MRGCTX;
 
 	if (method->flags & METHOD_ATTRIBUTE_STATIC || m_class_is_valuetype (method->klass))
-		return MONO_RGCTX_ACCESS_VTABLE;
+		return MONO_RGCTX_ACCESS_MRGCTX;
 
 	return MONO_RGCTX_ACCESS_THIS;
 }

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1104,12 +1104,14 @@ typedef struct {
 
 typedef struct {
 	MonoVTable *class_vtable; /* must be the first element */
+	MonoMethod *method;
 	MonoGenericInst *method_inst;
+	gpointer *entries;
 	gpointer infos [MONO_ZERO_LEN_ARRAY];
 } MonoMethodRuntimeGenericContext;
 
 /* MONO_ABI_SIZEOF () would include the 'infos' field as well */
-#define MONO_SIZEOF_METHOD_RUNTIME_GENERIC_CONTEXT (TARGET_SIZEOF_VOID_P * 2)
+#define MONO_SIZEOF_METHOD_RUNTIME_GENERIC_CONTEXT (TARGET_SIZEOF_VOID_P * 4)
 
 #define MONO_RGCTX_SLOT_MAKE_RGCTX(i)	(i)
 #define MONO_RGCTX_SLOT_MAKE_MRGCTX(i)	((i) | 0x80000000)
@@ -1123,6 +1125,12 @@ typedef struct {
 	MonoRuntimeGenericContextInfoTemplate *entries;
 	int num_entries, count_entries;
 } MonoGSharedVtMethodInfo;
+
+typedef struct {
+	MonoMethod *method;
+	MonoRuntimeGenericContextInfoTemplate *entries;
+	int num_entries, count_entries;
+} MonoGSharedMethodInfo;
 
 /* This is used by gsharedvt methods to allocate locals and compute local offsets */
 typedef struct {
@@ -1379,6 +1387,8 @@ typedef struct {
 	MonoGenericSharingContext gsctx;
 	MonoGenericContext *gsctx_context;
 
+	MonoGSharedMethodInfo *gshared_info;
+
 	MonoGSharedVtMethodInfo *gsharedvt_info;
 
 	gpointer jit_mm;
@@ -1393,8 +1403,8 @@ typedef struct {
 	/* Points to a MonoGSharedVtMethodRuntimeInfo at runtime */
 	MonoInst *gsharedvt_info_var;
 
-	/* For native-to-managed wrappers, CEE_MONO_JIT_(AT|DE)TACH opcodes */
-	MonoInst *orig_domain_var;
+	/* Points to the call to mini_init_method_rgctx () */
+	MonoInst *init_method_rgctx_ins;
 
 	MonoInst *lmf_var;
 	MonoInst *lmf_addr_var;
@@ -2817,6 +2827,9 @@ MonoMethod* mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig);
 MonoMethod* mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig);
 MonoMethodSignature* mini_get_gsharedvt_out_sig_wrapper_signature (gboolean has_this, gboolean has_ret, int param_count);
 gboolean mini_gsharedvt_runtime_invoke_supported (MonoMethodSignature *sig);
+gpointer mini_instantiate_gshared_info (MonoRuntimeGenericContextInfoTemplate *oti,
+										MonoGenericContext *context, MonoClass *klass);
+
 G_EXTERN_C void mono_interp_entry_from_trampoline (gpointer ccontext, gpointer imethod);
 G_EXTERN_C void mono_interp_to_native_trampoline (gpointer addr, gpointer ccontext);
 MonoMethod* mini_get_interp_in_wrapper (MonoMethodSignature *sig);

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -1086,8 +1086,6 @@ typedef enum {
 	MONO_RGCTX_ACCESS_THIS = 1,
 	/* Loaded from an additional mrgctx argument */
 	MONO_RGCTX_ACCESS_MRGCTX = 2,
-	/* Loaded from an additional vtable argument */
-	MONO_RGCTX_ACCESS_VTABLE = 3
 } MonoRgctxAccess;
 
 typedef struct _MonoRuntimeGenericContextInfoTemplate {

--- a/src/mono/mono/mini/patch-info.h
+++ b/src/mono/mono/mini/patch-info.h
@@ -88,3 +88,6 @@ PATCH_INFO(METHOD_PINVOKE_ADDR_CACHE, "pinvoke_addr_cache")
 
 /* MonoMethod* -> llvmonly interp entry */
 PATCH_INFO(LLVMONLY_INTERP_ENTRY, "llvmonly_interp_entry")
+
+/* A MonoGSharedMethodInfo structure */
+PATCH_INFO(GSHARED_METHOD_INFO, "gshared_method_info")


### PR DESCRIPTION
  Previously, rgctx entries where stored either in the class rgctx
or the method rgctx in linked structures, and accessed using
rgctx trampolines (for non-llvmonly configuration), or
inline code and fallback C code (for llvmonly configuration).
However, if a method has an mrgctx parameter, all the rgctx entries
can be stored as an array in the mrgctx and accessed using a simple
load.
One complication is that the mrgctx might need to be allocated before
the method is compiled/loaded, so the rgctx entries need to be stored
in a separate array, and the array needs to be initialized on
demand.

* Add an 'entries' field to MonoMethodRuntimeGenericContext which stores
the rgctx entries.
* Add a MonoGSharedMethodInfo structure which stores the information
needed to initialize a MonoMethodRuntimeGenericContext, i.e. the
number of rgctx entries and their contents.
* Add a MONO_PATCH_INFO_GSHARED_METHOD_INFO patch type to refer
to the previous structure.
* Add a mini_init_method_rgctx () JIT icall, which initializes
an mrgctx if needed and generate code in the prolog of gshared methods
to call it.