### PR TITLE
Don't reference .NETFramework shims in libraries product or test composition

### DIFF
--- a/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/libraries/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -176,7 +176,6 @@ System.Data.Odbc.OdbcTransaction</PackageDescription>
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading.ThreadPool" />
     <Reference Include="System.Threading.Timer" />
-    <Reference Include="System.Transactions" />
     <Reference Include="System.Transactions.Local" />
     <Reference Include="System.Xml.ReaderWriter" />
   </ItemGroup>

--- a/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
+++ b/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
@@ -49,7 +49,6 @@ System.Formats.Cbor.CborWriter</PackageDescription>
   </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <Reference Include="System" />
     <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Memory" />

--- a/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/EncryptDecrypt.cs
@@ -3,9 +3,7 @@
 
 using Microsoft.DotNet.XUnitExtensions;
 using System.Diagnostics;
-using System.Diagnostics.Eventing.Reader;
 using System.Security;
-using System.ServiceProcess;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketDuplicationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketDuplicationTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Drawing.Drawing2D;
 using System.IO;
 using System.IO.Pipes;
 using System.Runtime.Serialization.Formatters.Binary;


### PR DESCRIPTION
Stop referencing .NETFramework shims in libraries ref, source or test projects as those are supplementary and shouldn't impact the product composition.