### PR TITLE
Fix several bugs in NullabilityInfoContext.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace System.Reflection
 {
@@ -71,13 +72,11 @@ namespace System.Reflection
 
             EnsureIsSupported();
 
-            if (parameterInfo.Member is MethodInfo method && IsPrivateOrInternalMethodAndAnnotationDisabled(method))
-            {
-                return new NullabilityInfo(parameterInfo.ParameterType, NullabilityState.Unknown, NullabilityState.Unknown, null, Array.Empty<NullabilityInfo>());
-            }
-
             IList<CustomAttributeData> attributes = parameterInfo.GetCustomAttributesData();
-            NullabilityInfo nullability = GetNullabilityInfo(parameterInfo.Member, parameterInfo.ParameterType, attributes);
+            NullableAttributeStateParser parser = parameterInfo.Member is MethodBase method && IsPrivateOrInternalMethodAndAnnotationDisabled(method)
+                ? NullableAttributeStateParser.Unknown
+                : CreateParser(attributes);
+            NullabilityInfo nullability = GetNullabilityInfo(parameterInfo.Member, parameterInfo.ParameterType, parser);
 
             if (nullability.ReadState != NullabilityState.Unknown)
             {
@@ -114,7 +113,7 @@ namespace System.Reflection
 
                 if (metaParameter != null)
                 {
-                    CheckGenericParameters(nullability, metaMethod, metaParameter.ParameterType);
+                    CheckGenericParameters(nullability, metaMethod, metaParameter.ParameterType, parameter.Member.ReflectedType);
                 }
             }
         }
@@ -131,39 +130,44 @@ namespace System.Reflection
 
         private void CheckNullabilityAttributes(NullabilityInfo nullability, IList<CustomAttributeData> attributes)
         {
+            var codeAnalysisReadState = NullabilityState.Unknown;
+            var codeAnalysisWriteState = NullabilityState.Unknown;
+
             foreach (CustomAttributeData attribute in attributes)
             {
                 if (attribute.AttributeType.Namespace == "System.Diagnostics.CodeAnalysis")
                 {
-                    if (attribute.AttributeType.Name == "NotNullAttribute" &&
-                        nullability.ReadState == NullabilityState.Nullable)
+                    if (attribute.AttributeType.Name == "NotNullAttribute")
                     {
-                        nullability.ReadState = NullabilityState.NotNull;
-                        break;
+                        codeAnalysisReadState = NullabilityState.NotNull;
                     }
                     else if ((attribute.AttributeType.Name == "MaybeNullAttribute" ||
                             attribute.AttributeType.Name == "MaybeNullWhenAttribute") &&
-                            nullability.ReadState == NullabilityState.NotNull &&
+                            codeAnalysisReadState == NullabilityState.Unknown &&
                             !nullability.Type.IsValueType)
                     {
-                        nullability.ReadState = NullabilityState.Nullable;
-                        break;
+                        codeAnalysisReadState = NullabilityState.Nullable;
                     }
-
-                    if (attribute.AttributeType.Name == "DisallowNullAttribute" &&
-                        nullability.WriteState == NullabilityState.Nullable)
+                    else if (attribute.AttributeType.Name == "DisallowNullAttribute")
                     {
-                        nullability.WriteState = NullabilityState.NotNull;
-                        break;
+                        codeAnalysisWriteState = NullabilityState.NotNull;
                     }
                     else if (attribute.AttributeType.Name == "AllowNullAttribute" &&
-                        nullability.WriteState == NullabilityState.NotNull &&
+                        codeAnalysisWriteState == NullabilityState.Unknown &&
                         !nullability.Type.IsValueType)
                     {
-                        nullability.WriteState = NullabilityState.Nullable;
-                        break;
+                        codeAnalysisWriteState = NullabilityState.Nullable;
                     }
                 }
+            }
+
+            if (codeAnalysisReadState != NullabilityState.Unknown)
+            {
+                nullability.ReadState = codeAnalysisReadState;
+            }
+            if (codeAnalysisWriteState != NullabilityState.Unknown)
+            {
+                nullability.WriteState = codeAnalysisWriteState;
             }
         }
 
@@ -184,17 +188,15 @@ namespace System.Reflection
 
             EnsureIsSupported();
 
