### PR TITLE
Override all `Read` methods in `NullTextReader` and `NullStreamReader`

### DIFF
--- a/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
@@ -131,16 +131,57 @@ namespace System.IO.Tests
 
             if (sr != null)
                 Assert.True(sr.EndOfStream, "EndOfStream property didn't return true");
-            input.ReadLine();
+            Assert.Null(input.ReadLine());
             input.Dispose();
 
             input.ReadLine();
             if (sr != null)
                 Assert.True(sr.EndOfStream, "EndOfStream property didn't return true");
-            input.Read();
-            input.Peek();
-            input.Read(new char[2], 0, 2);
-            input.ReadToEnd();
+            Assert.Equal(-1, input.Read());
+            Assert.Equal(-1, input.Peek());
+
+            var chars = new char[2];
+            Assert.Equal(0, input.Read(chars, 0, chars.Length));
+            Assert.Equal(0, input.Read(chars.AsSpan()));
+            Assert.Equal(0, input.ReadBlock(chars, 0, chars.Length));
+            Assert.Equal(0, input.ReadBlock(chars.AsSpan()));
+            Assert.Equal("", input.ReadToEnd());
+            input.Dispose();
+        }
+
+        [Theory]
+        [MemberData(nameof(NullReaders))]
+        public static async Task TestNullTextReaderAsync(TextReader input)
+        {
+            var chars = new char[2];
+            Assert.Equal(0, await input.ReadAsync(chars, 0, chars.Length));
+            Assert.Equal(0, await input.ReadAsync(chars.AsMemory(), default));
+            Assert.Equal(0, await input.ReadBlockAsync(chars, 0, chars.Length));
+            Assert.Equal(0, await input.ReadBlockAsync(chars.AsMemory(), default));
+            Assert.Null(await input.ReadLineAsync());
+            Assert.Null(await input.ReadLineAsync(default));
+            Assert.Equal("", await input.ReadToEndAsync());
+            Assert.Equal("", await input.ReadToEndAsync(default));
+            input.Dispose();
+        }
+
+        [Theory]
+        [MemberData(nameof(NullReaders))]
+        public static async Task TestCanceledNullTextReaderAsync(TextReader input)
+        {
+            using var tokenSource = new CancellationTokenSource();
+            tokenSource.Cancel();
+            var token = tokenSource.Token;
+            var chars = new char[2];
+            OperationCanceledException ex;
+            ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await input.ReadAsync(chars.AsMemory(), token));
+            Assert.Equal(token, ex.CancellationToken);
+            ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await input.ReadBlockAsync(chars.AsMemory(), token));
+            Assert.Equal(token, ex.CancellationToken);
+            ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await input.ReadLineAsync(token));
+            Assert.Equal(token, ex.CancellationToken);
+            ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await input.ReadToEndAsync(token));
+            Assert.Equal(token, ex.CancellationToken);
             input.Dispose();
         }
 

--- a/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
@@ -123,6 +123,17 @@ namespace System.IO.Tests
             Assert.Equal(0, source.Position);
         }
 
+
+        [Theory]
+        [MemberData(nameof(NullReaders))]
+        public static void TestNullTextReaderDispose(TextReader input)
+        {
+            // dispose should be a no-op
+            input.Dispose();
+            input.Dispose();
+            Assert.Equal("", input.ReadToEnd());
+        }
+
         [Theory]
         [MemberData(nameof(NullReaders))]
         public static void TestNullTextReader(TextReader input)
@@ -132,14 +143,11 @@ namespace System.IO.Tests
             if (sr != null)
                 Assert.True(sr.EndOfStream, "EndOfStream property didn't return true");
             Assert.Null(input.ReadLine());
-            input.Dispose();
-
-            input.ReadLine();
             if (sr != null)
                 Assert.True(sr.EndOfStream, "EndOfStream property didn't return true");
+
             Assert.Equal(-1, input.Read());
             Assert.Equal(-1, input.Peek());
-
             var chars = new char[2];
             Assert.Equal(0, input.Read(chars, 0, chars.Length));
             Assert.Equal(0, input.Read(chars.AsSpan()));
@@ -169,7 +177,7 @@ namespace System.IO.Tests
         [MemberData(nameof(NullReaders))]
         public static async Task TestCanceledNullTextReaderAsync(TextReader input)
         {
-            using var tokenSource = new CancellationTokenSource();
+            using CancellationTokenSource tokenSource = new CancellationTokenSource();
             tokenSource.Cancel();
             var token = tokenSource.Token;
             var chars = new char[2];

--- a/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
@@ -123,7 +123,6 @@ namespace System.IO.Tests
             Assert.Equal(0, source.Position);
         }
 
-
         [Theory]
         [MemberData(nameof(NullReaders))]
         public static void TestNullTextReaderDispose(TextReader input)

--- a/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
@@ -242,15 +242,10 @@ namespace System.IO.Tests
             Stream.Null.Write(new byte[42]); // still usable
         }
 
