### PR TITLE
Update the managed type system to more gracefully fail when calling a varargs method.

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -255,6 +255,8 @@ namespace Internal.TypeSystem.Ecma
                         return _tsc.GetFunctionPointerType(sig);
                     else
                         return null;
+                case SignatureTypeCode.Sentinel:
+                    throw new TypeSystemException.BadImageFormatException();
                 default:
                     throw new BadImageFormatException();
             }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -257,7 +257,7 @@ namespace Internal.TypeSystem.Ecma
                         return null;
                 default:
                     ThrowHelper.ThrowBadImageFormatException();
-                    break;
+                    return null;
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -255,10 +255,9 @@ namespace Internal.TypeSystem.Ecma
                         return _tsc.GetFunctionPointerType(sig);
                     else
                         return null;
-                case SignatureTypeCode.Sentinel:
-                    throw new TypeSystemException.BadImageFormatException();
                 default:
-                    throw new BadImageFormatException();
+                    ThrowHelper.ThrowBadImageFormatException();
+                    break;
             }
         }
 


### PR DESCRIPTION
Throw the `TypeSystemException`-derived `BadImageFormatException` when we encounter a Sentinel token in a signature instead of a regular `BadImageFormatException`. By throwing the `TypeSystemException`-derived variant, crossgen2 will skip emitting code for the method and NativeAOT will emit a throwing stub. The behavior today is an exception that bubbles up all the way and takes down the process.

Fixes https://github.com/dotnet/runtime/issues/64172