### PR TITLE
gcc compilations for ARM64 can not initialize extern "C" variables.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -109,7 +109,8 @@ struct DotNetRuntimeDebugHeader
 #ifdef TARGET_WINDOWS
 #pragma comment (linker, "/EXPORT:DotNetRuntimeDebugHeader,DATA")
 #endif
-extern "C" DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader = {};
+extern "C" struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader;
+struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader = {};
 
 #define MAKE_DEBUG_ENTRY(TypeName, FieldName, Value)                             \
     do                                                                           \

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -585,7 +585,8 @@ void RedhawkGCInterface::UnregisterFrozenSegment(GcSegmentHandle segment)
     GCHeapUtilities::GetGCHeap()->UnregisterFrozenSegment((segment_handle)segment);
 }
 
-EXTERN_C UInt32_BOOL g_fGcStressStarted = UInt32_FALSE; // UInt32_BOOL because asm code reads it
+EXTERN_C UInt32_BOOL g_fGcStressStarted;
+UInt32_BOOL g_fGcStressStarted = UInt32_FALSE; // UInt32_BOOL because asm code reads it
 #ifdef FEATURE_GC_STRESS
 // static
 void RedhawkGCInterface::StressGc()

--- a/src/coreclr/nativeaot/Runtime/startup.cpp
+++ b/src/coreclr/nativeaot/Runtime/startup.cpp
@@ -45,14 +45,17 @@ static bool DetectCPUFeatures();
 
 extern RhConfig * g_pRhConfig;
 
-EXTERN_C bool g_fHasFastFxsave = false;
+EXTERN_C bool g_fHasFastFxsave;
+bool g_fHasFastFxsave = false;
 
 CrstStatic g_CastCacheLock;
 CrstStatic g_ThunkPoolLock;
 
 #if defined(HOST_X86) || defined(HOST_AMD64) || defined(HOST_ARM64)
 // This field is inspected from the generated code to determine what intrinsics are available.
-EXTERN_C int g_cpuFeatures = 0;
+EXTERN_C int g_cpuFeatures;
+int g_cpuFeatures = 0;
+
 // This field is defined in the generated code and sets the ISA expectations.
 EXTERN_C int g_requiredCpuFeatures;
 #endif

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -27,7 +27,8 @@
 #include "slist.inl"
 #include "GCMemoryHelpers.h"
 
-EXTERN_C volatile uint32_t RhpTrapThreads = (uint32_t)TrapThreadsFlags::None;
+EXTERN_C volatile uint32_t RhpTrapThreads;
+volatile uint32_t RhpTrapThreads = (uint32_t)TrapThreadsFlags::None;
 
 GVAL_IMPL_INIT(PTR_Thread, RhpSuspendingThread, 0);
 
@@ -373,7 +374,8 @@ COOP_PINVOKE_HELPER(void, RhpCancelThreadAbort, (void* thread))
 
 C_ASSERT(sizeof(Thread) == sizeof(ThreadBuffer));
 
-EXTERN_C DECLSPEC_THREAD ThreadBuffer tls_CurrentThread =
+EXTERN_C DECLSPEC_THREAD ThreadBuffer tls_CurrentThread;
+DECLSPEC_THREAD ThreadBuffer tls_CurrentThread =
 {
     { 0 },                              // m_rgbAllocContextBuffer
     Thread::TSF_Unknown,                // m_ThreadStateFlags

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1125,10 +1125,10 @@ extern "C" void *JIT_WriteBarrier_Loc;
 #ifdef TARGET_ARM64
 extern "C" void (*JIT_WriteBarrier_Table)();
 
-extern void *JIT_WriteBarrier_Loc;
+extern "C" void *JIT_WriteBarrier_Loc;
 void *JIT_WriteBarrier_Loc = 0;
 
-extern void *JIT_WriteBarrier_Table_Loc;
+extern "C" void *JIT_WriteBarrier_Table_Loc;
 void *JIT_WriteBarrier_Table_Loc = 0;
 #endif // TARGET_ARM64
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1124,7 +1124,11 @@ extern "C" void *JIT_WriteBarrier_Loc;
 
 #ifdef TARGET_ARM64
 extern "C" void (*JIT_WriteBarrier_Table)();
+
+extern void *JIT_WriteBarrier_Loc;
 void *JIT_WriteBarrier_Loc = 0;
+
+extern void *JIT_WriteBarrier_Table_Loc;
 void *JIT_WriteBarrier_Table_Loc = 0;
 #endif // TARGET_ARM64
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1124,8 +1124,8 @@ extern "C" void *JIT_WriteBarrier_Loc;
 
 #ifdef TARGET_ARM64
 extern "C" void (*JIT_WriteBarrier_Table)();
-extern "C" void *JIT_WriteBarrier_Loc = 0;
-extern "C" void *JIT_WriteBarrier_Table_Loc = 0;
+void *JIT_WriteBarrier_Loc = 0;
+void *JIT_WriteBarrier_Table_Loc = 0;
 #endif // TARGET_ARM64
 
 #ifdef TARGET_ARM


### PR DESCRIPTION
Some versions of clang targeted to ARM64 do not allow extern "C"
variables to be initialized at the point of extern "C" declarations,
although this many not be caught until the assembler of linker is run,
at which time an illegal relocation type is discovered.

Per advice from Jan Vorlicek.