### PR TITLE
Fix remote unwind

### DIFF
--- a/src/coreclr/pal/src/libunwind/src/oop/_OOP_find_proc_info.c
+++ b/src/coreclr/pal/src/libunwind/src/oop/_OOP_find_proc_info.c
@@ -28,6 +28,8 @@ _OOP_find_proc_info (
     int ret = 0;
 
     unw_dyn_info_t di;
+    memset(&di, 0, sizeof(di));
+
     di.start_ip = start_ip;
     di.end_ip = end_ip;
     di.gp = pi->gp;


### PR DESCRIPTION
The `_OOP_find_proc_info` was setting only a couple of members of the
`unw_dyn_info_t` instance on stack. So the remaining ones had random
values. The `load_offset` was a recently added member to the struct.
When we have updated libunwind, this change came in. The `load_offset` was
random and that has broken unwinding as this offset is subtracted from
the IP when looking up unwind info.

The fix clears the whole struct. I have verified that the issue we had no
longer happens with the fix.

Close #64168