### PR TITLE
Skip tests using AsyncIO in FileSystemAclExtensionsTests where it's not supported

### DIFF
--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -409,8 +409,8 @@ namespace System.IO
             where !(rights == FileSystemRights.CreateFiles &&
                     (mode == FileMode.Append || mode == FileMode.Create || mode == FileMode.CreateNew)) &&
                   !(mode == FileMode.Truncate && rights != FileSystemRights.Write) &&
-                  options != FileOptions.Encrypted || // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
-                  (options == FileOptions.Asynchronous && PlatformDetection.IsAsyncFileIOSupported)// Async IO not supported on Windows using Mono runtime https://github.com/dotnet/runtime/issues/34582
+                  (options != FileOptions.Encrypted && // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
+                  !(options == FileOptions.Asynchronous && !PlatformDetection.IsAsyncFileIOSupported))// Async IO not supported on Windows using Mono runtime https://github.com/dotnet/runtime/issues/34582
             select new object[] { mode, rights, share, options };
 
         [Theory]
@@ -433,8 +433,8 @@ namespace System.IO
             from rights in s_readableRights
             from share in Enum.GetValues<FileShare>()
             from options in Enum.GetValues<FileOptions>()
-            where options != FileOptions.Encrypted || // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
-            (options == FileOptions.Asynchronous && PlatformDetection.IsAsyncFileIOSupported) // Async IO not supported on Windows using Mono runtime https://github.com/dotnet/runtime/issues/34582
+            where options != FileOptions.Encrypted && // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
+            !(options == FileOptions.Asynchronous && !PlatformDetection.IsAsyncFileIOSupported) // Async IO not supported on Windows using Mono runtime https://github.com/dotnet/runtime/issues/34582
             select new object[] { mode, rights, share, options };
 
         [Theory]

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -409,7 +409,8 @@ namespace System.IO
             where !(rights == FileSystemRights.CreateFiles &&
                     (mode == FileMode.Append || mode == FileMode.Create || mode == FileMode.CreateNew)) &&
                   !(mode == FileMode.Truncate && rights != FileSystemRights.Write) &&
-                  options != FileOptions.Encrypted // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
+                  options != FileOptions.Encrypted || // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
+                  (options == FileOptions.Asynchronous && PlatformDetection.IsAsyncFileIOSupported)// Async IO not supported on Windows using Mono runtime https://github.com/dotnet/runtime/issues/34582
             select new object[] { mode, rights, share, options };
 
         [Theory]
@@ -432,7 +433,8 @@ namespace System.IO
             from rights in s_readableRights
             from share in Enum.GetValues<FileShare>()
             from options in Enum.GetValues<FileOptions>()
-            where options != FileOptions.Encrypted // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
+            where options != FileOptions.Encrypted || // Using FileOptions.Encrypted throws UnauthorizedAccessException when attempting to read the created file
+            (options == FileOptions.Asynchronous && PlatformDetection.IsAsyncFileIOSupported) // Async IO not supported on Windows using Mono runtime https://github.com/dotnet/runtime/issues/34582
             select new object[] { mode, rights, share, options };
 
         [Theory]


### PR DESCRIPTION
The mono runtime does not yet support AsyncIO on Windows and there were some tests failing on CI because of it.
Fixes https://github.com/dotnet/runtime/issues/64221