### PR TITLE
Update tests to expect RemoteExecutor to check exit code

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void EnsureEnvironmentExitDoesntHang()
         {
-            // SIGTERM is only handled on net6.0+, so the workaround to "clobber" the exit code is still in place on NetFramework
+            // SIGTERM is only handled on net6.0+, so the workaround to "clobber" the exit code is still in place on .NET Framework
             int expectedExitCode = PlatformDetection.IsNetFramework ? 0 : 125;
 
             using var remoteHandle = RemoteExecutor.Invoke(async () =>

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
@@ -105,10 +105,10 @@ namespace Microsoft.Extensions.Hosting.Tests
                         services.AddHostedService<EnsureEnvironmentExitCodeWorker>();
                     })
                     .RunConsoleAsync();
-            });
+            }, new RemoteInvokeOptions() { ExpectedExitCode = 124 });
 
+            // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
             remoteHandle.Process.WaitForExit();
-
             Assert.Equal(124, remoteHandle.Process.ExitCode);
         }
 
@@ -130,6 +130,9 @@ namespace Microsoft.Extensions.Hosting.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void EnsureEnvironmentExitDoesntHang()
         {
+            // SIGTERM is only handled on net6.0+, so the workaround to "clobber" the exit code is still in place on NetFramework
+            int expectedExitCode = PlatformDetection.IsNetFramework ? 0 : 125;
+
             using var remoteHandle = RemoteExecutor.Invoke(async () =>
             {
                 await Host.CreateDefaultBuilder()
@@ -139,12 +142,11 @@ namespace Microsoft.Extensions.Hosting.Tests
                         services.AddHostedService<EnsureEnvironmentExitDoesntHangWorker>();
                     })
                     .RunConsoleAsync();
-            }, new RemoteInvokeOptions() { TimeOut = 30_000 }); // give a 30 second time out, so if this does hang, it doesn't hang for the full timeout
+            }, new RemoteInvokeOptions() { TimeOut = 30_000, ExpectedExitCode = expectedExitCode }); // give a 30 second time out, so if this does hang, it doesn't hang for the full timeout
 
             Assert.True(remoteHandle.Process.WaitForExit(30_000), "The hosted process should have exited within 30 seconds");
 
-            // SIGTERM is only handled on net6.0+, so the workaround to "clobber" the exit code is still in place on NetFramework
-            int expectedExitCode = PlatformDetection.IsNetFramework ? 0 : 125;
+            // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
             Assert.Equal(expectedExitCode, remoteHandle.Process.ExitCode);
         }
 

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
@@ -618,6 +618,8 @@ namespace Microsoft.VisualBasic.Tests
                             {
                             }
                         }
+
+                        return 0;
                     },
                     fileName,
                     text,

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
@@ -618,12 +618,9 @@ namespace Microsoft.VisualBasic.Tests
                             {
                             }
                         }
-
-                        return 0;
                     },
                     fileName,
-                    text,
-                    new RemoteInvokeOptions() { ExpectedExitCode = 0 }).Dispose();
+                    text).Dispose();
             }
         }
 

--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -78,7 +78,7 @@ public partial class CancelKeyPressTests
 
             // Release CancelKeyPress
             mre.Set();
-        }).Dispose();
+        }, new RemoteInvokeOptions() { CheckExitCode = false }).Dispose();
     }
 
     private void HandlerInvokedForSignal(int signalOuter, bool redirectStandardInput)

--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -78,7 +78,7 @@ public partial class CancelKeyPressTests
 
             // Release CancelKeyPress
             mre.Set();
-        }, new RemoteInvokeOptions() { CheckExitCode = false }).Dispose();
+        }, new RemoteInvokeOptions() { ExpectedExitCode = 130 }).Dispose();
     }
 
     private void HandlerInvokedForSignal(int signalOuter, bool redirectStandardInput)

--- a/src/libraries/System.Runtime/tests/System/ExitCodeTests.Unix.cs
+++ b/src/libraries/System.Runtime/tests/System/ExitCodeTests.Unix.cs
@@ -42,6 +42,7 @@ namespace System.Tests
 
             RemoteInvokeOptions options = new RemoteInvokeOptions();
             options.StartInfo.RedirectStandardOutput = true;
+            options.CheckExitCode = false;
             using (RemoteInvokeHandle remoteExecution = RemoteExecutor.Invoke(action, exitCodeOnSigterm?.ToString() ?? string.Empty, options))
             {
                 Process process = remoteExecution.Process;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         public static void Converters_AndTypeInfoCreator_NotRooted_WhenMetadataNotPresent()
         {
             RemoteExecutor.Invoke(
-                new Action(() =>
+                () =>
                 {
                     object[] objArr = new object[] { new MyStruct() };
 
@@ -56,7 +56,9 @@ namespace System.Text.Json.SourceGeneration.Tests
                         Assert.NotNull(fieldInfo);
                         Assert.Null(fieldInfo.GetValue(optionsInstance));
                     }
-                }),
+
+                    return 0;
+                },
                 new RemoteInvokeOptions() { ExpectedExitCode = 0 }).Dispose();
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSerializerContextTests.cs
@@ -56,10 +56,7 @@ namespace System.Text.Json.SourceGeneration.Tests
                         Assert.NotNull(fieldInfo);
                         Assert.Null(fieldInfo.GetValue(optionsInstance));
                     }
-
-                    return 0;
-                },
-                new RemoteInvokeOptions() { ExpectedExitCode = 0 }).Dispose();
+                }).Dispose();
         }
 
         [Fact]


### PR DESCRIPTION
In preparation for https://github.com/dotnet/arcade/pull/8369