-        public static IEnumerable<object[]> NullReaders
-        {
-            get
-            {
-                yield return new object[] { TextReader.Null };
-                yield return new object[] { StreamReader.Null };
-                yield return new object[] { StringReader.Null };
-            }
-        }
+        public static IEnumerable<object[]> NullReaders =>
+            new[] { TextReader.Null, StreamReader.Null, StringReader.Null }
+                .Distinct()
+                .Select(x => new object[] { x });
 
         public static IEnumerable<object[]> NullWriters
         {

--- a/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
+++ b/src/libraries/System.IO/tests/Stream/Stream.NullTests.cs
@@ -242,10 +242,15 @@ namespace System.IO.Tests
             Stream.Null.Write(new byte[42]); // still usable
         }
 
-        public static IEnumerable<object[]> NullReaders =>
-            new[] { TextReader.Null, StreamReader.Null, StringReader.Null }
-                .Distinct()
-                .Select(x => new object[] { x });
+        public static IEnumerable<object[]> NullReaders
+        {
+            get
+            {
+                yield return new object[] { TextReader.Null };
+                yield return new object[] { StreamReader.Null };
+                yield return new object[] { StringReader.Null };
+            }
+        }
 
         public static IEnumerable<object[]> NullWriters
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1386,7 +1386,7 @@ namespace System.IO
 
         // No data, class doesn't need to be serializable.
         // Note this class is threadsafe.
-        private sealed class NullStreamReader : StreamReader
+        internal sealed class NullStreamReader : StreamReader
         {
             public override Encoding CurrentEncoding => Encoding.Unicode;
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1395,35 +1395,43 @@ namespace System.IO
                 // Do nothing - this is essentially unclosable.
             }
 
-            public override int Peek()
-            {
-                return -1;
-            }
+            public override int Peek() => -1;
 
-            public override int Read()
-            {
-                return -1;
-            }
+            public override int Read() => -1;
 
-            public override int Read(char[] buffer, int index, int count)
-            {
-                return 0;
-            }
+            public override int Read(char[] buffer, int index, int count) => 0;
 
-            public override string? ReadLine()
-            {
-                return null;
-            }
+            public override int Read(Span<char> buffer) => 0;
 
-            public override string ReadToEnd()
-            {
-                return string.Empty;
-            }
+            public override Task<int> ReadAsync(char[] buffer, int index, int count) => Task.FromResult(0);
 
-            internal override int ReadBuffer()
-            {
-                return 0;
-            }
+            public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) : default;
+
+            public override int ReadBlock(char[] buffer, int index, int count) => 0;
+
+            public override int ReadBlock(Span<char> buffer) => 0;
+
+            public override Task<int> ReadBlockAsync(char[] buffer, int index, int count) => Task.FromResult(0);
+
+            public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) : default;
+
+            public override string? ReadLine() => null;
+
+            public override Task<string?> ReadLineAsync() => Task.FromResult<string?>(null);
+
+            public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<string?>(cancellationToken) : default;
+
+            public override string ReadToEnd() => "";
+
+            public override Task<string> ReadToEndAsync() => Task.FromResult("");
+
+            public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
+
+            internal override int ReadBuffer() => 0;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1426,10 +1426,10 @@ namespace System.IO
 
             public override string ReadToEnd() => "";
 
-            public override Task<string> ReadToEndAsync() => TaskCache.s_emptyStringTask;
+            public override Task<string> ReadToEndAsync() => Task.FromResult("");
 
             public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : TaskCache.s_emptyStringTask;
+                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
 
             internal override int ReadBuffer() => 0;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1426,10 +1426,10 @@ namespace System.IO
 
             public override string ReadToEnd() => "";
 
-            public override Task<string> ReadToEndAsync() => Task.FromResult("");
+            public override Task<string> ReadToEndAsync() => TaskCache.s_emptyStringTask;
 
             public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
+                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : TaskCache.s_emptyStringTask;
 
             internal override int ReadBuffer() => 0;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -1431,6 +1431,9 @@ namespace System.IO
             public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
                 cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
 
+            internal override ValueTask<int> ReadAsyncInternal(Memory<char> buffer, CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) : default;
+
             internal override int ReadBuffer() => 0;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -19,7 +19,8 @@ namespace System.IO
     // There are methods on the Stream class for reading bytes.
     public abstract partial class TextReader : MarshalByRefObject, IDisposable
     {
-        public static readonly TextReader Null = StreamReader.Null;
+        // Create our own instance to avoid static field initialization order problems on Mono.
+        public static readonly TextReader Null = new StreamReader.NullStreamReader();
 
         protected TextReader() { }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -373,10 +373,10 @@ namespace System.IO
 
             public override string ReadToEnd() => "";
 
-            public override Task<string> ReadToEndAsync() => TaskCache.s_emptyStringTask;
+            public override Task<string> ReadToEndAsync() => Task.FromResult("");
 
             public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : TaskCache.s_emptyStringTask;
+                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
         }
 
         public static TextReader Synchronized(TextReader reader)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -342,15 +342,41 @@ namespace System.IO
         {
             public NullTextReader() { }
 
-            public override int Read(char[] buffer, int index, int count)
-            {
-                return 0;
-            }
+            public override int Peek() => -1;
 
-            public override string? ReadLine()
-            {
-                return null;
-            }
+            public override int Read() => -1;
+
+            public override int Read(char[] buffer, int index, int count) => 0;
+
+            public override int Read(Span<char> buffer) => 0;
+
+            public override Task<int> ReadAsync(char[] buffer, int index, int count) => Task.FromResult(0);
+
+            public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) : default;
+
+            public override int ReadBlock(char[] buffer, int index, int count) => 0;
+
+            public override int ReadBlock(Span<char> buffer) => 0;
+
+            public override Task<int> ReadBlockAsync(char[] buffer, int index, int count) => Task.FromResult(0);
+
+            public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) : default;
+
+            public override string? ReadLine() => null;
+
+            public override Task<string?> ReadLineAsync() => Task.FromResult<string?>(null);
+
+            public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<string?>(cancellationToken) : default;
+
+            public override string ReadToEnd() => "";
+
+            public override Task<string> ReadToEndAsync() => Task.FromResult("");
+
+            public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
+                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
         }
 
         public static TextReader Synchronized(TextReader reader)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -373,10 +373,10 @@ namespace System.IO
 
             public override string ReadToEnd() => "";
 
