### PR TITLE
Allow symbols 3 external symbols into the gcc/gcov library.

### DIFF
--- a/src/native/libs/verify-entrypoints.sh
+++ b/src/native/libs/verify-entrypoints.sh
@@ -18,6 +18,9 @@ for line in $($nmCommand $1); do
       init) ;;
       fini) ;;
       etext) ;;
+      mangle_path) ;;  # for gcc gcov support
+      _gcov_dump) ;;   # for gcc gcov support
+      _gcov_reset) ;;  # for gcc gcov support
       PROCEDURE_LINKAGE_TABLE_) ;;
       *)    dllList+=(${BASH_REMATCH[1]});;
     esac


### PR DESCRIPTION
Place 3 symbols {mangle_path, _gcov_dump and _gcov_reset}
on the white list of unresolved symbols for verified
compilation units.  These symbols are needed to support
the gcc/gcov (statement coverage) compilation.

I do not know what the equivalent symbols are for clang builds.

I do not fully understand the security implications of this.