### PR TITLE
Fix unique VNs for `ADDR`s

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_64208/Runtime_64208.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64208/Runtime_64208.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+public class Runtime_64208
+{
+    public static int Main(string[] args)
+    {
+        if (Method0() != null)
+        {
+            return 101;
+        }
+
+        return 100;
+    }
+
+    public struct S1
+    {
+        public string string_0;
+    }
+
+    static S1 s_s1_32 = new S1();
+
+    public static S1 LeafMethod15() => s_s1_32;
+
+    public static string Method0()
+    {
+        return LeafMethod15().string_0;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64208/Runtime_64208.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64208/Runtime_64208.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <CLRTestBatchPreCommands><![CDATA[
+      $(CLRTestBatchPreCommands)
+      set DOTNET_JitAggressiveInlining=1
+      ]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+      $(BashCLRTestPreCommands)
+      export DOTNET_JitAggressiveInlining=1
+      ]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
They need to keep the exception sets.

Fixes #64208.