### PR TITLE
Clean up RegexCode opcodes and debug-only tracing

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3353,9 +3353,9 @@ namespace System.Text.RegularExpressions.Generator
                 if (!needsCulture)
                 {
                     int[] codes = rm.Code.Codes;
-                    for (int codepos = 0; codepos < codes.Length; codepos += RegexCode.OpcodeSize(codes[codepos]))
+                    for (int codepos = 0; codepos < codes.Length; codepos += RegexCode.OpcodeSize((RegexOpcode)codes[codepos]))
                     {
-                        if ((codes[codepos] & RegexCode.Ci) == RegexCode.Ci)
+                        if (((RegexOpcode)codes[codepos] & RegexOpcode.CaseInsensitive) == RegexOpcode.CaseInsensitive)
                         {
                             needsCulture = true;
                             break;
@@ -3710,7 +3710,7 @@ namespace System.Text.RegularExpressions.Generator
                 RegexCharClass.NotWordClass => "any character other than a word character",
                 RegexCharClass.SpaceClass => "a whitespace character",
                 RegexCharClass.WordClass => "a word character",
-                _ => $"a character in the set {RegexCharClass.SetDescription(charClass)}",
+                _ => $"a character in the set {RegexCharClass.DescribeSet(charClass)}",
             };
 
         /// <summary>Writes a textual description of the node tree fit for rending in source.</summary>

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -150,19 +150,16 @@ namespace System.Text.RegularExpressions.Generator
 
             // Validate the options
             const RegexOptions SupportedOptions =
-                RegexOptions.IgnoreCase |
-                RegexOptions.Multiline |
-                RegexOptions.ExplicitCapture |
                 RegexOptions.Compiled |
-                RegexOptions.Singleline |
-                RegexOptions.IgnorePatternWhitespace |
-                RegexOptions.RightToLeft |
-#if DEBUG
-                RegexOptions.Debug |
-#endif
-                RegexOptions.ECMAScript |
                 RegexOptions.CultureInvariant |
-                RegexOptions.NonBacktracking;
+                RegexOptions.ECMAScript |
+                RegexOptions.ExplicitCapture |
+                RegexOptions.IgnoreCase |
+                RegexOptions.IgnorePatternWhitespace |
+                RegexOptions.Multiline |
+                RegexOptions.NonBacktracking |
+                RegexOptions.RightToLeft |
+                RegexOptions.Singleline;
             if ((regexOptions & ~SupportedOptions) != 0)
             {
                 return Diagnostic.Create(DiagnosticDescriptors.InvalidRegexArguments, methodSyntax.GetLocation(), "options");

--- a/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
+++ b/src/libraries/System.Text.RegularExpressions/gen/System.Text.RegularExpressions.Generator.csproj
@@ -36,6 +36,7 @@
     <Compile Include="..\src\System\Text\RegularExpressions\RegexFindOptimizations.cs" Link="Production\RegexFindOptimizations.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexNode.cs" Link="Production\RegexNode.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexNodeKind.cs" Link="Production\RegexNodeKind.cs" />
+    <Compile Include="..\src\System\Text\RegularExpressions\RegexOpcode.cs" Link="Production\RegexOpcode.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexOptions.cs" Link="Production\RegexOptions.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexParseError.cs" Link="Production\RegexParseError.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexParseException.cs" Link="Production\RegexParseException.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -34,6 +34,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexMatchTimeoutException.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexNode.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexNodeKind.cs" />
+    <Compile Include="System\Text\RegularExpressions\RegexOpcode.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexOptions.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexParseError.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexParseException.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -329,31 +329,6 @@ namespace System.Text.RegularExpressions
 
             _balancing = false;
         }
-
-#if DEBUG
-        [ExcludeFromCodeCoverage(Justification = "Debug only")]
-        internal bool IsDebug => _regex != null && _regex.IsDebug;
-
-        internal virtual void Dump()
-        {
-            for (int i = 0; i < _matchcount.Length; i++)
-            {
-                Debug.WriteLine($"Capnum {i}:");
-
-                for (int j = 0; j < _matchcount[i]; j++)
-                {
-                    string text = "";
-
-                    if (_matches[i][j * 2] >= 0)
-                    {
-                        text = Text.Substring(_matches[i][j * 2], _matches[i][j * 2 + 1]);
-                    }
-
-                    Debug.WriteLine($"  ({_matches[i][j * 2]},{_matches[i][j * 2 + 1]}) {text}");
-                }
-            }
-        }
-#endif
     }
 
     /// <summary>
@@ -361,8 +336,7 @@ namespace System.Text.RegularExpressions
     /// </summary>
     internal sealed class MatchSparse : Match
     {
-        // the lookup hashtable
-        internal new readonly Hashtable _caps;
+        private new readonly Hashtable _caps;
 
         internal MatchSparse(Regex regex, Hashtable caps, int capcount, string text, int begpos, int len, int startpos) :
             base(regex, capcount, text, begpos, len, startpos)
@@ -371,22 +345,5 @@ namespace System.Text.RegularExpressions
         }
 
         public override GroupCollection Groups => _groupcoll ??= new GroupCollection(this, _caps);
-
-#if DEBUG
-        [ExcludeFromCodeCoverage(Justification = "Debug only")]
-        internal override void Dump()
-        {
-            if (_caps != null)
-            {
-                foreach (object? entry in _caps)
-                {
-                    DictionaryEntry kvp = (DictionaryEntry)entry!;
-                    Debug.WriteLine($"Slot {kvp.Key} -> {kvp.Value}");
-                }
-            }
-
-            base.Dump();
-        }
-#endif
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if DEBUG
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.RegularExpressions.Symbolic;
@@ -11,16 +12,17 @@ namespace System.Text.RegularExpressions
 {
     public partial class Regex
     {
-        /// <summary>True if the regex has debugging enabled.</summary>
+        /// <summary>True if debug tracing should be enabled, only in debug builds.</summary>
         [ExcludeFromCodeCoverage(Justification = "Debug only")]
-        internal bool IsDebug
+        internal static bool EnableDebugTracing
         {
             // These members aren't used from IsDebug, but we want to keep them in debug builds for now,
-            // so this is a convient place to include them rather than needing a debug-only illink file.
+            // so this is a convenient place to include them rather than needing a debug-only illink file.
             [DynamicDependency(nameof(SaveDGML))]
             [DynamicDependency(nameof(GenerateUnicodeTables))]
             [DynamicDependency(nameof(GenerateRandomMembers))]
-            get => (roptions & RegexOptions.Debug) != 0;
+            get;
+            set;
         }
 
         /// <summary>Unwind the regex and save the resulting state graph in DGML</summary>
@@ -62,7 +64,7 @@ namespace System.Text.RegularExpressions
         /// <param name="negative">if true then generate inputs that do not match</param>
         /// <returns></returns>
         [ExcludeFromCodeCoverage(Justification = "Debug only")]
-        internal Collections.Generic.IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative)
+        internal IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative)
         {
             if (factory is not SymbolicRegexRunnerFactory srmFactory)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -110,13 +110,6 @@ namespace System.Text.RegularExpressions
             internalMatchTimeout = matchTimeout;
             roptions = options;
 
-#if DEBUG
-            if (IsDebug)
-            {
-                Debug.WriteLine($"Pattern: {pattern}    Options: {options & ~RegexOptions.Debug}    Timeout: {(matchTimeout == InfiniteMatchTimeout ? "infinite" : matchTimeout.ToString())}");
-            }
-#endif
-
             // Parse the input
             RegexTree tree = RegexParser.Parse(pattern, roptions, culture);
 
@@ -153,11 +146,7 @@ namespace System.Text.RegularExpressions
         {
             if (((((uint)options) >> MaxOptionShift) != 0) ||
                 ((options & RegexOptions.ECMAScript) != 0 &&
-                 (options & ~(RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.NonBacktracking |
-#if DEBUG
-                             RegexOptions.Debug |
-#endif
-                             RegexOptions.CultureInvariant)) != 0))
+                 (options & ~(RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled | RegexOptions.NonBacktracking | RegexOptions.CultureInvariant)) != 0))
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.options);
             }
@@ -394,12 +383,7 @@ namespace System.Text.RegularExpressions
             RegexRunner runner = Interlocked.Exchange(ref _runner, null) ?? CreateRunner();
             try
             {
-                // Do the scan starting at the requested position
-                Match? match = runner.Scan(this, input, beginning, beginning + length, startat, prevlen, quick, internalMatchTimeout);
-#if DEBUG
-                if (IsDebug) match?.Dump();
-#endif
-                return match;
+                return runner.Scan(this, input, beginning, beginning + length, startat, prevlen, quick, internalMatchTimeout);
             }
             finally
             {
@@ -410,6 +394,7 @@ namespace System.Text.RegularExpressions
         internal void Run<TState>(string input, int startat, ref TState state, MatchCallback<TState> callback, bool reuseMatchObject)
         {
             Debug.Assert((uint)startat <= (uint)input.Length);
+
             RegexRunner runner = Interlocked.Exchange(ref _runner, null) ?? CreateRunner();
             try
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1815,7 +1815,7 @@ namespace System.Text.RegularExpressions
         /// Produces a human-readable description for a set string.
         /// </summary>
         [ExcludeFromCodeCoverage]
-        public static string SetDescription(string set)
+        public static string DescribeSet(string set)
         {
             int setLength = set[SetLengthIndex];
             int categoryLength = set[CategoryLengthIndex];
@@ -1841,7 +1841,7 @@ namespace System.Text.RegularExpressions
                     (char)(set[index + 1] - 1) :
                     LastChar;
 
-                desc.Append(CharDescription(ch1));
+                desc.Append(DescribeChar(ch1));
 
                 if (ch2 != ch1)
                 {
@@ -1850,7 +1850,7 @@ namespace System.Text.RegularExpressions
                         desc.Append('-');
                     }
 
-                    desc.Append(CharDescription(ch2));
+                    desc.Append(DescribeChar(ch2));
                 }
                 index += 2;
             }
@@ -1899,7 +1899,7 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
-                    desc.Append(CategoryDescription(ch1));
+                    desc.Append(DescribeCategory(ch1));
                 }
 
                 index++;
@@ -1907,7 +1907,7 @@ namespace System.Text.RegularExpressions
 
             if (set.Length > endPosition)
             {
-                desc.Append('-').Append(SetDescription(set.Substring(endPosition)));
+                desc.Append('-').Append(DescribeSet(set.Substring(endPosition)));
             }
 
             return desc.Append(']').ToString();
@@ -1915,7 +1915,7 @@ namespace System.Text.RegularExpressions
 
         /// <summary>Produces a human-readable description for a single character.</summary>
         [ExcludeFromCodeCoverage]
-        public static string CharDescription(char ch) =>
+        public static string DescribeChar(char ch) =>
             ch switch
             {
                 '\a' => "\\a",
@@ -1931,7 +1931,7 @@ namespace System.Text.RegularExpressions
             };
 
         [ExcludeFromCodeCoverage]
