### PR TITLE
Simplify the creation of diagnostics using DiagnosticId

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -242,6 +242,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(_IlcTrimmedAssemblies->'--trim:%(Identity)')" />
       <IlcArg Include="@(_IlcNoSingleWarnAssemblies->'--nosinglewarnassembly:%(Filename)')" />
       <IlcArg Condition="'$(TrimmerDefaultAction)' == 'copyused' or '$(TrimmerDefaultAction)' == 'copy'" Include="--defaultrooting" />
+      <IlcArg Include="--resilient" />
 
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Reflection.IsReflectionExecutionAvailable=false" />
 

--- a/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
@@ -24,6 +24,7 @@ namespace ILCompiler
         protected IEnumerable<ICompilationRootProvider> _compilationRoots = Array.Empty<ICompilationRootProvider>();
         protected OptimizationMode _optimizationMode = OptimizationMode.None;
         protected int _parallelism = -1;
+        protected bool _resilient;
 
         public CompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup compilationGroup, NameMangler nameMangler)
         {
@@ -69,6 +70,12 @@ namespace ILCompiler
         public CompilationBuilder UseOptimizationMode(OptimizationMode mode)
         {
             _optimizationMode = mode;
+            return this;
+        }
+
+        public CompilationBuilder UseResilience(bool resilient)
+        {
+            _resilient = resilient;
             return this;
         }
 

--- a/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
@@ -83,7 +83,7 @@ namespace ILCompiler
             return _dependencyTrackingLevel.CreateDependencyGraph(factory, comparer);
         }
 
-        public abstract ICompilation ToCompilation(bool ignoreUnresolved);
+        public abstract ICompilation ToCompilation();
     }
 
     /// <summary>

--- a/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilationBuilder.cs
@@ -83,7 +83,7 @@ namespace ILCompiler
             return _dependencyTrackingLevel.CreateDependencyGraph(factory, comparer);
         }
 
-        public abstract ICompilation ToCompilation();
+        public abstract ICompilation ToCompilation(bool ignoreUnresolved);
     }
 
     /// <summary>

--- a/src/coreclr/tools/Common/Compiler/Logger.cs
+++ b/src/coreclr/tools/Common/Compiler/Logger.cs
@@ -128,6 +128,26 @@ namespace ILCompiler
             LogWarning(_origin, id, args);
         }
 
+        public void LogError(string text, int code, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null)
+        {
+            MessageContainer? error = MessageContainer.CreateErrorMessage(text, code, subcategory, origin);
+            if (error.HasValue)
+                Writer.WriteLine(error.Value.ToMSBuildString());
+        }
+
+        public void LogError(MessageOrigin? origin, DiagnosticId id, params string[] args)
+        {
+            MessageContainer? error = MessageContainer.CreateErrorMessage(origin, id, args);
+            if (error.HasValue)
+                Writer.WriteLine(error.Value.ToMSBuildString());
+        }
+
+        public void LogError(string text, int code, TypeSystemEntity origin, string subcategory = MessageSubCategory.None) =>
+            LogError(text, code, subcategory, new MessageOrigin(origin));
+
+        public void LogError(TypeSystemEntity origin, DiagnosticId id, params string[] args) =>
+            LogError(new MessageOrigin(origin), id, args);
+
         internal bool IsWarningSuppressed(int code, MessageOrigin origin)
         {
             // This is causing too much noise

--- a/src/coreclr/tools/Common/Compiler/Logger.cs
+++ b/src/coreclr/tools/Common/Compiler/Logger.cs
@@ -62,21 +62,11 @@ namespace ILCompiler
                 Writer.WriteLine(warning.Value.ToMSBuildString());
         }
 
-        public void LogWarning(string text, int code, TypeSystemEntity origin, string subcategory = MessageSubCategory.None)
-        {
-            MessageOrigin messageOrigin = new MessageOrigin(origin);
-            MessageContainer? warning = MessageContainer.CreateWarningMessage(this, text, code, messageOrigin, subcategory);
-            if (warning.HasValue)
-                Writer.WriteLine(warning.Value.ToMSBuildString());
-        }
+        public void LogWarning(string text, int code, TypeSystemEntity origin, string subcategory = MessageSubCategory.None) =>
+            LogWarning(text, code, new MessageOrigin(origin), subcategory);
 
-        public void LogWarning(TypeSystemEntity origin, DiagnosticId id, params string[] args)
-        {
-            MessageOrigin messageOrigin = new MessageOrigin(origin);
-            MessageContainer? warning = MessageContainer.CreateWarningMessage(this, messageOrigin, id, args);
-            if (warning.HasValue)
-                Writer.WriteLine(warning.Value.ToMSBuildString());
-        }
+        public void LogWarning(TypeSystemEntity origin, DiagnosticId id, params string[] args) =>
+            LogWarning(new MessageOrigin(origin), id, args);
 
         public void LogWarning(string text, int code, MethodIL origin, int ilOffset, string subcategory = MessageSubCategory.None)
         {

--- a/src/coreclr/tools/Common/Compiler/Logger.cs
+++ b/src/coreclr/tools/Common/Compiler/Logger.cs
@@ -48,6 +48,13 @@ namespace ILCompiler
         {
         }
 
+        public void LogMessage(string message)
+        {
+            MessageContainer? messageContainer = MessageContainer.CreateInfoMessage(message);
+            if(messageContainer.HasValue)
+                Writer.WriteLine(messageContainer.Value.ToMSBuildString());
+        }
+
         public void LogWarning(string text, int code, MessageOrigin origin, string subcategory = MessageSubCategory.None)
         {
             MessageContainer? warning = MessageContainer.CreateWarningMessage(this, text, code, origin, subcategory);

--- a/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
@@ -68,6 +68,22 @@ namespace ILCompiler.Logging
         }
 
         /// <summary>
+        /// Create an error message.
+        /// </summary>
+        /// <param name="origin">Filename, line, and column where the error was found</param>
+        /// <param name="id">Unique error ID. Please see https://github.com/dotnet/linker/blob/main/docs/error-codes.md
+        /// for the list of errors and possibly add a new one</param>
+        /// <param name="args">Additional arguments to form a humanly readable message describing the warning</param>
+        /// <returns>New MessageContainer of 'Error' category</returns>
+        internal static MessageContainer CreateErrorMessage(MessageOrigin? origin, DiagnosticId id, params string[] args)
+        {
+            if (!((int)id >= 1000 && (int)id <= 2000))
+                throw new ArgumentOutOfRangeException(nameof(id), $"The provided code '{(int)id}' does not fall into the error category, which is in the range of 1000 to 2000 (inclusive).");
+
+            return new MessageContainer(MessageCategory.Error, id, origin: origin, args: args);
+        }
+
+        /// <summary>
         /// Create a warning message.
         /// </summary>
         /// <param name="context">Context with the relevant warning suppression info.</param>
@@ -87,6 +103,23 @@ namespace ILCompiler.Logging
             return CreateWarningMessageContainer(context, text, code, origin, subcategory);
         }
 
