### PR TITLE
[wasm] Cancel pending ReadableStream on Dispose or cancelationToken

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -86,7 +86,7 @@ namespace System.Net.Test.Common
             CloseWebSocket();
         }
 
-        public async Task WaitForClose(CancellationToken cancellationToken)
+        public async Task WaitForCloseAsync(CancellationToken cancellationToken)
         {
             while (_websocket != null
                     ? _websocket.State != WebSocketState.Closed
@@ -150,7 +150,7 @@ namespace System.Net.Test.Common
         public abstract Task WaitForCancellationAsync(bool ignoreIncomingData = true);
 
         /// <summary>Waits for the client to signal cancellation.</summary>
-        public abstract Task WaitForClose(CancellationToken cancellationToken);
+        public abstract Task WaitForCloseAsync(CancellationToken cancellationToken);
 
         /// <summary>Helper function to make it easier to convert old test with strings.</summary>
         public async Task SendResponseBodyAsync(string content, bool isFinal = true)

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -86,6 +86,22 @@ namespace System.Net.Test.Common
             CloseWebSocket();
         }
 
+        public async Task WaitForClose(CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                if (_websocket != null
+                    ? _websocket.State == WebSocketState.Closed
+                    : _socket.Poll(1, SelectMode.SelectRead) && _socket.Available == 0)
+                {
+                    break;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Delay(100);
+            }
+        }
+
         public void Shutdown(SocketShutdown how)
         {
             _socket?.Shutdown(how);
@@ -137,6 +153,9 @@ namespace System.Net.Test.Common
 
         /// <summary>Waits for the client to signal cancellation.</summary>
         public abstract Task WaitForCancellationAsync(bool ignoreIncomingData = true);
+
+        /// <summary>Waits for the client to signal cancellation.</summary>
+        public abstract Task WaitForClose(CancellationToken cancellationToken);
 
         /// <summary>Helper function to make it easier to convert old test with strings.</summary>
         public async Task SendResponseBodyAsync(string content, bool isFinal = true)

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -88,15 +88,10 @@ namespace System.Net.Test.Common
 
         public async Task WaitForClose(CancellationToken cancellationToken)
         {
-            while (true)
+            while (_websocket != null
+                    ? _websocket.State != WebSocketState.Closed
+                    : !(_socket.Poll(1, SelectMode.SelectRead) && _socket.Available == 0))
             {
-                if (_websocket != null
-                    ? _websocket.State == WebSocketState.Closed
-                    : _socket.Poll(1, SelectMode.SelectRead) && _socket.Available == 0)
-                {
-                    break;
-                }
-
                 cancellationToken.ThrowIfCancellationRequested();
                 await Task.Delay(100);
             }

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -985,7 +985,7 @@ namespace System.Net.Test.Common
             Assert.Equal((int)ProtocolErrors.CANCEL, rstStreamFrame.ErrorCode);
         }
 
-        public override Task WaitForClose(CancellationToken cancellationToken)
+        public override Task WaitForCloseAsync(CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -984,5 +984,10 @@ namespace System.Net.Test.Common
             RstStreamFrame rstStreamFrame = Assert.IsType<RstStreamFrame>(frame);
             Assert.Equal((int)ProtocolErrors.CANCEL, rstStreamFrame.ErrorCode);
         }
+
+        public override Task WaitForClose(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.Net.Http.Functional.Tests;
 using Xunit;
+using System.Threading;
 
 namespace System.Net.Test.Common
 {
@@ -304,6 +305,11 @@ namespace System.Net.Test.Common
         public override async Task WaitForCancellationAsync(bool ignoreIncomingData = true)
         {
             await GetOpenRequest().WaitForCancellationAsync(ignoreIncomingData).ConfigureAwait(false);
+        }
+
+        public override Task WaitForClose(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -307,7 +307,7 @@ namespace System.Net.Test.Common
             await GetOpenRequest().WaitForCancellationAsync(ignoreIncomingData).ConfigureAwait(false);
         }
 
-        public override Task WaitForClose(CancellationToken cancellationToken)
+        public override Task WaitForCloseAsync(CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -232,7 +232,7 @@ namespace System.Net.Http.Functional.Tests
 
 #if TARGET_BROWSER
                         // make sure that the browser closed the connection
-                        await connection.WaitForClose(CancellationToken.None);
+                        await connection.WaitForCloseAsync(CancellationToken.None);
 #endif
                     });
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(false, CancellationMode.Token)]
         [InlineData(true, CancellationMode.Token)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64333", TestPlatforms.Browser)] // out of memory
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36634", TestPlatforms.Browser)] // out of memory
         public async Task PostAsync_CancelDuringRequestContentSend_TaskCanceledQuickly(bool chunkedTransfer, CancellationMode mode)
         {
             if (LoopbackServerFactory.Version >= HttpVersion20.Value && chunkedTransfer)

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -227,7 +227,7 @@ namespace System.Net.Http.Functional.Tests
                         }
 
                         await connection.ReadRequestDataAsync();
-                        await connection.SendResponseAsync(HttpStatusCode.OK, headers: headers, isFinal: false, content: chunkedTransfer ? "8\r\nTooShort\r\n" : "TooShort");
+                        await connection.SendResponseAsync(HttpStatusCode.OK, headers: headers, isFinal: false);
                         await clientFinished.Task;
 
                         if (PlatformDetection.IsBrowser)

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -229,6 +229,12 @@ namespace System.Net.Http.Functional.Tests
                         await connection.ReadRequestDataAsync();
                         await connection.SendResponseAsync(HttpStatusCode.OK, headers: headers, isFinal: false, content: chunkedTransfer ? "8\r\nTooShort\r\n" : "TooShort");
                         await clientFinished.Task;
+
+                        if (PlatformDetection.IsBrowser)
+                        {
+                            // make sure that the browser closed the connection
+                            await connection.WaitForClose(CancellationToken.None);
+                        }
                     });
 
                     var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -230,21 +230,19 @@ namespace System.Net.Http.Functional.Tests
                         await connection.SendResponseAsync(HttpStatusCode.OK, headers: headers, isFinal: false);
                         await clientFinished.Task;
 
-                        if (PlatformDetection.IsBrowser)
-                        {
-                            // make sure that the browser closed the connection
-                            await connection.WaitForClose(CancellationToken.None);
-                        }
+#if TARGET_BROWSER
+                        // make sure that the browser closed the connection
+                        await connection.WaitForClose(CancellationToken.None);
+#endif
                     });
 
                     var req = new HttpRequestMessage(HttpMethod.Get, url) { Version = UseVersion };
                     req.Headers.ConnectionClose = connectionClose;
 
