### PR TITLE
Use stable outputs in illink targets

### DIFF
--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -25,7 +25,7 @@
       <OOBAssemblyToIgnore Include="System.Speech" />
 
       <NetCoreAppCurrentAssembly Include="$(NetCoreAppCurrentRuntimePath)*.dll"
-                                 Exclude="$(NetCoreAppCurrentRuntimePath)*.Generator.dll;
+                                 Exclude="$(NetCoreAppCurrentRuntimePath)*.Generator*.dll;
                                           $(NetCoreAppCurrentRuntimePath)*.Native.dll;
                                           $(NetCoreAppCurrentRuntimePath)*msquic.dll" />
       <SharedFrameworkAssembly Include="$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)*.dll" />

--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -5,7 +5,7 @@
 
     <PropertyGroup>
       <OOBAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-oobs'))</OOBAssembliesTrimmedArtifactsPath>
-      <OOBAssembliesMarkerFile>$(ILLinkTrimAssemblyArtifactsRootDir)oob-marker.txt</OOBAssembliesMarkerFile>
+      <OOBAssembliesMarkerFile>$(BaseIntermediateOutputPath)oob-linker-marker.txt</OOBAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -5,7 +5,7 @@
 
     <PropertyGroup>
       <OOBAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-oobs'))</OOBAssembliesTrimmedArtifactsPath>
-      <OOBAssembliesMarkerFile>$(IntermediateOutputPath)oob-linker-$(TargetOS)-marker.txt</OOBAssembliesMarkerFile>
+      <OOBAssembliesMarkerFile>$(IntermediateOutputPath)oob-linker-$(TargetOS)-$(TargetArchitecture)-marker.txt</OOBAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -4,7 +4,7 @@
           DependsOnTargets="PrepareForAssembliesTrim">
 
     <PropertyGroup>
-      <OOBAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizePath('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-oobs'))</OOBAssembliesTrimmedArtifactsPath>
+      <OOBAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-oobs'))</OOBAssembliesTrimmedArtifactsPath>
       <OOBAssembliesMarkerFile>$(ILLinkTrimAssemblyArtifactsRootDir)oob-marker.txt</OOBAssembliesMarkerFile>
     </PropertyGroup>
 

--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -75,6 +75,7 @@
         ToolPath="$(_DotNetHostDirectory)" />
 
     <!-- Create a marker file which serves as the target's output to enable incremental builds. -->
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(OOBAssembliesMarkerFile)'))" />
     <Touch Files="$(OOBAssembliesMarkerFile)"
            AlwaysCreate="true" />
 

--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -5,6 +5,7 @@
 
     <PropertyGroup>
       <OOBAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizePath('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-oobs'))</OOBAssembliesTrimmedArtifactsPath>
+      <OOBAssembliesMarkerFile>$(ILLinkTrimAssemblyArtifactsRootDir)oob-marker.txt</OOBAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -56,7 +57,7 @@
           AfterTargets="Build"
           DependsOnTargets="GetOOBAssembliesToTrim;PrepareForAssembliesTrim"
           Inputs="$(ILLinkTasksAssembly);@(OOBAssemblyToTrim);@(OOBAssemblyReference);@(OOBLibrarySuppressionsXml)"
-          Outputs="@(OOBLibraryTrimmed)">
+          Outputs="$(OOBAssembliesMarkerFile)">
 
     <Message Text="Trimming $(PackageRID) out-of-band assemblies with ILLinker..." Importance="high" />
 
@@ -72,6 +73,10 @@
         ExtraArgs="$(OOBILLinkArgs)"
         ToolExe="$(_DotNetHostFileName)"
         ToolPath="$(_DotNetHostDirectory)" />
+
+    <!-- Create a marker file which serves as the target's output to enable incremental builds. -->
+    <Touch Files="$(OOBAssembliesMarkerFile)"
+           AlwaysCreate="true" />
 
   </Target>
 

--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -5,7 +5,7 @@
 
     <PropertyGroup>
       <OOBAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-oobs'))</OOBAssembliesTrimmedArtifactsPath>
-      <OOBAssembliesMarkerFile>$(BaseIntermediateOutputPath)oob-linker-marker.txt</OOBAssembliesMarkerFile>
+      <OOBAssembliesMarkerFile>$(IntermediateOutputPath)oob-linker-$(TargetOS)-marker.txt</OOBAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -4,7 +4,8 @@
           DependsOnTargets="PrepareForAssembliesTrim">
 
     <PropertyGroup>