+        /// <summary>
+        /// Create a warning message.
+        /// </summary>
+        /// <param name="context">Context with the relevant warning suppression info.</param>
+        /// <param name="origin">Filename or member where the warning is coming from</param>
+        /// <param name="id">Unique warning ID. Please see https://github.com/dotnet/linker/blob/main/docs/error-codes.md
+        /// for the list of warnings and possibly add a new one</param>
+        /// <param name="args">Additional arguments to form a humanly readable message describing the warning</param>
+        /// <returns>New MessageContainer of 'Warning' category</returns>
+        internal static MessageContainer? CreateWarningMessage(Logger context, MessageOrigin origin, DiagnosticId id, params string[] args)
+        {
+            //if (!((int)id > 2000 && (int)id <= 6000))
+            //    throw new ArgumentOutOfRangeException(nameof(id), $"The provided code '{(int)id}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
+
+            return CreateWarningMessageContainer(context, origin, id, id.GetDiagnosticSubcategory(), args);
+        }
+
         private static MessageContainer? CreateWarningMessageContainer(Logger context, string text, int code, MessageOrigin origin, string subcategory = MessageSubCategory.None)
         {
             if (context.IsWarningSuppressed(code, origin))
@@ -99,6 +132,20 @@ namespace ILCompiler.Logging
                 return new MessageContainer(MessageCategory.WarningAsError, text, code, subcategory, origin);
 
             return new MessageContainer(MessageCategory.Warning, text, code, subcategory, origin);
+        }
+
+        private static MessageContainer? CreateWarningMessageContainer(Logger context, MessageOrigin origin, DiagnosticId id, string subcategory, params string[] args)
+        {
+            if (context.IsWarningSuppressed((int)id, origin))
+                return null;
+
+            if (TryLogSingleWarning(context, (int)id, origin, subcategory))
+                return null;
+
+            if (context.IsWarningAsError((int)id))
+                return new MessageContainer(MessageCategory.WarningAsError, id, subcategory, origin, args);
+
+            return new MessageContainer(MessageCategory.Warning, id, subcategory, origin, args);
         }
 
         private static bool TryLogSingleWarning(Logger context, int code, MessageOrigin origin, string subcategory)