-            NullabilityInfo nullability = GetNullabilityInfo(propertyInfo, propertyInfo.PropertyType, propertyInfo.GetCustomAttributesData());
             MethodInfo? getter = propertyInfo.GetGetMethod(true);
             MethodInfo? setter = propertyInfo.GetSetMethod(true);
+            bool annotationsDisabled = (getter == null || IsPrivateOrInternalMethodAndAnnotationDisabled(getter))
+                && (setter == null || IsPrivateOrInternalMethodAndAnnotationDisabled(setter));
+            NullableAttributeStateParser parser = annotationsDisabled ? NullableAttributeStateParser.Unknown : CreateParser(propertyInfo.GetCustomAttributesData());
+            NullabilityInfo nullability = GetNullabilityInfo(propertyInfo, propertyInfo.PropertyType, parser);
 
             if (getter != null)
             {
-                if (IsPrivateOrInternalMethodAndAnnotationDisabled(getter))
-                {
-                    nullability.ReadState = NullabilityState.Unknown;
-                }
-
                 CheckNullabilityAttributes(nullability, getter.ReturnParameter.GetCustomAttributesData());
             }
             else
@@ -204,12 +206,7 @@ namespace System.Reflection
 
             if (setter != null)
             {
-                if (IsPrivateOrInternalMethodAndAnnotationDisabled(setter))
-                {
-                    nullability.WriteState = NullabilityState.Unknown;
-                }
-
-                CheckNullabilityAttributes(nullability, setter.GetParameters()[0].GetCustomAttributesData());
+                CheckNullabilityAttributes(nullability, setter.GetParameters()[^1].GetCustomAttributesData());
             }
             else
             {
@@ -219,7 +216,7 @@ namespace System.Reflection
             return nullability;
         }
 
-        private bool IsPrivateOrInternalMethodAndAnnotationDisabled(MethodInfo method)
+        private bool IsPrivateOrInternalMethodAndAnnotationDisabled(MethodBase method)
         {
             if ((method.IsPrivate || method.IsFamilyAndAssembly || method.IsAssembly) &&
                IsPublicOnly(method.IsPrivate, method.IsFamilyAndAssembly, method.IsAssembly, method.Module))
@@ -247,7 +244,7 @@ namespace System.Reflection
 
             EnsureIsSupported();
 
-            return GetNullabilityInfo(eventInfo, eventInfo.EventHandlerType!, eventInfo.GetCustomAttributesData());
+            return GetNullabilityInfo(eventInfo, eventInfo.EventHandlerType!, CreateParser(eventInfo.GetCustomAttributesData()));
         }
 
         /// <summary>
@@ -267,13 +264,9 @@ namespace System.Reflection
 
             EnsureIsSupported();
 
-            if (IsPrivateOrInternalFieldAndAnnotationDisabled(fieldInfo))
-            {
-                return new NullabilityInfo(fieldInfo.FieldType, NullabilityState.Unknown, NullabilityState.Unknown, null, Array.Empty<NullabilityInfo>());
-            }
-
             IList<CustomAttributeData> attributes = fieldInfo.GetCustomAttributesData();
-            NullabilityInfo nullability = GetNullabilityInfo(fieldInfo, fieldInfo.FieldType, attributes);
+            NullableAttributeStateParser parser = IsPrivateOrInternalFieldAndAnnotationDisabled(fieldInfo) ? NullableAttributeStateParser.Unknown : CreateParser(attributes);
+            NullabilityInfo nullability = GetNullabilityInfo(fieldInfo, fieldInfo.FieldType, parser);
             CheckNullabilityAttributes(nullability, attributes);
             return nullability;
         }
@@ -341,13 +334,13 @@ namespace System.Reflection
             return NotAnnotatedStatus.None;
         }
 
-        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes)
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser)
         {
             int index = 0;
-            return GetNullabilityInfo(memberInfo, type, customAttributes, ref index);
+            return GetNullabilityInfo(memberInfo, type, parser, ref index);
         }
 
-        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, IList<CustomAttributeData> customAttributes, ref int index)
+        private NullabilityInfo GetNullabilityInfo(MemberInfo memberInfo, Type type, NullableAttributeStateParser parser, ref int index)
         {
             NullabilityState state = NullabilityState.Unknown;
             NullabilityInfo? elementState = null;
@@ -368,21 +361,18 @@ namespace System.Reflection
                     state = NullabilityState.NotNull;
                 }
 
