### PR TITLE
[mono] Avoid inlining the wrappers used by CALLI.

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3803,7 +3803,9 @@ mono_marshal_get_native_func_wrapper_indirect (MonoClass *caller_class, MonoMeth
 	mb->method->save_lmf = 1;
 
 	WrapperInfo *info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NATIVE_FUNC_INDIRECT);
-	info->d.managed_to_native.method = NULL;
+	//info->d.managed_to_native.method = NULL;
+	info->d.native_func.klass = caller_class;
+	info->d.native_func.sig = sig;
 
 	MonoMethodPInvoke *piinfo = NULL;
 	MonoMarshalSpec **mspecs = g_new0 (MonoMarshalSpec *, 1 + sig->param_count);

--- a/src/mono/mono/metadata/marshal.h
+++ b/src/mono/mono/metadata/marshal.h
@@ -233,6 +233,11 @@ typedef struct {
 	MonoLLVMFuncWrapperSubtype subtype;
 } LLVMFuncWrapperInfo;
 
+typedef struct {
+	MonoClass *klass;
+	MonoMethodSignature *sig;
+} NativeFuncWrapperInfo;
+
 /*
  * This structure contains additional information to uniquely identify a given wrapper
  * method. It can be retrieved by mono_marshal_get_wrapper_info () for certain types
@@ -277,6 +282,8 @@ typedef struct {
 		AOTInitWrapperInfo aot_init;
 		/* LLVM_FUNC */
 		LLVMFuncWrapperInfo llvm_func;
+		/* NATIVE_FUNC_INDIRECT */
+		NativeFuncWrapperInfo native_func;
 	} d;
 } WrapperInfo;
 

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3671,6 +3671,8 @@ encode_signature (MonoAotCompile *acfg, MonoMethodSignature *sig, guint8 *buf, g
 		flags |= 0x20;
 	if (sig->explicit_this)
 		flags |= 0x40;
+	if (sig->pinvoke)
+		flags |= 0x80;
 	flags |= (sig->call_convention & 0x0F);
 
 	*p = flags;
@@ -3772,6 +3774,9 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 				encode_value (info->d.icall.jit_icall_id, p, &p);
 			} else if (info->subtype == WRAPPER_SUBTYPE_NATIVE_FUNC_AOT) {
 				encode_method_ref (acfg, info->d.managed_to_native.method, p, &p);
+			} else if (info->subtype == WRAPPER_SUBTYPE_NATIVE_FUNC_INDIRECT) {
+				encode_klass_ref (acfg, info->d.native_func.klass, p, &p);
+				encode_signature (acfg, info->d.native_func.sig, p, &p);
 			} else {
 				g_assert (info->subtype == WRAPPER_SUBTYPE_NONE || info->subtype == WRAPPER_SUBTYPE_PINVOKE);
 				encode_method_ref (acfg, info->d.managed_to_native.method, p, &p);

--- a/src/mono/mono/mini/aot-runtime.h
+++ b/src/mono/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 182
+#define MONO_AOT_FILE_VERSION 183
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7214,17 +7214,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 					g_assert (!fsig->hasthis && !fsig->pinvoke);
 
-					gboolean inline_wrapper = cfg->opt & MONO_OPT_INLINE || cfg->compile_aot;
-					if (inline_wrapper) {
-						int costs = inline_method (cfg, wrapper, fsig, sp, ip, cfg->real_offset, TRUE, NULL);
-						CHECK_CFG_EXCEPTION;
-						g_assert (costs > 0);
-						cfg->real_offset += 5;
-						inline_costs += costs;
-						ins = sp[0];
-					} else {
-						ins = mono_emit_method_call (cfg, wrapper, /*args*/sp, NULL);
-					}
+					ins = mono_emit_method_call (cfg, wrapper, /*args*/sp, NULL);
 					goto calli_end;
 				}
 			}


### PR DESCRIPTION
They contain an LMF and the inlining removes it.

Fixes https://github.com/dotnet/runtime/issues/64073.