-        private static string CategoryDescription(char ch) =>
+        private static string DescribeCategory(char ch) =>
             (short)ch switch
             {
                 SpaceConst => @"\s",

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -110,8 +110,8 @@ namespace System.Text.RegularExpressions
                 case RegexOpcode.One:
                 case RegexOpcode.Notone:
                 case RegexOpcode.Multi:
-                case RegexOpcode.Ref:
-                case RegexOpcode.Testref:
+                case RegexOpcode.Backreference:
+                case RegexOpcode.TestBackreference:
                 case RegexOpcode.Goto:
                 case RegexOpcode.Nullcount:
                 case RegexOpcode.Setcount:
@@ -206,8 +206,8 @@ namespace System.Text.RegularExpressions
                     sb.Append(Indent()).Append('"').Append(Strings[Codes[opcodeOffset + 1]]).Append('"');
                     break;
 
-                case RegexOpcode.Ref:
-                case RegexOpcode.Testref:
+                case RegexOpcode.Backreference:
+                case RegexOpcode.TestBackreference:
                     sb.Append(Indent()).Append("index = ").Append(Codes[opcodeOffset + 1]);
                     break;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -1,18 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// This RegexCode class is internal to the regular expression package.
-
-// Implementation notes:
-//
-// Regexps are built into RegexCodes, which contain an operation array,
-// a string table, and some constants.
-//
-// Each operation is one of the codes below, followed by the integer
-// operands specified for each op.
-//
-// Strings and sets are indices into a string table.
-
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -20,92 +8,30 @@ using System.Globalization;
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>Representation of a regular expression, written by <see cref="RegexWriter"/> and containing the code evaluated by <see cref="RegexInterpreter"/>.</summary>
+    /// <remarks>It currently stores some data used by engines other than the interpreter; that can be refactored out in the future.</remarks>
     internal sealed class RegexCode
     {
-        // The following primitive operations come directly from the parser
-
-                                                  // lef/back operands        description
-        public const int Onerep = 0;              // lef,back char,min,max    a {n}
-        public const int Notonerep = 1;           // lef,back char,min,max    .{n}
-        public const int Setrep = 2;              // lef,back set,min,max     [\d]{n}
-
-        public const int Oneloop = 3;             // lef,back char,min,max    a {,n}
-        public const int Notoneloop = 4;          // lef,back char,min,max    .{,n}
-        public const int Setloop = 5;             // lef,back set,min,max     [\d]{,n}
-
-        public const int Onelazy = 6;             // lef,back char,min,max    a {,n}?
-        public const int Notonelazy = 7;          // lef,back char,min,max    .{,n}?
-        public const int Setlazy = 8;             // lef,back set,min,max     [\d]{,n}?
-
-        public const int One = 9;                 // lef      char            a
-        public const int Notone = 10;             // lef      char            [^a]
-        public const int Set = 11;                // lef      set             [a-z\s]  \w \s \d
-
-        public const int Multi = 12;              // lef      string          abcd
-        public const int Ref = 13;                // lef      group           \#
-
-        public const int Bol = 14;                //                          ^
-        public const int Eol = 15;                //                          $
-        public const int Boundary = 16;           //                          \b
-        public const int NonBoundary = 17;        //                          \B
-        public const int Beginning = 18;          //                          \A
-        public const int Start = 19;              //                          \G
-        public const int EndZ = 20;               //                          \Z
-        public const int End = 21;                //                          \Z
-
-        public const int Nothing = 22;            //                          Reject!
-
-        // Primitive control structures
-
-        public const int Lazybranch = 23;         // back     jump            straight first
-        public const int Branchmark = 24;         // back     jump            branch first for loop
-        public const int Lazybranchmark = 25;     // back     jump            straight first for loop
-        public const int Nullcount = 26;          // back     val             set counter, null mark
-        public const int Setcount = 27;           // back     val             set counter, make mark
-        public const int Branchcount = 28;        // back     jump,limit      branch++ if zero<=c<limit
-        public const int Lazybranchcount = 29;    // back     jump,limit      same, but straight first
-        public const int Nullmark = 30;           // back                     save position
-        public const int Setmark = 31;            // back                     save position
-        public const int Capturemark = 32;        // back     group           define group
-        public const int Getmark = 33;            // back                     recall position
-        public const int Setjump = 34;            // back                     save backtrack state
-        public const int Backjump = 35;           //                          zap back to saved state
-        public const int Forejump = 36;           //                          zap backtracking state
-        public const int Testref = 37;            //                          backtrack if ref undefined
-        public const int Goto = 38;               //          jump            just go
-
-        public const int Stop = 40;               //                          done!
-
-        public const int ECMABoundary = 41;       //                          \b
-        public const int NonECMABoundary = 42;    //                          \B
-
-        // Manufactured primitive operations, derived from the tree that comes from the parser.
-        // These exist to reduce backtracking (both actually performing it and spitting code for it).
-
-        public const int Oneloopatomic = 43;      // lef,back char,min,max    (?> a {,n} )
-        public const int Notoneloopatomic = 44;   // lef,back set,min,max     (?> . {,n} )
-        public const int Setloopatomic = 45;      // lef,back set,min,max     (?> [\d]{,n} )
-        public const int UpdateBumpalong = 46;    // updates the bumpalong position to the current position
-
-        // Modifiers for alternate modes
-        public const int Mask = 63;   // Mask to get unmodified ordinary operator
-        public const int Rtl = 64;    // bit to indicate that we're reverse scanning.
-        public const int Back = 128;  // bit to indicate that we're backtracking.
-        public const int Back2 = 256; // bit to indicate that we're backtracking on a second branch.
-        public const int Ci = 512;    // bit to indicate that we're case-insensitive.
-
-        public readonly RegexTree Tree;                                                 // the optimized parse tree
-        public readonly int[] Codes;                                                    // the code
-        public readonly string[] Strings;                                               // the string/set table
-        public readonly uint[]?[] StringsAsciiLookup;                                   // the ASCII lookup table optimization for the sets in Strings
-        public readonly int TrackCount;                                                 // how many instructions use backtracking
-        public readonly Hashtable? Caps;                                                // mapping of user group numbers -> impl group slots
-        public readonly int CapSize;                                                    // number of impl group slots
-        public readonly bool RightToLeft;                                               // true if right to left
+        /// <summary>The optimized parse tree.</summary>
+        public readonly RegexTree Tree;
+        /// <summary>RegexOpcodes and arguments written by <see cref="RegexWriter"/>.</summary>
+        public readonly int[] Codes;
+        /// <summary>The string / set table. <see cref="Codes"/> includes offsets into this table, for string and set arguments.</summary>
+        public readonly string[] Strings;
+        /// <summary>ASCII lookup table optimization for sets in <see cref="Strings"/>.</summary>
+        public readonly uint[]?[] StringsAsciiLookup;
+        /// <summary>How many instructions in <see cref="Codes"/> use backtracking.</summary>
+        public readonly int TrackCount;
+        /// <summary>Mapping of user group numbers to impl group slots.</summary>
+        public readonly Hashtable? Caps;
+        /// <summary>Number of impl group slots.</summary>
+        public readonly int CapSize;
+        /// <summary>True if right to left.</summary>
+        public readonly bool RightToLeft;
+        /// <summary>Optimization mode and supporting data to enable quickly finding the next possible match location.</summary>
         public readonly RegexFindOptimizations FindOptimizations;
 
-        public RegexCode(RegexTree tree, CultureInfo culture, int[] codes, string[] strings, int trackcount,
-                         Hashtable? caps, int capsize)
+        public RegexCode(RegexTree tree, CultureInfo culture, int[] codes, string[] strings, int trackcount, Hashtable? caps, int capsize)
         {
             Tree = tree;
             Codes = codes;
@@ -118,32 +44,33 @@ namespace System.Text.RegularExpressions
             FindOptimizations = new RegexFindOptimizations(tree, culture);
         }
 
-        public static bool OpcodeBacktracks(int Op)
+        /// <summary>Gets whether the specified opcode may incur backtracking.</summary>
+        public static bool OpcodeBacktracks(RegexOpcode opcode)
         {
-            Op &= Mask;
+            opcode &= RegexOpcode.OperatorMask;
 
-            switch (Op)
+            switch (opcode)
             {
-                case Oneloop:
-                case Notoneloop:
-                case Setloop:
-                case Onelazy:
-                case Notonelazy:
-                case Setlazy:
-                case Lazybranch:
-                case Branchmark:
-                case Lazybranchmark:
-                case Nullcount:
-                case Setcount:
-                case Branchcount:
-                case Lazybranchcount:
-                case Setmark:
-                case Capturemark:
-                case Getmark:
-                case Setjump:
-                case Backjump:
-                case Forejump:
-                case Goto:
+                case RegexOpcode.Oneloop:
+                case RegexOpcode.Onelazy:
+                case RegexOpcode.Notoneloop:
+                case RegexOpcode.Notonelazy:
+                case RegexOpcode.Setloop:
+                case RegexOpcode.Setlazy:
+                case RegexOpcode.Lazybranch:
+                case RegexOpcode.Branchmark:
+                case RegexOpcode.Lazybranchmark:
+                case RegexOpcode.Nullcount:
+                case RegexOpcode.Setcount:
+                case RegexOpcode.Branchcount:
+                case RegexOpcode.Lazybranchcount:
+                case RegexOpcode.Setmark:
+                case RegexOpcode.Capturemark:
+                case RegexOpcode.Getmark:
+                case RegexOpcode.Setjump:
+                case RegexOpcode.Backjump:
+                case RegexOpcode.Forejump:
+                case RegexOpcode.Goto:
                     return true;
 
                 default:
@@ -151,265 +78,188 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        public static int OpcodeSize(int opcode)
+        /// <summary>Gets the number of integers required to store an operation represented by the specified opcode (including the opcode).</summary>
+        /// <returns>Values range from 1 (just the opcode) to 3 (the opcode plus up to two operands).</returns>
+        public static int OpcodeSize(RegexOpcode opcode)
         {
-            opcode &= Mask;
-
+            opcode &= RegexOpcode.OperatorMask;
             switch (opcode)
             {
-                case Nothing:
-                case Bol:
-                case Eol:
-                case Boundary:
-                case NonBoundary:
-                case ECMABoundary:
-                case NonECMABoundary:
-                case Beginning:
-                case Start:
-                case EndZ:
-                case End:
-                case Nullmark:
-                case Setmark:
-                case Getmark:
-                case Setjump:
-                case Backjump:
-                case Forejump:
-                case Stop:
-                case UpdateBumpalong:
+                case RegexOpcode.Nothing:
+                case RegexOpcode.Bol:
+                case RegexOpcode.Eol:
+                case RegexOpcode.Boundary:
+                case RegexOpcode.NonBoundary:
+                case RegexOpcode.ECMABoundary:
+                case RegexOpcode.NonECMABoundary:
+                case RegexOpcode.Beginning:
+                case RegexOpcode.Start:
+                case RegexOpcode.EndZ:
+                case RegexOpcode.End:
+                case RegexOpcode.Nullmark:
+                case RegexOpcode.Setmark:
+                case RegexOpcode.Getmark:
+                case RegexOpcode.Setjump:
+                case RegexOpcode.Backjump:
+                case RegexOpcode.Forejump:
+                case RegexOpcode.Stop:
+                case RegexOpcode.UpdateBumpalong:
+                    // The opcode has no operands.
                     return 1;
 
-                case One:
-                case Notone:
-                case Multi:
-                case Ref:
-                case Testref:
-                case Goto:
-                case Nullcount:
-                case Setcount:
-                case Lazybranch:
-                case Branchmark:
-                case Lazybranchmark:
-                case Set:
+                case RegexOpcode.One:
+                case RegexOpcode.Notone:
+                case RegexOpcode.Multi:
+                case RegexOpcode.Ref:
+                case RegexOpcode.Testref:
+                case RegexOpcode.Goto:
+                case RegexOpcode.Nullcount:
+                case RegexOpcode.Setcount:
+                case RegexOpcode.Lazybranch:
+                case RegexOpcode.Branchmark:
+                case RegexOpcode.Lazybranchmark:
+                case RegexOpcode.Set:
+                    // The opcode has one operand.
                     return 2;
 
-                case Capturemark:
-                case Branchcount:
-                case Lazybranchcount:
-                case Onerep:
-                case Notonerep:
-                case Oneloop:
-                case Oneloopatomic:
-                case Notoneloop:
-                case Notoneloopatomic:
-                case Onelazy:
-                case Notonelazy:
-                case Setlazy:
-                case Setrep:
-                case Setloop:
-                case Setloopatomic:
+                case RegexOpcode.Capturemark:
+                case RegexOpcode.Branchcount:
+                case RegexOpcode.Lazybranchcount:
+                case RegexOpcode.Onerep:
+                case RegexOpcode.Notonerep:
+                case RegexOpcode.Oneloop:
+                case RegexOpcode.Oneloopatomic:
+                case RegexOpcode.Notoneloop:
+                case RegexOpcode.Notoneloopatomic:
+                case RegexOpcode.Onelazy:
+                case RegexOpcode.Notonelazy:
+                case RegexOpcode.Setlazy:
+                case RegexOpcode.Setrep:
+                case RegexOpcode.Setloop:
+                case RegexOpcode.Setloopatomic:
+                    // The opcode has two operands.
                     return 3;
 
                 default:
-                    Debug.Fail($"Unexpected opcode: {opcode}");
-                    return 0;
+                    Debug.Fail($"Unknown opcode: {opcode}");
+                    goto case RegexOpcode.Stop;
             }
-        }
-
-        [ExcludeFromCodeCoverage]
-        private static string OperatorDescription(int Opcode)
-        {
-            string codeStr = (Opcode & Mask) switch
-            {
-                Onerep => nameof(Onerep),
-                Notonerep => nameof(Notonerep),
-                Setrep => nameof(Setrep),
-                Oneloop => nameof(Oneloop),
-                Notoneloop => nameof(Notoneloop),
-                Setloop => nameof(Setloop),
-                Onelazy => nameof(Onelazy),
-                Notonelazy => nameof(Notonelazy),
-                Setlazy => nameof(Setlazy),
-                One => nameof(One),
-                Notone => nameof(Notone),
-                Set => nameof(Set),
-                Multi => nameof(Multi),
-                Ref => nameof(Ref),
-                Bol => nameof(Bol),
-                Eol => nameof(Eol),
-                Boundary => nameof(Boundary),
-                NonBoundary => nameof(NonBoundary),
-                Beginning => nameof(Beginning),
-                Start => nameof(Start),
-                EndZ => nameof(EndZ),
-                End => nameof(End),
-                Nothing => nameof(Nothing),
-                Lazybranch => nameof(Lazybranch),
-                Branchmark => nameof(Branchmark),
-                Lazybranchmark => nameof(Lazybranchmark),
-                Nullcount => nameof(Nullcount),
-                Setcount => nameof(Setcount),
-                Branchcount => nameof(Branchcount),
-                Lazybranchcount => nameof(Lazybranchcount),
-                Nullmark => nameof(Nullmark),
-                Setmark => nameof(Setmark),
-                Capturemark => nameof(Capturemark),
-                Getmark => nameof(Getmark),
-                Setjump => nameof(Setjump),
-                Backjump => nameof(Backjump),
-                Forejump => nameof(Forejump),
-                Testref => nameof(Testref),
-                Goto => nameof(Goto),
-                Stop => nameof(Stop),
-                ECMABoundary => nameof(ECMABoundary),
-                NonECMABoundary => nameof(NonECMABoundary),
-                Oneloopatomic => nameof(Oneloopatomic),
-                Notoneloopatomic => nameof(Notoneloopatomic),
-                Setloopatomic => nameof(Setloopatomic),
-                UpdateBumpalong => nameof(UpdateBumpalong),
-                _ => "(unknown)"
-            };
-
-            return
-                codeStr +
-                ((Opcode & Ci) != 0 ? "-Ci" : "") +
-                ((Opcode & Rtl) != 0 ? "-Rtl" : "") +
-                ((Opcode & Back) != 0 ? "-Back" : "") +
-                ((Opcode & Back2) != 0 ? "-Back2" : "");
-        }
-
-        [ExcludeFromCodeCoverage]
-        internal string OpcodeDescription(int offset) => OpcodeDescription(offset, Codes, Strings);
-
-        [ExcludeFromCodeCoverage]
-        internal static string OpcodeDescription(int offset, int[] codes, string[] strings)
-        {
-            var sb = new StringBuilder();
-            int opcode = codes[offset];
-
-            sb.Append($"{offset:D6} ");
-            sb.Append(OpcodeBacktracks(opcode & Mask) ? '*' : ' ');
-            sb.Append(OperatorDescription(opcode));
-
-            opcode &= Mask;
-
-            switch (opcode)
-            {
-                case One:
-                case Notone:
-                case Onerep:
-                case Notonerep:
-                case Oneloop:
-                case Oneloopatomic:
-                case Notoneloop:
-                case Notoneloopatomic:
-                case Onelazy:
-                case Notonelazy:
-                    sb.Append(Indent()).Append('\'').Append(RegexCharClass.CharDescription((char)codes[offset + 1])).Append('\'');
-                    break;
-
-                case Set:
-                case Setrep:
-                case Setloop:
-                case Setloopatomic:
-                case Setlazy:
-                    sb.Append(Indent()).Append(RegexCharClass.SetDescription(strings[codes[offset + 1]]));
-                    break;
-
-                case Multi:
-                    sb.Append(Indent()).Append('"').Append(strings[codes[offset + 1]]).Append('"');
-                    break;
-
-                case Ref:
-                case Testref:
-                    sb.Append(Indent()).Append("index = ").Append(codes[offset + 1]);
-                    break;
-
-                case Capturemark:
-                    sb.Append(Indent()).Append("index = ").Append(codes[offset + 1]);
-                    if (codes[offset + 2] != -1)
-                    {
-                        sb.Append(", unindex = ").Append(codes[offset + 2]);
-                    }
-                    break;
-
-                case Nullcount:
-                case Setcount:
-                    sb.Append(Indent()).Append("value = ").Append(codes[offset + 1]);
-                    break;
-
-                case Goto:
-                case Lazybranch:
-                case Branchmark:
-                case Lazybranchmark:
-                case Branchcount:
-                case Lazybranchcount:
-                    sb.Append(Indent()).Append("addr = ").Append(codes[offset + 1]);
-                    break;
-            }
-
-            switch (opcode)
-            {
-                case Onerep:
-                case Notonerep:
-                case Oneloop:
-                case Oneloopatomic:
-                case Notoneloop:
-                case Notoneloopatomic:
-                case Onelazy:
-                case Notonelazy:
-                case Setrep:
-                case Setloop:
-                case Setloopatomic:
-                case Setlazy:
-                    sb.Append(", rep = ");
-                    if (codes[offset + 2] == int.MaxValue)
-                    {
-                        sb.Append("inf");
-                    }
-                    else
-                    {
-                        sb.Append(codes[offset + 2]);
-                    }
-                    break;
-
-                case Branchcount:
-                case Lazybranchcount:
-                    sb.Append(", limit = ");
-                    if (codes[offset + 2] == int.MaxValue)
-                    {
-                        sb.Append("inf");
-                    }
-                    else
-                    {
-                        sb.Append(codes[offset + 2]);
-                    }
-                    break;
-            }
-
-            string Indent() => new string(' ', Math.Max(1, 25 - sb.Length));
-
-            return sb.ToString();
         }
 
 #if DEBUG
-        [ExcludeFromCodeCoverage]
-        public void Dump() => Debug.WriteLine(ToString());
-
         [ExcludeFromCodeCoverage]
         public override string ToString()
         {
             var sb = new StringBuilder();
 
-            sb.AppendLine($"Direction:  {(RightToLeft ? "right-to-left" : "left-to-right")}");
-            sb.AppendLine($"Anchor:     {FindOptimizations.LeadingAnchor}");
+            sb.AppendLine($"Direction: {(RightToLeft ? "right-to-left" : "left-to-right")}");
+            sb.AppendLine($"Anchor:    {FindOptimizations.LeadingAnchor}");
             sb.AppendLine();
-            for (int i = 0; i < Codes.Length; i += OpcodeSize(Codes[i]))
+            for (int i = 0; i < Codes.Length; i += OpcodeSize((RegexOpcode)Codes[i]))
             {
-                sb.AppendLine(OpcodeDescription(i));
+                sb.AppendLine(DescribeInstruction(i));
             }
-            sb.AppendLine();
 
             return sb.ToString();
+        }
+
+        [ExcludeFromCodeCoverage]
+        internal string DescribeInstruction(int opcodeOffset)
+        {
+            RegexOpcode opcode = (RegexOpcode)Codes[opcodeOffset];
+
+            var sb = new StringBuilder();
+            sb.Append($"{opcodeOffset:D6} ");
+            sb.Append(OpcodeBacktracks(opcode & RegexOpcode.OperatorMask) ? '~' : ' ');
+            sb.Append(opcode & RegexOpcode.OperatorMask);
+            if ((opcode & RegexOpcode.CaseInsensitive) != 0) sb.Append("-Ci");
+            if ((opcode & RegexOpcode.RightToLeft) != 0) sb.Append("-Rtl");
+            if ((opcode & RegexOpcode.Backtracking) != 0) sb.Append("-Back");
+            if ((opcode & RegexOpcode.BacktrackingSecond) != 0) sb.Append("-Back2");
+
+            opcode &= RegexOpcode.OperatorMask;
+
+            switch (opcode)
+            {
+                case RegexOpcode.One:
+                case RegexOpcode.Onerep:
+                case RegexOpcode.Oneloop:
+                case RegexOpcode.Oneloopatomic:
+                case RegexOpcode.Onelazy:
+                case RegexOpcode.Notone:
+                case RegexOpcode.Notonerep:
+                case RegexOpcode.Notoneloop:
+                case RegexOpcode.Notoneloopatomic:
+                case RegexOpcode.Notonelazy:
+                    sb.Append(Indent()).Append('\'').Append(RegexCharClass.DescribeChar((char)Codes[opcodeOffset + 1])).Append('\'');
+                    break;
+
+                case RegexOpcode.Set:
+                case RegexOpcode.Setrep:
+                case RegexOpcode.Setloop:
+                case RegexOpcode.Setloopatomic:
+                case RegexOpcode.Setlazy:
+                    sb.Append(Indent()).Append(RegexCharClass.DescribeSet(Strings[Codes[opcodeOffset + 1]]));
+                    break;
+
+                case RegexOpcode.Multi:
+                    sb.Append(Indent()).Append('"').Append(Strings[Codes[opcodeOffset + 1]]).Append('"');
+                    break;
+
+                case RegexOpcode.Ref:
+                case RegexOpcode.Testref:
+                    sb.Append(Indent()).Append("index = ").Append(Codes[opcodeOffset + 1]);
+                    break;
+
+                case RegexOpcode.Capturemark:
+                    sb.Append(Indent()).Append("index = ").Append(Codes[opcodeOffset + 1]);
+                    if (Codes[opcodeOffset + 2] != -1)
+                    {
+                        sb.Append(", unindex = ").Append(Codes[opcodeOffset + 2]);
+                    }
+                    break;
+
+                case RegexOpcode.Nullcount:
+                case RegexOpcode.Setcount:
+                    sb.Append(Indent()).Append("value = ").Append(Codes[opcodeOffset + 1]);
+                    break;
+
+                case RegexOpcode.Goto:
+                case RegexOpcode.Lazybranch:
+                case RegexOpcode.Branchmark:
+                case RegexOpcode.Lazybranchmark:
+                case RegexOpcode.Branchcount:
+                case RegexOpcode.Lazybranchcount:
+                    sb.Append(Indent()).Append("addr = ").Append(Codes[opcodeOffset + 1]);
+                    break;
+            }
+
+            switch (opcode)
+            {
+                case RegexOpcode.Onerep:
+                case RegexOpcode.Oneloop:
+                case RegexOpcode.Oneloopatomic:
+                case RegexOpcode.Onelazy:
+                case RegexOpcode.Notonerep:
+                case RegexOpcode.Notoneloop:
+                case RegexOpcode.Notoneloopatomic:
+                case RegexOpcode.Notonelazy:
+                case RegexOpcode.Setrep:
+                case RegexOpcode.Setloop:
+                case RegexOpcode.Setloopatomic:
+                case RegexOpcode.Setlazy:
+                    sb.Append(", rep = ").Append(Codes[opcodeOffset + 2] == int.MaxValue ? "inf" : Codes[opcodeOffset + 2]);
+                    break;
+
+                case RegexOpcode.Branchcount:
+                case RegexOpcode.Lazybranchcount:
+                    sb.Append(", limit = ").Append(Codes[opcodeOffset + 2] == int.MaxValue ? "inf" : Codes[opcodeOffset + 2]);
+                    break;
+            }
+
+            return sb.ToString();
+
+            string Indent() => new string(' ', Math.Max(1, 25 - sb.Length));
         }
 #endif
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -3934,9 +3934,9 @@ namespace System.Text.RegularExpressions
                 if (!needsCulture)
                 {
                     int[] codes = _code!.Codes;
-                    for (int codepos = 0; codepos < codes.Length; codepos += RegexCode.OpcodeSize(codes[codepos]))
+                    for (int codepos = 0; codepos < codes.Length; codepos += RegexCode.OpcodeSize((RegexOpcode)codes[codepos]))
                     {
-                        if ((codes[codepos] & RegexCode.Ci) == RegexCode.Ci)
+                        if (((RegexOpcode)codes[codepos] & RegexOpcode.CaseInsensitive) == RegexOpcode.CaseInsensitive)
                         {
                             needsCulture = true;
                             break;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -16,7 +16,7 @@ namespace System.Text.RegularExpressions
         private readonly RegexCode _code;
         private readonly TextInfo _textInfo;
 
-        private int _operator;
+        private RegexOpcode _operator;
         private int _codepos;
         private bool _rightToLeft;
         private bool _caseInsensitive;
@@ -35,7 +35,7 @@ namespace System.Text.RegularExpressions
         private void Advance(int i)
         {
             _codepos += i + 1;
-            SetOperator(_code.Codes[_codepos]);
+            SetOperator((RegexOpcode)_code.Codes[_codepos]);
         }
 
         private void Goto(int newpos)
@@ -47,7 +47,7 @@ namespace System.Text.RegularExpressions
             }
 
             _codepos = newpos;
-            SetOperator(_code.Codes[newpos]);
+            SetOperator((RegexOpcode)_code.Codes[newpos]);
         }
 
         private void Trackto(int newpos) => runtrackpos = runtrack!.Length - newpos;
@@ -122,21 +122,16 @@ namespace System.Text.RegularExpressions
             runtrackpos++;
 
 #if DEBUG
-            if (runmatch!.IsDebug)
-            {
-                Debug.WriteLine(newpos < 0 ?
-                    $"       Backtracking (back2) to code position {-newpos}" :
-                    $"       Backtracking to code position {newpos}");
-            }
+            Debug.WriteLineIf(Regex.EnableDebugTracing, $"       Backtracking{(newpos < 0 ? " (back2)" : "")} to code position {Math.Abs(newpos)}");
 #endif
 
-            int back = RegexCode.Back;
+            int back = (int)RegexOpcode.Backtracking;
             if (newpos < 0)
             {
                 newpos = -newpos;
-                back = RegexCode.Back2;
+                back = (int)RegexOpcode.BacktrackingSecond;
             }
-            SetOperator(_code.Codes[newpos] | back);
+            SetOperator((RegexOpcode)(_code.Codes[newpos] | back));
 
             // When branching backward, ensure storage.
             if (newpos < _codepos)
@@ -148,11 +143,11 @@ namespace System.Text.RegularExpressions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetOperator(int op)
+        private void SetOperator(RegexOpcode op)
         {
-            _operator = op & ~(RegexCode.Rtl | RegexCode.Ci);
-            _caseInsensitive = (op & RegexCode.Ci) != 0;
-            _rightToLeft = (op & RegexCode.Rtl) != 0;
+            _operator = op & ~(RegexOpcode.RightToLeft | RegexOpcode.CaseInsensitive);
+            _caseInsensitive = (op & RegexOpcode.CaseInsensitive) != 0;
+            _rightToLeft = (op & RegexOpcode.RightToLeft) != 0;
         }
 
         private void TrackPop() => runtrackpos++;
@@ -334,7 +329,7 @@ namespace System.Text.RegularExpressions
 
         protected override void Go()
         {
-            SetOperator(_code.Codes[0]);
+            SetOperator((RegexOpcode)_code.Codes[0]);
             _codepos = 0;
             int advance = -1;
             ReadOnlySpan<char> inputSpan = runtext;
@@ -349,26 +344,26 @@ namespace System.Text.RegularExpressions
                     advance = -1;
                 }
 #if DEBUG
-                if (runmatch!.IsDebug)
+                if (Regex.EnableDebugTracing)
                 {
-                    DumpState();
+                    DebugTraceCurrentState();
                 }
 #endif
                 CheckTimeout();
 
                 switch (_operator)
                 {
-                    case RegexCode.Stop:
+                    case RegexOpcode.Stop:
                         return;
 
-                    case RegexCode.Nothing:
+                    case RegexOpcode.Nothing:
                         break;
 
-                    case RegexCode.Goto:
+                    case RegexOpcode.Goto:
                         Goto(Operand(0));
                         continue;
 
-                    case RegexCode.Testref:
+                    case RegexOpcode.Testref:
                         if (!IsMatched(Operand(0)))
                         {
                             break;
@@ -376,47 +371,47 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexCode.Lazybranch:
+                    case RegexOpcode.Lazybranch:
                         TrackPush(runtextpos);
                         advance = 1;
                         continue;
 
-                    case RegexCode.Lazybranch | RegexCode.Back:
+                    case RegexOpcode.Lazybranch | RegexOpcode.Backtracking:
                         TrackPop();
                         runtextpos = TrackPeek();
                         Goto(Operand(0));
                         continue;
 
-                    case RegexCode.Setmark:
+                    case RegexOpcode.Setmark:
                         StackPush(runtextpos);
                         TrackPush();
                         advance = 0;
                         continue;
 
-                    case RegexCode.Nullmark:
+                    case RegexOpcode.Nullmark:
                         StackPush(-1);
                         TrackPush();
                         advance = 0;
                         continue;
 
-                    case RegexCode.Setmark | RegexCode.Back:
-                    case RegexCode.Nullmark | RegexCode.Back:
+                    case RegexOpcode.Setmark | RegexOpcode.Backtracking:
+                    case RegexOpcode.Nullmark | RegexOpcode.Backtracking:
                         StackPop();
                         break;
 
-                    case RegexCode.Getmark:
+                    case RegexOpcode.Getmark:
                         StackPop();
                         TrackPush(StackPeek());
                         runtextpos = StackPeek();
                         advance = 0;
                         continue;
 
-                    case RegexCode.Getmark | RegexCode.Back:
+                    case RegexOpcode.Getmark | RegexOpcode.Backtracking:
                         TrackPop();
                         StackPush(TrackPeek());
                         break;
 
-                    case RegexCode.Capturemark:
+                    case RegexOpcode.Capturemark:
                         if (Operand(1) != -1 && !IsMatched(Operand(1)))
                         {
                             break;
@@ -434,7 +429,7 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Capturemark | RegexCode.Back:
+                    case RegexOpcode.Capturemark | RegexOpcode.Backtracking:
                         TrackPop();
                         StackPush(TrackPeek());
                         Uncapture();
@@ -444,7 +439,7 @@ namespace System.Text.RegularExpressions
                         }
                         break;
 
-                    case RegexCode.Branchmark:
+                    case RegexOpcode.Branchmark:
                         StackPop();
                         if (runtextpos != StackPeek())
                         {
@@ -461,7 +456,7 @@ namespace System.Text.RegularExpressions
                         }
                         continue;
 
-                    case RegexCode.Branchmark | RegexCode.Back:
+                    case RegexOpcode.Branchmark | RegexOpcode.Backtracking:
                         TrackPop(2);
                         StackPop();
                         runtextpos = TrackPeek(1); // Recall position
@@ -469,12 +464,12 @@ namespace System.Text.RegularExpressions
                         advance = 1;               // Straight
                         continue;
 
-                    case RegexCode.Branchmark | RegexCode.Back2:
+                    case RegexOpcode.Branchmark | RegexOpcode.BacktrackingSecond:
                         TrackPop();
                         StackPush(TrackPeek()); // Recall old mark
                         break;                  // Backtrack
 
-                    case RegexCode.Lazybranchmark:
+                    case RegexOpcode.Lazybranchmark:
                         // We hit this the first time through a lazy loop and after each
                         // successful match of the inner expression.  It simply continues
                         // on and doesn't loop.
@@ -506,13 +501,13 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexCode.Lazybranchmark | RegexCode.Back:
+                    case RegexOpcode.Lazybranchmark | RegexOpcode.Backtracking:
                         {
-                            // After the first time, Lazybranchmark | RegexCode.Back occurs
+                            // After the first time, Lazybranchmark | RegexOpcode.Back occurs
                             // with each iteration of the loop, and therefore with every attempted
                             // match of the inner expression.  We'll try to match the inner expression,
                             // then go back to Lazybranchmark if successful.  If the inner expression
-                            // fails, we go to Lazybranchmark | RegexCode.Back2
+                            // fails, we go to Lazybranchmark | RegexOpcode.Back2
                             TrackPop(2);
                             int pos = TrackPeek(1);
                             TrackPush2(TrackPeek()); // Save old mark
@@ -522,7 +517,7 @@ namespace System.Text.RegularExpressions
                         }
                         continue;
 
-                    case RegexCode.Lazybranchmark | RegexCode.Back2:
+                    case RegexOpcode.Lazybranchmark | RegexOpcode.BacktrackingSecond:
                         // The lazy loop has failed.  We'll do a true backtrack and
                         // start over before the lazy loop.
                         StackPop();
@@ -530,25 +525,25 @@ namespace System.Text.RegularExpressions
                         StackPush(TrackPeek()); // Recall old mark
                         break;
 
-                    case RegexCode.Setcount:
+                    case RegexOpcode.Setcount:
                         StackPush(runtextpos, Operand(0));
                         TrackPush();
                         advance = 1;
                         continue;
 
-                    case RegexCode.Nullcount:
+                    case RegexOpcode.Nullcount:
                         StackPush(-1, Operand(0));
                         TrackPush();
                         advance = 1;
                         continue;
 
-                    case RegexCode.Setcount | RegexCode.Back:
-                    case RegexCode.Nullcount | RegexCode.Back:
-                    case RegexCode.Setjump | RegexCode.Back:
+                    case RegexOpcode.Setcount | RegexOpcode.Backtracking:
+                    case RegexOpcode.Nullcount | RegexOpcode.Backtracking:
+                    case RegexOpcode.Setjump | RegexOpcode.Backtracking:
                         StackPop(2);
                         break;
 
-                    case RegexCode.Branchcount:
+                    case RegexOpcode.Branchcount:
                         // StackPush:
                         //  0: Mark
                         //  1: Count
@@ -573,7 +568,7 @@ namespace System.Text.RegularExpressions
                         }
                         continue;
 
-                    case RegexCode.Branchcount | RegexCode.Back:
+                    case RegexOpcode.Branchcount | RegexOpcode.Backtracking:
                         // TrackPush:
                         //  0: Previous mark
                         // StackPush:
@@ -592,7 +587,7 @@ namespace System.Text.RegularExpressions
                         StackPush(TrackPeek(), StackPeek(1) - 1);      // Recall old mark, old count
                         break;
 
-                    case RegexCode.Branchcount | RegexCode.Back2:
+                    case RegexOpcode.Branchcount | RegexOpcode.BacktrackingSecond:
                         // TrackPush:
                         //  0: Previous mark
                         //  1: Previous count
@@ -600,7 +595,7 @@ namespace System.Text.RegularExpressions
                         StackPush(TrackPeek(), TrackPeek(1)); // Recall old mark, old count
                         break;                                // Backtrack
 
-                    case RegexCode.Lazybranchcount:
+                    case RegexOpcode.Lazybranchcount:
                         // StackPush:
                         //  0: Mark
                         //  1: Count
@@ -624,7 +619,7 @@ namespace System.Text.RegularExpressions
                         }
                         continue;
 
-                    case RegexCode.Lazybranchcount | RegexCode.Back:
+                    case RegexOpcode.Lazybranchcount | RegexOpcode.Backtracking:
                         // TrackPush:
                         //  0: Mark
                         //  1: Count
@@ -650,7 +645,7 @@ namespace System.Text.RegularExpressions
                             }
                         }
 
-                    case RegexCode.Lazybranchcount | RegexCode.Back2:
+                    case RegexOpcode.Lazybranchcount | RegexOpcode.BacktrackingSecond:
                         // TrackPush:
                         //  0: Previous mark
                         // StackPush:
@@ -661,13 +656,13 @@ namespace System.Text.RegularExpressions
                         StackPush(TrackPeek(), StackPeek(1) - 1); // Recall old mark, count
                         break;                                    // Backtrack
 
-                    case RegexCode.Setjump:
+                    case RegexOpcode.Setjump:
                         StackPush(Trackpos(), Crawlpos());
                         TrackPush();
                         advance = 0;
                         continue;
 
-                    case RegexCode.Backjump:
+                    case RegexOpcode.Backjump:
                         // StackPush:
                         //  0: Saved trackpos
                         //  1: Crawlpos
@@ -679,7 +674,7 @@ namespace System.Text.RegularExpressions
                         }
                         break;
 
-                    case RegexCode.Forejump:
+                    case RegexOpcode.Forejump:
                         // StackPush:
                         //  0: Saved trackpos
                         //  1: Crawlpos
@@ -689,7 +684,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.Forejump | RegexCode.Back:
+                    case RegexOpcode.Forejump | RegexOpcode.Backtracking:
                         // TrackPush:
                         //  0: Crawlpos
                         TrackPop();
@@ -699,7 +694,7 @@ namespace System.Text.RegularExpressions
                         }
                         break;
 
-                    case RegexCode.Bol:
+                    case RegexOpcode.Bol:
                         if (Leftchars() > 0 && inputSpan[runtextpos - 1] != '\n')
                         {
                             break;
@@ -707,7 +702,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.Eol:
+                    case RegexOpcode.Eol:
                         if (Rightchars() > 0 && inputSpan[runtextpos] != '\n')
                         {
                             break;
@@ -715,7 +710,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.Boundary:
+                    case RegexOpcode.Boundary:
                         if (!IsBoundary(runtextpos, runtextbeg, runtextend))
                         {
                             break;
@@ -723,7 +718,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.NonBoundary:
+                    case RegexOpcode.NonBoundary:
                         if (IsBoundary(runtextpos, runtextbeg, runtextend))
                         {
                             break;
@@ -731,7 +726,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.ECMABoundary:
+                    case RegexOpcode.ECMABoundary:
                         if (!IsECMABoundary(runtextpos, runtextbeg, runtextend))
                         {
                             break;
@@ -739,7 +734,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.NonECMABoundary:
+                    case RegexOpcode.NonECMABoundary:
                         if (IsECMABoundary(runtextpos, runtextbeg, runtextend))
                         {
                             break;
@@ -747,7 +742,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.Beginning:
+                    case RegexOpcode.Beginning:
                         if (Leftchars() > 0)
                         {
                             break;
@@ -755,7 +750,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.Start:
+                    case RegexOpcode.Start:
                         if (runtextpos != runtextstart)
                         {
                             break;
@@ -763,7 +758,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.EndZ:
+                    case RegexOpcode.EndZ:
                         if (Rightchars() > 1 || Rightchars() == 1 && inputSpan[runtextpos] != '\n')
                         {
                             break;
@@ -771,7 +766,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.End:
+                    case RegexOpcode.End:
                         if (Rightchars() > 0)
                         {
                             break;
@@ -779,7 +774,7 @@ namespace System.Text.RegularExpressions
                         advance = 0;
                         continue;
 
-                    case RegexCode.One:
+                    case RegexOpcode.One:
                         if (Forwardchars() < 1 || Forwardcharnext(inputSpan) != (char)Operand(0))
                         {
                             break;
@@ -787,7 +782,7 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexCode.Notone:
+                    case RegexOpcode.Notone:
                         if (Forwardchars() < 1 || Forwardcharnext(inputSpan) == (char)Operand(0))
                         {
                             break;
@@ -795,7 +790,7 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexCode.Set:
+                    case RegexOpcode.Set:
                         if (Forwardchars() < 1)
                         {
                             break;
@@ -811,7 +806,7 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexCode.Multi:
+                    case RegexOpcode.Multi:
                         if (!MatchString(_code.Strings[Operand(0)], inputSpan))
                         {
                             break;
@@ -819,7 +814,7 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexCode.Ref:
+                    case RegexOpcode.Ref:
                         {
                             int capnum = Operand(0);
                             if (IsMatched(capnum))
@@ -840,7 +835,7 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexCode.Onerep:
+                    case RegexOpcode.Onerep:
                         {
                             int c = Operand(1);
                             if (Forwardchars() < c)
@@ -860,7 +855,7 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Notonerep:
+                    case RegexOpcode.Notonerep:
                         {
                             int c = Operand(1);
                             if (Forwardchars() < c)
@@ -880,7 +875,7 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Setrep:
+                    case RegexOpcode.Setrep:
                         {
                             int c = Operand(1);
                             if (Forwardchars() < c)
@@ -909,8 +904,8 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Oneloop:
-                    case RegexCode.Oneloopatomic:
+                    case RegexOpcode.Oneloop:
+                    case RegexOpcode.Oneloopatomic:
                         {
                             int len = Math.Min(Operand(1), Forwardchars());
                             char ch = (char)Operand(0);
@@ -925,7 +920,7 @@ namespace System.Text.RegularExpressions
                                 }
                             }
 
-                            if (len > i && _operator == RegexCode.Oneloop)
+                            if (len > i && _operator == RegexOpcode.Oneloop)
                             {
                                 TrackPush(len - i - 1, runtextpos - Bump());
                             }
@@ -933,8 +928,8 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Notoneloop:
-                    case RegexCode.Notoneloopatomic:
+                    case RegexOpcode.Notoneloop:
+                    case RegexOpcode.Notoneloopatomic:
                         {
                             int len = Math.Min(Operand(1), Forwardchars());
                             char ch = (char)Operand(0);
@@ -968,7 +963,7 @@ namespace System.Text.RegularExpressions
                                 }
                             }
 
-                            if (len > i && _operator == RegexCode.Notoneloop)
+                            if (len > i && _operator == RegexOpcode.Notoneloop)
                             {
                                 TrackPush(len - i - 1, runtextpos - Bump());
                             }
@@ -976,8 +971,8 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Setloop:
-                    case RegexCode.Setloopatomic:
+                    case RegexOpcode.Setloop:
+                    case RegexOpcode.Setloopatomic:
                         {
                             int len = Math.Min(Operand(1), Forwardchars());
                             int operand0 = Operand(0);
@@ -1000,7 +995,7 @@ namespace System.Text.RegularExpressions
                                 }
                             }
 
-                            if (len > i && _operator == RegexCode.Setloop)
+                            if (len > i && _operator == RegexOpcode.Setloop)
                             {
                                 TrackPush(len - i - 1, runtextpos - Bump());
                             }
@@ -1008,9 +1003,9 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Oneloop | RegexCode.Back:
-                    case RegexCode.Notoneloop | RegexCode.Back:
-                    case RegexCode.Setloop | RegexCode.Back:
+                    case RegexOpcode.Oneloop | RegexOpcode.Backtracking:
+                    case RegexOpcode.Notoneloop | RegexOpcode.Backtracking:
+                    case RegexOpcode.Setloop | RegexOpcode.Backtracking:
                         TrackPop(2);
                         {
                             int i = TrackPeek();
@@ -1024,9 +1019,9 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Onelazy:
-                    case RegexCode.Notonelazy:
-                    case RegexCode.Setlazy:
+                    case RegexOpcode.Onelazy:
+                    case RegexOpcode.Notonelazy:
+                    case RegexOpcode.Setlazy:
                         {
                             int c = Math.Min(Operand(1), Forwardchars());
                             if (c > 0)
@@ -1037,7 +1032,7 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Onelazy | RegexCode.Back:
+                    case RegexOpcode.Onelazy | RegexOpcode.Backtracking:
                         TrackPop(2);
                         {
                             int pos = TrackPeek(1);
@@ -1057,7 +1052,7 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Notonelazy | RegexCode.Back:
+                    case RegexOpcode.Notonelazy | RegexOpcode.Backtracking:
                         TrackPop(2);
                         {
                             int pos = TrackPeek(1);
@@ -1077,7 +1072,7 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.Setlazy | RegexCode.Back:
+                    case RegexOpcode.Setlazy | RegexOpcode.Backtracking:
                         TrackPop(2);
                         {
                             int pos = TrackPeek(1);
@@ -1098,7 +1093,7 @@ namespace System.Text.RegularExpressions
                         advance = 2;
                         continue;
 
-                    case RegexCode.UpdateBumpalong:
+                    case RegexOpcode.UpdateBumpalong:
                         // UpdateBumpalong should only exist in the code stream at such a point where the root
                         // of the backtracking stack contains the runtextpos from the start of this Go call. Replace
                         // that tracking value with the current runtextpos value if it's greater.
@@ -1125,14 +1120,10 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
         [ExcludeFromCodeCoverage(Justification = "Debug only")]
-        internal override void DumpState()
+        internal override void DebugTraceCurrentState()
         {
-            base.DumpState();
-            Debug.WriteLine(
-                "       " +
-                _code.OpcodeDescription(_codepos) +
-                ((_operator & RegexCode.Back) != 0 ? " Back" : "") +
-                ((_operator & RegexCode.Back2) != 0 ? " Back2" : ""));
+            base.DebugTraceCurrentState();
+            Debug.WriteLine($"       {_code.DescribeInstruction(_codepos)} {((_operator & RegexOpcode.Backtracking) != 0 ? " Back" : "")} {((_operator & RegexOpcode.BacktrackingSecond) != 0 ? " Back2" : "")}");
             Debug.WriteLine("");
         }
 #endif

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -363,7 +363,7 @@ namespace System.Text.RegularExpressions
                         Goto(Operand(0));
                         continue;
 
-                    case RegexOpcode.Testref:
+                    case RegexOpcode.TestBackreference:
                         if (!IsMatched(Operand(0)))
                         {
                             break;
@@ -814,7 +814,7 @@ namespace System.Text.RegularExpressions
                         advance = 1;
                         continue;
 
-                    case RegexOpcode.Ref:
+                    case RegexOpcode.Backreference:
                         {
                             int capnum = Operand(0);
                             if (IsMatched(capnum))

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -190,7 +190,7 @@ namespace System.Text.RegularExpressions
                 for (int i = 0; i < childCount; i++)
                 {
                     RegexNode child = node.Child(i);
-                    Debug.Assert(child.Parent == node, $"{child.Description()} missing reference to parent {node.Description()}");
+                    Debug.Assert(child.Parent == node, $"{child.Describe()} missing reference to parent {node.Describe()}");
 
                     toExamine.Push(child);
                 }
@@ -2568,7 +2568,40 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
         [ExcludeFromCodeCoverage]
-        public string Description()
+        public override string ToString()
+        {
+            RegexNode? curNode = this;
+            int curChild = 0;
+            var sb = new StringBuilder().AppendLine(curNode.Describe());
+            var stack = new List<int>();
+            while (true)
+            {
+                if (curChild < curNode!.ChildCount())
+                {
+                    stack.Add(curChild + 1);
+                    curNode = curNode.Child(curChild);
+                    curChild = 0;
+
+                    sb.Append(new string(' ', stack.Count * 2)).Append(curNode.Describe()).AppendLine();
+                }
+                else
+                {
+                    if (stack.Count == 0)
+                    {
+                        break;
+                    }
+
+                    curChild = stack[stack.Count - 1];
+                    stack.RemoveAt(stack.Count - 1);
+                    curNode = curNode.Parent;
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        [ExcludeFromCodeCoverage]
+        private string Describe()
         {
             var sb = new StringBuilder(Kind.ToString());
 
@@ -2590,7 +2623,7 @@ namespace System.Text.RegularExpressions
                 case RegexNodeKind.Notonelazy:
                 case RegexNodeKind.One:
                 case RegexNodeKind.Notone:
-                    sb.Append(" '").Append(RegexCharClass.CharDescription(Ch)).Append('\'');
+                    sb.Append(" '").Append(RegexCharClass.DescribeChar(Ch)).Append('\'');
                     break;
                 case RegexNodeKind.Capture:
                     sb.Append(' ').Append($"index = {M}");
@@ -2610,7 +2643,7 @@ namespace System.Text.RegularExpressions
                 case RegexNodeKind.Setloop:
                 case RegexNodeKind.Setloopatomic:
                 case RegexNodeKind.Setlazy:
-                    sb.Append(' ').Append(RegexCharClass.SetDescription(Str!));
+                    sb.Append(' ').Append(RegexCharClass.DescribeSet(Str!));
                     break;
             }
 
@@ -2635,42 +2668,6 @@ namespace System.Text.RegularExpressions
                         (N == M) ? $"{{{M}}}" :
                         $"{{{M}, {N}}}");
                     break;
-            }
-
-            return sb.ToString();
-        }
-
-        [ExcludeFromCodeCoverage]
-        public void Dump() => Debug.WriteLine(ToString());
-
-        [ExcludeFromCodeCoverage]
-        public override string ToString()
-        {
-            RegexNode? curNode = this;
-            int curChild = 0;
-            var sb = new StringBuilder().AppendLine(curNode.Description());
-            var stack = new List<int>();
-            while (true)
-            {
-                if (curChild < curNode!.ChildCount())
-                {
-                    stack.Add(curChild + 1);
-                    curNode = curNode.Child(curChild);
-                    curChild = 0;
-
-                    sb.Append(new string(' ', stack.Count * 2)).Append(curNode.Description()).AppendLine();
-                }
-                else
-                {
-                    if (stack.Count == 0)
-                    {
-                        break;
-                    }
-
-                    curChild = stack[stack.Count - 1];
-                    stack.RemoveAt(stack.Count - 1);
-                    curNode = curNode.Parent;
-                }
             }
 
             return sb.ToString();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
@@ -14,95 +14,95 @@ namespace System.Text.RegularExpressions
 
         /// <summary>A specific character, e.g. `a`.</summary>
         /// <remarks>The character is specified in <see cref="RegexNode.Ch"/>.</remarks>
-        One = RegexCode.One,
+        One = RegexOpcode.One,
         /// <summary>Anything other than a specific character, e.g. `.` when not in <see cref="RegexOptions.Singleline"/> mode, or `[^a]`.</summary>
         /// <remarks>The character is specified in <see cref="RegexNode.Ch"/>.</remarks>
-        Notone = RegexCode.Notone,
+        Notone = RegexOpcode.Notone,
         /// <summary>A character class / set, e.g. `[a-z1-9]` or `\w`.</summary>
         /// <remarks>The <see cref="RegexCharClass"/> set string is specified in <see cref="RegexNode.Str"/>.</remarks>
-        Set = RegexCode.Set,
+        Set = RegexOpcode.Set,
 
         /// <summary>A sequence of at least two specific characters, e.g. `abc`.</summary>
         /// <remarks>The characters are specified in <see cref="RegexNode.Str"/>.  This is purely a representational optimization, equivalent to multiple <see cref="One"/> nodes concatenated together.</remarks>
-        Multi = RegexCode.Multi,
+        Multi = RegexOpcode.Multi,
 
         /// <summary>A loop around a specific character, e.g. `a*`.</summary>
         /// <remarks>
         /// The character is specified in <see cref="RegexNode.Ch"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.
         /// This is purely a representational optimization, equivalent to a <see cref="Loop"/> wrapped around a <see cref="One"/>.
         /// </remarks>
-        Oneloop = RegexCode.Oneloop,
+        Oneloop = RegexOpcode.Oneloop,
         /// <summary>A loop around anything other than a specific character, e.g. `.*` when not in <see cref="RegexOptions.Singleline"/> mode, or `[^a]*`.</summary>
         /// <remarks>The character is specified in <see cref="RegexNode.Ch"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.</remarks>
         /// This is purely a representational optimization, equivalent to a <see cref="Loop"/> wrapped around a <see cref="Notone"/>.
-        Notoneloop = RegexCode.Notoneloop,
+        Notoneloop = RegexOpcode.Notoneloop,
         /// <summary>A loop around a character class / set, e.g. `[a-z1-9]*` or `\w*`.</summary>
         /// <remarks>The <see cref="RegexCharClass"/> set string is specified in <see cref="RegexNode.Str"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.</remarks>
         /// This is purely a representational optimization, equivalent to a <see cref="Loop"/> wrapped around a <see cref="Set"/>.
-        Setloop = RegexCode.Setloop,
+        Setloop = RegexOpcode.Setloop,
 
         /// <summary>A lazy loop around a specific character, e.g. `a*?`.</summary>
         /// <remarks>The character is specified in <see cref="RegexNode.Ch"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.</remarks>
         /// This is purely a representational optimization, equivalent to a <see cref="Lazyloop"/> wrapped around a <see cref="One"/>.
-        Onelazy = RegexCode.Onelazy,
+        Onelazy = RegexOpcode.Onelazy,
         /// <summary>A lazy loop around anything other than a specific character, e.g. `.*?` when not in <see cref="RegexOptions.Singleline"/> mode, or `[^a]*?`.</summary>
         /// <remarks>The character is specified in <see cref="RegexNode.Ch"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.</remarks>
         /// This is purely a representational optimization, equivalent to a <see cref="Lazyloop"/> wrapped around a <see cref="Notone"/>.
-        Notonelazy = RegexCode.Notonelazy,
+        Notonelazy = RegexOpcode.Notonelazy,
         /// <summary>A lazy loop around a character class / set, e.g. `[a-z1-9]*?` or `\w?`.</summary>
         /// <remarks>The <see cref="RegexCharClass"/> set string is specified in <see cref="RegexNode.Str"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.</remarks>
         /// This is purely a representational optimization, equivalent to a <see cref="Lazyloop"/> wrapped around a <see cref="Set"/>.
-        Setlazy = RegexCode.Setlazy,
+        Setlazy = RegexOpcode.Setlazy,
 
         /// <summary>An atomic loop around a specific character, e.g. `(?> a*)`.</summary>
         /// <remarks>
         /// The character is specified in <see cref="RegexNode.Ch"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.
         /// This is purely a representational optimization, equivalent to a <see cref="Atomic"/> wrapped around a <see cref="Oneloop"/>.
         /// </remarks>
-        Oneloopatomic = RegexCode.Oneloopatomic,
+        Oneloopatomic = RegexOpcode.Oneloopatomic,
         /// <summary>An atomic loop around anything other than a specific character, e.g. `(?>.*)` when not in <see cref="RegexOptions.Singleline"/> mode.</summary>
         /// <remarks>
         /// The character is specified in <see cref="RegexNode.Ch"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.
         /// This is purely a representational optimization, equivalent to a <see cref="Atomic"/> wrapped around a <see cref="Notoneloop"/>.
         /// </remarks>
-        Notoneloopatomic = RegexCode.Notoneloopatomic,
+        Notoneloopatomic = RegexOpcode.Notoneloopatomic,
         /// <summary>An atomic loop around a character class / set, e.g. `(?>\d*)`.</summary>
         /// <remarks>
         /// The <see cref="RegexCharClass"/> set string is specified in <see cref="RegexNode.Str"/>, the minimum number of iterations in <see cref="RegexNode.M"/>, and the maximum number of iterations in <see cref="RegexNode.N"/>.
         /// This is purely a representational optimization, equivalent to a <see cref="Atomic"/> wrapped around a <see cref="Setloop"/>.
         /// </remarks>
-        Setloopatomic = RegexCode.Setloopatomic,
+        Setloopatomic = RegexOpcode.Setloopatomic,
 
         /// <summary>A backreference, e.g. `\1`.</summary>
         /// <remarks>The capture group number referenced is stored in <see cref="RegexNode.M"/>.</remarks>
-        Backreference = RegexCode.Ref,
+        Backreference = RegexOpcode.Ref,
 
         /// <summary>A beginning-of-line anchor, e.g. `^` in <see cref="RegexOptions.Multiline"/> mode.</summary>
-        Bol = RegexCode.Bol,
+        Bol = RegexOpcode.Bol,
         /// <summary>An end-of-line anchor, e.g. `$` in <see cref="RegexOptions.Multiline"/> mode.</summary>
-        Eol = RegexCode.Eol,
+        Eol = RegexOpcode.Eol,
         /// <summary>A word boundary anchor, e.g. `\b`.</summary>
-        Boundary = RegexCode.Boundary,
+        Boundary = RegexOpcode.Boundary,
         /// <summary>Not a word boundary anchor, e.g. `\B`.</summary>
-        NonBoundary = RegexCode.NonBoundary,
+        NonBoundary = RegexOpcode.NonBoundary,
         /// <summary>A word boundary anchor, e.g. `\b` in <see cref="RegexOptions.ECMAScript"/> mode.</summary>
-        ECMABoundary = RegexCode.ECMABoundary,
+        ECMABoundary = RegexOpcode.ECMABoundary,
         /// <summary>Not a word boundary anchor, e.g. `\B` in <see cref="RegexOptions.ECMAScript"/> mode..</summary>
-        NonECMABoundary = RegexCode.NonECMABoundary,
+        NonECMABoundary = RegexOpcode.NonECMABoundary,
         /// <summary>A beginning-of-string anchor, e.g. `\A`, or `^` when not in <see cref="RegexOptions.Multiline"/> mode.</summary>
-        Beginning = RegexCode.Beginning,
+        Beginning = RegexOpcode.Beginning,
         /// <summary>A start anchor, e.g. `\G`.</summary>
-        Start = RegexCode.Start,
+        Start = RegexOpcode.Start,
         /// <summary>A end-of-string-or-before-ending-newline anchor, e.g. `\Z`, or `$` when not in <see cref="RegexOptions.Multiline"/> mode.</summary>
-        EndZ = RegexCode.EndZ,
+        EndZ = RegexOpcode.EndZ,
         /// <summary>A end-of-string-only anchor, e.g. `\z`.</summary>
-        End = RegexCode.End,
+        End = RegexOpcode.End,
 
         /// <summary>A fabricated node injected during analyses to signal a location in the matching where the engine may set the next bumpalong position to the current position.</summary>
-        UpdateBumpalong = RegexCode.UpdateBumpalong,
+        UpdateBumpalong = RegexOpcode.UpdateBumpalong,
 
         /// <summary>Fails when matching an empty string, e.g. `(?!)`.</summary>
-        Nothing = 22,
+        Nothing = RegexOpcode.Nothing,
         /// <summary>Matches the empty string, e.g. ``.</summary>
         Empty = 23,
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNodeKind.cs
@@ -75,7 +75,7 @@ namespace System.Text.RegularExpressions
 
         /// <summary>A backreference, e.g. `\1`.</summary>
         /// <remarks>The capture group number referenced is stored in <see cref="RegexNode.M"/>.</remarks>
-        Backreference = RegexOpcode.Ref,
+        Backreference = RegexOpcode.Backreference,
 
         /// <summary>A beginning-of-line anchor, e.g. `^` in <see cref="RegexOptions.Multiline"/> mode.</summary>
         Bol = RegexOpcode.Bol,
@@ -128,7 +128,7 @@ namespace System.Text.RegularExpressions
         /// One and only one child, the expression in the loop. The minimum number of iterations is in <see cref="RegexNode.M"/>,
         /// and the maximum number of iterations is in <see cref="RegexNode.N"/>.
         /// </remarks>
-        Loop = 26,                                   // m,x      * + ? {,}
+        Loop = 26,
         /// <summary>A lazy loop around an arbitrary <see cref="RegexNode"/>, e.g. `(ab|cd)*?`.</summary>
         /// <remarks>
         /// One and only one child, the expression in the loop. The minimum number of iterations is in <see cref="RegexNode.M"/>,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOpcode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOpcode.cs
@@ -70,7 +70,7 @@ namespace System.Text.RegularExpressions
 
         /// <summary>Backreference to a capture group.</summary>
         /// <remarks>Operand 0 is the capture group number.</remarks>
-        Ref = 13,
+        Backreference = 13,
 
         /// <summary>Beginning-of-line anchor (^ with RegexOptions.Multiline).</summary>
         Bol = 14,
@@ -92,7 +92,7 @@ namespace System.Text.RegularExpressions
         Nothing = 22,
         /// <summary>Word boundary (\b with RegexOptions.ECMAScript).</summary>
         ECMABoundary = 41,
-        /// <summary>Word boundary (\B with RegexOptions.ECMAScript).</summary>
+        /// <summary>Word non-boundary (\B with RegexOptions.ECMAScript).</summary>
         NonECMABoundary = 42,
 
         /// <summary>Atomic loop of the specified character.</summary>
@@ -140,7 +140,7 @@ namespace System.Text.RegularExpressions
         /// <summary>zap backtracking state.</summary>
         Forejump = 36,
         /// <summary>Backtrack if ref undefined.</summary>
-        Testref = 37,
+        TestBackreference = 37,
         /// <summary>jump            just go.</summary>
         Goto = 38,
         /// <summary>done!</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOpcode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOpcode.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.RegularExpressions
+{
+    /// <summary>Opcodes written by <see cref="RegexWriter"/> and used by <see cref="RegexInterpreter"/> to process a regex.</summary>
+    /// <remarks>
+    /// <see cref="RegexCode"/> stores an int[] containing all of the codes that make up the instructions for
+    /// the interpreter to process the regular expression.  The array contains a packed sequence of operations,
+    /// each of which is an <see cref="RegexOpcode"/> stored as an int, followed immediately by all of the operands
+    /// required for that operation.  For example, the subexpression `a{2,7}[^b]` would be represented as the sequence
+    ///     0 97 2 3 97 5 10 98
+    /// which is interpreted as:
+    ///     0  = opcode for Onerep (a{2, 7} is written out as a repeater for the minimum followed by a loop for the maximum minus the minimum)
+    ///     97 = 'a'
+    ///     2  = repeat count
+    ///     3  = opcode for Oneloop
+    ///     97 = 'a'
+    ///     5  = max iteration count
+    ///     10 = opcode for Notone
+    ///     98 = 'b'
+    /// </remarks>
+    internal enum RegexOpcode
+    {
+        // Primitive operations
+
+        /// <summary>Repeater of the specified character.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the repetition count.</remarks>
+        Onerep = 0,
+        /// <summary>Repeater of a single character other than the one specified.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the repetition count.</remarks>
+        Notonerep = 1,
+        /// <summary>Repeater of a single character matching the specified set</summary>
+        /// <remarks>Operand 0 is index into the strings table of the character class description. Operand 1 is the repetition count.</remarks>
+        Setrep = 2,
+
+        /// <summary>Greedy loop of the specified character.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
+        Oneloop = 3,
+        /// <summary>Greedy loop of a single character other than the one specified.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
+        Notoneloop = 4,
+        /// <summary>Greedy loop of a single character matching the specified set</summary>
+        /// <remarks>Operand 0 is index into the strings table of the character class description. Operand 1 is the repetition count.</remarks>
+        Setloop = 5,
+
+        /// <summary>Lazy loop of the specified character.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
+        Onelazy = 6,
+        /// <summary>Lazy loop of a single character other than the one specified.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
+        Notonelazy = 7,
+        /// <summary>Lazy loop of a single character matching the specified set</summary>
+        /// <remarks>Operand 0 is index into the strings table of the character class description. Operand 1 is the repetition count.</remarks>
+        Setlazy = 8,
+
+        /// <summary>Single specified character.</summary>
+        /// <remarks>Operand 0 is the character.</remarks>
+        One = 9,
+        /// <summary>Single character other than the one specified.</summary>
+        /// <remarks>Operand 0 is the character.</remarks>
+        Notone = 10,
+        /// <summary>Single character matching the specified set.</summary>
+        /// <remarks>Operand 0 is index into the strings table of the character class description.</remarks>
+        Set = 11,
+
+        /// <summary>Multiple characters in sequence.</summary>
+        /// <remarks>Operand 0 is index into the strings table for the string of characters.</remarks>
+        Multi = 12,
+
+        /// <summary>Backreference to a capture group.</summary>
+        /// <remarks>Operand 0 is the capture group number.</remarks>
+        Ref = 13,
+
+        /// <summary>Beginning-of-line anchor (^ with RegexOptions.Multiline).</summary>
+        Bol = 14,
+        /// <summary>End-of-line anchor ($ with RegexOptions.Multiline).</summary>
+        Eol = 15,
+        /// <summary>Word boundary (\b).</summary>
+        Boundary = 16,
+        /// <summary>Word non-boundary (\B).</summary>
+        NonBoundary = 17,
+        /// <summary>Beginning-of-input anchor (\A).</summary>
+        Beginning = 18,
+        /// <summary>Start-of-input anchor (\G).</summary>
+        Start = 19,
+        /// <summary>End-of-input anchor (\Z).</summary>
+        EndZ = 20,
+        /// <summary>End-of-input anchor (\z).</summary>
+        End = 21,
+        /// <summary>Match nothing (fail).</summary>
+        Nothing = 22,
+        /// <summary>Word boundary (\b with RegexOptions.ECMAScript).</summary>
+        ECMABoundary = 41,
+        /// <summary>Word boundary (\B with RegexOptions.ECMAScript).</summary>
+        NonECMABoundary = 42,
+
+        /// <summary>Atomic loop of the specified character.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
+        Oneloopatomic = 43,
+        /// <summary>Atomic loop of a single character other than the one specified.</summary>
+        /// <remarks>Operand 0 is the character. Operand 1 is the max iteration count.</remarks>
+        Notoneloopatomic = 44,
+        /// <summary>Atomic loop of a single character matching the specified set</summary>
+        /// <remarks>Operand 0 is index into the strings table of the character class description. Operand 1 is the repetition count.</remarks>
+        Setloopatomic = 45,
+
+        /// <summary>Updates the bumpalong position to the current position.</summary>
+        UpdateBumpalong = 46,
+
+        // Primitive control structures
+        // TODO: Figure out what these comments mean / what these control structures actually do :)
+
+        /// <summary>back     jump            straight first.</summary>
+        Lazybranch = 23,
+        /// <summary>back     jump            branch first for loop.</summary>
+        Branchmark = 24,
+        /// <summary>back     jump            straight first for loop.</summary>
+        Lazybranchmark = 25,
+        /// <summary>back     val             set counter, null mark.</summary>
+        Nullcount = 26,
+        /// <summary>back     val             set counter, make mark</summary>
+        Setcount = 27,
+        /// <summary>back     jump,limit      branch++ if zero&lt;=c&lt;limit.</summary>
+        Branchcount = 28,
+        /// <summary>back     jump,limit      same, but straight first.</summary>
+        Lazybranchcount = 29,
+        /// <summary>back                     save position.</summary>
+        Nullmark = 30,
+        /// <summary>back                     save position.</summary>
+        Setmark = 31,
+        /// <summary>back     group           define group.</summary>
+        Capturemark = 32,
+        /// <summary>back                     recall position.</summary>
+        Getmark = 33,
+        /// <summary>back                     save backtrack state.</summary>
+        Setjump = 34,
+        /// <summary>zap back to saved state.</summary>
+        Backjump = 35,
+        /// <summary>zap backtracking state.</summary>
+        Forejump = 36,
+        /// <summary>Backtrack if ref undefined.</summary>
+        Testref = 37,
+        /// <summary>jump            just go.</summary>
+        Goto = 38,
+        /// <summary>done!</summary>
+        Stop = 40,
+
+        // Modifiers for alternate modes
+
+        /// <summary>Mask to get unmodified ordinary operator.</summary>
+        OperatorMask = 63,
+        /// <summary>Indicates that we're reverse scanning.</summary>
+        RightToLeft = 64,
+        /// <summary>Indicates that we're backtracking.</summary>
+        Backtracking = 128,
+        /// <summary>Indicates that we're backtracking on a second branch.</summary>
+        BacktrackingSecond = 256,
+        /// <summary>Indicates that we're case-insensitive</summary>
+        CaseInsensitive = 512,
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -30,7 +30,7 @@ namespace System.Text.RegularExpressions
         ExplicitCapture         = 0x0004, // "n"
 
         /// <summary>Compile the regular expression to Microsoft intermediate language (MSIL).</summary>
-        Compiled                = 0x0008, // "c"
+        Compiled                = 0x0008,
 
         /// <summary>
         /// Use single-line mode, where the period (.) matches every character (instead of every character except \n).
@@ -41,15 +41,10 @@ namespace System.Text.RegularExpressions
         IgnorePatternWhitespace = 0x0020, // "x"
 
         /// <summary>Change the search direction. Search moves from right to left instead of from left to right.</summary>
-        RightToLeft             = 0x0040, // "r"
-
-#if DEBUG
-        /// <summary>Enable Regex debugging.</summary>
-        Debug                   = 0x0080, // "d"
-#endif
+        RightToLeft             = 0x0040,
 
         /// <summary>Enable ECMAScript-compliant behavior for the expression.</summary>
-        ECMAScript              = 0x0100, // "e"
+        ECMAScript              = 0x0100,
 
         /// <summary>Ignore cultural differences in language.</summary>
         CultureInvariant        = 0x0200,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1783,7 +1783,7 @@ namespace System.Text.RegularExpressions
             return capname;
         }
 
-        /// <summary>Returns ReNode type for zero-length assertions with a \ code.</summary>
+        /// <summary>Returns the node kind for zero-length assertions with a \ code.</summary>
         private RegexNodeKind TypeFromCode(char ch) =>
             ch switch
             {
@@ -1796,28 +1796,17 @@ namespace System.Text.RegularExpressions
                 _ => RegexNodeKind.Nothing,
             };
 
-        /// <summary>Returns option bit from single-char (?cimsx) code.</summary>
-        private static RegexOptions OptionFromCode(char ch)
-        {
-            // case-insensitive
-            if ((uint)(ch - 'A') <= 'Z' - 'A')
-            {
-                ch += (char)('a' - 'A');
-            }
-
-            return ch switch
+        /// <summary>Returns option bit from single-char (?imnsx) code.</summary>
+        private static RegexOptions OptionFromCode(char ch) =>
+            (char)(ch | 0x20) switch
             {
                 'i' => RegexOptions.IgnoreCase,
                 'm' => RegexOptions.Multiline,
                 'n' => RegexOptions.ExplicitCapture,
                 's' => RegexOptions.Singleline,
                 'x' => RegexOptions.IgnorePatternWhitespace,
-#if DEBUG
-                'd' => RegexOptions.Debug,
-#endif
-                _ => 0,
+                _ => RegexOptions.None,
             };
-        }
 
         /// <summary>
         /// A prescanner for deducing the slots used for captures by doing a partial tokenization of the pattern.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -1,14 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// RegexTree is just a wrapper for a node tree with some
-// global information attached.
-
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>Wrapper for a node tree with additional information attached.</summary>
     internal sealed class RegexTree
     {
         public readonly RegexNode Root;
@@ -31,16 +28,5 @@ namespace System.Text.RegularExpressions
             Options = options;
             MinRequiredLength = minRequiredLength;
         }
-
-#if DEBUG
-        [ExcludeFromCodeCoverage]
-        public void Dump() => Root.Dump();
-
-        [ExcludeFromCodeCoverage]
-        public override string ToString() => Root.ToString();
-
-        [ExcludeFromCodeCoverage]
-        public bool Debug => (Options & RegexOptions.Debug) != 0;
-#endif
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -270,7 +270,7 @@ namespace System.Text.RegularExpressions
                             Emit(RegexOpcode.Setjump);
                             _intStack.Append(_emitted.Length);
                             Emit(RegexOpcode.Lazybranch, 0);
-                            Emit(RegexOpcode.Testref, RegexParser.MapCaptureNumber(node.M, _caps));
+                            Emit(RegexOpcode.TestBackreference, RegexParser.MapCaptureNumber(node.M, _caps));
                             Emit(RegexOpcode.Forejump);
                             break;
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -46,23 +46,12 @@ namespace System.Text.RegularExpressions
 
         /// <summary>
         /// This is the only function that should be called from outside.
-        /// It takes a RegexTree and creates a corresponding RegexCode.
+        /// It takes a <see cref="RegexTree"/> and creates a corresponding <see cref="RegexCode"/>.
         /// </summary>
         public static RegexCode Write(RegexTree tree, CultureInfo culture)
         {
-            var writer = new RegexWriter(stackalloc int[EmittedSize], stackalloc int[IntStackSize]);
-            RegexCode code = writer.RegexCodeFromRegexTree(tree, culture);
-            writer.Dispose();
-
-#if DEBUG
-            if (tree.Debug)
-            {
-                tree.Dump();
-                code.Dump();
-            }
-#endif
-
-            return code;
+            using var writer = new RegexWriter(stackalloc int[EmittedSize], stackalloc int[IntStackSize]);
+            return writer.RegexCodeFromRegexTree(tree, culture);
         }
 
         /// <summary>
@@ -102,7 +91,7 @@ namespace System.Text.RegularExpressions
 
             // Every written code begins with a lazy branch.  This will be back-patched
             // to point to the ending Stop after the whole expression has been written.
-            Emit(RegexCode.Lazybranch, 0);
+            Emit(RegexOpcode.Lazybranch, 0);
 
             // Emit every node.
             RegexNode curNode = tree.Root;
@@ -138,7 +127,7 @@ namespace System.Text.RegularExpressions
 
             // Patch the starting Lazybranch, emit the final Stop, and get the resulting code array.
             PatchJump(0, _emitted.Length);
-            Emit(RegexCode.Stop);
+            Emit(RegexOpcode.Stop);
             int[] emitted = _emitted.AsSpan().ToArray();
 
             // Convert the string table into an ordered string array.
@@ -166,37 +155,37 @@ namespace System.Text.RegularExpressions
         /// functions all run in two modes: they can emit code, or
         /// they can just count the size of the code.
         /// </summary>
-        private void Emit(int op)
+        private void Emit(RegexOpcode op)
         {
             if (RegexCode.OpcodeBacktracks(op))
             {
                 _trackCount++;
             }
 
-            _emitted.Append(op);
+            _emitted.Append((int)op);
         }
 
         /// <summary>Emits a one-argument operation.</summary>
-        private void Emit(int op, int opd1)
+        private void Emit(RegexOpcode op, int opd1)
         {
             if (RegexCode.OpcodeBacktracks(op))
             {
                 _trackCount++;
             }
 
-            _emitted.Append(op);
+            _emitted.Append((int)op);
             _emitted.Append(opd1);
         }
 
         /// <summary>Emits a two-argument operation.</summary>
-        private void Emit(int op, int opd1, int opd2)
+        private void Emit(RegexOpcode op, int opd1, int opd2)
         {
             if (RegexCode.OpcodeBacktracks(op))
             {
                 _trackCount++;
             }
 
-            _emitted.Append(op);
+            _emitted.Append((int)op);
             _emitted.Append(opd1);
             _emitted.Append(opd2);
         }
@@ -230,14 +219,14 @@ namespace System.Text.RegularExpressions
         /// </summary>
         private void EmitFragment(RegexNodeKind nodeType, RegexNode node, int curIndex)
         {
-            int bits = 0;
+            RegexOpcode bits = 0;
             if ((node.Options & RegexOptions.RightToLeft) != 0)
             {
-                bits |= RegexCode.Rtl;
+                bits |= RegexOpcode.RightToLeft;
             }
             if ((node.Options & RegexOptions.IgnoreCase) != 0)
             {
-                bits |= RegexCode.Ci;
+                bits |= RegexOpcode.CaseInsensitive;
             }
 
             switch (nodeType)
@@ -251,7 +240,7 @@ namespace System.Text.RegularExpressions
                     if (curIndex < node.ChildCount() - 1)
                     {
                         _intStack.Append(_emitted.Length);
-                        Emit(RegexCode.Lazybranch, 0);
+                        Emit(RegexOpcode.Lazybranch, 0);
                     }
                     break;
 
@@ -261,7 +250,7 @@ namespace System.Text.RegularExpressions
                         {
                             int lazyBranchPos = _intStack.Pop();
                             _intStack.Append(_emitted.Length);
-                            Emit(RegexCode.Goto, 0);
+                            Emit(RegexOpcode.Goto, 0);
                             PatchJump(lazyBranchPos, _emitted.Length);
                         }
                         else
@@ -278,11 +267,11 @@ namespace System.Text.RegularExpressions
                     switch (curIndex)
                     {
                         case 0:
-                            Emit(RegexCode.Setjump);
+                            Emit(RegexOpcode.Setjump);
                             _intStack.Append(_emitted.Length);
-                            Emit(RegexCode.Lazybranch, 0);
-                            Emit(RegexCode.Testref, RegexParser.MapCaptureNumber(node.M, _caps));
-                            Emit(RegexCode.Forejump);
+                            Emit(RegexOpcode.Lazybranch, 0);
+                            Emit(RegexOpcode.Testref, RegexParser.MapCaptureNumber(node.M, _caps));
+                            Emit(RegexOpcode.Forejump);
                             break;
                     }
                     break;
@@ -294,9 +283,9 @@ namespace System.Text.RegularExpressions
                             {
                                 int Branchpos = _intStack.Pop();
                                 _intStack.Append(_emitted.Length);
-                                Emit(RegexCode.Goto, 0);
+                                Emit(RegexOpcode.Goto, 0);
                                 PatchJump(Branchpos, _emitted.Length);
-                                Emit(RegexCode.Forejump);
+                                Emit(RegexOpcode.Forejump);
                                 break;
                             }
                         case 1:
@@ -309,10 +298,10 @@ namespace System.Text.RegularExpressions
                     switch (curIndex)
                     {
                         case 0:
-                            Emit(RegexCode.Setjump);
-                            Emit(RegexCode.Setmark);
+                            Emit(RegexOpcode.Setjump);
+                            Emit(RegexOpcode.Setmark);
                             _intStack.Append(_emitted.Length);
-                            Emit(RegexCode.Lazybranch, 0);
+                            Emit(RegexOpcode.Lazybranch, 0);
                             break;
                     }
                     break;
@@ -321,16 +310,16 @@ namespace System.Text.RegularExpressions
                     switch (curIndex)
                     {
                         case 0:
-                            Emit(RegexCode.Getmark);
-                            Emit(RegexCode.Forejump);
+                            Emit(RegexOpcode.Getmark);
+                            Emit(RegexOpcode.Forejump);
                             break;
                         case 1:
                             int Branchpos = _intStack.Pop();
                             _intStack.Append(_emitted.Length);
-                            Emit(RegexCode.Goto, 0);
+                            Emit(RegexOpcode.Goto, 0);
                             PatchJump(Branchpos, _emitted.Length);
-                            Emit(RegexCode.Getmark);
-                            Emit(RegexCode.Forejump);
+                            Emit(RegexOpcode.Getmark);
+                            Emit(RegexOpcode.Forejump);
                             break;
                         case 2:
                             PatchJump(_intStack.Pop(), _emitted.Length);
@@ -342,14 +331,14 @@ namespace System.Text.RegularExpressions
                 case RegexNodeKind.Lazyloop | BeforeChild:
 
                     if (node.N < int.MaxValue || node.M > 1)
-                        Emit(node.M == 0 ? RegexCode.Nullcount : RegexCode.Setcount, node.M == 0 ? 0 : 1 - node.M);
+                        Emit(node.M == 0 ? RegexOpcode.Nullcount : RegexOpcode.Setcount, node.M == 0 ? 0 : 1 - node.M);
                     else
-                        Emit(node.M == 0 ? RegexCode.Nullmark : RegexCode.Setmark);
+                        Emit(node.M == 0 ? RegexOpcode.Nullmark : RegexOpcode.Setmark);
 
                     if (node.M == 0)
                     {
                         _intStack.Append(_emitted.Length);
-                        Emit(RegexCode.Goto, 0);
+                        Emit(RegexOpcode.Goto, 0);
                     }
                     _intStack.Append(_emitted.Length);
                     break;
@@ -361,9 +350,9 @@ namespace System.Text.RegularExpressions
                         int Lazy = (nodeType - (RegexNodeKind.Loop | AfterChild));
 
                         if (node.N < int.MaxValue || node.M > 1)
-                            Emit(RegexCode.Branchcount + Lazy, _intStack.Pop(), node.N == int.MaxValue ? int.MaxValue : node.N - node.M);
+                            Emit(RegexOpcode.Branchcount + Lazy, _intStack.Pop(), node.N == int.MaxValue ? int.MaxValue : node.N - node.M);
                         else
-                            Emit(RegexCode.Branchmark + Lazy, _intStack.Pop());
+                            Emit(RegexOpcode.Branchmark + Lazy, _intStack.Pop());
 
                         if (node.M == 0)
                             PatchJump(_intStack.Pop(), StartJumpPos);
@@ -375,46 +364,46 @@ namespace System.Text.RegularExpressions
                     break;
 
                 case RegexNodeKind.Capture | BeforeChild:
-                    Emit(RegexCode.Setmark);
+                    Emit(RegexOpcode.Setmark);
                     break;
 
                 case RegexNodeKind.Capture | AfterChild:
-                    Emit(RegexCode.Capturemark, RegexParser.MapCaptureNumber(node.M, _caps), RegexParser.MapCaptureNumber(node.N, _caps));
+                    Emit(RegexOpcode.Capturemark, RegexParser.MapCaptureNumber(node.M, _caps), RegexParser.MapCaptureNumber(node.N, _caps));
                     break;
 
                 case RegexNodeKind.PositiveLookaround | BeforeChild:
-                    Emit(RegexCode.Setjump); // causes lookahead/lookbehind to be non-backtracking
-                    Emit(RegexCode.Setmark);
+                    Emit(RegexOpcode.Setjump); // causes lookahead/lookbehind to be non-backtracking
+                    Emit(RegexOpcode.Setmark);
                     break;
 
                 case RegexNodeKind.PositiveLookaround | AfterChild:
-                    Emit(RegexCode.Getmark);
-                    Emit(RegexCode.Forejump); // causes lookahead/lookbehind to be non-backtracking
+                    Emit(RegexOpcode.Getmark);
+                    Emit(RegexOpcode.Forejump); // causes lookahead/lookbehind to be non-backtracking
                     break;
 
                 case RegexNodeKind.NegativeLookaround | BeforeChild:
-                    Emit(RegexCode.Setjump);
+                    Emit(RegexOpcode.Setjump);
                     _intStack.Append(_emitted.Length);
-                    Emit(RegexCode.Lazybranch, 0);
+                    Emit(RegexOpcode.Lazybranch, 0);
                     break;
 
                 case RegexNodeKind.NegativeLookaround | AfterChild:
-                    Emit(RegexCode.Backjump);
+                    Emit(RegexOpcode.Backjump);
                     PatchJump(_intStack.Pop(), _emitted.Length);
-                    Emit(RegexCode.Forejump);
+                    Emit(RegexOpcode.Forejump);
                     break;
 
                 case RegexNodeKind.Atomic | BeforeChild:
-                    Emit(RegexCode.Setjump);
+                    Emit(RegexOpcode.Setjump);
                     break;
 
                 case RegexNodeKind.Atomic | AfterChild:
-                    Emit(RegexCode.Forejump);
+                    Emit(RegexOpcode.Forejump);
                     break;
 
                 case RegexNodeKind.One:
                 case RegexNodeKind.Notone:
-                    Emit((int)node.Kind | bits, node.Ch);
+                    Emit((RegexOpcode)node.Kind | bits, node.Ch);
                     break;
 
                 case RegexNodeKind.Notoneloop:
@@ -426,11 +415,11 @@ namespace System.Text.RegularExpressions
                     if (node.M > 0)
                     {
                         Emit(((node.Kind is RegexNodeKind.Oneloop or RegexNodeKind.Oneloopatomic or RegexNodeKind.Onelazy) ?
-                              RegexCode.Onerep : RegexCode.Notonerep) | bits, node.Ch, node.M);
+                              RegexOpcode.Onerep : RegexOpcode.Notonerep) | bits, node.Ch, node.M);
                     }
                     if (node.N > node.M)
                     {
-                        Emit((int)node.Kind | bits, node.Ch, node.N == int.MaxValue ? int.MaxValue : node.N - node.M);
+                        Emit((RegexOpcode)node.Kind | bits, node.Ch, node.N == int.MaxValue ? int.MaxValue : node.N - node.M);
                     }
                     break;
 
@@ -441,25 +430,25 @@ namespace System.Text.RegularExpressions
                         int stringCode = StringCode(node.Str!);
                         if (node.M > 0)
                         {
-                            Emit(RegexCode.Setrep | bits, stringCode, node.M);
+                            Emit(RegexOpcode.Setrep | bits, stringCode, node.M);
                         }
                         if (node.N > node.M)
                         {
-                            Emit((int)node.Kind | bits, stringCode, (node.N == int.MaxValue) ? int.MaxValue : node.N - node.M);
+                            Emit((RegexOpcode)node.Kind | bits, stringCode, (node.N == int.MaxValue) ? int.MaxValue : node.N - node.M);
                         }
                     }
                     break;
 
                 case RegexNodeKind.Multi:
-                    Emit((int)node.Kind | bits, StringCode(node.Str!));
+                    Emit((RegexOpcode)node.Kind | bits, StringCode(node.Str!));
                     break;
 
                 case RegexNodeKind.Set:
-                    Emit((int)node.Kind | bits, StringCode(node.Str!));
+                    Emit((RegexOpcode)node.Kind | bits, StringCode(node.Str!));
                     break;
 
                 case RegexNodeKind.Backreference:
-                    Emit((int)node.Kind | bits, RegexParser.MapCaptureNumber(node.M, _caps));
+                    Emit((RegexOpcode)node.Kind | bits, RegexParser.MapCaptureNumber(node.M, _caps));
                     break;
 
                 case RegexNodeKind.Nothing:
@@ -474,7 +463,7 @@ namespace System.Text.RegularExpressions
                 case RegexNodeKind.EndZ:
                 case RegexNodeKind.End:
                 case RegexNodeKind.UpdateBumpalong:
-                    Emit((int)node.Kind);
+                    Emit((RegexOpcode)node.Kind);
                     break;
 
                 default:


### PR DESCRIPTION
No functional changes (other than deleting some useless debug-only tracing).  Cleans up RegexCode's const int opcodes by moving them into a dedicated enum, and cleans up some unused debugging-related code.  We may want to remove even more, but I at least wanted to get rid of RegexOptions.Debug so that we didn't have the extra option littered throughout the code.