### PR TITLE
Improve Regex handling of anchors

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -61,9 +61,6 @@ namespace System.Text.RegularExpressions
             _textend = begpos + len;
             _textstart = startpos;
             _balancing = false;
-
-            Debug.Assert(!(_textbeg < 0 || _textstart < _textbeg || _textend < _textstart || Text.Length < _textend),
-                "The parameters are out of range.");
         }
 
         /// <summary>Returns an empty Match object.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -401,7 +401,7 @@ namespace System.Text.RegularExpressions
             var sb = new StringBuilder();
 
             sb.AppendLine($"Direction:  {(RightToLeft ? "right-to-left" : "left-to-right")}");
-            sb.AppendLine($"Anchor:     {RegexPrefixAnalyzer.AnchorDescription(FindOptimizations.LeadingAnchor)}");
+            sb.AppendLine($"Anchor:     {FindOptimizations.LeadingAnchor}");
             sb.AppendLine();
             for (int i = 0; i < Codes.Length; i += OpcodeSize(Codes[i]))
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -211,6 +211,10 @@ namespace System.Text.RegularExpressions
         public RegexNodeKind TrailingAnchor { get; }
 
         /// <summary>The maximum possible length an input could be to match the pattern.</summary>
+        /// <remarks>
+        /// This is currently only set when <see cref="TrailingAnchor"/> is found to be an end anchor.
+        /// That can be expanded in the future as needed.
+        /// </remarks>
         public int? MaxPossibleLength { get; }
 
         /// <summary>Gets the leading prefix.  May be an empty string.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -10,7 +10,8 @@ namespace System.Text.RegularExpressions
     /// <summary>Contains state and provides operations related to finding the next location a match could possibly begin.</summary>
     internal sealed class RegexFindOptimizations
     {
-        /// <summary>The minimum required length an input need be to match the pattern.  May be 0.</summary>
+        /// <summary>The minimum required length an input need be to match the pattern.</summary>
+        /// <remarks>0 is a valid minimum length.  This value may also be the max (and hence fixed) length of the expression.</remarks>
         private readonly int _minRequiredLength;
         /// <summary>True if the input should be processed right-to-left rather than left-to-right.</summary>
         private readonly bool _rightToLeft;
@@ -27,26 +28,46 @@ namespace System.Text.RegularExpressions
 
             // Compute any anchor starting the expression.  If there is one, we won't need to search for anything,
             // as we can just match at that single location.
-            LeadingAnchor = RegexPrefixAnalyzer.FindLeadingAnchor(tree);
-            if (_rightToLeft)
+            LeadingAnchor = RegexPrefixAnalyzer.FindLeadingAnchor(tree.Root);
+            if (_rightToLeft && LeadingAnchor == RegexNodeKind.Bol)
             {
                 // Filter out Bol for RightToLeft, as we don't currently optimize for it.
-                LeadingAnchor &= ~RegexPrefixAnalyzer.Bol;
+                LeadingAnchor = RegexNodeKind.Unknown;
             }
-            if ((LeadingAnchor & (RegexPrefixAnalyzer.Beginning | RegexPrefixAnalyzer.Start | RegexPrefixAnalyzer.EndZ | RegexPrefixAnalyzer.End)) != 0)
+            if (LeadingAnchor is RegexNodeKind.Beginning or RegexNodeKind.Start or RegexNodeKind.EndZ or RegexNodeKind.End)
             {
                 FindMode = (LeadingAnchor, _rightToLeft) switch
                 {
-                    (RegexPrefixAnalyzer.Beginning, false) => FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning,
-                    (RegexPrefixAnalyzer.Beginning, true) => FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning,
-                    (RegexPrefixAnalyzer.Start, false) => FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Start,
-                    (RegexPrefixAnalyzer.Start, true) => FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Start,
-                    (RegexPrefixAnalyzer.End, false) => FindNextStartingPositionMode.LeadingAnchor_LeftToRight_End,
-                    (RegexPrefixAnalyzer.End, true) => FindNextStartingPositionMode.LeadingAnchor_RightToLeft_End,
+                    (RegexNodeKind.Beginning, false) => FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Beginning,
+                    (RegexNodeKind.Beginning, true) => FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Beginning,
+                    (RegexNodeKind.Start, false) => FindNextStartingPositionMode.LeadingAnchor_LeftToRight_Start,
+                    (RegexNodeKind.Start, true) => FindNextStartingPositionMode.LeadingAnchor_RightToLeft_Start,
+                    (RegexNodeKind.End, false) => FindNextStartingPositionMode.LeadingAnchor_LeftToRight_End,
+                    (RegexNodeKind.End, true) => FindNextStartingPositionMode.LeadingAnchor_RightToLeft_End,
                     (_, false) => FindNextStartingPositionMode.LeadingAnchor_LeftToRight_EndZ,
                     (_, true) => FindNextStartingPositionMode.LeadingAnchor_RightToLeft_EndZ,
                 };
                 return;
+            }
+
+            // Compute any anchor trailing the expression.  If there is one, and we can also compute a fixed length
+            // for the whole expression, we can use that to quickly jump to the right location in the input.
+            if (!_rightToLeft) // haven't added FindNextStartingPositionMode support for RTL
+            {
+                TrailingAnchor = RegexPrefixAnalyzer.FindTrailingAnchor(tree.Root);
+                if (TrailingAnchor is RegexNodeKind.End or RegexNodeKind.EndZ &&
+                    tree.Root.ComputeMaxLength() is int maxLength)
+                {
+                    Debug.Assert(maxLength >= _minRequiredLength, $"{maxLength} should have been greater than {_minRequiredLength} minimum");
+                    MaxPossibleLength = maxLength;
+                    if (_minRequiredLength == maxLength)
+                    {
+                        FindMode = TrailingAnchor == RegexNodeKind.End ?
+                            FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_End :
+                            FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ;
+                        return;
+                    }
+                }
             }
 
             // If there's a leading case-sensitive substring, just use IndexOf and inherit all of its optimizations.
@@ -183,8 +204,14 @@ namespace System.Text.RegularExpressions
         /// <summary>Gets the selected mode for performing the next <see cref="TryFindNextStartingPosition"/> operation</summary>
         public FindNextStartingPositionMode FindMode { get; } = FindNextStartingPositionMode.NoSearch;
 
-        /// <summary>Gets the leading anchor, if one exists (RegexPrefixAnalyzer.Bol, etc).</summary>
-        public int LeadingAnchor { get; }
+        /// <summary>Gets the leading anchor (e.g. RegexNodeKind.Bol) if one exists and was computed.</summary>
+        public RegexNodeKind LeadingAnchor { get; }
+
+        /// <summary>Gets the trailing anchor (e.g. RegexNodeKind.Bol) if one exists and was computed.</summary>
+        public RegexNodeKind TrailingAnchor { get; }
+
+        /// <summary>The maximum possible length an input could be to match the pattern.</summary>
+        public int? MaxPossibleLength { get; }
 
         /// <summary>Gets the leading prefix.  May be an empty string.</summary>
         public string LeadingCaseSensitivePrefix { get; } = string.Empty;
@@ -230,7 +257,7 @@ namespace System.Text.RegularExpressions
             // other anchors like Beginning, there are potentially multiple places a BOL can match.  So unlike
             // the other anchors, which all skip all subsequent processing if found, with BOL we just use it
             // to boost our position to the next line, and then continue normally with any searches.
-            if (LeadingAnchor == RegexPrefixAnalyzer.Bol)
+            if (LeadingAnchor == RegexNodeKind.Bol)
             {
                 // If we're not currently positioned at the beginning of a line (either
                 // the beginning of the string or just after a line feed), find the next
@@ -312,6 +339,20 @@ namespace System.Text.RegularExpressions
                     {
                         pos = beginning;
                         return false;
+                    }
+                    return true;
+
+                case FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_EndZ:
+                    if (pos < end - _minRequiredLength - 1)
+                    {
+                        pos = end - _minRequiredLength - 1;
+                    }
+                    return true;
+
+                case FindNextStartingPositionMode.TrailingAnchor_FixedLength_LeftToRight_End:
+                    if (pos < end - _minRequiredLength)
+                    {
+                        pos = end - _minRequiredLength;
                     }
                     return true;
 
@@ -697,6 +738,11 @@ namespace System.Text.RegularExpressions
         LeadingAnchor_RightToLeft_EndZ,
         /// <summary>An "end" anchor at the beginning of the right-to-left pattern.  This is rare.</summary>
         LeadingAnchor_RightToLeft_End,
+
+        /// <summary>An "end" anchor at the end of the pattern, with the pattern always matching a fixed-length expression.</summary>
+        TrailingAnchor_FixedLength_LeftToRight_End,
+        /// <summary>An "endz" anchor at the end of the pattern, with the pattern always matching a fixed-length expression.</summary>
+        TrailingAnchor_FixedLength_LeftToRight_EndZ,
 
         /// <summary>A case-sensitive multi-character substring at the beginning of the pattern.</summary>
         LeadingPrefix_LeftToRight_CaseSensitive,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
@@ -1,17 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Threading;
-
 namespace System.Text.RegularExpressions
 {
     /// <summary>Specifies the kind of a <see cref="RegexNode"/>.</summary>
     internal enum RegexNodeKind
     {
+        /// <summary>Unknown node type.</summary>
+        /// <remarks>This should never occur on an actual node, and instead is used as a sentinel.</remarks>
+        Unknown = 0,
+
         // The following are leaves (no children) and correspond to primitive operations in the regular expression.
 
         /// <summary>A specific character, e.g. `a`.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -16,16 +15,6 @@ namespace System.Text.RegularExpressions
         private const int StackBufferSize = 32;
         private const RegexNodeKind BeforeChild = (RegexNodeKind)64;
         private const RegexNodeKind AfterChild = (RegexNodeKind)128;
-
-        // where the regex can be pegged
-        public const int Beginning = 0x0001;
-        public const int Bol = 0x0002;
-        public const int Start = 0x0004;
-        public const int Eol = 0x0008;
-        public const int EndZ = 0x0010;
-        public const int End = 0x0020;
-        public const int Boundary = 0x0040;
-        public const int ECMABoundary = 0x0080;
 
         private readonly List<RegexFC> _fcStack;
         private ValueListBuilder<int> _intStack;    // must not be readonly
@@ -654,93 +643,115 @@ namespace System.Text.RegularExpressions
             return null;
         }
 
-        /// <summary>Takes a RegexTree and computes the leading anchor that it encounters.</summary>
-        public static int FindLeadingAnchor(RegexTree tree)
+        /// <summary>Computes the leading anchor of a node.</summary>
+        public static RegexNodeKind FindLeadingAnchor(RegexNode node) =>
+            FindLeadingOrTrailingAnchor(node, leading: true);
+
+        /// <summary>Computes the leading anchor of a node.</summary>
+        public static RegexNodeKind FindTrailingAnchor(RegexNode node) =>
+            FindLeadingOrTrailingAnchor(node, leading: false);
+
+        /// <summary>Computes the leading or trailing anchor of a node.</summary>
+        private static RegexNodeKind FindLeadingOrTrailingAnchor(RegexNode node, bool leading)
         {
-            RegexNode curNode = tree.Root;
-            RegexNode? concatNode = null;
-            int nextChild = 0;
+            if (!StackHelper.TryEnsureSufficientExecutionStack())
+            {
+                // We only recur for alternations, but with a really deep nesting of alternations we could potentially overflow.
+                // In such a case, simply stop searching for an anchor.
+                return RegexNodeKind.Unknown;
+            }
 
             while (true)
             {
-                switch (curNode.Kind)
+                switch (node.Kind)
                 {
                     case RegexNodeKind.Bol:
-                        return Bol;
-
                     case RegexNodeKind.Eol:
-                        return Eol;
-
-                    case RegexNodeKind.Boundary:
-                        return Boundary;
-
-                    case RegexNodeKind.ECMABoundary:
-                        return ECMABoundary;
-
                     case RegexNodeKind.Beginning:
-                        return Beginning;
-
                     case RegexNodeKind.Start:
-                        return Start;
-
                     case RegexNodeKind.EndZ:
-                        return EndZ;
-
                     case RegexNodeKind.End:
-                        return End;
-
-                    case RegexNodeKind.Concatenate:
-                        if (curNode.ChildCount() > 0)
-                        {
-                            concatNode = curNode;
-                            nextChild = 0;
-                        }
-                        break;
+                    case RegexNodeKind.Boundary:
+                    case RegexNodeKind.ECMABoundary:
+                        // Return any anchor found.
+                        return node.Kind;
 
                     case RegexNodeKind.Atomic:
                     case RegexNodeKind.Capture:
-                        curNode = curNode.Child(0);
-                        concatNode = null;
+                        // For groups, continue exploring the sole child.
+                        node = node.Child(0);
                         continue;
 
-                    case RegexNodeKind.Empty:
-                    case RegexNodeKind.PositiveLookaround:
-                    case RegexNodeKind.NegativeLookaround:
-                        break;
+                    case RegexNodeKind.Concatenate:
+                        // For concatenations, we expect primarily to explore its last child, but we can also skip over
+                        // certain kinds of nodes (e.g. Empty), and thus iterate through its children backward looking for the
+                        // last we shouldn't skip.
+                        {
+                            int childCount = node.ChildCount();
+                            RegexNode? child = null;
+                            if (leading)
+                            {
+                                for (int i = 0; i < childCount; i++)
+                                {
+                                    if (node.Child(i).Kind is not (RegexNodeKind.Empty or RegexNodeKind.PositiveLookaround or RegexNodeKind.NegativeLookaround))
+                                    {
+                                        child = node.Child(i);
+                                        break;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                for (int i = childCount - 1; i >= 0; i--)
+                                {
+                                    if (node.Child(i).Kind is not (RegexNodeKind.Empty or RegexNodeKind.PositiveLookaround or RegexNodeKind.NegativeLookaround))
+                                    {
+                                        child = node.Child(i);
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (child is not null)
+                            {
+                                node = child;
+                                continue;
+                            }
+
+                            goto default;
+                        }
+
+                    case RegexNodeKind.Alternate:
+                        // For alternations, every branch needs to lead or trail with the same anchor.
+                        {
+                            // Get the leading/trailing anchor of the first branch.  If there isn't one, bail.
+                            RegexNodeKind anchor = FindLeadingOrTrailingAnchor(node.Child(0), leading);
+                            if (anchor == RegexNodeKind.Unknown)
+                            {
+                                return RegexNodeKind.Unknown;
+                            }
+
+                            // Look at each subsequent branch and validate it has the same leading or trailing
+                            // anchor.  If any doesn't, bail.
+                            int childCount = node.ChildCount();
+                            for (int i = 1; i < childCount; i++)
+                            {
+                                if (FindLeadingOrTrailingAnchor(node.Child(i), leading) != anchor)
+                                {
+                                    return RegexNodeKind.Unknown;
+                                }
+                            }
+
+                            // All branches have the same leading/trailing anchor.  Return it.
+                            return anchor;
+                        }
 
                     default:
-                        return 0;
+                        // For everything else, we couldn't find an anchor.
+                        return RegexNodeKind.Unknown;
                 }
-
-                if (concatNode == null || nextChild >= concatNode.ChildCount())
-                {
-                    return 0;
-                }
-
-                curNode = concatNode.Child(nextChild++);
             }
         }
-
-#if DEBUG
-        [ExcludeFromCodeCoverage]
-        public static string AnchorDescription(int anchors)
-        {
-            var sb = new StringBuilder();
-
-            if ((anchors & Beginning) != 0) sb.Append(", Beginning");
-            if ((anchors & Start) != 0) sb.Append(", Start");
-            if ((anchors & Bol) != 0) sb.Append(", Bol");
-            if ((anchors & Boundary) != 0) sb.Append(", Boundary");
-            if ((anchors & ECMABoundary) != 0) sb.Append(", ECMABoundary");
-            if ((anchors & Eol) != 0) sb.Append(", Eol");
-            if ((anchors & End) != 0) sb.Append(", End");
-            if ((anchors & EndZ) != 0) sb.Append(", EndZ");
-
-            return sb.Length >= 2 ?
-                sb.ToString(2, sb.Length - 2) :
-                "None";
-        }
-#endif
 
         /// <summary>
         /// To avoid recursion, we use a simple integer stack.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -683,9 +683,9 @@ namespace System.Text.RegularExpressions
                         continue;
 
                     case RegexNodeKind.Concatenate:
-                        // For concatenations, we expect primarily to explore its last child, but we can also skip over
-                        // certain kinds of nodes (e.g. Empty), and thus iterate through its children backward looking for the
-                        // last we shouldn't skip.
+                        // For concatenations, we expect primarily to explore its first (for leading) or last (for trailing) child,
+                        // but we can also skip over certain kinds of nodes (e.g. Empty), and thus iterate through its children backward
+                        // looking for the last we shouldn't skip.
                         {
                             int childCount = node.ChildCount();
                             RegexNode? child = null;

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -284,8 +284,42 @@ namespace System.Text.RegularExpressions.Tests
                 // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"
                 yield return (@"\Aaaa\w+zzz\Z", "aaaasdfajsdlfjzzza", RegexOptions.None, 0, 18, false, string.Empty);
 
+                // Anchors
+                foreach (RegexOptions anchorOptions in new[] { RegexOptions.None, RegexOptions.Multiline })
+                {
+                    yield return (@"^abc", "abc", anchorOptions, 0, 3, true, "abc");
+                    yield return (@"^abc", " abc", anchorOptions, 0, 4, false, "");
+                    yield return (@"^abc|^def", "def", anchorOptions, 0, 3, true, "def");
+                    yield return (@"^abc|^def", " abc", anchorOptions, 0, 4, false, "");
+                    yield return (@"^abc|^def", " def", anchorOptions, 0, 4, false, "");
+                    yield return (@"abc|^def", " abc", anchorOptions, 0, 4, true, "abc");
+                    yield return (@"abc|^def|^efg", " abc", anchorOptions, 0, 4, true, "abc");
+                    yield return (@"^abc|def|^efg", " def", anchorOptions, 0, 4, true, "def");
+                    yield return (@"^abc|def", " def", anchorOptions, 0, 4, true, "def");
+                    yield return (@"abcd$", "1234567890abcd", anchorOptions, 0, 14, true, "abcd");
+                    yield return (@"abc{1,4}d$", "1234567890abcd", anchorOptions, 0, 14, true, "abcd");
+                    yield return (@"abc{1,4}d$", "1234567890abccccd", anchorOptions, 0, 17, true, "abccccd");
+                }
+                if (!RegexHelpers.IsNonBacktracking(engine))
+                {
+                    yield return (@"\Gabc", "abc", RegexOptions.None, 0, 3, true, "abc");
+                    yield return (@"\Gabc", " abc", RegexOptions.None, 0, 4, false, "");
+                    yield return (@"\Gabc", " abc", RegexOptions.None, 1, 3, true, "abc");
+                    yield return (@"\Gabc|\Gdef", "def", RegexOptions.None, 0, 3, true, "def");
+                    yield return (@"\Gabc|\Gdef", " abc", RegexOptions.None, 0, 4, false, "");
+                    yield return (@"\Gabc|\Gdef", " def", RegexOptions.None, 0, 4, false, "");
+                    yield return (@"\Gabc|\Gdef", " abc", RegexOptions.None, 1, 3, true, "abc");
+                    yield return (@"\Gabc|\Gdef", " def", RegexOptions.None, 1, 3, true, "def");
+                    yield return (@"abc|\Gdef", " abc", RegexOptions.None, 0, 4, true, "abc");
+                    yield return (@"\Gabc|def", " def", RegexOptions.None, 0, 4, true, "def");
+                }
+
                 // Anchors and multiline
-                yield return (@"^A$", "ABC\n", RegexOptions.Multiline, 0, 2, false, string.Empty);
+                yield return (@"^A$", "A\n", RegexOptions.Multiline, 0, 2, true, "A");
+                yield return (@"^A$", "ABC\n", RegexOptions.Multiline, 0, 4, false, string.Empty);
+                yield return (@"^A$", "123\nA", RegexOptions.Multiline, 0, 5, true, "A");
+                yield return (@"^A$", "123\nA\n456", RegexOptions.Multiline, 0, 9, true, "A");
+                yield return (@"^A$|^B$", "123\nB\n456", RegexOptions.Multiline, 0, 9, true, "B");
 
                 // Using beginning/end of string chars \A, \Z: Actual - "\\Aaaa\\w+zzz\\Z"
                 yield return (@"\A(line2\n)line3\Z", "line2\nline3\n", RegexOptions.Multiline, 0, 12, true, "line2\nline3");
@@ -905,7 +939,7 @@ namespace System.Text.RegularExpressions.Tests
             }
             string input = new string(chars);
 
-            Regex re = await RegexHelpers.GetRegexAsync(engine, @"a.{20}$", RegexOptions.None, TimeSpan.FromMilliseconds(10));
+            Regex re = await RegexHelpers.GetRegexAsync(engine, @"a.{20}^", RegexOptions.None, TimeSpan.FromMilliseconds(10));
             Assert.Throws<RegexMatchTimeoutException>(() => { re.Match(input); });
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexReductionTests.cs
@@ -18,6 +18,8 @@ namespace System.Text.RegularExpressions.Tests
         private static readonly FieldInfo s_regexCode;
         private static readonly FieldInfo s_regexCodeCodes;
         private static readonly FieldInfo s_regexCodeTree;
+        private static readonly FieldInfo s_regexCodeFindOptimizations;
+        private static readonly PropertyInfo s_regexCodeFindOptimizationsMaxPossibleLength;
         private static readonly FieldInfo s_regexCodeTreeMinRequiredLength;
 
         static RegexReductionTests()
@@ -30,6 +32,12 @@ namespace System.Text.RegularExpressions.Tests
 
             s_regexCode = typeof(Regex).GetField("_code", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(s_regexCode);
+
+            s_regexCodeFindOptimizations = s_regexCode.FieldType.GetField("FindOptimizations", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(s_regexCodeFindOptimizations);
+
+            s_regexCodeFindOptimizationsMaxPossibleLength = s_regexCodeFindOptimizations.FieldType.GetProperty("MaxPossibleLength", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(s_regexCodeFindOptimizationsMaxPossibleLength);
 
             s_regexCodeCodes = s_regexCode.FieldType.GetField("Codes", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(s_regexCodeCodes);
@@ -69,6 +77,20 @@ namespace System.Text.RegularExpressions.Tests
             Assert.IsType<int>(minRequiredLength);
 
             return (int)minRequiredLength;
+        }
+
+        private static int? GetMaxPossibleLength(Regex r)
+        {
+            object code = s_regexCode.GetValue(r);
+            Assert.NotNull(code);
+
+            object findOpts = s_regexCodeFindOptimizations.GetValue(code);
+            Assert.NotNull(findOpts);
+
+            object maxPossibleLength = s_regexCodeFindOptimizationsMaxPossibleLength.GetValue(findOpts);
+            Assert.True(maxPossibleLength is null || maxPossibleLength is int);
+
+            return (int?)maxPossibleLength;
         }
 
         [Theory]
@@ -535,70 +557,100 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Not computed in netfx")]
-        [InlineData(@"a", 1)]
-        [InlineData(@"[^a]", 1)]
-        [InlineData(@"[abcdefg]", 1)]
-        [InlineData(@"abcd", 4)]
-        [InlineData(@"a*", 0)]
-        [InlineData(@"a*?", 0)]
-        [InlineData(@"a?", 0)]
-        [InlineData(@"a??", 0)]
-        [InlineData(@"a+", 1)]
-        [InlineData(@"a+?", 1)]
-        [InlineData(@"a{2}", 2)]
-        [InlineData(@"a{2}?", 2)]
-        [InlineData(@"a{3,17}", 3)]
-        [InlineData(@"a{3,17}?", 3)]
-        [InlineData(@"(abcd){5}", 20)]
-        [InlineData(@"(abcd|ef){2,6}", 4)]
-        [InlineData(@"abcef|de", 2)]
-        [InlineData(@"abc(def|ghij)k", 7)]
-        [InlineData(@"\d{1,2}-\d{1,2}-\d{2,4}", 6)]
-        [InlineData(@"1(?=9)\d", 2)]
-        [InlineData(@"1(?!\d)\w", 2)]
-        [InlineData(@"a*a*a*a*a*a*a*b*", 0)]
-        [InlineData(@"((a{1,2}){4}){3,7}", 12)]
-        [InlineData(@"\b\w{4}\b", 4)]
-        [InlineData(@"abcd(?=efgh)efgh", 8)]
-        [InlineData(@"abcd(?<=cd)efgh", 8)]
-        [InlineData(@"abcd(?!ab)efgh", 8)]
-        [InlineData(@"abcd(?<!ef)efgh", 8)]
-        [InlineData(@"(a{1073741824}){2}", 2147483647)]
-        [InlineData(@"a{1073741824}b{1073741824}", 2147483647)]
-        [InlineData(@"((((((((((((((((((((((((((((((ab|cd+)|ef+)|gh+)|ij+)|kl+)|mn+)|op+)|qr+)|st+)|uv+)|wx+)|yz+)|01+)|23+)|45+)|67+)|89+)|AB+)|CD+)|EF+)|GH+)|IJ+)|KL+)|MN+)|OP+)|QR+)|ST+)|UV+)|WX+)|YZ)", 2)]
-        [InlineData(@"(YZ+|(WX+|(UV+|(ST+|(QR+|(OP+|(MN+|(KL+|(IJ+|(GH+|(EF+|(CD+|(AB+|(89+|(67+|(45+|(23+|(01+|(yz+|(wx+|(uv+|(st+|(qr+|(op+|(mn+|(kl+|(ij+|(gh+|(ef+|(de+|(a|bc+)))))))))))))))))))))))))))))))", 1)]
-        [InlineData(@"a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(ab|cd+)|ef+)|gh+)|ij+)|kl+)|mn+)|op+)|qr+)|st+)|uv+)|wx+)|yz+)|01+)|23+)|45+)|67+)|89+)|AB+)|CD+)|EF+)|GH+)|IJ+)|KL+)|MN+)|OP+)|QR+)|ST+)|UV+)|WX+)|YZ+)", 3)]
-        [InlineData(@"(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((a)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))", 1)]
-        [InlineData(@"(?(\d)\d{3}|\d)", 1)]
-        [InlineData(@"(?(\d{7})\d{3}|\d{2})", 2)]
-        [InlineData(@"(?(\d{7})\d{2}|\d{3})", 2)]
-        [InlineData(@"(?(\d)\d{3}|\d{2})", 2)]
-        [InlineData(@"(?(\d)|\d{2})", 0)]
-        [InlineData(@"(?(\d)\d{3})", 0)]
-        [InlineData(@"(abc)(?(1)\d{3}|\d{2})", 5)]
-        [InlineData(@"(abc)(?(1)\d{2}|\d{3})", 5)]
-        [InlineData(@"(abc)(?(1)|\d{2})", 3)]
-        [InlineData(@"(abc)(?(1)\d{3})", 3)]
-        [InlineData(@"(abc|)", 0)]
-        [InlineData(@"(|abc)", 0)]
-        [InlineData(@"(?(x)abc|)", 0)]
-        [InlineData(@"(?(x)|abc)", 0)]
-        public void MinRequiredLengthIsCorrect(string pattern, int expectedLength)
+        [InlineData(@"a", RegexOptions.None, 1, 1)]
+        [InlineData(@"[^a]", RegexOptions.None, 1, 1)]
+        [InlineData(@"[abcdefg]", RegexOptions.None, 1, 1)]
+        [InlineData(@"abcd", RegexOptions.None, 4, 4)]
+        [InlineData(@"a*", RegexOptions.None, 0, null)]
+        [InlineData(@"a*?", RegexOptions.None, 0, null)]
+        [InlineData(@"a?", RegexOptions.None, 0, 1)]
+        [InlineData(@"a??", RegexOptions.None, 0, 1)]
+        [InlineData(@"a+", RegexOptions.None, 1, null)]
+        [InlineData(@"a+?", RegexOptions.None, 1, null)]
+        [InlineData(@"a{2}", RegexOptions.None, 2, 2)]
+        [InlineData(@"a{2}?", RegexOptions.None, 2, 2)]
+        [InlineData(@"a{3,17}", RegexOptions.None, 3, 17)]
+        [InlineData(@"a{3,17}?", RegexOptions.None, 3, 17)]
+        [InlineData(@"[^a]{3,17}", RegexOptions.None, 3, 17)]
+        [InlineData(@"[^a]{3,17}?", RegexOptions.None, 3, 17)]
+        [InlineData(@"(abcd){5}", RegexOptions.None, 20, 20)]
+        [InlineData(@"(abcd|ef){2,6}", RegexOptions.None, 4, 24)]
+        [InlineData(@"abcef|de", RegexOptions.None, 2, 5)]
+        [InlineData(@"abc(def|ghij)k", RegexOptions.None, 7, 8)]
+        [InlineData(@"abc(def|ghij|k||lmnopqrs|t)u", RegexOptions.None, 4, 12)]
+        [InlineData(@"(ab)c(def|ghij|k|l|\1|m)n", RegexOptions.None, 4, null)]
+        [InlineData(@"abc|de*f|ghi", RegexOptions.None, 2, null)]
+        [InlineData(@"abc|de+f|ghi", RegexOptions.None, 3, null)]
+        [InlineData(@"abc|(def)+|ghi", RegexOptions.None, 3, null)]
+        [InlineData(@"(abc)+|def", RegexOptions.None, 3, null)]
+        [InlineData(@"\d{1,2}-\d{1,2}-\d{2,4}", RegexOptions.None, 6, 10)]
+        [InlineData(@"\d{1,2}-(?>\d{1,2})-\d{2,4}", RegexOptions.None, 6, 10)]
+        [InlineData(@"1(?=9)\d", RegexOptions.None, 2, 2)]
+        [InlineData(@"1(?!\d)\w", RegexOptions.None, 2, 2)]
+        [InlineData(@"a*a*a*a*a*a*a*b*", RegexOptions.None, 0, null)]
+        [InlineData(@"((a{1,2}){4}){3,7}", RegexOptions.None, 12, 56)]
+        [InlineData(@"((a{1,2}){4}?){3,7}", RegexOptions.None, 12, 56)]
+        [InlineData(@"\b\w{4}\b", RegexOptions.None, 4, 4)]
+        [InlineData(@"\b\w{4}\b", RegexOptions.ECMAScript,  4, 4)]
+        [InlineData(@"abcd(?=efgh)efgh", RegexOptions.None, 8, 8)]
+        [InlineData(@"abcd(?<=cd)efgh", RegexOptions.None, 8, 8)]
+        [InlineData(@"abcd(?!ab)efgh", RegexOptions.None, 8, 8)]
+        [InlineData(@"abcd(?<!ef)efgh", RegexOptions.None, 8, 8)]
+        [InlineData(@"(a{1073741824}){2}", RegexOptions.None, 2147483646, null)] // min length max is bound to int.MaxValue - 1 for convenience in other places where we need to be able to add 1 without risk of overflow
+        [InlineData(@"a{1073741824}b{1073741824}", RegexOptions.None, 2147483646, null)]
+        [InlineData(@"((((((((((((((((((((((((((((((ab|cd+)|ef+)|gh+)|ij+)|kl+)|mn+)|op+)|qr+)|st+)|uv+)|wx+)|yz+)|01+)|23+)|45+)|67+)|89+)|AB+)|CD+)|EF+)|GH+)|IJ+)|KL+)|MN+)|OP+)|QR+)|ST+)|UV+)|WX+)|YZ)", RegexOptions.None, 2, null)]
+        [InlineData(@"(YZ+|(WX+|(UV+|(ST+|(QR+|(OP+|(MN+|(KL+|(IJ+|(GH+|(EF+|(CD+|(AB+|(89+|(67+|(45+|(23+|(01+|(yz+|(wx+|(uv+|(st+|(qr+|(op+|(mn+|(kl+|(ij+|(gh+|(ef+|(de+|(a|bc+)))))))))))))))))))))))))))))))", RegexOptions.None, 1, null)]
+        [InlineData(@"a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(a(ab|cd+)|ef+)|gh+)|ij+)|kl+)|mn+)|op+)|qr+)|st+)|uv+)|wx+)|yz+)|01+)|23+)|45+)|67+)|89+)|AB+)|CD+)|EF+)|GH+)|IJ+)|KL+)|MN+)|OP+)|QR+)|ST+)|UV+)|WX+)|YZ+)", RegexOptions.None, 3, null)]
+        [InlineData(@"(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((a)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))", RegexOptions.None, 1, 1)]
+        [InlineData(@"(?(\d)\d{3}|\d)", RegexOptions.None, 1, 3)]
+        [InlineData(@"(?(\d{7})\d{3}|\d{2})", RegexOptions.None, 2, 3)]
+        [InlineData(@"(?(\d{7})\d{2}|\d{3})", RegexOptions.None, 2, 3)]
+        [InlineData(@"(?(\d)\d{3}|\d{2})", RegexOptions.None, 2, 3)]
+        [InlineData(@"(?(\d)|\d{2})", RegexOptions.None, 0, 2)]
+        [InlineData(@"(?(\d)\d{3})", RegexOptions.None, 0, 3)]
+        [InlineData(@"(abc)(?(1)\d{3}|\d{2})", RegexOptions.None, 5, 6)]
+        [InlineData(@"(abc)(?(1)\d{2}|\d{3})", RegexOptions.None, 5, 6)]
+        [InlineData(@"(abc)(?(1)|\d{2})", RegexOptions.None, 3, 5)]
+        [InlineData(@"(abc)(?(1)\d{3})", RegexOptions.None, 3, 6)]
+        [InlineData(@"(abc|)", RegexOptions.None, 0, 3)]
+        [InlineData(@"(|abc)", RegexOptions.None, 0, 3)]
+        [InlineData(@"(?(x)abc|)", RegexOptions.None, 0, 3)]
+        [InlineData(@"(?(x)|abc)", RegexOptions.None, 0, 3)]
+        [InlineData(@"(?(x)|abc)^\A\G\z\Z$", RegexOptions.None, 0, 3)]
+        [InlineData(@"(?(x)|abc)^\A\G\z$\Z", RegexOptions.Multiline, 0, 3)]
+        [InlineData(@"^\A\Gabc", RegexOptions.None, 3, null)] // leading anchor currently prevents ComputeMaxLength from being invoked, as it's not needed
+        [InlineData(@"^\A\Gabc", RegexOptions.Multiline, 3, null)]
+        [InlineData(@"abc            def", RegexOptions.IgnorePatternWhitespace, 6, 6)]
+        [InlineData(@"abcdef", RegexOptions.RightToLeft, 6, null)]
+        public void MinMaxLengthIsCorrect(string pattern, RegexOptions options, int expectedMin, int? expectedMax)
         {
-            var r = new Regex(pattern);
-            Assert.Equal(expectedLength, GetMinRequiredLength(r));
+            var r = new Regex(pattern, options);
+            Assert.Equal(expectedMin, GetMinRequiredLength(r));
+            if (!pattern.EndsWith("$", StringComparison.Ordinal) &&
+                !pattern.EndsWith(@"\Z", StringComparison.OrdinalIgnoreCase))
+            {
+                // MaxPossibleLength is currently only computed/stored if there's a trailing End{Z} anchor as the max length is otherwise unused
+                r = new Regex($"(?:{pattern})$", options);
+            }
+            Assert.Equal(expectedMax, GetMaxPossibleLength(r));
         }
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Not computed in netfx")]
-        public void MinRequiredLengthIsCorrect_HugeDepth()
+        public void MinMaxLengthIsCorrect_HugeDepth()
         {
             const int Depth = 10_000;
-            var r = new Regex($"{new string('(', Depth)}a{new string(')', Depth)}"); // too deep for analysis on some platform default stack sizes
+            var r = new Regex($"{new string('(', Depth)}a{new string(')', Depth)}$"); // too deep for analysis on some platform default stack sizes
+
             int minRequiredLength = GetMinRequiredLength(r);
             Assert.True(
                 minRequiredLength == 1 /* successfully analyzed */ || minRequiredLength == 0 /* ran out of stack space to complete analysis */,
                 $"Expected 1 or 0, got {minRequiredLength}");
+
+            int? maxPossibleLength = GetMaxPossibleLength(r);
+            Assert.True(
+                maxPossibleLength == 1 /* successfully analyzed */ || maxPossibleLength is null /* ran out of stack space to complete analysis */,
+                $"Expected 1 or null, got {maxPossibleLength}");
         }
     }
 }


### PR DESCRIPTION
- Extend search for leading anchor to support alternations.  This means that an expression like `^abc|^def` will now observe the leading `^` whereas previously it didn't.
- Add a FindFirstChar optimization that jumps to the right position for a pattern that matches a computeable max length and ends with an end anchor. For example, with the expression `\d{5}$|\d{5}-\d{4}$`, FindFirstChar will now jump to 10 characters before the end of the input and skip over all match attempts earlier.

Fixes https://github.com/dotnet/runtime/issues/62697
Contributes to https://github.com/dotnet/runtime/issues/64097