-                if (underlyingType.IsGenericType)
-                {
-                    index++;
-                }
+                if (underlyingType.IsGenericType) { ++index; }
             }
             else
             {
-                if (!ParseNullableState(customAttributes, index++, ref state))
+                if (!parser.ParseNullableState(index++, ref state))
                 {
                     state = GetNullableContext(memberInfo);
                 }
 
                 if (type.IsArray)
                 {
-                    elementState = GetNullabilityInfo(memberInfo, type.GetElementType()!, customAttributes, ref index);
+                    elementState = GetNullabilityInfo(memberInfo, type.GetElementType()!, parser, ref index);
                 }
             }
 
@@ -393,7 +383,7 @@ namespace System.Reflection
 
                 for (int i = 0; i < genericArguments.Length; i++)
                 {
-                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], customAttributes, ref index);
+                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], parser, ref index);
                 }
             }
 
@@ -407,7 +397,7 @@ namespace System.Reflection
             return nullability;
         }
 
-        private static bool ParseNullableState(IList<CustomAttributeData> customAttributes, int index, ref NullabilityState state)
+        private static NullableAttributeStateParser CreateParser(IList<CustomAttributeData> customAttributes)
         {
             foreach (CustomAttributeData attribute in customAttributes)
             {
@@ -415,26 +405,11 @@ namespace System.Reflection
                     attribute.AttributeType.Namespace == CompilerServicesNameSpace &&
                     attribute.ConstructorArguments.Count == 1)
                 {
-                    object? o = attribute.ConstructorArguments[0].Value;
-
-                    if (o is byte b)
-                    {
-                        state = TranslateByte(b);
-                        return true;
-                    }
-                    else if (o is ReadOnlyCollection<CustomAttributeTypedArgument> args &&
-                            index < args.Count &&
-                            args[index].Value is byte elementB)
-                        {
-                            state = TranslateByte(elementB);
-                            return true;
-                        }
-
-                    break;
+                    return new(attribute.ConstructorArguments[0].Value);
                 }
             }
 
-            return false;
+            return new(null);
         }
 
         private void TryLoadGenericMetaTypeNullability(MemberInfo memberInfo, NullabilityInfo nullability)
@@ -452,7 +427,7 @@ namespace System.Reflection
 
             if (metaType != null)
             {
-                CheckGenericParameters(nullability, metaMember!, metaType);
+                CheckGenericParameters(nullability, metaMember!, metaType, memberInfo.ReflectedType);
             }
         }
 
@@ -477,19 +452,14 @@ namespace System.Reflection
             return property.GetSetMethod(true)!.GetParameters()[0].ParameterType;
         }
 
-        private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType)
+        private void CheckGenericParameters(NullabilityInfo nullability, MemberInfo metaMember, Type metaType, Type? reflectedType)
         {
             if (metaType.IsGenericParameter)
             {
-                NullabilityState state = nullability.ReadState;
-
-                if (state == NullabilityState.NotNull && !ParseNullableState(metaType.GetCustomAttributesData(), 0, ref state))
+                if (nullability.ReadState == NullabilityState.NotNull)
                 {
-                    state = GetNullableContext(metaType);
+                    UpdateGenericParameterNullability(nullability, metaType, reflectedType);
                 }
-
-                nullability.ReadState = state;
-                nullability.WriteState = state;
             }
             else if (metaType.ContainsGenericParameters)
             {
@@ -499,37 +469,124 @@ namespace System.Reflection
 
                     for (int i = 0; i < genericArguments.Length; i++)
                     {
-                        if (genericArguments[i].IsGenericParameter)
-                        {
-                            int index = i + 1;
-                            NullabilityInfo n = GetNullabilityInfo(metaMember, genericArguments[i], genericArguments[i].GetCustomAttributesData(), ref index);
-                            nullability.GenericTypeArguments[i].ReadState = n.ReadState;
-                            nullability.GenericTypeArguments[i].WriteState = n.WriteState;
-                        }
-                        else
-                        {
-                            UpdateGenericArrayElements(nullability.GenericTypeArguments[i].ElementType, metaMember, genericArguments[i]);
-                        }
+                        CheckGenericParameters(nullability.GenericTypeArguments[i], metaMember, genericArguments[i], reflectedType);
                     }
                 }
-                else
+                else if (nullability.ElementType is { } elementNullability && metaType.IsArray)
                 {
-                    UpdateGenericArrayElements(nullability.ElementType, metaMember, metaType);
+                    CheckGenericParameters(elementNullability, metaMember, metaType.GetElementType()!, reflectedType);
                 }
             }
         }
 