-                    if (PlatformDetection.IsBrowser)
-                    {
-                        var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
-                        req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
-                    }
+#if TARGET_BROWSER
+                    var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
+                    req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
+#endif
 
                     Task<HttpResponseMessage> getResponse = client.SendAsync(TestAsync, req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
                     await ValidateClientCancellationAsync(async () =>

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -1066,9 +1066,9 @@ namespace System.Net.Test.Common
                 }
             }
 
-            public override Task WaitForClose(CancellationToken cancellationToken)
+            public override Task WaitForCloseAsync(CancellationToken cancellationToken)
             {
-                return _socket.WaitForClose(cancellationToken);
+                return _socket.WaitForCloseAsync(cancellationToken);
             }
         }
 

--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -1065,6 +1065,11 @@ namespace System.Net.Test.Common
                     }
                 }
             }
+
+            public override Task WaitForClose(CancellationToken cancellationToken)
+            {
+                return _socket.WaitForClose(cancellationToken);
+            }
         }
 
         public override async Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "")

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -264,37 +264,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
-        public async Task BrowserHttpHandler_StreamingCancel()
-        {
-            var WebAssemblyEnableStreamingResponseKey = new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse");
-
-            var size = 1500 * 1024 * 1024;
-            var req = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.RemoteSecureHttp11Server.BaseUri + "large.ashx?size=" + size);
-
-            req.Options.Set(WebAssemblyEnableStreamingResponseKey, true);
-
-            using (HttpClient client = CreateHttpClientForRemoteServer(Configuration.Http.RemoteSecureHttp11Server))
-            // we need to switch off Response buffering of default ResponseContentRead option
-            using (HttpResponseMessage response = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
-            {
-                Assert.Equal(typeof(StreamContent), response.Content.GetType());
-
-                Assert.Equal("application/octet-stream", response.Content.Headers.ContentType.MediaType);
-                Assert.True(size == response.Content.Headers.ContentLength, "ContentLength");
-
-                var stream = await response.Content.ReadAsStreamAsync();
-                Assert.Equal("ReadOnlyStream", stream.GetType().Name);
-                var buffer = new byte[1024 * 1024];
-
-                // with WebAssemblyEnableStreamingResponse option set, we will be using https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/read
-                await stream.ReadAsync(buffer, 0, buffer.Length);
-
-                // dispose before end of the stream
-            }
-        }
-
         [Theory]
         [InlineData(TransferType.ContentLength, TransferError.ContentLengthTooLarge)]
         [InlineData(TransferType.Chunked, TransferError.MissingChunkTerminator)]

