### PR TITLE
[mono] Always store to allocas in OP_LLVM_OUTARG_VT

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -7486,7 +7486,7 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 				addresses [ins->dreg] = addresses [ins->sreg1];
 			} else {
 				if (!addresses [ins->sreg1]) {
-					addresses [ins->sreg1] = build_alloca (ctx, t);
+					addresses [ins->sreg1] = build_named_alloca (ctx, t, "llvm_outarg_vt");
 					g_assert (values [ins->sreg1]);
 					LLVMBuildStore (builder, convert (ctx, values [ins->sreg1], type_to_llvm_type (ctx, t)), addresses [ins->sreg1]);
 					addresses [ins->dreg] = addresses [ins->sreg1];
@@ -7496,6 +7496,11 @@ process_bb (EmitContext *ctx, MonoBasicBlock *bb)
 					LLVMValueRef v = LLVMBuildLoad (builder, addresses [ins->sreg1], "llvm_outarg_vt_copy");
 					LLVMBuildStore (builder, convert (ctx, v, type_to_llvm_type (ctx, t)), addresses [ins->dreg]);
 				} else {
+					if (values [ins->sreg1]) {
+						LLVMTypeRef src_t = LLVMTypeOf (values [ins->sreg1]);
+						LLVMValueRef dst = convert (ctx, addresses [ins->sreg1], LLVMPointerType (src_t, 0));
+						LLVMBuildStore (builder, values [ins->sreg1], dst);
+					}
 					addresses [ins->dreg] = addresses [ins->sreg1];
 				}
 			}

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2809,9 +2809,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/Arm/ArmBase/Yield_*/**">
             <Issue>https://github.com/dotnet/runtime/issues/64179</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/VectorExp_*/**">
-            <Issue>https://github.com/dotnet/runtime/issues/64179</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono' and ('$(RuntimeVariant)' == 'llvmfullaot' or '$(RuntimeVariant)' == 'llvmaot')">


### PR DESCRIPTION
OP_LLVM_OUTARG_VT will, for some argument passing conventions, create an
alloca and mirror its source SSA value into this alloca. If such an
OP_LLVM_OUTARG_VT is first encountered in a basic block that does not
contain the definition of the SSA value being mirrored, then sibling
basic blocks (e.g. a loop body that may sometimes be skipped) can use
garbage data if they also have OP_LLVM_OUTARG_VT opcodes referring to
the same SSA values.

This commit works around this by unconditionally storing the source
OP_LLVM_OUTARG_VT value into its associated alloca. The resulting IR
would be a little easier to read if we eagerly stored to an alloca
mirror exactly once at each value's definition, but that would require
more work to implement.

Fixes JIT/SIMD/VectorExp_ro/VectorExp_ro. See https://github.com/dotnet/runtime/issues/64179.