### PR TITLE
Add marshaler for TypeLoad failure cases

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -95,6 +95,9 @@ namespace Internal.TypeSystem.Interop
                 case MarshallerKind.OleDateTime:
                     return context.GetWellKnownType(WellKnownType.Double);
 
+                case MarshallerKind.FailedTypeLoad:
+                    return context.GetWellKnownType(WellKnownType.IntPtr);
+
                 case MarshallerKind.SafeHandle:
                 case MarshallerKind.CriticalHandle:
                     return context.GetWellKnownType(WellKnownType.IntPtr);
@@ -456,7 +459,7 @@ namespace Internal.TypeSystem.Interop
                     case NativeTypeKind.Array:
                         {
                             if (isField)
-                                return MarshallerKind.Invalid;
+                                return MarshallerKind.FailedTypeLoad;
 
                             var arrayType = (ArrayType)type;
 
@@ -583,6 +586,8 @@ namespace Internal.TypeSystem.Interop
             }
             else if (type.IsObject)
             {
+                if (nativeType == NativeTypeKind.AsAny && isField)
+                    return MarshallerKind.FailedTypeLoad;
                 if (nativeType == NativeTypeKind.AsAny)
                     return isAnsi ? MarshallerKind.AsAnyA : MarshallerKind.AsAnyW;
                 else

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.Aot.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.Aot.cs
@@ -86,6 +86,8 @@ namespace Internal.TypeSystem.Interop
                     return new OleDateTimeMarshaller();
                 case MarshallerKind.OleCurrency:
                     return new OleCurrencyMarshaller();
+                case MarshallerKind.FailedTypeLoad:
+                    return new FailedTypeLoadMarshaller();
                 case MarshallerKind.Variant:
                     return new VariantMarshaller();
                 default:
@@ -1070,6 +1072,19 @@ namespace Internal.TypeSystem.Interop
             codeStream.Emit(ILOpcode.call, emitter.NewToken(helper));
 
             StoreManagedValue(codeStream);
+        }
+    }
+
+    class FailedTypeLoadMarshaller : Marshaller
+    {
+        protected override void TransformManagedToNative(ILCodeStream codeStream)
+        {
+            ThrowHelper.ThrowTypeLoadException(ManagedType);
+        }
+
+        protected override void TransformNativeToManaged(ILCodeStream codeStream)
+        {
+            ThrowHelper.ThrowTypeLoadException(ManagedType);
         }
     }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshallerKind.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshallerKind.cs
@@ -45,6 +45,7 @@ namespace Internal.TypeSystem.Interop
         LayoutClassPtr,
         AsAnyA,
         AsAnyW,
+        FailedTypeLoad,
         ComInterface,
         BlittableValueClassWithCopyCtor,
         Invalid

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -920,13 +920,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/Callback/CallbackTests/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/206</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Array/MarshalArrayAsField/AsLPArray/AsLPArrayTest/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/168</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/176: VARIANT marshalling</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/176: VARIANT marshalling</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/ArrayWithOffset/ArrayWithOffsetTest/*">


### PR DESCRIPTION
This is marshaller used when there incorrect configuration of marshaller applied to fields mostly