-        private void UpdateGenericArrayElements(NullabilityInfo? elementState, MemberInfo metaMember, Type metaType)
+        private void UpdateGenericParameterNullability(NullabilityInfo nullability, Type genericParameter, Type? reflectedType)
         {
-            if (metaType.IsArray && elementState != null
-                && metaType.GetElementType()!.IsGenericParameter)
+            Debug.Assert(genericParameter.IsGenericParameter);
+
+            if (reflectedType is not null
+                && !genericParameter.IsGenericMethodParameter
+                && TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, reflectedType, reflectedType))
             {
-                Type elementType = metaType.GetElementType()!;
-                int index = 0;
-                NullabilityInfo n = GetNullabilityInfo(metaMember, elementType, elementType.GetCustomAttributesData(), ref index);
-                elementState.ReadState = n.ReadState;
-                elementState.WriteState = n.WriteState;
+                return;
             }
+
+            var state = NullabilityState.Unknown;
+            if (CreateParser(genericParameter.GetCustomAttributesData()).ParseNullableState(0, ref state))
+            {
+                nullability.ReadState = state;
+                nullability.WriteState = state;
+                return;
+            }
+        }
+
+        private bool TryUpdateGenericTypeParameterNullabilityFromReflectedType(NullabilityInfo nullability, Type genericParameter, Type context, Type reflectedType)
+        {
+            Debug.Assert(genericParameter.IsGenericParameter && !genericParameter.IsGenericMethodParameter);
+
+            Type contextTypeDefinition = context.IsGenericType && !context.IsGenericTypeDefinition ? context.GetGenericTypeDefinition() : context;
+            if (genericParameter.DeclaringType == contextTypeDefinition)
+            {
+                return false;
+            }
+
+            Type? baseType = contextTypeDefinition.BaseType;
+            if (baseType is null)
+            {
+                return false;
+            }
+
+            if (!baseType.IsGenericType
+                || (baseType.IsGenericTypeDefinition ? baseType : baseType.GetGenericTypeDefinition()) != genericParameter.DeclaringType)
+            {
+                return TryUpdateGenericTypeParameterNullabilityFromReflectedType(nullability, genericParameter, baseType, reflectedType);
+            }
+
+            Type[] genericArguments = baseType.GetGenericArguments();
+            Type genericArgument = genericArguments[genericParameter.GenericParameterPosition];
+            if (genericArgument.IsGenericParameter)
+            {
+                UpdateGenericParameterNullability(nullability, genericArgument, reflectedType);
+                return true;
+            }
+
+            NullableAttributeStateParser parser = CreateParser(contextTypeDefinition.GetCustomAttributesData());
+            int nullabilityStateIndex = 1; // start at 1 since index 0 is the type itself
+            for (int i = 0; i < genericParameter.GenericParameterPosition; i++)
+            {
+                nullabilityStateIndex += CountNullabilityStates(genericArguments[i]);
+            }
+            return TryPopulateNullabilityInfo(nullability, parser, ref nullabilityStateIndex);
+
+            static int CountNullabilityStates(Type type)
+            {
+                Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+                if (underlyingType.IsGenericType)
+                {
+                    int count = 1;
+                    foreach (Type genericArgument in underlyingType.GetGenericArguments())
+                    {
+                        count += CountNullabilityStates(genericArgument);
+                    }
+                    return count;
+                }
+
+                return type.IsValueType ? 0 : 1;
+            }
+        }
+
+        private bool TryPopulateNullabilityInfo(NullabilityInfo nullability, NullableAttributeStateParser parser, ref int index)
+        {
+            bool isValueType = nullability.Type.IsValueType;
+            if (!isValueType)
+            {
+                var state = NullabilityState.Unknown;
+                if (!parser.ParseNullableState(index, ref state))
+                {
+                    return false;
+                }
+
+                nullability.ReadState = state;
+                nullability.WriteState = state;
+            }
+
+            if (!isValueType || (Nullable.GetUnderlyingType(nullability.Type) ?? nullability.Type).IsGenericType)
+            {
+                index++;
+            }
+
+            if (nullability.GenericTypeArguments.Length > 0)
+            {
+                foreach (NullabilityInfo genericTypeArgumentNullability in nullability.GenericTypeArguments)
+                {
+                    TryPopulateNullabilityInfo(genericTypeArgumentNullability, parser, ref index);
+                }
+            }
+            else if (nullability.ElementType is { } elementTypeNullability)
+            {
+                TryPopulateNullabilityInfo(elementTypeNullability, parser, ref index);
+            }
+
+            return true;
         }
 
         private static NullabilityState TranslateByte(object? value)