--- a/src/libraries/Common/tests/System/Net/Prerequisites/RemoteLoopServer/Handlers/RemoteLoopHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/RemoteLoopServer/Handlers/RemoteLoopHandler.cs
@@ -102,6 +102,13 @@ namespace RemoteLoopServer
                             }
                             if (!close)
                             {
+                                if ((tested.Poll(1, SelectMode.SelectRead) && tested.Available == 0))
+                                {
+                                    close = true;
+                                }
+                            }
+                            if (!close)
+                            {
                                 testedNext = tested.ReceiveAsync(new Memory<byte>(testedBuffer), SocketFlags.None, cts.Token).AsTask();
                             }
                         }
@@ -142,14 +149,14 @@ namespace RemoteLoopServer
                     }
                     catch (WebSocketException ex)
                     {
-                        logger.LogWarning("ProcessWebSocketRequest closing failed", ex);
+                        logger.LogWarning("RemoteLoopHandler.ProcessWebSocketRequest closing failed", ex);
                     }
                 }
                 cts.Cancel();
             }
             catch (Exception ex)
             {
-                logger.LogError("ProcessWebSocketRequest failed", ex);
+                logger.LogError("RemoteLoopHandler.ProcessWebSocketRequest failed", ex);
             }
             finally
             {

--- a/src/libraries/Common/tests/System/Net/Prerequisites/RemoteLoopServer/Handlers/RemoteLoopHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/RemoteLoopServer/Handlers/RemoteLoopHandler.cs
@@ -100,12 +100,10 @@ namespace RemoteLoopServer
                                 var slice = new ArraySegment<byte>(testedBuffer, 0, testedNext.Result);
                                 await control.SendAsync(slice, WebSocketMessageType.Binary, true, cts.Token).ConfigureAwait(false);
                             }
