### PR TITLE
Catch UnicodeEncodeErrors during printing superpmi logs

### DIFF
--- a/src/coreclr/scripts/jitutil.py
+++ b/src/coreclr/scripts/jitutil.py
@@ -85,11 +85,30 @@ def set_pipeline_variable(name, value):
     print(define_variable_format.format(name, value))  # set variable
 
 
+
 ################################################################################
 ##
 ## Helper functions
 ##
 ################################################################################
+
+def decode_string(str_to_decode):
+    """Decode a UTF-8 encoded bytes to string.
+
+    Args:
+        str_to_decode (byte stream): Byte stream to decode
+
+    Returns:
+        String output. If there any encoding/decoding errors, it will replace it with
+        UnicodeEncodeError.
+    """
+    try:
+        output = str_to_decode.decode("utf-8", errors='replace')
+    except UnicodeEncodeError:
+        output = "UnicodeEncodeError"
+    except UnicodeDecodeError:
+        output = "UnicodeDecodeError"
+    return output
 
 def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _output_file=None):
     """ Runs the command.
@@ -119,15 +138,15 @@ def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _output_file=Non
                     if proc.poll() is not None:
                         break
                     if output:
-                        output_str = output.strip().decode("utf-8", errors='replace')
+                        output_str = decode_string(output.strip())
                         print(output_str)
                         of.write(output_str + "\n")
         else:
             command_stdout, command_stderr = proc.communicate()
             if len(command_stdout) > 0:
-                print(command_stdout.decode("utf-8", errors='replace'))
+                print(decode_string(command_stdout))
             if len(command_stderr) > 0:
-                print(command_stderr.decode("utf-8", errors='replace'))
+                print(decode_string(command_stderr))
 
         return_code = proc.returncode
         if _exit_on_fail and return_code != 0:


### PR DESCRIPTION
One of the option to simplify the fix is to just replace the encode/decode errors if any with a text. There might be better ways to address this, but this one looks quickest and simplest.