### PR TITLE
make sure failed SSL does not impact other sessions

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -389,12 +389,12 @@ internal static partial class Interop
                 }
             }
 
-            Exception? innerError = null;
             try
             {
                 int retVal = Ssl.SslDoHandshake(context);
                 if (retVal != 1)
                 {
+                    Exception? innerError = null;
                     Ssl.SslErrorCode error = GetSslError(context, retVal, out innerError);
 
                     if (error == Ssl.SslErrorCode.SSL_ERROR_WANT_X509_LOOKUP)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -75,13 +75,13 @@ internal static partial class Interop
         }
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslWrite", SetLastError = true)]
-        internal static partial int SslWrite(SafeSslHandle ssl, ref byte buf, int num);
+        internal static partial int SslWrite(SafeSslHandle ssl, ref byte buf, int num, out SslErrorCode error);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslRead", SetLastError = true)]
-        internal static partial int SslRead(SafeSslHandle ssl, ref byte buf, int num);
+        internal static partial int SslRead(SafeSslHandle ssl, ref byte buf, int num, out SslErrorCode error);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslRenegotiate")]
-        internal static partial int SslRenegotiate(SafeSslHandle ssl);
+        internal static partial int SslRenegotiate(SafeSslHandle ssl, out SslErrorCode error);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_IsSslRenegotiatePending")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -97,7 +97,7 @@ internal static partial class Interop
         internal static partial void SslSetBio(SafeSslHandle ssl, SafeBioHandle rbio, SafeBioHandle wbio);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDoHandshake", SetLastError = true)]
-        internal static partial int SslDoHandshake(SafeSslHandle ssl);
+        internal static partial int SslDoHandshake(SafeSslHandle ssl, out SslErrorCode error);
 
         [GeneratedDllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_IsSslStateOK")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -412,10 +412,20 @@ void CryptoNative_SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio)
     SSL_set_bio(ssl, rbio, wbio);
 }
 
-int32_t CryptoNative_SslDoHandshake(SSL* ssl)
+int32_t CryptoNative_SslDoHandshake(SSL* ssl, int32_t* error)
 {
     ERR_clear_error();
-    return SSL_do_handshake(ssl);
+    int32_t result = SSL_do_handshake(ssl);
+    if (result == 1)
+    {
+        *error = SSL_ERROR_NONE;
+    }
+    else
+    {
+        *error = CryptoNative_SslGetError(ssl, result);
+    }
+
+    return result;
 }
 
 int32_t CryptoNative_IsSslStateOK(SSL* ssl)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
@@ -211,7 +211,7 @@ Shims the SSL_write method.
 Returns the positive number of bytes written when successful, 0 or a negative number
 when an error is encountered.
 */
-PALEXPORT int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num);
+PALEXPORT int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num, int32_t* error);
 
 /*
 Shims the SSL_read method.
@@ -219,14 +219,14 @@ Shims the SSL_read method.
 Returns the positive number of bytes read when successful, 0 or a negative number
 when an error is encountered.
 */
-PALEXPORT int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num);
+PALEXPORT int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num, int32_t* error);
 
 /*
 Shims the SSL_renegotiate method.
 
 Returns 1 when renegotiation started; 0 on error.
 */
-PALEXPORT int32_t CryptoNative_SslRenegotiate(SSL* ssl);
+PALEXPORT int32_t CryptoNative_SslRenegotiate(SSL* ssl, int32_t* error);
 
 /*
 Shims the SSL_renegotiate_pending method.

--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.h
@@ -259,7 +259,7 @@ Returns:
 and by the specifications of the TLS/SSL protocol;
 <0 if the handshake was not successful because of a fatal error.
 */