-            public override Task<string> ReadToEndAsync() => Task.FromResult("");
+            public override Task<string> ReadToEndAsync() => TaskCache.s_emptyStringTask;
 
             public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
+                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : TaskCache.s_emptyStringTask;
         }
 
         public static TextReader Synchronized(TextReader reader)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -19,7 +19,7 @@ namespace System.IO
     // There are methods on the Stream class for reading bytes.
     public abstract partial class TextReader : MarshalByRefObject, IDisposable
     {
-        public static readonly TextReader Null = new NullTextReader();
+        public static readonly TextReader Null = StreamReader.Null;
 
         protected TextReader() { }
 
@@ -337,47 +337,6 @@ namespace System.IO
             return n;
         }
         #endregion
-
-        private sealed class NullTextReader : TextReader
-        {
-            public NullTextReader() { }
-
-            public override int Peek() => -1;
-
-            public override int Read() => -1;
-
-            public override int Read(char[] buffer, int index, int count) => 0;
-
-            public override int Read(Span<char> buffer) => 0;
-
-            public override Task<int> ReadAsync(char[] buffer, int index, int count) => Task.FromResult(0);
-
-            public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) : default;
-
-            public override int ReadBlock(char[] buffer, int index, int count) => 0;
-
-            public override int ReadBlock(Span<char> buffer) => 0;
-
-            public override Task<int> ReadBlockAsync(char[] buffer, int index, int count) => Task.FromResult(0);
-
-            public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) : default;
-
-            public override string? ReadLine() => null;
-
-            public override Task<string?> ReadLineAsync() => Task.FromResult<string?>(null);
-
-            public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<string?>(cancellationToken) : default;
-
-            public override string ReadToEnd() => "";
-
-            public override Task<string> ReadToEndAsync() => Task.FromResult("");
-
-            public override Task<string> ReadToEndAsync(CancellationToken cancellationToken) =>
-                cancellationToken.IsCancellationRequested ? Task.FromCanceled<string>(cancellationToken) : Task.FromResult("");
-        }
 
         public static TextReader Synchronized(TextReader reader)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
@@ -13,8 +13,6 @@ namespace System.Threading.Tasks
         internal static readonly Task<bool> s_trueTask = CreateCacheableTask(result: true);
         /// <summary>A cached Task{Boolean}.Result == false.</summary>
         internal static readonly Task<bool> s_falseTask = CreateCacheableTask(result: false);
-        /// <summary>A cached Task{String}.Result == "".</summary>
-        internal static readonly Task<string> s_emptyStringTask = CreateCacheableTask(result: "");
         /// <summary>The cache of Task{Int32}.</summary>
         internal static readonly Task<int>[] s_int32Tasks = CreateInt32Tasks();
         /// <summary>The minimum value, inclusive, for which we want a cached task.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCache.cs
@@ -13,6 +13,8 @@ namespace System.Threading.Tasks
         internal static readonly Task<bool> s_trueTask = CreateCacheableTask(result: true);
         /// <summary>A cached Task{Boolean}.Result == false.</summary>
         internal static readonly Task<bool> s_falseTask = CreateCacheableTask(result: false);
+        /// <summary>A cached Task{String}.Result == "".</summary>
+        internal static readonly Task<string> s_emptyStringTask = CreateCacheableTask(result: "");
         /// <summary>The cache of Task{Int32}.</summary>
         internal static readonly Task<int>[] s_int32Tasks = CreateInt32Tasks();
         /// <summary>The minimum value, inclusive, for which we want a cached task.</summary>


### PR DESCRIPTION
This is a fast-follow to https://github.com/dotnet/runtime/pull/61898#discussion_r789742168:

> There are a few other TextReader-derived types in dotnet/runtime, e.g. a couple in System.Console, and NullTextReader in corelib. We should likely override the new overloads on those as well. (I'm not sure why NullTextReader doesn't already override most of the virtuals, but it seems it should, for perf.) Same goes for NullStreamReader.

CC @adamsitnik 