@@ -137,7 +184,7 @@ namespace ILCompiler.Logging
         private static bool IsTrimmableAssembly(ModuleDesc assembly)
         {
             if (assembly is EcmaAssembly ecmaAssembly)
-            {   
+            {
                 foreach (var attribute in ecmaAssembly.GetDecodedCustomAttributes("System.Reflection", "AssemblyMetadataAttribute"))
                 {
                     if (attribute.FixedArguments.Length != 2)
@@ -195,6 +242,15 @@ namespace ILCompiler.Logging
             Text = text;
         }
 
+        private MessageContainer(MessageCategory category, DiagnosticId id, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null, params string[] args)
+        {
+            Code = (int)id;
+            Category = category;
+            Origin = origin;
+            SubCategory = subcategory;
+            Text = new DiagnosticString(id).GetMessage(args);
+        }
+
         public override string ToString() => ToMSBuildString();
 
         public string ToMSBuildString()
@@ -240,7 +296,7 @@ namespace ILCompiler.Logging
             {
                 if (Origin?.MemberDefinition is MethodDesc method)
                     sb.Append(method.GetDisplayName());
-                else 
+                else
                     sb.Append(Origin?.MemberDefinition.ToString());
 
                 sb.Append(": ");

--- a/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
@@ -97,8 +97,8 @@ namespace ILCompiler.Logging
         /// <returns>New MessageContainer of 'Warning' category</returns>
         internal static MessageContainer? CreateWarningMessage(Logger context, string text, int code, MessageOrigin origin, string subcategory = MessageSubCategory.None)
         {
-            //if (!(code > 2000 && code <= 6000))
-            //    throw new ArgumentOutOfRangeException(nameof(code), $"The provided code '{code}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
+            if (!(code > 2000 && code <= 6000))
+                throw new ArgumentOutOfRangeException(nameof(code), $"The provided code '{code}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
 
             return CreateWarningMessageContainer(context, text, code, origin, subcategory);
         }
@@ -114,8 +114,8 @@ namespace ILCompiler.Logging
         /// <returns>New MessageContainer of 'Warning' category</returns>
         internal static MessageContainer? CreateWarningMessage(Logger context, MessageOrigin origin, DiagnosticId id, params string[] args)
         {
-            //if (!((int)id > 2000 && (int)id <= 6000))
-            //    throw new ArgumentOutOfRangeException(nameof(id), $"The provided code '{(int)id}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
+            if (!((int)id > 2000 && (int)id <= 6000))
+                throw new ArgumentOutOfRangeException(nameof(id), $"The provided code '{(int)id}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
 
             return CreateWarningMessageContainer(context, origin, id, id.GetDiagnosticSubcategory(), args);
         }

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/DocumentationSignatureGenerator.PartVisitor.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/DocumentationSignatureGenerator.PartVisitor.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -147,7 +146,10 @@ namespace Mono.Linker
 				}
 
 				if (typeReference.IsNested) {
-					VisitTypeReference (typeReference.GetInflatedDeclaringType (resolver), builder, resolver);
+					Debug.Assert (typeReference is not SentinelType && typeReference is not PinnedType);
+					// GetInflatedDeclaringType may return null for generic parameters, byrefs, and pointers, but these
+					// are separately handled above.
+					VisitTypeReference (typeReference.GetInflatedDeclaringType (resolver)!, builder, resolver);
 					builder.Append ('.');
 				}
 

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/DocumentationSignatureParser.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/DocumentationSignatureParser.cs
@@ -1,8 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-#nullable enable
 
 using System;
 using System.Collections.Generic;

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageContainer.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageContainer.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
+using ILLink.Shared;
 using Mono.Cecil;
 
 namespace Mono.Linker
@@ -55,6 +56,22 @@ namespace Mono.Linker
 		}
 
 		/// <summary>
+		/// Create an error message.
+		/// </summary>
+		/// <param name="origin">Filename, line, and column where the error was found</param>
+		/// <param name="id">Unique error ID. Please see https://github.com/dotnet/linker/blob/main/docs/error-codes.md
+		/// for the list of errors and possibly add a new one</param>
+		/// <param name="args">Additional arguments to form a humanly readable message describing the warning</param>
+		/// <returns>New MessageContainer of 'Error' category</returns>
+		internal static MessageContainer CreateErrorMessage (MessageOrigin? origin, DiagnosticId id, params string[] args)
+		{
+			if (!((int) id >= 1000 && (int) id <= 2000))
+				throw new ArgumentOutOfRangeException (nameof (id), $"The provided code '{(int) id}' does not fall into the error category, which is in the range of 1000 to 2000 (inclusive).");
+
+			return new MessageContainer (MessageCategory.Error, id, origin: origin, args: args);
+		}
+
+		/// <summary>
 		/// Create a custom error message.
 		/// </summary>
 		/// <param name="text">Humanly readable message describing the error</param>
@@ -94,6 +111,25 @@ namespace Mono.Linker
 				throw new ArgumentOutOfRangeException (nameof (code), $"The provided code '{code}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
 
 			return CreateWarningMessageContainer (context, text, code, origin, version, subcategory);
+		}
+
+		/// <summary>
+		/// Create a warning message.
+		/// </summary>
+		/// <param name="context">Context with the relevant warning suppression info.</param>
+		/// <param name="origin">Filename or member where the warning is coming from</param>
+		/// <param name="id">Unique warning ID. Please see https://github.com/dotnet/linker/blob/main/docs/error-codes.md
+		/// for the list of warnings and possibly add a new one</param>
+		/// <param name="version">Optional warning version number. Versioned warnings can be controlled with the
+		/// warning wave option --warn VERSION. Unversioned warnings are unaffected by this option. </param>
+		/// <param name="args">Additional arguments to form a humanly readable message describing the warning</param>
+		/// <returns>New MessageContainer of 'Warning' category</returns>
+		internal static MessageContainer CreateWarningMessage (LinkContext context, MessageOrigin origin, DiagnosticId id, WarnVersion version, params string[] args)
+		{
+			if (!((int) id > 2000 && (int) id <= 6000))
+				throw new ArgumentOutOfRangeException (nameof (id), $"The provided code '{(int) id}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
+
+			return CreateWarningMessageContainer (context, origin, id, version, id.GetDiagnosticSubcategory (), args);
 		}
 
 		/// <summary>
@@ -141,6 +177,26 @@ namespace Mono.Linker
 			return new MessageContainer (MessageCategory.Warning, text, code, subcategory, origin);
 		}
 
+		private static MessageContainer CreateWarningMessageContainer (LinkContext context, MessageOrigin origin, DiagnosticId id, WarnVersion version, string subcategory, params string[] args)
+		{
+			if (!(version >= WarnVersion.ILLink0 && version <= WarnVersion.Latest))
+				throw new ArgumentException ($"The provided warning version '{version}' is invalid.");
+
+			if (context.IsWarningSuppressed ((int) id, origin))
+				return Empty;
+
+			if (version > context.WarnVersion)
+				return Empty;
+
+			if (TryLogSingleWarning (context, (int) id, origin, subcategory))
+				return Empty;
+
+			if (context.IsWarningAsError ((int) id))
+				return new MessageContainer (MessageCategory.WarningAsError, id, subcategory, origin, args);
+
+			return new MessageContainer (MessageCategory.Warning, id, subcategory, origin, args);
+		}
+
 		public bool IsWarningMessage ([NotNullWhen (true)] out int? code)
 		{
 			code = null;
@@ -159,15 +215,16 @@ namespace Mono.Linker
 			if (subcategory != MessageSubCategory.TrimAnalysis)
 				return false;
 
-			Debug.Assert (origin.Provider != null);
+			// There are valid cases where we can't map the message to an assembly
+			// For example if it's caused by something in an xml file passed on the command line
+			// In that case, give up on single-warn collapse and just print out the warning on its own.
 			var assembly = origin.Provider switch {
 				AssemblyDefinition asm => asm,
 				TypeDefinition type => type.Module.Assembly,
 				IMemberDefinition member => member.DeclaringType.Module.Assembly,
-				_ => throw new NotSupportedException ()
+				_ => null
 			};
 
-			Debug.Assert (assembly != null);
 			if (assembly == null)
 				return false;
 
@@ -181,7 +238,7 @@ namespace Mono.Linker
 				return false;
 
 			if (context.AssembliesWithGeneratedSingleWarning.Add (assemblyName))
-				context.LogWarning ($"Assembly '{assemblyName}' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries", 2104, context.GetAssemblyLocation (assembly));
+				context.LogWarning (context.GetAssemblyLocation (assembly), DiagnosticId.AssemblyProducedTrimWarnings, assemblyName);
 
 			return true;
 		}
@@ -213,6 +270,15 @@ namespace Mono.Linker
 			Origin = origin;
 			SubCategory = subcategory;
 			Text = text;
+		}
+
+		private MessageContainer (MessageCategory category, DiagnosticId id, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null, params string[] args)
+		{
+			Code = (int) id;
+			Category = category;
+			Origin = origin;
+			SubCategory = subcategory;
+			Text = new DiagnosticString (id).GetMessage (args);
 		}
 
 		public override string ToString () => ToMSBuildString ();
@@ -256,6 +322,8 @@ namespace Mono.Linker
 			if (Origin?.Provider != null) {
 				if (Origin?.Provider is MethodDefinition method)
 					sb.Append (method.GetDisplayName ());
+				else if (Origin?.Provider is MemberReference memberRef)
+					sb.Append (memberRef.GetDisplayName ());
 				else if (Origin?.Provider is IMemberDefinition member)
 					sb.Append (member.FullName);
 				else if (Origin?.Provider is AssemblyDefinition assembly)
@@ -274,7 +342,7 @@ namespace Mono.Linker
 		public bool Equals (MessageContainer other) =>
 			(Category, Text, Code, SubCategory, Origin) == (other.Category, other.Text, other.Code, other.SubCategory, other.Origin);
 
-		public override bool Equals (object obj) => obj is MessageContainer messageContainer && Equals (messageContainer);
+		public override bool Equals (object? obj) => obj is MessageContainer messageContainer && Equals (messageContainer);
 		public override int GetHashCode () => (Category, Text, Code, SubCategory, Origin).GetHashCode ();
 
 		public int CompareTo (MessageContainer other)

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
@@ -12,49 +12,55 @@ namespace Mono.Linker
 {
 	public readonly struct MessageOrigin : IComparable<MessageOrigin>, IEquatable<MessageOrigin>
 	{
-#nullable enable
 		public string? FileName { get; }
 		public ICustomAttributeProvider? Provider { get; }
-		readonly ICustomAttributeProvider _suppressionContextMember;
+		readonly ICustomAttributeProvider? _suppressionContextMember;
 		public ICustomAttributeProvider? SuppressionContextMember {
 			get {
 				Debug.Assert (_suppressionContextMember == null || _suppressionContextMember is IMemberDefinition || _suppressionContextMember is AssemblyDefinition);
 				return _suppressionContextMember ?? Provider;
 			}
 		}
-#nullable disable
+
 		public int SourceLine { get; }
 		public int SourceColumn { get; }
 		public int? ILOffset { get; }
 
 		const int HiddenLineNumber = 0xfeefee;
 
-		public MessageOrigin (IMemberDefinition memberDefinition, int? ilOffset = null)
+		public MessageOrigin (IMemberDefinition? memberDefinition, int? ilOffset = null)
 			: this (memberDefinition as ICustomAttributeProvider, ilOffset)
 		{
 		}
 
-		public MessageOrigin (ICustomAttributeProvider provider)
+		public MessageOrigin (ICustomAttributeProvider? provider)
 			: this (provider, null)
 		{
 		}
 
 		public MessageOrigin (string fileName, int sourceLine = 0, int sourceColumn = 0)
+			: this (fileName, sourceLine, sourceColumn, null)
+		{
+		}
+
+		// The assembly attribute should be specified if available as it allows assigning the diagnostic
+		// to a an assembly (we group based on assembly).
+		public MessageOrigin (string fileName, int sourceLine, int sourceColumn, AssemblyDefinition? assembly)
 		{
 			FileName = fileName;
 			SourceLine = sourceLine;
 			SourceColumn = sourceColumn;
-			Provider = null;
+			Provider = assembly;
 			_suppressionContextMember = null;
 			ILOffset = null;
 		}
 
-		public MessageOrigin (ICustomAttributeProvider provider, int? ilOffset)
+		public MessageOrigin (ICustomAttributeProvider? provider, int? ilOffset)
 			: this (provider, ilOffset, null)
 		{
 		}
 
-		public MessageOrigin (ICustomAttributeProvider provider, int? ilOffset, ICustomAttributeProvider suppressionContextMember)
+		public MessageOrigin (ICustomAttributeProvider? provider, int? ilOffset, ICustomAttributeProvider? suppressionContextMember)
 		{
 			Debug.Assert (provider == null || provider is IMemberDefinition || provider is AssemblyDefinition);
 			Debug.Assert (suppressionContextMember == null || suppressionContextMember is IMemberDefinition || provider is AssemblyDefinition);
@@ -66,7 +72,7 @@ namespace Mono.Linker
 			ILOffset = ilOffset;
 		}
 
-		public MessageOrigin (MessageOrigin other, IMemberDefinition suppressionContextMember)
+		public MessageOrigin (MessageOrigin other, IMemberDefinition? suppressionContextMember)
 		{
 			FileName = other.FileName;
 			Provider = other.Provider;
@@ -76,21 +82,21 @@ namespace Mono.Linker
 			ILOffset = other.ILOffset;
 		}
 
-		public override string ToString ()
+		public override string? ToString ()
 		{
 			int sourceLine = SourceLine, sourceColumn = SourceColumn;
-			string fileName = FileName;
+			string? fileName = FileName;
 			if (Provider is MethodDefinition method &&
 				method.DebugInformation.HasSequencePoints) {
 				var offset = ILOffset ?? 0;
-				SequencePoint correspondingSequencePoint = method.DebugInformation.SequencePoints
+				SequencePoint? correspondingSequencePoint = method.DebugInformation.SequencePoints
 					.Where (s => s.Offset <= offset)?.Last ();
 
 				// If the warning comes from hidden line (compiler generated code typically)
 				// search for any sequence point with non-hidden line number and report that as a best effort.
-				if (correspondingSequencePoint.StartLine == HiddenLineNumber) {
+				if (correspondingSequencePoint?.StartLine == HiddenLineNumber) {
 					correspondingSequencePoint = method.DebugInformation.SequencePoints
-						.Where (s => s.StartLine != HiddenLineNumber)?.FirstOrDefault ();
+						.Where (s => s.StartLine != HiddenLineNumber).FirstOrDefault ();
 				}
 
 				if (correspondingSequencePoint != null) {
@@ -118,7 +124,7 @@ namespace Mono.Linker
 		public bool Equals (MessageOrigin other) =>
 			(FileName, Provider, SourceLine, SourceColumn, ILOffset) == (other.FileName, other.Provider, other.SourceLine, other.SourceColumn, other.ILOffset);
 
-		public override bool Equals (object obj) => obj is MessageOrigin messageOrigin && Equals (messageOrigin);
+		public override bool Equals (object? obj) => obj is MessageOrigin messageOrigin && Equals (messageOrigin);
 		public override int GetHashCode () => (FileName, Provider, SourceLine, SourceColumn).GetHashCode ();
 		public static bool operator == (MessageOrigin lhs, MessageOrigin rhs) => lhs.Equals (rhs);
 		public static bool operator != (MessageOrigin lhs, MessageOrigin rhs) => !lhs.Equals (rhs);
@@ -128,12 +134,12 @@ namespace Mono.Linker
 			if (Provider != null && other.Provider != null) {
 				var thisMember = Provider as IMemberDefinition;
 				var otherMember = other.Provider as IMemberDefinition;
-				TypeDefinition thisTypeDef = (Provider as TypeDefinition) ?? (Provider as IMemberDefinition)?.DeclaringType;
-				TypeDefinition otherTypeDef = (other.Provider as TypeDefinition) ?? (other.Provider as IMemberDefinition)?.DeclaringType;
+				TypeDefinition? thisTypeDef = (Provider as TypeDefinition) ?? (Provider as IMemberDefinition)?.DeclaringType;
+				TypeDefinition? otherTypeDef = (other.Provider as TypeDefinition) ?? (other.Provider as IMemberDefinition)?.DeclaringType;
 				var thisAssembly = thisTypeDef?.Module.Assembly ?? Provider as AssemblyDefinition;
 				var otherAssembly = otherTypeDef?.Module.Assembly ?? other.Provider as AssemblyDefinition;
-				int result = (thisAssembly.Name.Name, thisTypeDef?.Name, thisMember?.Name).CompareTo
-					((otherAssembly.Name.Name, otherTypeDef?.Name, otherMember?.Name));
+				int result = (thisAssembly?.Name.Name, thisTypeDef?.Name, thisMember?.Name).CompareTo
+					((otherAssembly?.Name.Name, otherTypeDef?.Name, otherMember?.Name));
 				if (result != 0)
 					return result;
 

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/README.md
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/README.md
@@ -1,1 +1,1 @@
-Sources from the dotnet/linker repo at commit c0567db0b9088e2ad4144cd0fe2a985611ec28f0.
+Sources from the dotnet/linker repo at commit 2999a6a9dd884d554be18d3c86a4a9db4b61e156.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -289,9 +289,7 @@ namespace ILCompiler.Dataflow
                     if (!IsTypeInterestingForDataflow(field.FieldType))
                     {
                         // Already know that there's a non-empty annotation on a field which is not System.Type/String and we're about to ignore it
-                        _logger.LogWarning(
-                            $"Field '{field.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.",
-                            2097, field, subcategory: MessageSubCategory.TrimAnalysis);
+                        _logger.LogWarning(field, DiagnosticId.DynamicallyAccessedMembersOnFieldCanOnlyApplyToTypesOrStrings, field.GetDisplayName());
                         continue;
                     }
 
@@ -343,9 +341,7 @@ namespace ILCompiler.Dataflow
                         }
                         else
                         {
-                            _logger.LogWarning(
-                                $"The 'DynamicallyAccessedMembersAttribute' is not allowed on methods. It is allowed on method return value or method parameters though.",
-                                2041, method, subcategory: MessageSubCategory.TrimAnalysis);
+                            _logger.LogWarning(method, DiagnosticId.DynamicallyAccessedMembersIsNotAllowedOnMethods);
                         }
                     }
 
@@ -364,9 +360,7 @@ namespace ILCompiler.Dataflow
                             returnAnnotation = GetMemberTypesForDynamicallyAccessedMembersAttribute(reader, parameter.GetCustomAttributes());
                             if (returnAnnotation != DynamicallyAccessedMemberTypes.None && !IsTypeInterestingForDataflow(signature.ReturnType))
                             {
-                                _logger.LogWarning(
-                                    $"Return type of method '{method.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.",
-                                    2106, method, subcategory: MessageSubCategory.TrimAnalysis);
+                                _logger.LogWarning(method, DiagnosticId.DynamicallyAccessedMembersOnMethodReturnValueCanOnlyApplyToTypesOrStrings, method.GetDisplayName());
                             }
                         }
                         else
@@ -377,9 +371,7 @@ namespace ILCompiler.Dataflow
 
                             if (!IsTypeInterestingForDataflow(signature[parameter.SequenceNumber - 1]))
                             {
-                                _logger.LogWarning(
-                                    $"Parameter #{parameter.SequenceNumber} of method '{method.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.",
-                                    2098, method, subcategory: MessageSubCategory.TrimAnalysis);
+                                _logger.LogWarning(method, DiagnosticId.DynamicallyAccessedMembersOnMethodParameterCanOnlyApplyToTypesOrStrings, $"#{parameter.SequenceNumber}", method.GetDisplayName());
                                 continue;
                             }
 
@@ -435,9 +427,7 @@ namespace ILCompiler.Dataflow
 
                     if (!IsTypeInterestingForDataflow(property.Signature.ReturnType))
                     {
-                        _logger.LogWarning(
-                            $"Property '{property.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.",
-                            2099, property, subcategory: MessageSubCategory.TrimAnalysis);
+                        _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersOnPropertyCanOnlyApplyToTypesOrStrings, property.GetDisplayName());
                         continue;
                     }
 
@@ -462,9 +452,7 @@ namespace ILCompiler.Dataflow
                         if (annotatedMethods.Any(a => a.Method == setMethod))
                         {
                             
-                            _logger.LogWarning(
-                                $"'DynamicallyAccessedMembersAttribute' on property '{property.GetDisplayName()}' conflicts with the same attribute on its accessor '{setMethod.GetDisplayName()}'.",
-                                2043, setMethod, subcategory: MessageSubCategory.TrimAnalysis);
+                            _logger.LogWarning(setMethod, DiagnosticId.DynamicallyAccessedMembersConflictsBetweenPropertyAndAccessor, property.GetDisplayName(), setMethod.GetDisplayName());
                         }
                         else
                         {
@@ -498,9 +486,7 @@ namespace ILCompiler.Dataflow
 
                         if (annotatedMethods.Any(a => a.Method == getMethod))
                         {
-                            _logger.LogWarning(
-                                $"'DynamicallyAccessedMembersAttribute' on property '{property.GetDisplayName()}' conflicts with the same attribute on its accessor '{getMethod.GetDisplayName()}'.",
-                                2043, getMethod, subcategory: MessageSubCategory.TrimAnalysis);
+                            _logger.LogWarning(getMethod, DiagnosticId.DynamicallyAccessedMembersConflictsBetweenPropertyAndAccessor, property.GetDisplayName(), getMethod.GetDisplayName());
                         }
                         else
                         {
@@ -512,9 +498,7 @@ namespace ILCompiler.Dataflow
                     if (backingFieldFromGetter != null && backingFieldFromSetter != null &&
                         backingFieldFromGetter != backingFieldFromSetter)
                     {
-                        _logger.LogWarning(
-                            $"Could not find a unique backing field for property '{property.GetDisplayName()}' to propagate 'DynamicallyAccessedMembersAttribute'.",
-                            2042, property, subcategory: MessageSubCategory.TrimAnalysis);
+                        _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersCouldNotFindBackingField, property.GetDisplayName());
                         backingField = null;
                     }
                     else
@@ -526,9 +510,7 @@ namespace ILCompiler.Dataflow
                     {
                         if (annotatedFields.Any(a => a.Field == backingField))
                         {
-                            _logger.LogWarning(
-                                $"'DynamicallyAccessedMemberAttribute' on property '{property.GetDisplayName()}' conflicts with the same attribute on its backing field '{backingField.GetDisplayName()}'.",
-                                2056, backingField, subcategory: MessageSubCategory.TrimAnalysis);
+                            _logger.LogWarning(backingField, DiagnosticId.DynamicallyAccessedMembersOnPropertyConflictsWithBackingField, property.GetDisplayName(), backingField.GetDisplayName());
                         }
                         else
                         {
@@ -731,33 +713,23 @@ namespace ILCompiler.Dataflow
             switch (provider)
             {
                 case int parameterNumber:
-                    _logger.LogWarning(
-                        $"'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the parameter #{parameterNumber} of method '{DiagnosticUtilities.GetMethodSignatureDisplayName(origin)}' " +
-                        $"don't match overridden parameter #{parameterNumber} of method '{DiagnosticUtilities.GetMethodSignatureDisplayName((MethodDesc)baseProvider)}'. " +
-                        $"All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.",
-                        2092, origin, subcategory: MessageSubCategory.TrimAnalysis);
+                    _logger.LogWarning(origin, DiagnosticId.DynamicallyAccessedMembersMismatchOnMethodParameterBetweenOverrides,
+                        $"#{parameterNumber}", DiagnosticUtilities.GetMethodSignatureDisplayName(origin),
+                        $"#{parameterNumber}", DiagnosticUtilities.GetMethodSignatureDisplayName((MethodDesc)baseProvider));
                     break;
                 case GenericParameterDesc genericParameterOverride:
-                    _logger.LogWarning(
-                        $"'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the generic parameter '{genericParameterOverride.Name}' of '{DiagnosticUtilities.GetGenericParameterDeclaringMemberDisplayName(new GenericParameterOrigin(genericParameterOverride))}' " +
-                        $"don't match overridden generic parameter '{((GenericParameterDesc)baseProvider).Name}' of '{DiagnosticUtilities.GetGenericParameterDeclaringMemberDisplayName(new GenericParameterOrigin((GenericParameterDesc)baseProvider))}'. " +
-                        $"All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.",
-                        2095, origin, subcategory: MessageSubCategory.TrimAnalysis);
+                    _logger.LogWarning(origin, DiagnosticId.DynamicallyAccessedMembersMismatchOnGenericParameterBetweenOverrides,
+                        genericParameterOverride.Name, DiagnosticUtilities.GetGenericParameterDeclaringMemberDisplayName(new GenericParameterOrigin(genericParameterOverride)),
+                        ((GenericParameterDesc)baseProvider).Name, DiagnosticUtilities.GetGenericParameterDeclaringMemberDisplayName(new GenericParameterOrigin((GenericParameterDesc)baseProvider)));
                     break;
                 case TypeDesc methodReturnType:
-                    _logger.LogWarning(
-                        $"'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the return value of method '{DiagnosticUtilities.GetMethodSignatureDisplayName(origin)}' " +
-                        $"don't match overridden return value of method '{DiagnosticUtilities.GetMethodSignatureDisplayName((MethodDesc)baseProvider)}'. " +
-                        $"All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.",
-                        2093, origin, subcategory: MessageSubCategory.TrimAnalysis);
+                    _logger.LogWarning(origin, DiagnosticId.DynamicallyAccessedMembersMismatchOnMethodReturnValueBetweenOverrides,
+                        DiagnosticUtilities.GetMethodSignatureDisplayName(origin), DiagnosticUtilities.GetMethodSignatureDisplayName((MethodDesc)baseProvider));
                     break;
                 // No fields - it's not possible to have a virtual field and override it
                 case MethodDesc methodDefinition:
-                    _logger.LogWarning(
-                        $"'DynamicallyAccessedMemberTypes' in 'DynamicallyAccessedMembersAttribute' on the implicit 'this' parameter of method '{DiagnosticUtilities.GetMethodSignatureDisplayName(methodDefinition)}' " +
-                        $"don't match overridden implicit 'this' parameter of method '{DiagnosticUtilities.GetMethodSignatureDisplayName((MethodDesc)baseProvider)}'. " +
-                        $"All overridden members must have the same 'DynamicallyAccessedMembersAttribute' usage.",
-                        2094, origin, subcategory: MessageSubCategory.TrimAnalysis);
+                    _logger.LogWarning(origin, DiagnosticId.DynamicallyAccessedMembersMismatchOnImplicitThisBetweenOverrides,
+                        DiagnosticUtilities.GetMethodSignatureDisplayName(methodDefinition), DiagnosticUtilities.GetMethodSignatureDisplayName((MethodDesc)baseProvider));
                     break;
                 default:
                     throw new NotImplementedException($"Unsupported provider type {provider.GetType()}");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -2226,9 +2226,8 @@ namespace ILCompiler.Dataflow
                         {
                             string arg1 = MessageFormat.FormatRequiresAttributeMessageArg(DiagnosticUtilities.GetRequiresAttributeMessage(calledMethod, "RequiresUnreferencedCodeAttribute"));
                             string arg2 = MessageFormat.FormatRequiresAttributeUrlArg(DiagnosticUtilities.GetRequiresAttributeUrl(calledMethod, "RequiresUnreferencedCodeAttribute"));
-                            string message = new DiagnosticString(DiagnosticId.RequiresUnreferencedCode).GetMessage(calledMethod.GetDisplayName(), arg1, arg2);
 
-                            _logger.LogWarning(message, (int)DiagnosticId.RequiresUnreferencedCode, callingMethodBody, offset, MessageSubCategory.TrimAnalysis);
+                            _logger.LogWarning(callingMethodBody, offset, DiagnosticId.RequiresUnreferencedCode, calledMethod.GetDisplayName(), arg1, arg2);
                         }
 
                         if (shouldEnableAotWarnings &&
@@ -2241,9 +2240,8 @@ namespace ILCompiler.Dataflow
                         {
                             string arg1 = MessageFormat.FormatRequiresAttributeMessageArg(DiagnosticUtilities.GetRequiresAttributeMessage(calledMethod, "RequiresDynamicCodeAttribute"));
                             string arg2 = MessageFormat.FormatRequiresAttributeUrlArg(DiagnosticUtilities.GetRequiresAttributeUrl(calledMethod, "RequiresDynamicCodeAttribute"));
-                            string message = new DiagnosticString(DiagnosticId.RequiresDynamicCode).GetMessage(calledMethod.GetDisplayName(), arg1, arg2);
 
-                            logger.LogWarning(message, (int)DiagnosticId.RequiresDynamicCode, callingMethodBody, offset, MessageSubCategory.AotAnalysis);
+                            logger.LogWarning(callingMethodBody, offset, DiagnosticId.RequiresDynamicCode, calledMethod.GetDisplayName(), arg1, arg2);
                         }
 
                         // To get good reporting of errors we need to track the origin of the value for all method calls
@@ -2933,32 +2931,20 @@ namespace ILCompiler.Dataflow
                 // are not suppressed in RUC scopes. Here the scope represents the DynamicallyAccessedMembers
                 // annotation on a type, not a callsite which uses the annotation. We always want to warn about
                 // possible reflection access indicated by these annotations.
-
-                var message = string.Format(
-                        "'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which has 'DynamicallyAccessedMembersAttribute' requirements.",
-                        ((TypeOrigin)context.MemberWithRequirements).GetDisplayName(),
-                        entity.GetDisplayName());
-                _logger.LogWarning(message, 2115, context.Source, MessageSubCategory.TrimAnalysis);
+                _logger.LogWarning(context.Source, DiagnosticId.DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithDynamicallyAccessedMembers,
+                    ((TypeOrigin)context.MemberWithRequirements).GetDisplayName(), entity.GetDisplayName());
             }
             else
             {
                 if (entity is FieldDesc && context.ReportingEnabled)
                 {
-                    _logger.LogWarning(
-                        $"Field '{entity.GetDisplayName()}' with 'DynamicallyAccessedMembersAttribute' is accessed via reflection. Trimmer can't guarantee availability of the requirements of the field.",
-                        2110,
-                        context.Source,
-                        MessageSubCategory.TrimAnalysis);
+                    _logger.LogWarning(context.Source, DiagnosticId.DynamicallyAccessedMembersFieldAccessedViaReflection, entity.GetDisplayName());
                 }
                 else
                 {
                     Debug.Assert(entity is MethodDesc);
 
-                    _logger.LogWarning(
-                    $"Method '{entity.GetDisplayName()}' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.",
-                    2111,
-                    context.Source,
-                    MessageSubCategory.TrimAnalysis);
+                    _logger.LogWarning(context.Source, DiagnosticId.DynamicallyAccessedMembersMethodAccessedViaReflection, entity.GetDisplayName());
                 }
             }
         }
@@ -2969,11 +2955,8 @@ namespace ILCompiler.Dataflow
             {
                 if (_purpose == ScanningPurpose.GetTypeDataflow)
                 {
-                    var message = string.Format(
-                        "'DynamicallyAccessedMembersAttribute' on '{0}' or one of its base types references '{1}' which requires unreferenced code.",
-                        ((TypeOrigin)reflectionContext.MemberWithRequirements).GetDisplayName(),
-                        method.GetDisplayName());
-                    _logger.LogWarning(message, 2113, reflectionContext.Source, MessageSubCategory.TrimAnalysis);
+                    _logger.LogWarning(reflectionContext.Source, DiagnosticId.DynamicallyAccessedMembersOnTypeReferencesMemberOnBaseWithRequiresUnreferencedCode,
+                        ((TypeOrigin)reflectionContext.MemberWithRequirements).GetDisplayName(), method.GetDisplayName());
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
@@ -234,14 +234,9 @@ namespace ILCompiler
                     if (!reportedProblems.Add(new EntityPair(ownerDefinition, referentDefinition)))
                         continue;
 
-                    string message = $"Generic expansion to '{actualProblem.Key.Referent.GetDisplayName()}' was aborted " +
-                        "due to generic recursion. An exception will be thrown at runtime if this codepath is ever reached. " +
-                        "Generic recursion also negatively affects compilation speed and the size of the compilation output. " +
-                        "It is advisable to remove the source of the generic recursion by restructuring the program around " +
-                        "the source of recursion. The source of generic recursion might include: ";
-
                     ModuleCycleInfo cycleInfo = actualProblem.Value;
                     bool first = true;
+                    string message = "";
                     foreach (TypeSystemEntity cycleEntity in cycleInfo.EntitiesInCycles)
                     {
                         if (!first)
@@ -252,7 +247,7 @@ namespace ILCompiler
                         message += $"'{cycleEntity.GetDisplayName()}'";
                     }
 
-                    logger.LogWarning(message, 3054, actualProblem.Key.Owner, MessageSubCategory.AotAnalysis);
+                    logger.LogWarning(actualProblem.Key.Owner, DiagnosticId.GenericRecursionCycle, actualProblem.Key.Referent.GetDisplayName(), message);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
@@ -73,12 +73,7 @@ namespace ILCompiler
                     reportedMethod = delegateThunkMethod.InvokeMethod;
                 }
 
-                var message = new DiagnosticString(DiagnosticId.CorrectnessOfAbstractDelegatesCannotBeGuaranteed).GetMessage(DiagnosticUtilities.GetMethodSignatureDisplayName(method));
-                _logger.LogWarning(
-                    message,
-                    (int)DiagnosticId.CorrectnessOfAbstractDelegatesCannotBeGuaranteed,
-                    reportedMethod,
-                    MessageSubCategory.AotAnalysis);
+                _logger.LogWarning(reportedMethod, DiagnosticId.CorrectnessOfAbstractDelegatesCannotBeGuaranteed, DiagnosticUtilities.GetMethodSignatureDisplayName(method));
             }
 
             // struct may contain delegate fields, hence we need to add dependencies for it

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -683,16 +683,12 @@ namespace ILCompiler
 
             if (baseMethodRequiresUnreferencedCode != overridingMethodRequiresUnreferencedCode)
             {
-                Logger.LogWarning(
-                    $"Presence of 'RequiresUnreferencedCodeAttribute' on method '{overridingMethod.GetDisplayName()}' doesn't match overridden method '{baseMethod.GetDisplayName()}'. " +
-                    $"All overridden methods must have 'RequiresUnreferencedCodeAttribute'.", 2046, overridingMethod, MessageSubCategory.TrimAnalysis);
+                Logger.LogWarning(overridingMethod, DiagnosticId.RequiresUnreferencedCodeAttributeMismatch, overridingMethod.GetDisplayName(), baseMethod.GetDisplayName());
             }
 
             if (baseMethodRequiresDynamicCode != overridingMethodRequiresDynamicCode)
             {
-                Logger.LogWarning(
-                    $"Presence of 'RequiresDynamicCodeAttribute' on method '{overridingMethod.GetDisplayName()}' doesn't match overridden method '{baseMethod.GetDisplayName()}'. " +
-                    $"All overridden methods must have 'RequiresDynamicCodeAttribute'.", 2046, overridingMethod, MessageSubCategory.AotAnalysis);
+                Logger.LogWarning(overridingMethod, DiagnosticId.RequiresDynamicCodeAttributeMismatch, overridingMethod.GetDisplayName(), baseMethod.GetDisplayName());
             }
 
             if (baseMethodRequiresDataflow || overridingMethodRequiresDataflow)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -24,7 +24,6 @@ namespace ILCompiler
         private readonly IEnumerable<string> _inputFiles;
         private readonly string _compositeRootPath;
         private bool _ibcTuning;
-        private bool _resilient;
         private bool _generateMapFile;
         private bool _generateMapCsvFile;
         private bool _generatePdbFile;
@@ -114,12 +113,6 @@ namespace ILCompiler
         public ReadyToRunCodegenCompilationBuilder UseIbcTuning(bool ibcTuning)
         {
             _ibcTuning = ibcTuning;
-            return this;
-        }
-
-        public ReadyToRunCodegenCompilationBuilder UseResilience(bool resilient)
-        {
-            _resilient = resilient;
             return this;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -205,7 +205,7 @@ namespace ILCompiler
             return this;
         }
 
-        public override ICompilation ToCompilation()
+        public override ICompilation ToCompilation(bool ignoreUnresolved)
         {
             // TODO: only copy COR headers for single-assembly build and for composite build with embedded MSIL
             IEnumerable<EcmaModule> inputModules = _compilationGroup.CompilationModuleSet;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -205,7 +205,7 @@ namespace ILCompiler
             return this;
         }
 
-        public override ICompilation ToCompilation(bool ignoreUnresolved)
+        public override ICompilation ToCompilation()
         {
             // TODO: only copy COR headers for single-assembly build and for composite build with embedded MSIL
             IEnumerable<EcmaModule> inputModules = _compilationGroup.CompilationModuleSet;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -213,7 +213,7 @@ namespace ILCompiler
                 }
                 else
                 {
-                    Logger.LogWarning($"Method will always throw because: {exception.Message}", 1005, method, MessageSubCategory.AotAnalysis);
+                    Logger.LogError($"Method will always throw because: {exception.Message}", 1005, method, MessageSubCategory.AotAnalysis);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -209,7 +209,7 @@ namespace ILCompiler
                     && method.OwningType is MetadataType mdOwningType
                     && mdOwningType.HasCustomAttribute("System.Runtime.InteropServices", "ClassInterfaceAttribute"))
                 {
-                    Logger.LogWarning("COM interop is not supported with full ahead of time compilation", 3052, method, MessageSubCategory.AotAnalysis);
+                    Logger.LogWarning(method, DiagnosticId.COMInteropNotSupportedInFullAOT);
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -27,7 +27,6 @@ namespace ILCompiler
         private readonly ProfileDataManager _profileDataManager;
         private readonly MethodImportationErrorProvider _methodImportationErrorProvider;
         private readonly int _parallelism;
-        private readonly bool _ignoreUnresolved;
 
         public InstructionSetSupport InstructionSetSupport { get; }
 
@@ -44,8 +43,7 @@ namespace ILCompiler
             ProfileDataManager profileDataManager,
             MethodImportationErrorProvider errorProvider,
             RyuJitCompilationOptions options,
-            int parallelism,
-            bool ignoreUnresolved)
+            int parallelism)
             : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, devirtualizationManager, inliningPolicy, logger)
         {
             _compilationOptions = options;
@@ -66,8 +64,6 @@ namespace ILCompiler
             _methodImportationErrorProvider = errorProvider;
 
             _parallelism = parallelism;
-
-            _ignoreUnresolved = ignoreUnresolved;
         }
 
         public ProfileDataManager ProfileData => _profileDataManager;
@@ -213,7 +209,7 @@ namespace ILCompiler
                 {
                     Logger.LogWarning(method, DiagnosticId.COMInteropNotSupportedInFullAOT);
                 }
-                if (_ignoreUnresolved)
+                if ((_compilationOptions & RyuJitCompilationOptions.UseResilience) != 0)
                     Logger.LogMessage($"Ignoring unresolved method {method}, because: {exception.Message}");
                 else
                     Logger.LogError($"Method will always throw because: {exception.Message}", 1005, method, MessageSubCategory.AotAnalysis);
@@ -249,5 +245,6 @@ namespace ILCompiler
         MethodBodyFolding = 0x1,
         ControlFlowGuardAnnotations = 0x2,
         UseDwarf5 = 0x4,
+        UseResilience = 0x8,
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -22,7 +22,6 @@ namespace ILCompiler
         private KeyValuePair<string, string>[] _ryujitOptions = Array.Empty<KeyValuePair<string, string>>();
         private ILProvider _ilProvider = new CoreRTILProvider();
         private ProfileDataManager _profileDataManager;
-        private bool _resilient;
 
         public RyuJitCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group)
             : base(context, group,
@@ -64,12 +63,6 @@ namespace ILCompiler
         public override CompilationBuilder UseILProvider(ILProvider ilProvider)
         {
             _ilProvider = ilProvider;
-            return this;
-        }
-
-        public CompilationBuilder UseResilience(bool resilient)
-        {
-            _resilient = resilient;
             return this;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -71,7 +71,7 @@ namespace ILCompiler
             return _ilProvider;
         }
 
-        public override ICompilation ToCompilation()
+        public override ICompilation ToCompilation(bool ignoreUnresolved)
         {
             ArrayBuilder<CorJitFlag> jitFlagBuilder = new ArrayBuilder<CorJitFlag>();
 
@@ -117,7 +117,7 @@ namespace ILCompiler
 
             JitConfigProvider.Initialize(_context.Target, jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, _methodImportationErrorProvider, options, _parallelism);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, _methodImportationErrorProvider, options, _parallelism, ignoreUnresolved);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -804,7 +804,7 @@ namespace ILCompiler
                 builder.UseMethodImportationErrorProvider(scanResults.GetMethodImportationErrorProvider());
             }
 
-            ((RyuJitCompilationBuilder)builder).UseResilience(_resilient);
+            builder.UseResilience(_resilient);
 
             ICompilation compilation = builder.ToCompilation();
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -85,6 +85,8 @@ namespace ILCompiler
 
         private IReadOnlyList<string> _directPInvokeLists = Array.Empty<string>();
 
+        private bool _ignoreUnresolved = true;
+
         private IReadOnlyList<string> _rootedAssemblies = Array.Empty<string>();
         private IReadOnlyList<string> _conditionallyRootedAssemblies = Array.Empty<string>();
         private IReadOnlyList<string> _trimmedAssemblies = Array.Empty<string>();
@@ -190,6 +192,7 @@ namespace ILCompiler
                 syntax.DefineOption("systemmodule", ref _systemModuleName, "System module name (default: System.Private.CoreLib)");
                 syntax.DefineOption("multifile", ref _multiFile, "Compile only input files (do not compile referenced assemblies)");
                 syntax.DefineOption("waitfordebugger", ref waitForDebugger, "Pause to give opportunity to attach debugger");
+                syntax.DefineOption("skip-unresolved", ref _ignoreUnresolved, "Ignore unresolved types, methods, and assemblies. Defaults to true");
                 syntax.DefineOptionList("codegenopt", ref _codegenOptions, "Define a codegen option");
                 syntax.DefineOptionList("rdxml", ref _rdXmlFilePaths, "RD.XML file(s) for compilation");
                 syntax.DefineOption("map", ref _mapFileName, "Generate a map file");
@@ -801,7 +804,7 @@ namespace ILCompiler
                 builder.UseMethodImportationErrorProvider(scanResults.GetMethodImportationErrorProvider());
             }
 
-            ICompilation compilation = builder.ToCompilation();
+            ICompilation compilation = builder.ToCompilation(_ignoreUnresolved);
 
             ObjectDumper dumper = _mapFileName != null ? new ObjectDumper(_mapFileName) : null;
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -85,7 +85,7 @@ namespace ILCompiler
 
         private IReadOnlyList<string> _directPInvokeLists = Array.Empty<string>();
 
-        private bool _ignoreUnresolved = true;
+        private bool _resilient;
 
         private IReadOnlyList<string> _rootedAssemblies = Array.Empty<string>();
         private IReadOnlyList<string> _conditionallyRootedAssemblies = Array.Empty<string>();
@@ -192,7 +192,7 @@ namespace ILCompiler
                 syntax.DefineOption("systemmodule", ref _systemModuleName, "System module name (default: System.Private.CoreLib)");
                 syntax.DefineOption("multifile", ref _multiFile, "Compile only input files (do not compile referenced assemblies)");
                 syntax.DefineOption("waitfordebugger", ref waitForDebugger, "Pause to give opportunity to attach debugger");
-                syntax.DefineOption("skip-unresolved", ref _ignoreUnresolved, "Ignore unresolved types, methods, and assemblies. Defaults to true");
+                syntax.DefineOption("resilient", ref _resilient, "Ignore unresolved types, methods, and assemblies. Defaults to false");
                 syntax.DefineOptionList("codegenopt", ref _codegenOptions, "Define a codegen option");
                 syntax.DefineOptionList("rdxml", ref _rdXmlFilePaths, "RD.XML file(s) for compilation");
                 syntax.DefineOption("map", ref _mapFileName, "Generate a map file");
@@ -804,7 +804,9 @@ namespace ILCompiler
                 builder.UseMethodImportationErrorProvider(scanResults.GetMethodImportationErrorProvider());
             }
 
-            ICompilation compilation = builder.ToCompilation(_ignoreUnresolved);
+            ((RyuJitCompilationBuilder)builder).UseResilience(_resilient);
+
+            ICompilation compilation = builder.ToCompilation();
 
             ObjectDumper dumper = _mapFileName != null ? new ObjectDumper(_mapFileName) : null;
 

--- a/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
+++ b/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
@@ -77,7 +77,7 @@ namespace ILLink.Shared
         _unused_RearrangedXmlWarning2 = 2021,
         XmlCouldNotFindMatchingConstructorForCustomAttribute = 2022,
         XmlMoreThanOneReturnElementForMethod = 2023,
-        XmlMoreThanOneValyForParameterOfMethod = 2024,
+        XmlMoreThanOneValueForParameterOfMethod = 2024,
         XmlDuplicatePreserveMember = 2025,
         RequiresUnreferencedCode = 2026,
         AttributeShouldOnlyBeUsedOnceOnMember = 2027,

--- a/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
+++ b/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
@@ -204,13 +204,13 @@ namespace ILLink.Shared
                 2045 => MessageSubCategory.TrimAnalysis,
                 2046 => MessageSubCategory.TrimAnalysis,
                 2050 => MessageSubCategory.TrimAnalysis,
-                var x when x >= 2055 && x <= 2099 => MessageSubCategory.TrimAnalysis,
+                >= 2055 and <= 2099 => MessageSubCategory.TrimAnalysis,
                 2103 => MessageSubCategory.TrimAnalysis,
                 2106 => MessageSubCategory.TrimAnalysis,
                 2107 => MessageSubCategory.TrimAnalysis,
-                var x when x >= 2109 && x <= 2116 => MessageSubCategory.TrimAnalysis,
-                var x when x >= 3050 && x <= 3052 => MessageSubCategory.AotAnalysis,
-                var x when x >= 3054 && x <= 3055 => MessageSubCategory.AotAnalysis,
+                >= 2109 and <= 2116 => MessageSubCategory.TrimAnalysis,
+                >= 3050 and <= 3052 => MessageSubCategory.AotAnalysis,
+                >= 3054 and <= 3055 => MessageSubCategory.AotAnalysis,
                 _ => MessageSubCategory.None,
             };
     }

--- a/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
+++ b/src/coreclr/tools/aot/ILLink.Shared/DiagnosticId.cs
@@ -183,10 +183,9 @@ namespace ILLink.Shared
         // Dynamic code diagnostic ids.
         RequiresDynamicCode = 3050,
         RequiresDynamicCodeAttributeMismatch = 3051,
-        // TODO: these are all unique to NativeAOT - mono/linker repo is not aware these error codes usage.
-        // IL3052 - COM
-        // IL3053 - AOT analysis warnings
-        // IL3054 - Generic cycle
+        COMInteropNotSupportedInFullAOT = 3052,
+        AssemblyProducedAOTWarnings = 3053,
+        GenericRecursionCycle = 3054,
         CorrectnessOfAbstractDelegatesCannotBeGuaranteed = 3055,
     }
 
@@ -210,6 +209,8 @@ namespace ILLink.Shared
                 2106 => MessageSubCategory.TrimAnalysis,
                 2107 => MessageSubCategory.TrimAnalysis,
                 var x when x >= 2109 && x <= 2116 => MessageSubCategory.TrimAnalysis,
+                var x when x >= 3050 && x <= 3052 => MessageSubCategory.AotAnalysis,
+                var x when x >= 3054 && x <= 3055 => MessageSubCategory.AotAnalysis,
                 _ => MessageSubCategory.None,
             };
     }

