### PR TITLE
[Codespaces] Make it possible to run wasm samples in the browser

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.
 	// Add the global tools dir to the PATH so that globally installed tools will work
 	"remoteEnv": {
-		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}:${containerWorkspaceFolder}/.dotnet-tools-global",
+		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerWorkspaceFolder}/.dotnet-tools-global:${containerEnv:PATH}",
 		"DOTNET_MULTILEVEL_LOOKUP": "0",
 		// Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
 		"EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,6 @@
 	"portsAttributes": {
 		"8000": {
 			"label": "mono wasm samples (8000)",
-			"onAutoForward": "notify"
 		}
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,9 @@
 
 	// Add the locally installed dotnet to the path to ensure that it is activated
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.
+    // Add the global tools dir to the PATH so that globally installed tools will work
 	"remoteEnv": {
-		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
+		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}:${containerEnv:HOME}/.dotnet/tools",
 		"DOTNET_MULTILEVEL_LOOKUP": "0",
         // Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
         "EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.
 	// Add the global tools dir to the PATH so that globally installed tools will work
 	"remoteEnv": {
-		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}:${localEnv:HOME}/.dotnet/tools",
+		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}:${containerWorkspaceFolder}/.dotnet-tools-global",
 		"DOTNET_MULTILEVEL_LOOKUP": "0",
 		// Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
 		"EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"name": "C# (.NET)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { 
+		"args": {
 			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
 			"VARIANT": "5.0",
 		}
@@ -34,7 +34,9 @@
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.
 	"remoteEnv": {
 		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}",
-		"DOTNET_MULTILEVEL_LOOKUP": "0"
+		"DOTNET_MULTILEVEL_LOOKUP": "0",
+        // Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
+        "EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",
 	},
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.
 	// Add the global tools dir to the PATH so that globally installed tools will work
 	"remoteEnv": {
-		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}:${containerEnv:HOME}/.dotnet/tools",
+		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}:${localEnv:HOME}/.dotnet/tools",
 		"DOTNET_MULTILEVEL_LOOKUP": "0",
 		// Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
 		"EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,23 +32,23 @@
 
 	// Add the locally installed dotnet to the path to ensure that it is activated
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.
-    // Add the global tools dir to the PATH so that globally installed tools will work
+	// Add the global tools dir to the PATH so that globally installed tools will work
 	"remoteEnv": {
 		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerEnv:PATH}:${containerEnv:HOME}/.dotnet/tools",
 		"DOTNET_MULTILEVEL_LOOKUP": "0",
-        // Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
-        "EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",
+		// Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
+		"EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",
 	},
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 
-    // Forward mono samples port
-    "forwardPorts": [8000],
-    "portsAttributes": {
-        "8000": {
-            "label": "mono wasm samples (8000)",
-            "onAutoForward": "notify"
-        }
-    }
+	// Forward mono samples port
+	"forwardPorts": [8000],
+	"portsAttributes": {
+		"8000": {
+			"label": "mono wasm samples (8000)",
+			"onAutoForward": "notify"
+		}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,5 +41,14 @@
 	},
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+
+    // Forward mono samples port
+    "forwardPorts": [8000],
+    "portsAttributes": {
+        "8000": {
+            "label": "mono wasm samples (8000)",
+            "onAutoForward": "notify"
+        }
+    }
 }

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -12,5 +12,8 @@ make -C src/mono/wasm provision-wasm
 export EMSDK_PATH=$PWD/src/mono/wasm/emsdk
 ./build.sh mono+libs -os Browser -c release
 
+# install dotnet-serve for running wasm samples
+./dotnet.sh tool install --global dotnet-serve
+
 # save the commit hash of the currently built assemblies, so developers know which version was built
 git rev-parse HEAD > ./artifacts/prebuild.sha

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -13,7 +13,7 @@ export EMSDK_PATH=$PWD/src/mono/wasm/emsdk
 ./build.sh mono+libs -os Browser -c release
 
 # install dotnet-serve for running wasm samples
-./dotnet.sh tool install --global dotnet-serve
+./dotnet.sh tool install dotnet-serve --tool-path ./.dotnet-tools-global
 
 # save the commit hash of the currently built assemblies, so developers know which version was built
 git rev-parse HEAD > ./artifacts/prebuild.sha

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ syntax: glob
 #       instead of directories), git will still ignore them.
 .dotnet
 .dotnet-mono
+.dotnet-tools-global
 .packages
 .tools
 

--- a/src/mono/sample/wasm/wasm.mk
+++ b/src/mono/sample/wasm/wasm.mk
@@ -11,7 +11,7 @@ CONFIG?=Release
 WASM_DEFAULT_BUILD_ARGS?=/p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Configuration=$(CONFIG)
 
 # if we're in a devcontainer, don't try to open the browser
