### PR TITLE
Add test for exception throw inside Reverse PInvoke

### DIFF
--- a/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
+++ b/src/tests/Exceptions/ForeignThread/ForeignThreadExceptions.cs
@@ -32,6 +32,17 @@ class ForeignThreadExceptionsTest
             }
         });
 
+        try
+        {
+            InvokeCallback(() => {
+                MethodThatThrows();
+            });
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Caught exception thrown inside unmanaged code in a function called by a delegate called through Reverse PInvoke.");
+        }
+
         InvokeCallbackOnNewThread(() => {
             try
             {


### PR DESCRIPTION
This test works on CoreCLR but fails at NativeAOT currently