@@ -544,5 +601,35 @@ namespace System.Reflection
                 2 => NullabilityState.Nullable,
                 _ => NullabilityState.Unknown
             };
+
+        private readonly struct NullableAttributeStateParser
+        {
+            private static readonly object UnknownByte = (byte)0;
+
+            private readonly object? _nullableAttributeArgument;
+
+            public NullableAttributeStateParser(object? nullableAttributeArgument)
+            {
+                this._nullableAttributeArgument = nullableAttributeArgument;
+            }
+
+            public static NullableAttributeStateParser Unknown => new(UnknownByte);
+
+            public bool ParseNullableState(int index, ref NullabilityState state)
+            {
+                switch (this._nullableAttributeArgument)
+                {
+                    case byte b:
+                        state = TranslateByte(b);
+                        return true;
+                    case ReadOnlyCollection<CustomAttributeTypedArgument> args
+                        when index < args.Count && args[index].Value is byte elementB:
+                        state = TranslateByte(elementB);
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -1039,6 +1039,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         public void TestDeeplyNestedGenericInheritance()
         {
             var copyToMethodInfo = nullabilityContext.Create(

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO.Enumeration;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -30,10 +31,10 @@ namespace System.Reflection.Tests
             yield return new object[] { "FieldDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "FieldAllowNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "FieldDisallowNull2", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
-            yield return new object[] { "FieldAllowNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+            yield return new object[] { "FieldAllowNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "FieldNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "FieldMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
-            yield return new object[] { "FieldMaybeNull2", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+            yield return new object[] { "FieldMaybeNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "FieldNotNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
         }
 
@@ -86,11 +87,12 @@ namespace System.Reflection.Tests
             yield return new object[] { "PropertyDisallowNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "PropertyAllowNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "PropertyDisallowNull2", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
-            yield return new object[] { "PropertyAllowNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+            yield return new object[] { "PropertyAllowNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "PropertyNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "PropertyMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
-            yield return new object[] { "PropertyMaybeNull2", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+            yield return new object[] { "PropertyMaybeNull2", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "PropertyNotNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
+            yield return new object[] { "Item", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
         }
 
         [Theory]
@@ -433,7 +435,7 @@ namespace System.Reflection.Tests
             Assert.Equal(type, nullability.Type);
         }
 
-        public static IEnumerable<object[]> GenericNotnullConstraintFieldsTestData()
+        public static IEnumerable<object[]> GenericNotNullConstraintFieldsTestData()
         {
             yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "FieldUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
@@ -441,7 +443,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GenericNotnullConstraintFieldsTestData))]
+        [MemberData(nameof(GenericNotNullConstraintFieldsTestData))]
         public void GenericNotNullConstraintFieldsTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
         {
             FieldInfo field = typeof(GenericTestConstrainedNotNull<string>).GetField(fieldName, flags)!;
@@ -570,7 +572,7 @@ namespace System.Reflection.Tests
 
         public static IEnumerable<object[]> MethodReturnParameterTestData()
         {
-            yield return new object[] { "MethodReturnsUnknown", NullabilityState.Unknown, NullabilityState.Unknown};
+            yield return new object[] { "MethodReturnsUnknown", NullabilityState.Unknown, NullabilityState.Unknown };
             yield return new object[] { "MethodReturnsNullNon", NullabilityState.Nullable, NullabilityState.NotNull };
             yield return new object[] { "MethodReturnsNullNull", NullabilityState.Nullable, NullabilityState.Nullable };
             yield return new object[] { "MethodReturnsNonNull", NullabilityState.NotNull, NullabilityState.Nullable };
@@ -671,7 +673,7 @@ namespace System.Reflection.Tests
 
         public static IEnumerable<object[]> MethodGenericParametersTestData()
         {
-            yield return new object[] { "MethodParametersUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown};
+            yield return new object[] { "MethodParametersUnknown", NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown, NullabilityState.Unknown };
             yield return new object[] { "MethodArgsNullGenericNullDictValueGeneric", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable };
             yield return new object[] { "MethodArgsGenericDictValueNullGeneric", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull };
         }
@@ -710,7 +712,7 @@ namespace System.Reflection.Tests
             Assert.Equal(param1State, param1.ReadState);
             Assert.Equal(param2State, param2.ReadState);
             Assert.Equal(param3State, param3.ReadState);
-            if (param2.ElementType  != null)
+            if (param2.ElementType != null)
             {
                 Assert.Equal(NullabilityState.Nullable, param2.ElementType.ReadState);
             }
@@ -739,7 +741,7 @@ namespace System.Reflection.Tests
             PropertyInfo publicGetPrivateSetNullableProperty = typeof(FileSystemEntry).GetProperty("Directory", flags)!;
             info = nullabilityContext.Create(publicGetPrivateSetNullableProperty);
             Assert.Equal(NullabilityState.NotNull, info.ReadState);
-            Assert.Equal(NullabilityState.Unknown, info.WriteState);
+            Assert.Equal(NullabilityState.NotNull, info.WriteState);
 
             MethodInfo protectedNullableReturnMethod = type.GetMethod("GetPropertyImpl", flags)!;
             info = nullabilityContext.Create(protectedNullableReturnMethod.ReturnParameter);
@@ -748,8 +750,8 @@ namespace System.Reflection.Tests
 
             MethodInfo privateValueTypeReturnMethod = type.GetMethod("BinarySearch", flags)!;
             info = nullabilityContext.Create(privateValueTypeReturnMethod.ReturnParameter);
-            Assert.Equal(NullabilityState.Unknown, info.ReadState);
-            Assert.Equal(NullabilityState.Unknown, info.WriteState);
+            Assert.Equal(NullabilityState.NotNull, info.ReadState);
+            Assert.Equal(NullabilityState.NotNull, info.WriteState);
 
             Type regexType = typeof(Regex);
             FieldInfo protectedInternalNullableField = regexType.GetField("pattern", flags)!;
@@ -761,13 +763,18 @@ namespace System.Reflection.Tests
             info = nullabilityContext.Create(privateNullableField);
             Assert.Equal(NullabilityState.Unknown, info.ReadState);
             Assert.Equal(NullabilityState.Unknown, info.WriteState);
+
+            ConstructorInfo privateConstructor = typeof(IndexOutOfRangeException)
+                .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, new[] { typeof(SerializationInfo), typeof(StreamingContext) })!;
+            info = nullabilityContext.Create(privateConstructor.GetParameters()[0]);
+            Assert.Equal(NullabilityState.Unknown, info.WriteState);
         }
 
         public static IEnumerable<object[]> DifferentContextTestData()
         {
             yield return new object[] { "PropertyDisabled", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
-            yield return new object[] { "PropertyDisabledAllowNull", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
-            yield return new object[] { "PropertyDisabledMaybeNull", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+            yield return new object[] { "PropertyDisabledAllowNull", NullabilityState.Unknown, NullabilityState.Nullable, typeof(string) };
+            yield return new object[] { "PropertyDisabledMaybeNull", NullabilityState.Nullable, NullabilityState.Unknown, typeof(string) };
             yield return new object[] { "PropertyEnabledAllowNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "PropertyEnabledNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "PropertyEnabledMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
@@ -984,6 +991,90 @@ namespace System.Reflection.Tests
             Assert.Equal(param1, tupleInfo.GenericTypeArguments[0].ReadState);
             Assert.Equal(param2, tupleInfo.GenericTypeArguments[1].ReadState);
         }
+
+        public static IEnumerable<object?[]> GenericInheritanceTestData()
+        {
+            yield return new object?[] { typeof(ListOfUnconstrained<string?>), NullabilityState.NotNull, null };
+            yield return new object?[] { typeof(ListUnconstrainedOfNullable<string>), NullabilityState.NotNull, null };
+            yield return new object?[] { typeof(ListUnconstrainedOfNullableOfObject<>), NullabilityState.NotNull, null };
+            yield return new object?[] { typeof(ListOfArrayOfNullableString), NullabilityState.NotNull, NullabilityState.Nullable };
+            yield return new object?[] { typeof(ListOfNotNull<ListOfNotNull<object>>), NullabilityState.NotNull, NullabilityState.NotNull };
+            yield return new object?[] { typeof(ListOfListOfObject<string?>), NullabilityState.NotNull, NullabilityState.NotNull };
+            yield return new object?[] { typeof(ListMultiGenericOfNotNull<object?, string, string?>), NullabilityState.NotNull, null };
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericInheritanceTestData))]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
+        public void TestGenericInheritance(Type listType, NullabilityState parameterState, NullabilityState? subState)
+        {
+            var addParameterInfo = nullabilityContext.Create(listType.GetMethod("Add")!.GetParameters()[0]);
+            Validate(addParameterInfo);
+
+            var copyToParameterInfo = nullabilityContext.Create(
+                listType.GetMethod("CopyTo", new[] { addParameterInfo.Type.MakeArrayType() })!
+                    .GetParameters()[0]);
+            Assert.Equal(NullabilityState.NotNull, copyToParameterInfo.ReadState);
+            Assert.Equal(NullabilityState.NotNull, copyToParameterInfo.WriteState);
+            Assert.NotNull(copyToParameterInfo.ElementType);
+            Validate(copyToParameterInfo.ElementType!);
+
+            void Validate(NullabilityInfo info)
+            {
+                Assert.Equal(parameterState, info.ReadState);
+                Assert.Equal(parameterState, info.WriteState);
+                if (subState != null)
+                {
+                    NullabilityInfo subInfo = info.ElementType ?? info.GenericTypeArguments[0];
+                    Assert.Equal(subState, subInfo.ReadState);
+                    Assert.Equal(subState, subInfo.WriteState);
+                    Assert.True(info.GenericTypeArguments.Length <= 1);
+                }
+                else
+                {
+                    Assert.Null(info.ElementType);
+                    Assert.Empty(info.GenericTypeArguments);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestDeeplyNestedGenericInheritance()
+        {
+            var copyToMethodInfo = nullabilityContext.Create(
+                typeof(ListOfTupleOfDictionaryOfStringNullableBoolIntNullableObject).GetMethod("CopyTo", new[] { typeof((Dictionary<string, bool?>, int, object?)[]) })!
+                    .GetParameters()[0]);
+
+            Check(copyToMethodInfo, typeof((Dictionary<string, bool?>, int, object?)[]), NullabilityState.NotNull);
+            Assert.NotNull(copyToMethodInfo.ElementType);
+
+            var tupleInfo = copyToMethodInfo.ElementType!;
+            Check(tupleInfo, typeof((Dictionary<string, bool?>, int, object?)), NullabilityState.NotNull);
+
+            var dictionaryInfo = tupleInfo.GenericTypeArguments[0];
+            Check(dictionaryInfo, typeof(Dictionary<string, bool?>), NullabilityState.NotNull);
+
+            var stringInfo = dictionaryInfo.GenericTypeArguments[0];
+            Check(stringInfo, typeof(string), NullabilityState.NotNull);
+
+            var nullableBoolInfo = dictionaryInfo.GenericTypeArguments[1];
+            Check(nullableBoolInfo, typeof(bool?), NullabilityState.Nullable);
+
+            var intInfo = tupleInfo.GenericTypeArguments[1];
+            Check(intInfo, typeof(int), NullabilityState.NotNull);
+
+            var objectInfo = tupleInfo.GenericTypeArguments[2];
+            Check(objectInfo, typeof(object), NullabilityState.Nullable);
+
+            void Check(NullabilityInfo info, Type type, NullabilityState state)
+            {
+                Assert.Equal(type, info.Type);
+                Assert.Equal(state, info.ReadState);
+                Assert.Equal(state, info.WriteState);
+                Assert.Equal(type.IsGenericType && type.GetGenericTypeDefinition() != typeof(Nullable<>) ? type.GetGenericArguments().Length : 0, info.GenericTypeArguments.Length);
+                Assert.Equal(type.IsArray, info.ElementType is not null);
+            }
+        }
     }
 
 #pragma warning disable CS0649, CS0067, CS0414
@@ -1023,7 +1114,7 @@ namespace System.Reflection.Tests
         [AllowNull] public string PropertyEnabledAllowNull { get; set; }
         [NotNull] public string? PropertyEnabledNotNull { get; set; } = null!;
         [DisallowNull] public string? PropertyEnabledDisallowNull { get; set; } = null!;
-        [MaybeNull] public string PropertyEnabledMaybeNull { get; set; } 
+        [MaybeNull] public string PropertyEnabledMaybeNull { get; set; }
         public string? PropertyEnabledNullable { get; set; }
         public string PropertyEnabledNonNullable { get; set; } = null!;
 #nullable disable
@@ -1059,14 +1150,15 @@ namespace System.Reflection.Tests
         [AllowNull] public string PropertyAllowNull { get; set; }
         [NotNull] public string? PropertyNotNull { get; set; }
         [MaybeNull] public string PropertyMaybeNull { get; set; }
-        // only AllowNull matter
+        // only DisallowNull matters
         [AllowNull, DisallowNull] public string PropertyAllowNull2 { get; set; }
-        // only DisallowNull matter
+        // only AllowNull matters
         [AllowNull, DisallowNull] public string? PropertyDisallowNull2 { get; set; }
-        // only NotNull matter
+        // only NotNull matters
         [NotNull, MaybeNull] public string? PropertyNotNull2 { get; set; }
-        // only MaybeNull matter
+        // only NotNull matters
         [NotNull, MaybeNull] public string PropertyMaybeNull2 { get; set; }
+        [DisallowNull] public string? this[int i] { get => null; set { } }
         private protected string?[]?[]? PropertyJaggedArrayNullNullNull { get; set; }
         public static string?[]?[] PropertyJaggedArrayNullNullNon { get; set; } = null!;
         public string?[][]? PropertyJaggedArrayNullNonNull { get; set; }
@@ -1174,7 +1266,7 @@ namespace System.Reflection.Tests
         [DisallowNull] public T? FieldDisallowNull;
         [AllowNull] protected T FieldAllowNull;
         [NotNull] public T? FieldNotNull = default;
-        [MaybeNull] protected internal  T FieldMaybeNull = default!;
+        [MaybeNull] protected internal T FieldMaybeNull = default!;
         public List<T> FieldListOfT = default!;
         public Dictionary<string, T> FieldDictionaryStringToT = default!;
 
@@ -1213,4 +1305,25 @@ namespace System.Reflection.Tests
         public T PropertyNullableEnabled { get; set; }
         public T? PropertyNullable { get; set; }
     }
+
+    public class ListOfUnconstrained<T> : List<T> { }
+
+    public class ListUnconstrainedOfNullable<T> : ListOfUnconstrained<T> where T : class? { }
+
+    public class ListUnconstrainedOfNullableOfObject<T> : ListUnconstrainedOfNullable<object> { }
+
+    public class ListOfArrayOfNullableString : List<string?[]> { }
+
+    public class ListOfNotNull<T> : List<T> where T : notnull { }
+
+    public class ListOfListOfObject<T> : List<List<object>> { }
+
+    public class ListMultiGenericOfNotNull<T, U, V> : List<V>
+        where T : class?
+        where U : class
+        where V : class?
+    {
+    }
+
+    public class ListOfTupleOfDictionaryOfStringNullableBoolIntNullableObject : List<(Dictionary<string, bool?>, int, object?)> { }
 }


### PR DESCRIPTION
In several cases, NullabilityInfoContext would return values which were
out of sync with the C# compiler's interpretation of the nullability
metadata. This fixes the following cases:
* The `NullablePublicOnly` attribute was not considered when analyzing
private constructor parameters.
* CodeAnalysis attributes on indexer properties were not recognized.
* CodeAnalysis attributes were not recognized in a `#nullable disabled`
context.
* Private value-typed members lacking nullable annotations were not
properly marked as nullable/notnull.
* Mixing CodeAnalysis attributes with opposite meanings (e. g.
`AllowNull` and `DisallowNull` produced the wrong result.
* Analysis of members inherited from generic base types did not
incorporate the nullable metadata associated with the inheritance.

Fix #63555
Fix #63846
Fix #63847
Fix #63848
Fix #63849
Fix #63853

Sorry, this probably should have been multiple commits. If it's important, I can go back and break up these changes.