-ifneq ("$(wildcard $(TOP)/artifacts/prebuild.sha)", "")
+ifeq ("$(CODESPACES)", "true")
   OPEN_BROWSER=
   V8_PATH=v8
 else

--- a/src/mono/sample/wasm/wasm.mk
+++ b/src/mono/sample/wasm/wasm.mk
@@ -10,8 +10,8 @@ CONFIG?=Release
 
 WASM_DEFAULT_BUILD_ARGS?=/p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Configuration=$(CONFIG)
 
-# if we're in a devcontainer, don't try to open the browser
-ifeq ("$(CODESPACES)", "true")
+# if we're in a container, don't try to open the browser
+ifneq ("$(wildcard /.dockerenv)", "")
   OPEN_BROWSER=
   V8_PATH=v8
 else

--- a/src/mono/sample/wasm/wasm.mk
+++ b/src/mono/sample/wasm/wasm.mk
@@ -13,8 +13,10 @@ WASM_DEFAULT_BUILD_ARGS?=/p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Confi
 # if we're in a devcontainer, don't try to open the browser
 ifneq ("$(wildcard $(TOP)/artifacts/prebuild.sha)", "")
   OPEN_BROWSER=
+  V8_PATH=v8
 else
   OPEN_BROWSER=-o
+  V8_PATH=~/.jsvu/v8
 endif
 
 all: publish
@@ -37,7 +39,7 @@ run-browser:
 	fi
 
 run-console:
-	cd bin/$(CONFIG)/AppBundle && ~/.jsvu/v8 --stack-trace-limit=1000 --single-threaded --expose_wasm $(MAIN_JS) -- $(DOTNET_MONO_LOG_LEVEL) --run $(CONSOLE_DLL) $(ARGS)
+	cd bin/$(CONFIG)/AppBundle && $(V8_PATH) --stack-trace-limit=1000 --single-threaded --expose_wasm $(MAIN_JS) -- $(DOTNET_MONO_LOG_LEVEL) --run $(CONSOLE_DLL) $(ARGS)
 
 run-console-node:
 	cd bin/$(CONFIG)/AppBundle && node --stack-trace-limit=1000 --single-threaded --expose_wasm $(MAIN_JS) -- $(DOTNET_MONO_LOG_LEVEL) --run $(CONSOLE_DLL) $(ARGS)

--- a/src/mono/sample/wasm/wasm.mk
+++ b/src/mono/sample/wasm/wasm.mk
@@ -29,7 +29,7 @@ clean:
 	rm -rf bin $(TOP)/artifacts/obj/mono/$(PROJECT_NAME:%.csproj=%)
 
 run-browser:
-	if ! $(DOTNET) tool list --global | grep dotnet-serve; then \
+	if ! $(DOTNET) tool list --global | grep dotnet-serve && ! which dotnet-serve ; then \
 		echo "The tool dotnet-serve could not be found. Install with: $(DOTNET) tool install --global dotnet-serve"; \
 		exit 1; \
 	else  \

--- a/src/mono/sample/wasm/wasm.mk
+++ b/src/mono/sample/wasm/wasm.mk
@@ -10,6 +10,13 @@ CONFIG?=Release
 
 WASM_DEFAULT_BUILD_ARGS?=/p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Configuration=$(CONFIG)
 
+# if we're in a devcontainer, don't try to open the browser
+ifneq ("$(wildcard $(TOP)/artifacts/prebuild.sha)", "")
+  OPEN_BROWSER=
+else
+  OPEN_BROWSER=-o
+endif
+
 all: publish
 
 build:
@@ -26,7 +33,7 @@ run-browser:
 		echo "The tool dotnet-serve could not be found. Install with: $(DOTNET) tool install --global dotnet-serve"; \
 		exit 1; \
 	else  \
-		$(DOTNET) serve -d:bin/$(CONFIG)/AppBundle -o -p:8000; \
+		$(DOTNET) serve -d:bin/$(CONFIG)/AppBundle $(OPEN_BROWSER) -p:8000; \
 	fi
 
 run-console:


### PR DESCRIPTION
With these changes, running the following in the Codespace will open the local browser to a page served from the codespace hosting the WASM sample:

```console
cd src/mono/sample/wasm/browser
make
make run-browser
```

Changes:

1. Set `EMSDK_PATH` in the container (allows rebuilding the runtime and libraries with `./build.sh --os browser -c Release`
2. Install `dotnet-serve` global tool and add it to the `PATH` in the container
3. Change mono samples not to pass `-o` to `dotnet-serve` if running in a .devcontainer
4. Automatically forward port 8000 from the Codespace to the local VS Code

Demo:
<img width="1406" alt="Screen Shot 2022-01-25 at 16 32 07" src="https://user-images.githubusercontent.com/480437/151065124-09fccca2-2ec0-44e7-ba0a-125aec22c7a9.png">