-      <SharedFrameworkAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizePath('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-runtimepack'))</SharedFrameworkAssembliesTrimmedArtifactsPath>
+      <SharedFrameworkAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-runtimepack'))</SharedFrameworkAssembliesTrimmedArtifactsPath>
+      <SharedFrameworkAssembliesMarkerFile>$(ILLinkTrimAssemblyArtifactsRootDir)sfx-marker.txt</SharedFrameworkAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -28,7 +29,7 @@
           AfterTargets="Build"
           DependsOnTargets="GetSharedFrameworkAssembliesToTrim;PrepareForAssembliesTrim"
           Inputs="$(ILLinkTasksAssembly);@(SharedFrameworkAssemblyToTrim);@(SharedFrameworkSuppressionsXml)"
-          Outputs="@(SharedFrameworkAssemblyTrimmed)">
+          Outputs="$(SharedFrameworkAssembliesMarkerFile)">
 
     <Message Text="Trimming $(PackageRID) shared framework assemblies with ILLinker..." Importance="high" />
 
@@ -54,6 +55,10 @@
         ExtraArgs="$(SharedFrameworkILLinkArgs)"
         ToolExe="$(_DotNetHostFileName)"
         ToolPath="$(_DotNetHostDirectory)" />
+
+    <!-- Create a marker file which serves as the target's output to enable incremental builds. -->
+    <Touch Files="$(SharedFrameworkAssembliesMarkerFile)"
+           AlwaysCreate="true" />
 
   </Target>
 

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -57,6 +57,7 @@
         ToolPath="$(_DotNetHostDirectory)" />
 
     <!-- Create a marker file which serves as the target's output to enable incremental builds. -->
+    <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(SharedFrameworkAssembliesMarkerFile)'))" />
     <Touch Files="$(SharedFrameworkAssembliesMarkerFile)"
            AlwaysCreate="true" />
 

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -5,7 +5,7 @@
 
     <PropertyGroup>
       <SharedFrameworkAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-runtimepack'))</SharedFrameworkAssembliesTrimmedArtifactsPath>
-      <SharedFrameworkAssembliesMarkerFile>$(IntermediateOutputPath)sfx-linker-$(TargetOS)-marker.txt</SharedFrameworkAssembliesMarkerFile>
+      <SharedFrameworkAssembliesMarkerFile>$(IntermediateOutputPath)sfx-linker-$(TargetOS)-$(TargetArchitecture)-marker.txt</SharedFrameworkAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -5,7 +5,7 @@
 
     <PropertyGroup>
       <SharedFrameworkAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-runtimepack'))</SharedFrameworkAssembliesTrimmedArtifactsPath>
-      <SharedFrameworkAssembliesMarkerFile>$(ILLinkTrimAssemblyArtifactsRootDir)sfx-marker.txt</SharedFrameworkAssembliesMarkerFile>
+      <SharedFrameworkAssembliesMarkerFile>$(BaseIntermediateOutputPath)sfx-linker-marker.txt</SharedFrameworkAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/libraries/illink-sharedframework.targets
+++ b/src/libraries/illink-sharedframework.targets
@@ -5,7 +5,7 @@
 
     <PropertyGroup>
       <SharedFrameworkAssembliesTrimmedArtifactsPath>$([MSBuild]::NormalizeDirectory('$(ILLinkTrimAssemblyArtifactsRootDir)', 'trimmed-runtimepack'))</SharedFrameworkAssembliesTrimmedArtifactsPath>
-      <SharedFrameworkAssembliesMarkerFile>$(BaseIntermediateOutputPath)sfx-linker-marker.txt</SharedFrameworkAssembliesMarkerFile>
+      <SharedFrameworkAssembliesMarkerFile>$(IntermediateOutputPath)sfx-linker-$(TargetOS)-marker.txt</SharedFrameworkAssembliesMarkerFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
While building locally multiple times, I noticed that the incremental build of the illink-targets are now to aggressive and could cause the targets to either never run or too often. This could be the case when the linker doesn't trim anything and copies the inputs to the outputs directory with preserving the timestamps. In such cases the inputs would always be newer than the outputs and the step would alway run. Also the path that was used to construct the outputs was missing a trailing directory separator. Using a marker file instead to not be dependent on the freshness of the linker output.