### PR TITLE
[release/6.0] make sure OpenSSL is initialized before Tls13Supported code runs

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -59,7 +59,7 @@ internal static partial class Interop
                     throw CreateSslException(SR.net_allocate_ssl_context_failed);
                 }
 
-                if (!Interop.Ssl.Tls13Supported)
+                if (!Interop.Ssl.Capabilities.Tls13Supported)
                 {
                     if (protocols != SslProtocols.None &&
                         CipherSuitesPolicyPal.WantsTls13(protocols))

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -141,9 +141,13 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Tls13Supported")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool Tls13SupportedImpl();
-        internal static readonly bool Tls13Supported = Tls13SupportedImpl();
+        private static extern int Tls13SupportedImpl();
+
+        internal static class Capabilities
+        {
+            // needs separate type (separate static cctor) to be sure OpenSSL is initialized.
+            internal static readonly bool Tls13Supported = Tls13SupportedImpl() != 0;
+        }
 
         internal static SafeSharedX509NameStackHandle SslGetClientCAList(SafeSslHandle ssl)
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
@@ -28,7 +28,7 @@ namespace System.Net.Security
 
         internal CipherSuitesPolicyPal(IEnumerable<TlsCipherSuite> allowedCipherSuites)
         {
-            if (!Interop.Ssl.Tls13Supported)
+            if (!Interop.Ssl.Capabilities.Tls13Supported)
             {
                 throw new PlatformNotSupportedException(SR.net_ssl_ciphersuites_policy_not_supported);
             }


### PR DESCRIPTION
This back port of #62973

Fixes #61891

## Customer Impact
Customer reported regression. When customer uses class `System.Net.Security.CipherSuitesPolicy` early in the process it will throw exception and it will also prevent ANY further usage of TLS 1.3 in that process.

The root cause is bad dependency of static constructors which won't initialize OpenSSL in time. TLS 1.3 detection will fail without initialized OpenSSL and the (failed) result will be stored in a static variable.

## Regression
Yes, it was introduced in 6.0

## Testing
Testing was manual as the behavior depends on loading native ship and sequence of operations - both happen before our test even start. I used the sample code from #62973 and debugger to verify that the property is properly set. 

## Risk
Small. This basically makes sure OpenSSL is initialized before we use it.