### PR TITLE
Fix PAL_wprintf for wide characters

### DIFF
--- a/src/coreclr/pal/src/cruntime/printfcpp.cpp
+++ b/src/coreclr/pal/src/cruntime/printfcpp.cpp
@@ -86,7 +86,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
             free(newBuff);
             return -1;
         }
-        ret = InternalFwrite(newBuff, 1, count, stream, &iError);
+        ret = InternalFwrite(newBuff, 1, nsize, stream, &iError);
         if (iError != 0)
         {
             ERROR("InternalFwrite did not write the whole buffer. Error is %d\n", iError);


### PR DESCRIPTION
```c++
int main(int argc, char* argv[])
{
    if (0 != PAL_Initialize(argc, argv))
    {
        fprintf(stderr,"Error: Fail to PAL_Initialize\n");
        exit(1);
    }

    LPCWSTR s = W("１２３４５６"); // U+FF11U+FF12U+FF13U+FF14U+FF15U+FF16
 
    wprintf(W("%s\n"), s);
    wprintf(W("%ls\n"), s);
    wprintf(W("%lS\n"), s);
 
    return 0;
}
```
before:
```
１２
１２
１２
```
after:
```
１２３４５６
１２３４５６
１２３４５６
```