### PR TITLE
[release/6.0] Fix profiling objectsallocatedbyclass (#63814)

### DIFF
--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -1274,7 +1274,7 @@ bool AllocByClassHelper(Object * pBO, void * pv)
     _ASSERTE(pv != NULL);
 
     {
-        BEGIN_PROFILER_CALLBACK(CORProfilerTrackAllocations());
+        BEGIN_PROFILER_CALLBACK(CORProfilerTrackGC());
         // Pass along the call
         g_profControlBlock.AllocByClass(
             (ObjectID) pBO,

--- a/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
+++ b/src/tests/profiler/native/gcprofiler/gcprofiler.cpp
@@ -37,6 +37,10 @@ HRESULT GCProfiler::Shutdown()
     {
         printf("GCProfiler::Shutdown: FAIL: Expected GarbageCollectionFinished to be called\n");
     }
+    else if (_allocatedByClassCalls == 0)
+    {
+        printf("GCProfiler::Shutdown: FAIL: Expected ObjectsAllocatedByClass to be called\n");
+    }
     else if (_pohObjectsSeenRootReferences == 0 || _pohObjectsSeenObjectReferences == 0)
     {
         printf("GCProfiler::Shutdown: FAIL: no POH objects seen. root references=%d object references=%d\n",
@@ -83,6 +87,20 @@ HRESULT GCProfiler::GarbageCollectionFinished()
     _pohObjectsSeenObjectReferences += NumPOHObjectsSeen(_objectReferencesSeen);
     _pohObjectsSeenRootReferences += NumPOHObjectsSeen(_rootReferencesSeen);
     
+    return S_OK;
+}
+
+HRESULT GCProfiler::ObjectsAllocatedByClass(ULONG cClassCount, ClassID classIds[], ULONG cObjects[])
+{
+    SHUTDOWNGUARD();
+
+    _allocatedByClassCalls++;
+    if (_gcStarts != _allocatedByClassCalls)
+    {
+        _failures++;
+        printf("GCProfiler::ObjectsAllocatedByClass: FAIL: Expected ObjectsAllocatedByClass Calls == GCStart. AllocatedByClassCalls=%d, GCStart=%d\n", (int)_allocatedByClassCalls, (int)_gcStarts);
+    }
+
     return S_OK;
 }
 

--- a/src/tests/profiler/native/gcprofiler/gcprofiler.h
+++ b/src/tests/profiler/native/gcprofiler/gcprofiler.h
@@ -16,6 +16,7 @@ public:
     GCProfiler() : Profiler(),
         _gcStarts(0),
         _gcFinishes(0),
+        _allocatedByClassCalls(0),
         _failures(0),
         _pohObjectsSeenRootReferences(0),
         _pohObjectsSeenObjectReferences(0),
@@ -28,12 +29,14 @@ public:
     virtual HRESULT STDMETHODCALLTYPE Shutdown();
     virtual HRESULT STDMETHODCALLTYPE GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason);
     virtual HRESULT STDMETHODCALLTYPE GarbageCollectionFinished();
+    virtual HRESULT STDMETHODCALLTYPE ObjectsAllocatedByClass(ULONG cClassCount, ClassID classIds[], ULONG cObjects[]);
     virtual HRESULT STDMETHODCALLTYPE ObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[]);
     virtual HRESULT STDMETHODCALLTYPE RootReferences(ULONG cRootRefs, ObjectID rootRefIds[]);
 
 private:
     std::atomic<int> _gcStarts;
     std::atomic<int> _gcFinishes;
+    std::atomic<int> _allocatedByClassCalls;
     std::atomic<int> _failures;
     std::atomic<int> _pohObjectsSeenRootReferences;
     std::atomic<int> _pohObjectsSeenObjectReferences;


### PR DESCRIPTION
Backport of #63814 to release/6.0

/cc @ogxd

A 6.0 PR introduced a regression in the profiling APIs, where the ObjectsAllocatedByClass API was triggered by the wrong profiler keyword.

## Customer Impact
As it stands in 6.0 profilers cannot enable ObjectsAllocatedByClass without enabling object allocation callbacks, which is extremely expensive, perturbs the process, and is impossible to do on attach.

## Testing
Manual and automated tests

## Risk
Low, the fix is targeted to just the ObjectsAllocatedByClass API.