### PR TITLE
[release/6.0]  Make sure that shared memory object name meets the length requiremens

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -324,6 +324,12 @@ int32_t SystemNative_Unlink(const char* path)
 
 intptr_t SystemNative_ShmOpen(const char* name, int32_t flags, int32_t mode)
 {
+#if defined(SHM_NAME_MAX) // macOS
+    assert(strlen(name) <= SHM_NAME_MAX);
+#elif defined(PATH_MAX) // other Unixes
+    assert(strlen(name) <= PATH_MAX);
+#endif
+
 #if HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP
     flags = ConvertOpenFlags(flags);
     if (flags == -1)

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateNew.Tests.cs
@@ -11,7 +11,6 @@ namespace System.IO.MemoryMappedFiles.Tests
     /// <summary>
     /// Tests for MemoryMappedFile.CreateNew.
     /// </summary>
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class MemoryMappedFileTests_CreateNew : MemoryMappedFilesTestBase
     {
         /// <summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -11,7 +11,6 @@ namespace System.IO.MemoryMappedFiles.Tests
     /// <summary>
     /// Tests for MemoryMappedViewAccessor.
     /// </summary>
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class MemoryMappedViewAccessorTests : MemoryMappedFilesTestBase
     {
         /// <summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -11,7 +11,6 @@ namespace System.IO.MemoryMappedFiles.Tests
     /// <summary>
     /// Tests for MemoryMappedViewStream.
     /// </summary>
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class MemoryMappedViewStreamTests : MemoryMappedFilesTestBase
     {
         /// <summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStreamConformanceTests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStreamConformanceTests.cs
@@ -45,7 +45,6 @@ namespace System.IO.MemoryMappedFiles.Tests
         }
     }
 
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/49104", typeof(PlatformDetection), nameof(PlatformDetection.IsMacOsAppleSilicon))]
     public class AnonymousMemoryMappedViewStreamConformanceTests : MemoryMappedViewStreamConformanceTests
     {
         protected override MemoryMappedFile CreateFile(int length) =>


### PR DESCRIPTION
A manual backport of #64099

The sys-call that we use to create shared memory mapped objects (`shm_open`) has distro-specific map name length requirements. On most Unix-like Operating Systems it's `PATH_MAX` (4096), while on macOS it's `SHM_NAME_MAX` which for the arm64 version currently maps to **32**. The code has been simply generating a string that is too long. 

## Customer Impact

Customer reported #63240 in 6.0. macOS arm64 users can't create a memory mapped file which is not backed by a real file (`MemoryMappedFile.CreateNew(mapName: null)`) . There is no workaround.

## Testing

The tests have been.. re-enabled. Yes, we had failing tests that were clearly saying that there is a bug but they got disabled rather than fixed.

## Risk

Low. By reducing the map name length we have reduced the entropy so chances for generating a name that is already in use have increased. However, a simple retry logic was added and it ensures that even if a shared map object with a given name already exists, a new name is generated and the process is repeated until it succeeds (or fails for other reasons).