--- a/src/coreclr/tools/aot/ILLink.Shared/SharedStrings.resx
+++ b/src/coreclr/tools/aot/ILLink.Shared/SharedStrings.resx
@@ -1100,6 +1100,30 @@
   <data name="RequiresDynamicCodeAttributeMismatchMessage" xml:space="preserve">
     <value>{0}. 'RequiresDynamicCodeAttribute' annotations must match across all interface implementations or overrides.</value>
   </data>
+  <data name="COMInteropNotSupportedInFullAOTTitle" xml:space="preserve">
+    <value>COM interop is not supported with full ahead of time compilation.</value>
+  </data>
+  <data name="COMInteropNotSupportedInFullAOTMessage" xml:space="preserve">
+    <value>COM interop is not supported with full ahead of time compilation.</value>
+  </data>
+  <data name="AssemblyProducedAOTWarningsTitle" xml:space="preserve">
+    <value>Assembly produced AOT analysis warnings.</value>
+  </data>
+  <data name="AssemblyProducedAOTWarningsMessage" xml:space="preserve">
+    <value>Assembly '{0}' produced AOT analysis warnings.</value>
+  </data>
+  <data name="GenericRecursionCycleTitle" xml:space="preserve">
+    <value>Generic expansion to was aborted due to generic recursion. An exception will be thrown at runtime if this codepath is ever reached.</value>
+  </data>
+  <data name="GenericRecursionCycleMessage" xml:space="preserve">
+    <value>Generic expansion to '{0}' was aborted due to generic recursion. An exception will be thrown at runtime if this codepath is ever reached. Generic recursion also negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: {1}</value>
+  </data>
+  <data name="CorrectnessOfAbstractDelegatesCannotBeGuaranteedTitle" xml:space="preserve">
+    <value>P/invoke method declares a parameter with an abstract delegate. Correctness of interop for abstract delegates cannot be guaranteed after native compilation.</value>
+  </data>
+  <data name="CorrectnessOfAbstractDelegatesCannotBeGuaranteedMessage" xml:space="preserve">
+    <value>P/invoke method '{0}' declares a parameter with an abstract delegate. Correctness of interop for abstract delegates cannot be guaranteed after native compilation: the marshalling code for the delegate might not be available. Use a non-abstract delegate type or ensure any delegate instance passed as parameter is marked with `UnmanagedFunctionPointerAttribute`.</value>
+  </data>
   <data name="BaseRequiresMismatchMessage" xml:space="preserve">
     <value>Base member '{2}' with '{0}' has a derived member '{1}' without '{0}'</value>
   </data>