-                            if (!close)
+                            // did we get TCP FIN?
+                            if (!close && (tested.Poll(1, SelectMode.SelectRead) && tested.Available == 0))
                             {
-                                if ((tested.Poll(1, SelectMode.SelectRead) && tested.Available == 0))
-                                {
-                                    close = true;
-                                }
+                                close = true;
                             }
                             if (!close)
                             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -231,7 +231,7 @@ namespace System.Net.Http
                 CancellationTokenSource abortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 CancellationTokenRegistration abortRegistration = abortCts.Token.Register((Action)(() =>
                 {
-                    if (abortController.JSHandle != -1)
+                    if (!abortController.IsDisposed)
                     {
                         abortController.Invoke("abort");
                         abortController?.Dispose();
@@ -387,6 +387,10 @@ namespace System.Net.Http
                 _abortRegistration.Dispose();
 
                 _fetchResponse?.Dispose();
+                if (_abortController != null && !_abortController.IsDisposed)
+                {
+                    _abortController.Invoke("abort");
+                }
                 _abortController?.Dispose();
             }
         }
@@ -568,7 +572,12 @@ namespace System.Net.Http
 
             protected override void Dispose(bool disposing)
             {
-                _reader?.Dispose();
+                if (_reader != null && !_reader.IsDisposed)
+                {
+                    _reader.Invoke("cancel");
+                    _reader.Dispose();
+                    _reader = null;
+                }
                 _status?.Dispose();
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -534,10 +534,9 @@ namespace System.Net.Http
                         if (cancellationToken.IsCancellationRequested)
                         {
                             _reader.Invoke("cancel");
-                            CancellationHelper.CreateOperationCanceledException(null, cancellationToken);
+                            throw CancellationHelper.CreateOperationCanceledException(null, cancellationToken);
                         }
 
-                        CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
                         if ((bool)read.GetObjectProperty("done"))
                         {
                             _reader.Dispose();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -148,10 +148,10 @@ namespace System.Net.Http
             {
                 throw new ArgumentNullException(nameof(request), SR.net_http_handler_norequest);
             }
-
+            CancellationTokenRegistration? abortRegistration = null;
             try
             {
-                var requestObject = new JSObject();
+                using var requestObject = new JSObject();
 
                 if (request.Options.TryGetValue(FetchOptions, out IDictionary<string, object>? fetchOptions))
                 {
@@ -221,44 +221,39 @@ namespace System.Net.Http
                 }
 
 
-                WasmHttpReadStream? wasmHttpReadStream = null;
-
                 JSObject abortController = new HostObject("AbortController");
-                JSObject signal = (JSObject)abortController.GetObjectProperty("signal");
+                using JSObject signal = (JSObject)abortController.GetObjectProperty("signal");
                 requestObject.SetObjectProperty("signal", signal);
-                signal.Dispose();
 
-                CancellationTokenSource abortCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                CancellationTokenRegistration abortRegistration = abortCts.Token.Register((Action)(() =>
+                abortRegistration = cancellationToken.Register(() =>
                 {
                     if (!abortController.IsDisposed)
                     {
                         abortController.Invoke("abort");
                         abortController?.Dispose();
                     }
-                    wasmHttpReadStream?.Dispose();
-                    abortCts.Dispose();
-                }));
+                });
 
-                var args = new System.Runtime.InteropServices.JavaScript.Array();
+                using var args = new System.Runtime.InteropServices.JavaScript.Array();
                 if (request.RequestUri != null)
                 {
                     args.Push(request.RequestUri.ToString());
                     args.Push(requestObject);
                 }
 
-                requestObject.Dispose();
 
-                var response = s_fetch?.Invoke("apply", s_window, args) as Task<object>;
-                args.Dispose();
-                if (response == null)
+                var responseTask = s_fetch?.Invoke("apply", s_window, args) as Task<object>;
+                if (responseTask == null)
                     throw new Exception(SR.net_http_marshalling_response_promise_from_fetch);
 
-                JSObject t = (JSObject)await response.ConfigureAwait(continueOnCapturedContext: true);
+                cancellationToken.ThrowIfCancellationRequested();
 
-                var status = new WasmFetchResponse(t, abortController, abortCts, abortRegistration);
-                HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)status.Status);
-                httpResponse.RequestMessage = request;
+                var fetchResponseJs = (JSObject)await responseTask.ConfigureAwait(continueOnCapturedContext: true);
+
+                var fetchResponse = new WasmFetchResponse(fetchResponseJs, abortController, abortRegistration.Value);
+                abortRegistration = null;
+                var responseMessage = new HttpResponseMessage((HttpStatusCode)fetchResponse.Status);
+                responseMessage.RequestMessage = request;
 
                 // Here we will set the ReasonPhrase so that it can be evaluated later.
                 // We do not have a status code but this will signal some type of what happened
@@ -267,9 +262,9 @@ namespace System.Net.Http
                 // https://developer.mozilla.org/en-US/docs/Web/API/Response/type
                 // opaqueredirect: The fetch request was made with redirect: "manual".
                 // The Response's status is 0, headers are empty, body is null and trailer is empty.
-                if (status.ResponseType == "opaqueredirect")
+                if (fetchResponse.ResponseType == "opaqueredirect")
                 {
-                    httpResponse.SetReasonPhraseWithoutValidation(status.ResponseType);
+                    responseMessage.SetReasonPhraseWithoutValidation(fetchResponse.ResponseType);
                 }
 
                 bool streamingEnabled = false;
@@ -278,9 +273,9 @@ namespace System.Net.Http
                     request.Options.TryGetValue(EnableStreamingResponse, out streamingEnabled);
                 }
 
-                httpResponse.Content = streamingEnabled
-                    ? new StreamContent(wasmHttpReadStream = new WasmHttpReadStream(status))
-                    : (HttpContent)new BrowserHttpContent(status);
+                responseMessage.Content = streamingEnabled
+                    ? new StreamContent(new WasmHttpReadStream(fetchResponse))
+                    : new BrowserHttpContent(fetchResponse);
 
                 // Fill the response headers
                 // CORS will only allow access to certain headers.
@@ -290,7 +285,7 @@ namespace System.Net.Http
                 // View more information https://developers.google.com/web/updates/2015/03/introduction-to-fetch#response_types
                 //
                 // Note: Some of the headers may not even be valid header types in .NET thus we use TryAddWithoutValidation
-                using (JSObject respHeaders = status.Headers)
+                using (JSObject respHeaders = fetchResponse.Headers)
                 {
                     if (respHeaders != null)
                     {
@@ -306,8 +301,8 @@ namespace System.Net.Http
                                     {
                                         var name = (string)resultValue[0];
                                         var value = (string)resultValue[1];
-                                        if (!httpResponse.Headers.TryAddWithoutValidation(name, value))
-                                            httpResponse.Content.Headers.TryAddWithoutValidation(name, value);
+                                        if (!responseMessage.Headers.TryAddWithoutValidation(name, value))
+                                            responseMessage.Content.Headers.TryAddWithoutValidation(name, value);
                                     }
                                     nextResult?.Dispose();
                                     nextResult = (JSObject)entriesIterator.Invoke("next");
@@ -320,7 +315,7 @@ namespace System.Net.Http
                         }
                     }
                 }
