### PR TITLE
Remove usage of codecvt from corerun

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -334,7 +334,7 @@ static int run(const configuration& config)
     int propertyCount = (int)propertyKeys.size();
 
     // Construct arguments
-    pal::string_utf8_t exe_path_utf8 = pal::convert_to_utf8(std::move(exe_path).c_str());
+    pal::string_utf8_t exe_path_utf8 = pal::convert_to_utf8(exe_path.c_str());
     std::vector<pal::string_utf8_t> argv_lifetime;
     pal::malloc_ptr<const char*> argv_utf8{ pal::convert_argv_to_utf8(config.entry_assembly_argc, config.entry_assembly_argv, argv_lifetime) };
     pal::string_utf8_t entry_assembly_utf8 = pal::convert_to_utf8(config.entry_assembly_fullpath.c_str());

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -291,9 +291,9 @@ static int run(const configuration& config)
     }
 
     // Construct CoreCLR properties.
-    pal::string_utf8_t tpa_list_utf8 = pal::convert_to_utf8(std::move(tpa_list));
-    pal::string_utf8_t app_path_utf8 = pal::convert_to_utf8(std::move(app_path));
-    pal::string_utf8_t native_search_dirs_utf8 = pal::convert_to_utf8(native_search_dirs.str());
+    pal::string_utf8_t tpa_list_utf8 = pal::convert_to_utf8(tpa_list.c_str());
+    pal::string_utf8_t app_path_utf8 = pal::convert_to_utf8(app_path.c_str());
+    pal::string_utf8_t native_search_dirs_utf8 = pal::convert_to_utf8(native_search_dirs.str().c_str());
 
     std::vector<pal::string_utf8_t> user_defined_keys_utf8;
     std::vector<pal::string_utf8_t> user_defined_values_utf8;
@@ -334,7 +334,7 @@ static int run(const configuration& config)
     int propertyCount = (int)propertyKeys.size();
 
     // Construct arguments
-    pal::string_utf8_t exe_path_utf8 = pal::convert_to_utf8(std::move(exe_path));
+    pal::string_utf8_t exe_path_utf8 = pal::convert_to_utf8(std::move(exe_path).c_str());
     std::vector<pal::string_utf8_t> argv_lifetime;
     pal::malloc_ptr<const char*> argv_utf8{ pal::convert_argv_to_utf8(config.entry_assembly_argc, config.entry_assembly_argv, argv_lifetime) };
     pal::string_utf8_t entry_assembly_utf8 = pal::convert_to_utf8(config.entry_assembly_fullpath.c_str());

--- a/src/coreclr/hosts/corerun/dotenv.cpp
+++ b/src/coreclr/hosts/corerun/dotenv.cpp
@@ -7,22 +7,8 @@
 #include <sstream>
 #include <algorithm>
 
-#ifdef TARGET_WINDOWS
-#include <codecvt>
-#endif
-
 namespace
 {
-    pal::string_t convert_to_string_t(std::string str)
-    {
-#ifdef TARGET_WINDOWS
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        return converter.from_bytes(str);
-#else
-        return str;
-#endif
-    }
-
     bool read_var_name(std::istream& file, std::string& var_name_out)
     {
         std::string var_name;
@@ -326,8 +312,7 @@ dotenv::dotenv(pal::string_t dotEnvFilePath, std::istream& contents)
                 {
                     return dot_env_entry->second;
                 }
-                pal::string_t env_var_name = convert_to_string_t(name);
-                return pal::convert_to_utf8(pal::getenv(env_var_name.c_str()));
+                return pal::getenvA(name.c_str());
             }, temp_value))
         {
             _environmentVariables = {};
@@ -341,9 +326,9 @@ void dotenv::load_into_current_process() const
 {
     for (std::pair<std::string, std::string> env_vars : _environmentVariables)
     {
-        pal::string_t name_string = convert_to_string_t(env_vars.first);
-        pal::string_t value_string = convert_to_string_t(env_vars.second);
-        pal::setenv(name_string.c_str(), std::move(value_string));
+        pal::string_utf8_t name_string = env_vars.first;
+        pal::string_utf8_t value_string = env_vars.second;
+        pal::setenvA(name_string.c_str(), std::move(value_string));
     }
 }
 


### PR DESCRIPTION
In #44466, we removed all usages of a deprecated header `codecvt` at the time.
This PR removes a usage from corerun, that was later added, by providing ANSI variant of `setenv` on Windows.

Also deleted unnecessary `convert_to_utf8` wrapper from `corerun` header (which was `std::move`ing string twice on Unix in some cases).