@@ -1111,11 +1135,5 @@
   </data>
   <data name="InterfaceRequiresMismatchMessage" xml:space="preserve">
     <value>Interface member '{2}' with '{0}' has an implementation member '{1}' without '{0}'</value>
-  </data>
-  <data name="CorrectnessOfAbstractDelegatesCannotBeGuaranteedTitle" xml:space="preserve">
-    <value>P/invoke method declares a parameter with an abstract delegate. Correctness of interop for abstract delegates cannot be guaranteed after native compilation.</value>
-  </data>
-  <data name="CorrectnessOfAbstractDelegatesCannotBeGuaranteedMessage" xml:space="preserve">
-    <value>P/invoke method '{0}' declares a parameter with an abstract delegate. Correctness of interop for abstract delegates cannot be guaranteed after native compilation: the marshalling code for the delegate might not be available. Use a non-abstract delegate type or ensure any delegate instance passed as parameter is marked with `UnmanagedFunctionPointerAttribute`.</value>
   </data>
 </root>

--- a/src/coreclr/tools/aot/ILLink.Shared/SharedStrings.resx
+++ b/src/coreclr/tools/aot/ILLink.Shared/SharedStrings.resx
@@ -524,10 +524,10 @@
   <data name="XmlMoreThanOneReturnElementForMethodMessage" xml:space="preserve">
     <value>There is more than one 'return' child element specified for method '{0}'.</value>
   </data>
