### PR TITLE
Drop the Debug Windows x64 NativeAOT leg since we have a Checked leg.

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -206,7 +206,6 @@ jobs:
     buildConfig: debug
     platforms:
     - Linux_x64
-    - windows_x64
     jobParameters:
       testGroup: innerloop
       timeoutInMinutes: 120


### PR DESCRIPTION
Since the Debug and Checked builds each contain asserts and other diagnostic assets, the runs for both Debug and Checked on Windows x64 for NativeAOT seems excessive. The last build times I noted are below. Seems like we would have enough coverage with just a Checked build.

Debug: ~90 minutes
Checked: ~60 minutes

/cc @MichalStrehovsky @agocke