### PR TITLE
Put back FindCaseSensitivePrefix regex alternation support

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexFindOptimizations.cs
@@ -50,7 +50,7 @@ namespace System.Text.RegularExpressions
             }
 
             // If there's a leading case-sensitive substring, just use IndexOf and inherit all of its optimizations.
-            string caseSensitivePrefix = RegexPrefixAnalyzer.FindCaseSensitivePrefix(tree);
+            string caseSensitivePrefix = RegexPrefixAnalyzer.FindCaseSensitivePrefix(tree.Root);
             if (caseSensitivePrefix.Length > 1)
             {
                 LeadingCaseSensitivePrefix = caseSensitivePrefix;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -87,6 +87,55 @@ namespace System.Text.RegularExpressions
                             return !rtl;
                         }
 
+                    // Alternation: find a string that's a shared prefix of all branches
+                    case RegexNodeKind.Alternate:
+                        {
+                            int childCount = node.ChildCount();
+
+                            // Store the initial branch into the target builder
+                            int initialLength = vsb.Length;
+                            bool keepExploring = Process(node.Child(0), ref vsb);
+                            int addedLength = vsb.Length - initialLength;
+
+                            // Then explore the rest of the branches, finding the length
+                            // a prefix they all share in common with the initial branch.
+                            if (addedLength != 0)
+                            {
+                                var alternateSb = new ValueStringBuilder(64);
+
+                                // Process each branch.  If we reach a point where we've proven there's
+                                // no overlap, we can bail early.
+                                for (int i = 1; i < childCount && addedLength != 0; i++)
+                                {
+                                    alternateSb.Length = 0;
+
+                                    // Process the branch.  We want to keep exploring after this alternation,
+                                    // but we can't if either this branch doesn't allow for it or if the prefix
+                                    // supplied by this branch doesn't entirely match all the previous ones.
+                                    keepExploring &= Process(node.Child(i), ref alternateSb);
+                                    keepExploring &= alternateSb.Length == addedLength;
+
+                                    addedLength = Math.Min(addedLength, alternateSb.Length);
+                                    for (int j = 0; j < addedLength; j++)
+                                    {
+                                        if (vsb[initialLength + j] != alternateSb[j])
+                                        {
+                                            addedLength = j;
+                                            keepExploring = false;
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                alternateSb.Dispose();
+
+                                // Then cull back on what was added based on the other branches.
+                                vsb.Length = initialLength + addedLength;
+                            }
+
+                            return !rtl && keepExploring;
+                        }
+
                     // One character
                     case RegexNodeKind.One when (node.Options & RegexOptions.IgnoreCase) == 0:
                         vsb.Append(node.Ch);

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -205,6 +205,10 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(^|($|a+))bc", " aabc", RegexOptions.None, 0, 5, true, "aabc");
                 yield return (@"yz(^|a+)bc", " yzaabc", RegexOptions.None, 0, 7, true, "yzaabc");
                 yield return (@"(^a|a$) bc", "a bc", RegexOptions.None, 0, 4, true, "a bc");
+                yield return (@"(abcdefg|abcdef|abc|a)h", "    ah  ", RegexOptions.None, 0, 8, true, "ah");
+                yield return (@"(^abcdefg|abcdef|^abc|a)h", "    abcdefh  ", RegexOptions.None, 0, 13, true, "abcdefh");
+                yield return (@"(a|^abcdefg|abcdef|^abc)h", "    abcdefh  ", RegexOptions.None, 0, 13, true, "abcdefh");
+                yield return (@"(abcdefg|abcdef)h", "    abcdefghij  ", RegexOptions.None, 0, 16, true, "abcdefgh");
 
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/63976#issuecomment-1019716016