### PR TITLE
[ILVerify] Fix casting check for arrays of generic parameters with class constraints

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CastingTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CastingTests.cs
@@ -203,6 +203,21 @@ namespace TypeSystemTests
         }
 
         [Fact]
+        public void TestGenericParameterArrayCasting()
+        {
+            TypeDesc baseArrayType = _testModule.GetType("Casting", "Base").MakeArrayType();
+            TypeDesc iFooArrayType = _testModule.GetType("Casting", "IFoo").MakeArrayType();
+
+            TypeDesc paramArrayWithBaseClassConstraint =
+                _testModule.GetType("Casting", "ClassWithBaseClassConstraint`1").Instantiation[0].MakeArrayType();
+            TypeDesc paramArrayWithInterfaceConstraint =
+                _testModule.GetType("Casting", "ClassWithInterfaceConstraint`1").Instantiation[0].MakeArrayType();
+
+            Assert.True(paramArrayWithBaseClassConstraint.CanCastTo(baseArrayType));
+            Assert.False(paramArrayWithInterfaceConstraint.CanCastTo(iFooArrayType));
+        }
+
+        [Fact]
         public void TestRecursiveCanCast()
         {
             // Tests the stack overflow protection in CanCastTo

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/Casting.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/Casting.cs
@@ -3,6 +3,8 @@
 
 namespace Casting
 {
+    class Base { }
+
     interface IFoo { }
 
     interface IContravariant<in T> { }
@@ -20,6 +22,8 @@ namespace Casting
     class ClassWithNoConstraint<T> { }
 
     class ClassWithValueTypeConstraint<T> where T : struct { }
+
+    class ClassWithBaseClassConstraint<T> where T : Base { }
 
     class ClassWithInterfaceConstraint<T> where T : IFoo { }
 


### PR DESCRIPTION
Fixes #63999