### PR TITLE
Change exception throw when ICustomMarshaller applied to field

### DIFF
--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -2520,7 +2520,7 @@ void MarshalInfo::ThrowTypeLoadExceptionForInvalidFieldMarshal(FieldDesc* pField
     StackSString errorString(W("Unknown error."));
     errorString.LoadResource(CCompRC::Error, resID);
 
-    COMPlusThrow(kTypeLoadException, IDS_EE_BADMARSHALFIELD_ERROR_MSG,
+    COMPlusThrow(kMarshalDirectiveException, IDS_EE_BADMARSHALFIELD_ERROR_MSG,
         GetFullyQualifiedNameForClassW(pFieldDesc->GetEnclosingMethodTable()),
         ssFieldName.GetUnicode(), errorString.GetUnicode());
 }

--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
@@ -594,9 +594,9 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int ThrowingCleanUpNativeDataMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ThrowingCleanUpNativeDataCustomMarshaler))] string str);
 
-        public static void Field_ParentIsStruct_ThrowsTypeLoadException()
+        public static void Field_ParentIsStruct_ThrowsMarshalDirectiveException()
         {
-            Assert.Throws<TypeLoadException>(() => StructWithCustomMarshalerFieldMethod(new StructWithCustomMarshalerField()));
+            Assert.Throws<MarshalDirectiveException>(() => StructWithCustomMarshalerFieldMethod(new StructWithCustomMarshalerField()));
         }
 
         public struct StructWithCustomMarshalerField
@@ -697,7 +697,7 @@ namespace System.Runtime.InteropServices.Tests
                 Parameter_GetInstanceMethodThrows_ThrowsActualException();
                 Parameter_MarshalManagedToNativeThrows_ThrowsActualException();
                 Parameter_CleanUpNativeDataMethodThrows_ThrowsActualException();
-                Field_ParentIsStruct_ThrowsTypeLoadException();
+                Field_ParentIsStruct_ThrowsMarshalDirectiveException();
                 Parameter_DifferentCustomMarshalerType_MarshalsCorrectly();
                 DelegateParameter_MarshalerOnRefInt_ThrowsMarshalDirectiveException();
             }


### PR DESCRIPTION
During work on ICustomMarshaller on NativeAOT in https://github.com/dotnet/runtime/pull/62921 was noticed that in case if ICustomMarshaller applied to field of struct exception throw is TypeLoadException which has 2 properties
- it is looks strange, why type failed to load instead of this is marshalling authoring error
- It require ILC to go to unnatural length if we want to have one-to-one compatibility with CoreCLR

I would like to propose change behavior in that case and throw `MarshallerDirectiveException`. Given `ICustomMarshaller` is relatively rare feature, and having it used in unsupported manner even more rare, I think that change maybe acceptable.