-PALEXPORT int32_t CryptoNative_SslDoHandshake(SSL* ssl);
+PALEXPORT int32_t CryptoNative_SslDoHandshake(SSL* ssl, int32_t* error);
 
 /*
 Gets a value indicating whether the SSL_state is SSL_ST_OK.


### PR DESCRIPTION
I was finally able to reproduce it while looking at something else. I have debug build of OpenSSL + custom tracing and that allowed me to have somewhat reliable repro (to fail on 10-15 minutes)

Here is what I saw:
Some test can Dispose SslStream while still in handshake. When this happens, The handle is released by the interior code as soon as we exit from the pinvoke.
```
  at Microsoft.Win32.SafeHandles.SafeSslHandle.ReleaseHandle() in /home/furt/github/wfurt-runtime/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs:line 460
   at System.Runtime.InteropServices.SafeHandle.InternalRelease(Boolean disposeOrFinalizeOperation) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs:line 249
   at Interop.Ssl.SslDoHandshake(SafeSslHandle ssl) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/Microsoft.Interop.DllImportGenerator/Microsoft.Interop.DllImportGenerator/GeneratedDllImports.g.cs:line 3276
   at Interop.OpenSsl.DoSslHandshake(SafeSslHandle context, ReadOnlySpan`1 input, Byte[]& sendBuf, Int32& sendCount) in /home/furt/github/wfurt-runtime/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs:line 448
   at System.Net.Security.SslStreamPal.HandshakeInternal(SafeFreeCredentials credential, SafeDeleteSslContext& context, ReadOnlySpan`1 inputBuffer, Byte[]& outputBuffer, SslAuthenticationOptions sslAuthenticationOptions) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs:line 162
   at System.Net.Security.SslStreamPal.InitializeSecurityContext(SafeFreeCredentials& credential, SafeDeleteSslContext& context, String targetName, ReadOnlySpan`1 inputBuffer, Byte[]& outputBuffer, SslAuthenticationOptions sslAuthenticationOptions) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs:line 36
   at System.Net.Security.SecureChannel.GenerateToken(ReadOnlySpan`1 inputBuffer, Byte[]& output) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs:line 808
   at System.Net.Security.SecureChannel.NextMessage(ReadOnlySpan`1 incomingBuffer) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs:line 730
   at System.Net.Security.SslStream.ProcessBlob(Int32 frameSize) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs:line 614
   at System.Net.Security.SslStream.ReceiveBlobAsync[TIOAdapter](TIOAdapter adapter) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs:line 576
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs:line 183
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs:line 324
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs:line 795
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:line 3374
   at System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetResult() in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncValueTaskMethodBuilder.cs:line 41
   at System.Net.Security.SslStream.<FillHandshakeBufferAsync>g__InternalFillHandshakeBufferAsync|189_0[TIOAdapter](TIOAdapter adap, ValueTask`1 task, Int32 minSize) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs:line 1133
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs:line 183
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs:line 324
   at System.Threading.ThreadPool.<>c.<.cctor>b__86_0(Object state) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs:line 1064
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.InvokeContinuation(Action`1 continuation, Object state, Boolean forceAsync, Boolean requiresExecutionContextFlow) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs:line 1352
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.OnCompleted(SocketAsyncEventArgs _) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs:line 1020
   at System.Net.Sockets.SocketAsyncEventArgs.OnCompletedInternal() in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs:line 206
   at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAsyncSuccess(Int32 bytesTransferred, SocketFlags flags) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs:line 981
   at System.Net.Sockets.SocketAsyncEventArgs.CompletionCallback(Int32 bytesTransferred, SocketFlags flags, SocketError socketError) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs:line 383
   at System.Net.Sockets.SocketAsyncEventArgs.TransferCompletionCallbackCore(Int32 bytesTransferred, Byte[] socketAddress, Int32 socketAddressSize, SocketFlags receivedFlags, SocketError socketError) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs:line 110
   at System.Net.Sockets.SocketAsyncContext.BufferMemoryReceiveOperation.InvokeCallback(Boolean allowPooling) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 500
   at System.Net.Sockets.SocketAsyncContext.OperationQueue`1.ProcessAsyncOperation(TOperation op) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 973
   at System.Net.Sockets.SocketAsyncContext.ProcessAsyncReadOperation(ReadOperation op) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 1382
   at System.Net.Sockets.SocketAsyncContext.ReadOperation.System.Threading.IThreadPoolWorkItem.Execute() in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 341
   at System.Net.Sockets.SocketAsyncContext.AsyncOperation.Process() in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 292
   at System.Net.Sockets.SocketAsyncContext.HandleEvents(SocketEvents events) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 2187
   at System.Net.Sockets.SocketAsyncEngine.System.Threading.IThreadPoolWorkItem.Execute() in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs:line 242
   at System.Threading.ThreadPoolWorkQueue.Dispatch() in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs:line 715
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart() in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs:line 77
   at System.Threading.Thread.StartCallback() in /home/furt/github/wfurt-runtime/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs:line 105
```

then handshake function reruns failure and we will try to get more info about it. However, because the handle is closed and released that fails
```
System.ObjectDisposedException: Safe handle has been closed.
Object name: 'SafeHandle'.
   at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success) in /home/furt/github/wfurt-runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeHandle.cs:line 150
   at Interop.Ssl.SslGetError(SafeSslHandle ssl, Int32 ret) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/Microsoft.Interop.DllImportGenerator/Microsoft.Interop.DllImportGenerator/GeneratedDllImports.g.cs:line 2601
   at Interop.OpenSsl.GetSslError(SafeSslHandle context, Int32 result, Exception& innerError) in /home/furt/github/wfurt-runtime/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs:line 934
   at Interop.OpenSsl.DoSslHandshake(SafeSslHandle context, ReadOnlySpan`1 input, Byte[]& sendBuf, Int32& sendCount) in /home/furt/github/wfurt-runtime/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs:line 453
   at System.Net.Security.SslStreamPal.HandshakeInternal(SafeFreeCredentials credential, SafeDeleteSslContext& context, ReadOnlySpan`1 inputBuffer, Byte[]& outputBuffer, SslAuthenticationOptions sslAuthenticationOptions) in /home/furt/github/wfurt-runtime/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs:line 162
```

so we throw and that bails out of the handshake leaving the error behind. The OpenSSL error queue is per-thread so when unrelated operation comes in and if there is debug build we hit the assert - that guards agains exactly this behavior. On release build we can mix the errors and return back something lame.  


It is somewhat unfortunate that with current logic, basically any call to OpenSSL with handle can throw. 
My First fix was to add `DangerousAddRef/Release` to keep the handle always alive through the handshake. 
I did ~ 1000 runs over night  and never hit a problem. 

Eventually I decided it is OK to throw and I added finally block to clean up the error. 
We may not need the cleanup if handshake finished successfully and we were able to get the error. 
But it its probably cheap enough to just keep it there as common case. 

We may explore how to use the handles and avoid cases like this but for now I decided to go with simplest fix as we see hits in CI and it is unpleasant as it kills whole set run.

fixes #57722