### PR TITLE
Fix generic method resolution in composite R2R images

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -432,7 +432,7 @@ void Module::SetNativeMetadataAssemblyRefInCache(DWORD rid, PTR_Assembly pAssemb
     _ASSERTE(m_NativeMetadataAssemblyRefMap != NULL);
 
     _ASSERTE(rid <= GetNativeMetadataAssemblyCount());
-    m_NativeMetadataAssemblyRefMap[rid - 1] = pAssembly;
+    VolatileStore(&m_NativeMetadataAssemblyRefMap[rid - 1], pAssembly);
 }
 
 // Module initialization occurs in two phases: the constructor phase and the Initialize phase.

--- a/src/coreclr/vm/nativeimage.h
+++ b/src/coreclr/vm/nativeimage.h
@@ -93,6 +93,7 @@ private:
 
 private:
     NativeImage(AssemblyBinder *pAssemblyBinder, PEImageLayout *peImageLayout, LPCUTF8 imageFileName);
+    void AddComponentAssemblyToCache(Assembly *assembly);
 
 protected:
     void Initialize(READYTORUN_HEADER *header, LoaderAllocator *loaderAllocator, AllocMemTracker *pamTracker);

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -307,10 +307,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
 {
     CONTRACT(BOOL)
     {
-        NOTHROW;
-        GC_NOTRIGGER;
         MODE_ANY;
-        FORBID_FAULT;
         PRECONDITION(CheckPointer(pModule));
         PRECONDITION(CheckPointer(pZapSigContext));
         PRECONDITION(CheckPointer(pZapSigContext->pModuleContext));
@@ -343,7 +340,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         {
             DWORD ix = CorSigUncompressData(pSig);
             CONTRACT_VIOLATION(ThrowsViolation|GCViolation);
-            pModule = pZapSigContext->GetZapSigModule()->GetModuleFromIndexIfLoaded(ix);
+            pModule = pZapSigContext->GetZapSigModule()->GetModuleFromIndex(ix);
             if (pModule == NULL)
                 RETURN FALSE;
             else


### PR DESCRIPTION
According to my recent investigation, worse perf in the presence
of composite R2R images is due to the inability to resolve certain
generic methods in them; as an initial improvement in that direction
I propose changing generic instance signature matching to
always load assemblies referenced in their signatures. I'm locally
seeing this fix cancel the previous composite-specific regression
I originally measured on the webapi project. Please let me know
if you have different suggestions how to tackle this issue.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib 
Fixes: #64170