### PR TITLE
Take ARMv6 out of PlatformGroup All

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -53,7 +53,7 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
-- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), in(parameters.platformGroup, 'gcstress')) }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -53,7 +53,7 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
-- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), or(and(eq(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'gcstress')), and(ne(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'all', 'gcstress'))) }}:
+- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), or(and(eq(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'gcstress')), and(ne(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'all', 'gcstress')))) }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -53,7 +53,7 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
-- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), in(parameters.platformGroup, 'gcstress')) }}:
+- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), or(and(eq(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'gcstress')), and(ne(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'all', 'gcstress'))) }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -53,7 +53,7 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
-- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), or(and(eq(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'gcstress')), and(ne(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'all', 'gcstress')))) }}:
+- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), or(and(ne(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'gcstress')), and(eq(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'all', 'gcstress')))) }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}


### PR DESCRIPTION
CoreCLR's outerloop build assumes PlatformGroup All means "fully supports every CoreCLR component"