-                return httpResponse;
+                return responseMessage;
 
             }
             catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
@@ -330,6 +325,10 @@ namespace System.Net.Http
             catch (JSException jse)
             {
                 throw TranslateJSException(jse, cancellationToken);
+            }
+            finally
+            {
+                abortRegistration?.Dispose();
             }
         }
 
@@ -350,15 +349,13 @@ namespace System.Net.Http
         {
             private readonly JSObject _fetchResponse;
             private readonly JSObject _abortController;
-            private readonly CancellationTokenSource _abortCts;
             private readonly CancellationTokenRegistration _abortRegistration;
             private bool _isDisposed;
 
-            public WasmFetchResponse(JSObject fetchResponse, JSObject abortController, CancellationTokenSource abortCts, CancellationTokenRegistration abortRegistration)
+            public WasmFetchResponse(JSObject fetchResponse, JSObject abortController, CancellationTokenRegistration abortRegistration)
             {
                 _fetchResponse = fetchResponse ?? throw new ArgumentNullException(nameof(fetchResponse));
                 _abortController = abortController ?? throw new ArgumentNullException(nameof(abortController));
-                _abortCts = abortCts;
                 _abortRegistration = abortRegistration;
             }
 
@@ -383,7 +380,6 @@ namespace System.Net.Http
 
                 _isDisposed = true;
 
-                _abortCts.Dispose();
                 _abortRegistration.Dispose();
 
                 _fetchResponse?.Dispose();
@@ -464,15 +460,15 @@ namespace System.Net.Http
 
         private sealed class WasmHttpReadStream : Stream
         {
-            private WasmFetchResponse? _status;
+            private WasmFetchResponse? _fetchResponse;
             private JSObject? _reader;
 
             private byte[]? _bufferedBytes;
             private int _position;
 
-            public WasmHttpReadStream(WasmFetchResponse status)
+            public WasmHttpReadStream(WasmFetchResponse fetchResponse)
             {
-                _status = status;
+                _fetchResponse = fetchResponse;
             }
 
             public override bool CanRead => true;
@@ -493,17 +489,19 @@ namespace System.Net.Http
 
             public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
             {
+                CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+
                 if (_reader == null)
                 {
                     // If we've read everything, then _reader and _status will be null
-                    if (_status == null)
+                    if (_fetchResponse == null)
                     {
                         return 0;
                     }
 
                     try
                     {
-                        using (JSObject body = _status.Body)
+                        using (JSObject body = _fetchResponse.Body)
                         {
                             _reader = (JSObject)body.Invoke("getReader");
                         }
@@ -518,6 +516,11 @@ namespace System.Net.Http
                     }
                 }
 
+                using var abortRegistration = cancellationToken.Register(() =>
+                {
+                    _reader.Invoke("cancel");
+                });
+
                 if (_bufferedBytes != null && _position < _bufferedBytes.Length)
                 {
                     return ReadBuffered();
@@ -528,13 +531,20 @@ namespace System.Net.Http
                     var t = (Task<object>)_reader.Invoke("read");
                     using (var read = (JSObject)await t.ConfigureAwait(continueOnCapturedContext: true))
                     {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            _reader.Invoke("cancel");
+                            CancellationHelper.CreateOperationCanceledException(null, cancellationToken);
+                        }
+
+                        CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
                         if ((bool)read.GetObjectProperty("done"))
                         {
                             _reader.Dispose();
                             _reader = null;
 
-                            _status?.Dispose();
-                            _status = null;
+                            _fetchResponse?.Dispose();
+                            _fetchResponse = null;
                             return 0;
                         }
 
@@ -572,13 +582,8 @@ namespace System.Net.Http
 
             protected override void Dispose(bool disposing)
             {
-                if (_reader != null && !_reader.IsDisposed)
-                {
-                    _reader.Invoke("cancel");
-                    _reader.Dispose();
-                    _reader = null;
-                }
-                _status?.Dispose();
+                _reader?.Dispose();
+                _fetchResponse?.Dispose();
             }
 
             public override void Flush()

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1044,12 +1044,12 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandlerTest_Cookies_Http11(ITestOutputHelper output) : base(output) { }
     }
 
-    [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
     public sealed class SocketsHttpHandler_HttpClientHandler_Http11_Cancellation_Test : SocketsHttpHandler_Cancellation_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Http11_Cancellation_Test(ITestOutputHelper output) : base(output) { }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void ConnectTimeout_Default()
         {
             using (var handler = new SocketsHttpHandler())
@@ -1062,6 +1062,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(0)]
         [InlineData(-2)]
         [InlineData(int.MaxValue + 1L)]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void ConnectTimeout_InvalidValues(long ms)
         {
             using (var handler = new SocketsHttpHandler())
@@ -1075,6 +1076,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(1)]
         [InlineData(int.MaxValue - 1)]
         [InlineData(int.MaxValue)]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void ConnectTimeout_ValidValues_Roundtrip(long ms)
         {
             using (var handler = new SocketsHttpHandler())
@@ -1085,6 +1087,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void ConnectTimeout_SetAfterUse_Throws()
         {
             using (var handler = new SocketsHttpHandler())
@@ -1098,6 +1101,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void Expect100ContinueTimeout_Default()
         {
             using (var handler = new SocketsHttpHandler())
@@ -1109,6 +1113,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(-2)]
         [InlineData(int.MaxValue + 1L)]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void Expect100ContinueTimeout_InvalidValues(long ms)
         {
             using (var handler = new SocketsHttpHandler())
@@ -1122,6 +1127,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(1)]
         [InlineData(int.MaxValue - 1)]
         [InlineData(int.MaxValue)]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void Expect100ContinueTimeout_ValidValues_Roundtrip(long ms)
         {
             using (var handler = new SocketsHttpHandler())
@@ -1132,6 +1138,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "ConnectTimeout is not supported on Browser")]
         public void Expect100ContinueTimeout_SetAfterUse_Throws()
         {
             using (var handler = new SocketsHttpHandler())


### PR DESCRIPTION
- call `ReadableStream.cancel` on cancelationToken of `WasmHttpReadStream.ReadAsync`
- call `AbortController.abort` when disposing `WasmFetchResponse` and `WasmHttpReadStream`
- enable some of `SocketsHttpHandler_HttpClientHandler_Http11_Cancellation_Test` tests for Browser target
- added `WaitForClose` to the `LoopbackServer`
- added disconnect detection to `RemoteLoopHandler`
- add unit test for the scenario

Fixes https://github.com/dotnet/runtime/issues/64225