### PR TITLE
Add Regex.Count string overloads

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -161,6 +161,10 @@ namespace System.Text.RegularExpressions
         public static void CompileToAssembly(System.Text.RegularExpressions.RegexCompilationInfo[] regexinfos, System.Reflection.AssemblyName assemblyname, System.Reflection.Emit.CustomAttributeBuilder[]? attributes) { }
         [System.ObsoleteAttribute("Regex.CompileToAssembly is obsolete and not supported. Use the RegexGeneratorAttribute with the regular expression source generator instead.", DiagnosticId = "SYSLIB0036", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static void CompileToAssembly(System.Text.RegularExpressions.RegexCompilationInfo[] regexinfos, System.Reflection.AssemblyName assemblyname, System.Reflection.Emit.CustomAttributeBuilder[]? attributes, string? resourceFile) { }
+        public int Count(string input) { throw null; }
+        public static int Count(string input, [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex)] string pattern) { throw null; }
+        public static int Count(string input, [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex, "options")] string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
+        public static int Count(string input, [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.Regex, "options")] string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
         public static string Escape(string str) { throw null; }
         public string[] GetGroupNames() { throw null; }
         public int[] GetGroupNumbers() { throw null; }

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -18,6 +18,7 @@
     <Compile Include="System\Text\RegularExpressions\MatchCollection.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Cache.cs" />
+    <Compile Include="System\Text\RegularExpressions\Regex.Count.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Debug.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Match.cs" />
     <Compile Include="System\Text\RegularExpressions\Regex.Replace.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Count.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Text.RegularExpressions
+{
+    public partial class Regex
+    {
+        /// <summary>Searches an input string for all occurrences of a regular expression and returns the number of matches.</summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <returns>The number of matches.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is null.</exception>
+        public int Count(string input)
+        {
+            if (input is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.input);
+            }
+
+            int count = 0;
+
+            Run(input, 0, ref count, static (ref int count, Match match) =>
+            {
+                count++;
+                return true;
+            }, reuseMatchObject: true);
+
+            return count;
+        }
+
+        /// <summary>Searches an input string for all occurrences of a regular expression and returns the number of matches.</summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <returns>The number of matches.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="pattern"/> is null.</exception>
+        /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
+        public static int Count(string input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern) =>
+            RegexCache.GetOrAdd(pattern).Count(input);
+
+        /// <summary>Searches an input string for all occurrences of a regular expression and returns the number of matches.</summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specify options for matching.</param>
+        /// <returns>The number of matches.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="pattern"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values.</exception>
+        /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
+        public static int Count(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options) =>
+            RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Count(input);
+
+        /// <summary>Searches an input string for all occurrences of a regular expression and returns the number of matches.</summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specify options for matching.</param>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="InfiniteMatchTimeout"/> to indicate that the method should not time out.</param>
+        /// <returns>The number of matches.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> or <paramref name="pattern"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not a valid bitwise combination of RegexOptions values, or <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.</exception>
+        /// <exception cref="RegexParseException">A regular expression parsing error occurred.</exception>
+        public static int Count(string input, [StringSyntax(StringSyntaxAttribute.Regex, "options")] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
+            RegexCache.GetOrAdd(pattern, options, matchTimeout).Count(input);
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Count.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Count.Tests.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    public class RegexCountTests
+    {
+        [Theory]
+        [MemberData(nameof(Count_ReturnsExpectedCount_TestData))]
+        public async Task Count_ReturnsExpectedCount(RegexEngine engine, string pattern, string input, RegexOptions options, int expectedCount)
+        {
+            Regex r = await RegexHelpers.GetRegexAsync(engine, pattern, options);
+            Assert.Equal(expectedCount, r.Count(input));
+            Assert.Equal(r.Count(input), r.Matches(input).Count);
+
+            if (options == RegexOptions.None && engine == RegexEngine.Interpreter)
+            {
+                Assert.Equal(expectedCount, Regex.Count(input, pattern));
+            }
+
+            switch (engine)
+            {
+                case RegexEngine.Interpreter:
+                case RegexEngine.Compiled:
+                case RegexEngine.NonBacktracking:
+                    RegexOptions engineOptions = RegexHelpers.OptionsFromEngine(engine);
+                    Assert.Equal(expectedCount, Regex.Count(input, pattern, options | engineOptions));
+                    Assert.Equal(expectedCount, Regex.Count(input, pattern, options | engineOptions, Regex.InfiniteMatchTimeout));
+                    break;
+            }
+        }
+
+        public static IEnumerable<object[]> Count_ReturnsExpectedCount_TestData()
+        {
+            foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
+            {
+                yield return new object[] { engine, @"", "", RegexOptions.None, 1 };
+                yield return new object[] { engine, @"", "a", RegexOptions.None, 2 };
+                yield return new object[] { engine, @"", "ab", RegexOptions.None, 3 };
+
+                yield return new object[] { engine, @"\w", "", RegexOptions.None, 0 };
+                yield return new object[] { engine, @"\w", "a", RegexOptions.None, 1 };
+                yield return new object[] { engine, @"\w", "ab", RegexOptions.None, 2 };
+
+                yield return new object[] { engine, @"\b\w+\b", "abc def ghi jkl", RegexOptions.None, 4 };
+
+                yield return new object[] { engine, @"A", "", RegexOptions.IgnoreCase, 0 };
+                yield return new object[] { engine, @"A", "a", RegexOptions.IgnoreCase, 1 };
+                yield return new object[] { engine, @"A", "aAaA", RegexOptions.IgnoreCase, 4 };
+
+                yield return new object[] { engine, @".", "\n\n\n", RegexOptions.None, 0 };
+                yield return new object[] { engine, @".", "\n\n\n", RegexOptions.Singleline, 3 };
+            }
+        }
+
+        [Fact]
+        public void Count_InvalidArguments_Throws()
+        {
+            // input is null
+            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Count(null));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Count(null, @"pattern"));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Count(null, @"pattern", RegexOptions.None));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Count(null, @"pattern", RegexOptions.None, TimeSpan.FromMilliseconds(1)));
+
+            // pattern is null
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Count("input", null));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Count("input", null, RegexOptions.None));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Count("input", null, RegexOptions.None, TimeSpan.FromMilliseconds(1)));
+
+            // pattern is invalid
+#pragma warning disable RE0001 // invalid regex pattern
+            AssertExtensions.Throws<RegexParseException>(() => Regex.Count("input", @"[abc"));
+            AssertExtensions.Throws<RegexParseException>(() => Regex.Count("input", @"[abc", RegexOptions.None));
+            AssertExtensions.Throws<RegexParseException>(() => Regex.Count("input", @"[abc", RegexOptions.None, TimeSpan.FromMilliseconds(1)));
+#pragma warning restore RE0001
+
+            // options is invalid
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Count("input", @"[abc]", (RegexOptions)(-1)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Count("input", @"[abc]", (RegexOptions)(-1), TimeSpan.FromMilliseconds(1)));
+
+            // matchTimeout is invalid
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.Count("input", @"[abc]", RegexOptions.None, TimeSpan.FromMilliseconds(-2)));
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public async Task Count_Timeout_ThrowsAfterTooLongExecution(RegexEngine engine)
+        {
+            if (RegexHelpers.IsNonBacktracking(engine))
+            {
+                // Test relies on backtracking taking a long time
+                return;
+            }
+
+            const string Pattern = @"^(\w+\s?)*$";
+            const string Input = "An input string that takes a very very very very very very very very very very very long time!";
+
+            Regex r = await RegexHelpers.GetRegexAsync(engine, Pattern, RegexOptions.None, TimeSpan.FromMilliseconds(1));
+
+            Stopwatch sw = Stopwatch.StartNew();
+            Assert.Throws<RegexMatchTimeoutException>(() => r.Count(Input));
+            Assert.InRange(sw.Elapsed.TotalSeconds, 0, 10); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
+
+            switch (engine)
+            {
+                case RegexEngine.Interpreter:
+                case RegexEngine.Compiled:
+                    sw = Stopwatch.StartNew();
+                    Assert.Throws<RegexMatchTimeoutException>(() => Regex.Count(Input, Pattern, RegexHelpers.OptionsFromEngine(engine), TimeSpan.FromMilliseconds(1)));
+                    Assert.InRange(sw.Elapsed.TotalSeconds, 0, 10); // arbitrary upper bound that should be well above what's needed with a 1ms timeout
+                    break;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -41,6 +41,7 @@
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Compile Include="Regex.Count.Tests.cs" />
     <Compile Include="RegexAssert.netcoreapp.cs" />
     <Compile Include="RegexParserTests.netcoreapp.cs" />
     <Compile Include="GroupCollectionReadOnlyDictionaryTests.cs" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/61425
This provides the string-based overloads in that issue.
@joperezr will follow-up with the span-based overloads.