### PR TITLE
[wasm][debugger] Don't show the wasm functions on callstack when debugging managed code

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -961,7 +961,9 @@ namespace Microsoft.WebAssembly.Diagnostics
                 string function_name = frame["functionName"]?.Value<string>();
                 string url = frame["url"]?.Value<string>();
                 if (!(function_name.StartsWith("wasm-function", StringComparison.Ordinal) ||
-                        url.StartsWith("wasm://wasm/", StringComparison.Ordinal) || function_name == "_mono_wasm_fire_debugger_agent_message"))
+                        url.StartsWith("wasm://wasm/", StringComparison.Ordinal) ||
+                        url.EndsWith(".wasm", StringComparison.Ordinal) ||
+                        function_name == "_mono_wasm_fire_debugger_agent_message"))
                 {
                     callFrames.Add(frame);
                 }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -237,6 +237,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         {
                             case var _ when url == "":
                             case var _ when url.StartsWith("wasm://", StringComparison.Ordinal):
+                            case var _ when url.EndsWith(".wasm", StringComparison.Ordinal):
                                 {
                                     Log("verbose", $"ignoring wasm: Debugger.scriptParsed {url}");
                                     return true;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -962,7 +962,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 string function_name = frame["functionName"]?.Value<string>();
                 string url = frame["url"]?.Value<string>();
                 if (!(function_name.StartsWith("wasm-function", StringComparison.Ordinal) ||
-                        url.StartsWith("wasm://wasm/", StringComparison.Ordinal) ||
+                        url.StartsWith("wasm://", StringComparison.Ordinal) ||
                         url.EndsWith(".wasm", StringComparison.Ordinal) ||
                         function_name == "_mono_wasm_fire_debugger_agent_message"))
                 {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -156,8 +156,11 @@ namespace DebuggerTests
                     CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 8, 4, scripts, scope["startLocation"]);
                     CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 14, 4, scripts, scope["endLocation"]);
 
-                    var not_wasm_frame = pause_location["callFrames"][2];
-                    Assert.Contains("dotnet.js", not_wasm_frame["url"].Value<string>());
+                    foreach (var frame in pause_location["callFrames"])
+                    {
+                        Assert.Equal(false, frame["url"].Value<string>().Contains(".wasm"));
+                        Assert.Equal(false, frame["url"].Value<string>().Contains("wasm://"));
+                    }
                     return Task.CompletedTask;
                 }
             );

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -155,6 +155,9 @@ namespace DebuggerTests
                     Assert.Equal("object", scope["object"]["type"]);
                     CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 8, 4, scripts, scope["startLocation"]);
                     CheckLocation("dotnet://debugger-test.dll/debugger-test.cs", 14, 4, scripts, scope["endLocation"]);
+
+                    var not_wasm_frame = pause_location["callFrames"][2];
+                    Assert.Contains("dotnet.js", not_wasm_frame["url"].Value<string>());
                     return Task.CompletedTask;
                 }
             );


### PR DESCRIPTION
This PR is what I would like to backport to 6.0.

On .net7 my plan is to check if there is dwarf symbols or create something to enable it, the callstack with wasm functions are useful when we want to debug the runtime code.

But I would like to merge this version and backport to make callstack have the same behavior that we had on .net5.

In the first time that we run the Blazor project we get this:
`"http://localhost:5174/_framework/dotnet.wasm"` in the URL field of the original callstack that came from the browser.
After stop and running again we get this:
`"wasm://wasm/00945abe"`

That is why the user was complaining about seeing different callstack on first and second execution.

Fixes #63466