-  <data name="XmlMoreThanOneValyForParameterOfMethodTitle" xml:space="preserve">
+  <data name="XmlMoreThanOneValueForParameterOfMethodTitle" xml:space="preserve">
     <value>Method has more than one parameter for the XML element 'parameter'. There can only be one value specified for each parameter.</value>
   </data>
-  <data name="XmlMoreThanOneValyForParameterOfMethodMessage" xml:space="preserve">
+  <data name="XmlMoreThanOneValueForParameterOfMethodMessage" xml:space="preserve">
     <value>More than one value specified for parameter '{0}' of method '{1}'.</value>
   </data>
   <data name="XmlDuplicatePreserveMemberTitle" xml:space="preserve">

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -730,7 +730,6 @@ namespace ILCompiler
 
                     builder
                         .UseIbcTuning(_commandLineOptions.Tuning)
-                        .UseResilience(_commandLineOptions.Resilient)
                         .UseMapFile(_commandLineOptions.Map)
                         .UseMapCsvFile(_commandLineOptions.MapCsv)
                         .UsePdbFile(_commandLineOptions.Pdb, _commandLineOptions.PdbPath)
@@ -748,6 +747,7 @@ namespace ILCompiler
                         .UseBackendOptions(_commandLineOptions.CodegenOptions)
                         .UseLogger(logger)
                         .UseParallelism(_commandLineOptions.Parallelism)
+                        .UseResilience(_commandLineOptions.Resilient)
                         .UseDependencyTracking(trackingLevel)
                         .UseCompilationRoots(compilationRoots)
                         .UseOptimizationMode(optimizationMode);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -755,7 +755,7 @@ namespace ILCompiler
                     if (_commandLineOptions.PrintReproInstructions)
                         builder.UsePrintReproInstructions(CreateReproArgumentString);
 
-                    compilation = builder.ToCompilation(true);
+                    compilation = builder.ToCompilation();
 
                 }
                 compilation.Compile(outFile);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -755,7 +755,7 @@ namespace ILCompiler
                     if (_commandLineOptions.PrintReproInstructions)
                         builder.UsePrintReproInstructions(CreateReproArgumentString);
 
-                    compilation = builder.ToCompilation();
+                    compilation = builder.ToCompilation(true);
 
                 }
                 compilation.Compile(outFile);


### PR DESCRIPTION
Simplify the creation of diagnostics using DiagnosticId
Add missing NativeAOT DiagnosticId, resource message, and resource title
Refactor code to use new diagnostic overloads