### PR TITLE
[mono] Re-enable tests that call MakeGenericType with non-RuntimeType arguments

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratedCodeTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratedCodeTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Generators.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
     public class LoggerMessageGeneratedCodeTests
     {
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Generators.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/52062", TestPlatforms.Browser)]
     public class LoggerMessageGeneratorEmitterTests
     {
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Generators.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
     public class LoggerMessageGeneratorEmitterTests
     {
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Generators.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/52062", TestPlatforms.Browser)]
     public class LoggerMessageGeneratorParserTests
     {
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Generators.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
     public class LoggerMessageGeneratorParserTests
     {
         [Fact]

--- a/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
+++ b/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
@@ -44,8 +44,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
                 : base("") { }
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void ShouldSucceed()
         {
             var rb = new RegistrationBuilder();
@@ -174,8 +173,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Export(typeof(IGenericInterface<>))]
         private class ClassExportingInterface<T> : IGenericInterface<T> { }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void GenericInterfaceExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingInterface<>));
@@ -188,8 +186,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Export(typeof(GenericBaseClass<>))]
         private class ClassExportingBaseClass<T> : GenericBaseClass<T> { }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void GenericBaseClassExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingBaseClass<>));
@@ -211,8 +208,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Export(typeof(ExplicitGenericClass<>))]
         private class ExplicitGenericClass<T> { }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void ExplicitGenericExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<>));
@@ -223,8 +219,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Export(typeof(ExplicitGenericClass<,>))]
         private class ExplicitGenericClass<T, U> { }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void ExplicitGenericArity2ExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<,>));

--- a/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
+++ b/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
@@ -45,7 +45,6 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
         public void ShouldSucceed()
         {
             var rb = new RegistrationBuilder();
@@ -175,7 +174,6 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ClassExportingInterface<T> : IGenericInterface<T> { }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
         public void GenericInterfaceExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingInterface<>));
@@ -189,7 +187,6 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ClassExportingBaseClass<T> : GenericBaseClass<T> { }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
         public void GenericBaseClassExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingBaseClass<>));
@@ -212,7 +209,6 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ExplicitGenericClass<T> { }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
         public void ExplicitGenericExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<>));
@@ -224,7 +220,6 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ExplicitGenericClass<T, U> { }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestRuntimes.Mono)]
         public void ExplicitGenericArity2ExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<,>));

--- a/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
+++ b/src/libraries/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
@@ -45,6 +45,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
         public void ShouldSucceed()
         {
             var rb = new RegistrationBuilder();
@@ -174,6 +175,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ClassExportingInterface<T> : IGenericInterface<T> { }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
         public void GenericInterfaceExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingInterface<>));
@@ -187,6 +189,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ClassExportingBaseClass<T> : GenericBaseClass<T> { }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
         public void GenericBaseClassExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingBaseClass<>));
@@ -209,6 +212,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ExplicitGenericClass<T> { }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
         public void ExplicitGenericExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<>));
@@ -220,6 +224,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ExplicitGenericClass<T, U> { }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/32743", TestPlatforms.tvOS)]
         public void ExplicitGenericArity2ExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<,>));


### PR DESCRIPTION
Partially fixes https://github.com/dotnet/runtime/issues/32743

The actual fix was in https://github.com/dotnet/runtime/pull/58014

Some of the re-enabled tests failed on wasm due to https://github.com/dotnet/runtime/issues/52062, so those have been disabled here.