### PR TITLE
Fix arm64/PInvoke so that NESTED_ENTRY/NESTED_END labels match.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.S
@@ -188,7 +188,7 @@ NoAbort:
         EPILOG_RESTORE_REG_PAIR_INDEXED   fp, lr, 0xA0
         EPILOG_RETURN
 
-    NESTED_END RhpReversePInvokeTrapThread
+    NESTED_END RhpReversePInvokeAttachOrTrapThread, _TEXT
 
 //
 // RhpPInvoke

--- a/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/PInvoke.asm
@@ -180,7 +180,7 @@ NoAbort
         EPILOG_RESTORE_REG_PAIR   fp, lr, #0xA0!
         EPILOG_RETURN
 
-    NESTED_END RhpReversePInvokeTrapThread
+    NESTED_END RhpReversePInvokeAttachOrTrapThread
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This was exposed by building on arm64 with gcc-12,
wherein the assembler complained about not being able
to evaluate the constant expression for .size for the symbol
on NESTED_END.  Since the symbol on NESTED_END is not
referenced anywhere else in the code base,
I concluded that it was wrong, and NESTED_ENTRY was right.

I have not tested this on anything but arm64 + gcc-12

area-NativeAOT-coreclr