### PR TITLE
Vector256.IsHardwareAccelerated to return true only on AVX2

### DIFF
--- a/src/coreclr/inc/corinfoinstructionset.h
+++ b/src/coreclr/inc/corinfoinstructionset.h
@@ -426,7 +426,7 @@ inline CORINFO_InstructionSetFlags EnsureInstructionSetFlagsAreValid(CORINFO_Ins
             resultflags.RemoveInstructionSet(InstructionSet_POPCNT);
         if (resultflags.HasInstructionSet(InstructionSet_Vector128) && !resultflags.HasInstructionSet(InstructionSet_SSE))
             resultflags.RemoveInstructionSet(InstructionSet_Vector128);
-        if (resultflags.HasInstructionSet(InstructionSet_Vector256) && !resultflags.HasInstructionSet(InstructionSet_AVX2))
+        if (resultflags.HasInstructionSet(InstructionSet_Vector256) && !resultflags.HasInstructionSet(InstructionSet_AVX))
             resultflags.RemoveInstructionSet(InstructionSet_Vector256);
         if (resultflags.HasInstructionSet(InstructionSet_AVXVNNI) && !resultflags.HasInstructionSet(InstructionSet_AVX2))
             resultflags.RemoveInstructionSet(InstructionSet_AVXVNNI);

--- a/src/coreclr/inc/corinfoinstructionset.h
+++ b/src/coreclr/inc/corinfoinstructionset.h
@@ -426,7 +426,7 @@ inline CORINFO_InstructionSetFlags EnsureInstructionSetFlagsAreValid(CORINFO_Ins
             resultflags.RemoveInstructionSet(InstructionSet_POPCNT);
         if (resultflags.HasInstructionSet(InstructionSet_Vector128) && !resultflags.HasInstructionSet(InstructionSet_SSE))
             resultflags.RemoveInstructionSet(InstructionSet_Vector128);
-        if (resultflags.HasInstructionSet(InstructionSet_Vector256) && !resultflags.HasInstructionSet(InstructionSet_AVX))
+        if (resultflags.HasInstructionSet(InstructionSet_Vector256) && !resultflags.HasInstructionSet(InstructionSet_AVX2))
             resultflags.RemoveInstructionSet(InstructionSet_Vector256);
         if (resultflags.HasInstructionSet(InstructionSet_AVXVNNI) && !resultflags.HasInstructionSet(InstructionSet_AVX2))
             resultflags.RemoveInstructionSet(InstructionSet_AVXVNNI);

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -289,9 +289,9 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
     if (isHardwareAccelerated)
     {
         // Special case: Some of Vector128/256 APIs are hardware accelerated with Sse1 and Avx1,
-        // but we want IsHardwareAccelerated to return true only all of them are (there are still
-        // can be cases where e.g. Sse41 might give an additional boost for Vector128, but it's not
-        // important enought to bump the minimal Sse version here)
+        // but we want IsHardwareAccelerated to return true only when all of them are (there are
+        // still can be cases where e.g. Sse41 might give an additional boost for Vector128, but it's
+        // not important enough to bump the minimal Sse version here)
         if (strcmp(className, "Vector128") == 0)
         {
             isa = InstructionSet_SSE2;

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -285,8 +285,9 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
 
     bool isIsaSupported = comp->compSupportsHWIntrinsic(isa);
 
-    bool isHardwareAccelerated = (strcmp(methodName, "get_IsHardwareAccelerated") == 0);
-    if (isHardwareAccelerated)
+    bool isHardwareAcceleratedProp = (strcmp(methodName, "get_IsHardwareAccelerated") == 0);
+#ifdef TARGET_XARCH
+    if (isHardwareAcceleratedProp)
     {
         // Special case: Some of Vector128/256 APIs are hardware accelerated with Sse1 and Avx1,
         // but we want IsHardwareAccelerated to return true only when all of them are (there are
@@ -301,8 +302,9 @@ NamedIntrinsic HWIntrinsicInfo::lookupId(Compiler*         comp,
             isa = InstructionSet_AVX2;
         }
     }
+#endif
 
-    if ((strcmp(methodName, "get_IsSupported") == 0) || isHardwareAccelerated)
+    if ((strcmp(methodName, "get_IsSupported") == 0) || isHardwareAcceleratedProp)
     {
         return isIsaSupported ? (comp->compExactlyDependsOn(isa) ? NI_IsSupported_True : NI_IsSupported_Dynamic)
                               : NI_IsSupported_False;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -64,7 +64,7 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Muła
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_BYTES:
-            if (Avx2.IsSupported && searchSpaceMinusValueTailLength - Vector256<byte>.Count >= 0)
+            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<byte>.Count >= 0)
             {
                 // Find the last unique (which is not equal to ch1) byte
                 // the algorithm is fine if both are equal, just a little bit less efficient
@@ -212,7 +212,7 @@ namespace System
         // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Muła
         // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_BYTES:
-            if (Avx2.IsSupported && searchSpaceMinusValueTailLength >= Vector256<byte>.Count)
+            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector256<byte>.Count)
             {
                 offset = searchSpaceMinusValueTailLength - Vector256<byte>.Count;
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -70,7 +70,7 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Muła
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_CHARS:
-            if (Avx2.IsSupported && searchSpaceMinusValueTailLength - Vector256<ushort>.Count >= 0)
+            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<ushort>.Count >= 0)
             {
                 // Find the last unique (which is not equal to ch1) character
                 // the algorithm is fine if both are equal, just a little bit less efficient
@@ -231,7 +231,7 @@ namespace System
             // Based on http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd "Algorithm 1: Generic SIMD" by Wojciech Muła
             // Some details about the implementation can also be found in https://github.com/dotnet/runtime/pull/63285
         SEARCH_TWO_CHARS:
-            if (Avx2.IsSupported && searchSpaceMinusValueTailLength >= Vector256<ushort>.Count)
+            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength >= Vector256<ushort>.Count)
             {
                 offset = searchSpaceMinusValueTailLength - Vector256<ushort>.Count;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34587/Runtime_34587.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34587/Runtime_34587.cs
@@ -664,7 +664,7 @@ class Runtime_34587
         {
             bool succeeded = true;
 
-            if (Avx.IsSupported)
+            if (Avx2.IsSupported)
             {
                 succeeded &= Vector256.IsHardwareAccelerated;
                 succeeded &= Vector256<byte>.Count == 32;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/64309

`Vector128.IsHardwareAccelerated` is fine with SSE2 