### PR TITLE
Add xarch `andn`

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -424,6 +424,9 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps tr
         case IF_RRD:
         case IF_RRW:
         case IF_RWR_RRD_RRD:
+        case IF_RWR_RRD_MRD:
+        case IF_RWR_RRD_ARD:
+        case IF_RWR_RRD_SRD:
             break;
         default:
             return false;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -423,6 +423,7 @@ bool emitter::AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps tr
         case IF_RWR:
         case IF_RRD:
         case IF_RRW:
+        case IF_RWR_RRD_RRD:
             break;
         default:
             return false;

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -592,7 +592,7 @@ INST3(LAST_AVXVNNI_INSTRUCTION, "LAST_AVXVNNI_INSTRUCTION", IUM_WR, BAD_CODE, BA
 
 // BMI1
 INST3(FIRST_BMI_INSTRUCTION, "FIRST_BMI_INSTRUCTION", IUM_WR, BAD_CODE, BAD_CODE, BAD_CODE, INS_FLAGS_None)
-INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
+INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Resets_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
 INST3(blsi,             "blsi",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
 INST3(blsmsk,           "blsmsk",           IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
 INST3(blsr,             "blsr",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Reset Lowest Set Bit

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -592,7 +592,7 @@ INST3(LAST_AVXVNNI_INSTRUCTION, "LAST_AVXVNNI_INSTRUCTION", IUM_WR, BAD_CODE, BA
 
 // BMI1
 INST3(FIRST_BMI_INSTRUCTION, "FIRST_BMI_INSTRUCTION", IUM_WR, BAD_CODE, BAD_CODE, BAD_CODE, INS_FLAGS_None)
-INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
+INST3(andn,             "andn",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF2),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Logical AND NOT
 INST3(blsi,             "blsi",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Extract Lowest Set Isolated Bit
 INST3(blsmsk,           "blsmsk",           IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             INS_Flags_IsDstDstSrcAVXInstruction)    // Get Mask Up to Lowest Set Bit
 INST3(blsr,             "blsr",             IUM_WR, BAD_CODE,     BAD_CODE,     SSE38(0xF3),                             Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Undefined_PF  | Writes_CF     | INS_Flags_IsDstDstSrcAVXInstruction)    // Reset Lowest Set Bit

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -139,7 +139,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_AND:
         case GT_OR:
         case GT_XOR:
-            return LowerBinaryArithmeticCommon(node->AsOp());
+            return LowerBinaryArithmetic(node->AsOp());
 
         case GT_MUL:
         case GT_MULHI:
@@ -5120,53 +5120,6 @@ GenTree* Lowering::LowerAdd(GenTreeOp* node)
         ContainCheckBinary(node);
     }
     return nullptr;
-}
-
-//------------------------------------------------------------------------
-// LowerBinaryArithmeticCommon: lowers the given binary arithmetic node.
-//
-// Recognizes opportunities for using target-independent "combined" nodes
-// (currently AND_NOT on ARMArch). Performs containment checks.
-//
-// Arguments:
-//    node - the arithmetic node to lower
-//
-// Returns:
-//    The next node to lower.
-//
-GenTree* Lowering::LowerBinaryArithmeticCommon(GenTreeOp* binOp)
-{
-    // TODO-CQ-XArch: support BMI2 "andn" in codegen and condition
-    // this logic on the support for the instruction set on XArch.
-    CLANG_FORMAT_COMMENT_ANCHOR;
-
-#ifdef TARGET_ARMARCH
-    if (comp->opts.OptimizationEnabled() && binOp->OperIs(GT_AND))
-    {
-        GenTree* opNode  = nullptr;
-        GenTree* notNode = nullptr;
-        if (binOp->gtGetOp1()->OperIs(GT_NOT))
-        {
-            notNode = binOp->gtGetOp1();
-            opNode  = binOp->gtGetOp2();
-        }
-        else if (binOp->gtGetOp2()->OperIs(GT_NOT))
-        {
-            notNode = binOp->gtGetOp2();
-            opNode  = binOp->gtGetOp1();
-        }
-
-        if (notNode != nullptr)
-        {
-            binOp->gtOp1 = opNode;
-            binOp->gtOp2 = notNode->AsUnOp()->gtGetOp1();
-            binOp->ChangeOper(GT_AND_NOT);
-            BlockRange().Remove(notNode);
-        }
-    }
-#endif
-
-    return LowerBinaryArithmetic(binOp);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -297,7 +297,6 @@ private:
     void LowerStoreIndir(GenTreeStoreInd* node);
     GenTree* LowerAdd(GenTreeOp* node);
     GenTree* LowerMul(GenTreeOp* mul);
-    GenTree* LowerBinaryArithmeticCommon(GenTreeOp* binOp);
     GenTree* LowerBinaryArithmetic(GenTreeOp* binOp);
     bool LowerUnsignedDivOrMod(GenTreeOp* divMod);
     GenTree* LowerConstIntDivOrMod(GenTree* node);
@@ -344,7 +343,8 @@ private:
     void LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node);
-    GenTree* TryLowerAndOpToResetLowestSetBit(GenTreeOp* binOp);
+    GenTree* TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode);
+    GenTree* TryLowerAndOpToAndNot(GenTreeOp* andNode);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3841,7 +3841,14 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
         opNode  = andNode->gtGetOp1();
     }
 
-    if (opNode == nullptr || !opNode->OperIs(GT_LCL_VAR))
+    if (opNode == nullptr)
+    {
+        return nullptr;
+    }
+
+    // We will avoid using "andn" when one of the operands is (likely to be) in memory:
+    // "and"'s RMW form provides for a shorter instruction sequence in that case.
+    if (!opNode->OperIs(GT_LCL_VAR))
     {
         return nullptr;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3735,7 +3735,7 @@ void Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
 }
 
 //----------------------------------------------------------------------------------------------
-// Lowering::TryLowerAndOpToResetLowestSetBit: Lowers a tree AND(X, ADD(X, -1) to HWIntrinsic::ResetLowestSetBit
+// Lowering::TryLowerAndOpToResetLowestSetBit: Lowers a tree AND(X, ADD(X, -1)) to HWIntrinsic::ResetLowestSetBit
 //
 // Arguments:
 //    andNode - GT_AND node of integral type
@@ -3743,6 +3743,8 @@ void Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
 // Return Value:
 //    Returns the replacement node if one is created else nullptr indicating no replacement
 //
+// Notes:
+//    Performs containment checks on the replacement node if one is created
 GenTree* Lowering::TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
 {
     assert(andNode->OperIs(GT_AND) && varTypeIsIntegral(andNode));
@@ -3811,6 +3813,17 @@ GenTree* Lowering::TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
     return blsrNode;
 }
 
+//----------------------------------------------------------------------------------------------
+// Lowering::TryLowerAndOpToAndNot: Lowers a tree AND(X, NOT(Y)) to HWIntrinsic::AndNot
+//
+// Arguments:
+//    andNode - GT_AND node of integral type
+//
+// Return Value:
+//    Returns the replacement node if one is created else nullptr indicating no replacement
+//
+// Notes:
+//    Performs containment checks on the replacement node if one is created
 GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
 {
     assert(andNode->OperIs(GT_AND) && varTypeIsIntegral(andNode));
@@ -3853,6 +3866,7 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
         return nullptr;
     }
 
+    // note that parameter order for andn is ~y, x so these are purposefully reversed when creating the node
     GenTreeHWIntrinsic* andnNode =
         comp->gtNewScalarHWIntrinsicNode(andNode->TypeGet(), notNode->AsUnOp()->gtGetOp1(), opNode, intrinsic);
 
@@ -3870,7 +3884,6 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
     ContainCheckHWIntrinsic(andnNode);
 
     return andnNode;
-    
 }
 
 #endif // FEATURE_HW_INTRINSICS

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -162,6 +162,9 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 //------------------------------------------------------------------------
 // LowerBinaryArithmetic: lowers the given binary arithmetic node.
 //
+// Recognizes opportunities for using target-independent "combined" nodes
+// Performs containment checks.
+//
 // Arguments:
 //    node - the arithmetic node to lower
 //
@@ -173,10 +176,16 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 #ifdef FEATURE_HW_INTRINSICS
     if (comp->opts.OptimizationEnabled() && binOp->OperIs(GT_AND) && varTypeIsIntegral(binOp))
     {
-        GenTree* blsrNode = TryLowerAndOpToResetLowestSetBit(binOp);
-        if (blsrNode != nullptr)
+        GenTree* replacementNode = TryLowerAndOpToAndNot(binOp);
+        if (replacementNode != nullptr)
         {
-            return blsrNode->gtNext;
+            return replacementNode->gtNext;
+        }
+
+        replacementNode = TryLowerAndOpToResetLowestSetBit(binOp);
+        if (replacementNode != nullptr)
+        {
+            return replacementNode->gtNext;
         }
     }
 #endif
@@ -3800,6 +3809,68 @@ GenTree* Lowering::TryLowerAndOpToResetLowestSetBit(GenTreeOp* andNode)
     ContainCheckHWIntrinsic(blsrNode);
 
     return blsrNode;
+}
+
+GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
+{
+    assert(andNode->OperIs(GT_AND) && varTypeIsIntegral(andNode));
+
+    GenTree* opNode  = nullptr;
+    GenTree* notNode = nullptr;
+    if (andNode->gtGetOp1()->OperIs(GT_NOT))
+    {
+        notNode = andNode->gtGetOp1();
+        opNode  = andNode->gtGetOp2();
+    }
+    else if (andNode->gtGetOp2()->OperIs(GT_NOT))
+    {
+        notNode = andNode->gtGetOp2();
+        opNode  = andNode->gtGetOp1();
+    }
+
+    if (opNode == nullptr || !opNode->OperIs(GT_LCL_VAR))
+    {
+        return nullptr;
+    }
+
+    NamedIntrinsic intrinsic;
+    if (andNode->TypeIs(TYP_LONG) && comp->compOpportunisticallyDependsOn(InstructionSet_BMI1_X64))
+    {
+        intrinsic = NamedIntrinsic::NI_BMI1_X64_AndNot;
+    }
+    else if (comp->compOpportunisticallyDependsOn(InstructionSet_BMI1))
+    {
+        intrinsic = NamedIntrinsic::NI_BMI1_AndNot;
+    }
+    else
+    {
+        return nullptr;
+    }
+
+    LIR::Use use;
+    if (!BlockRange().TryGetUse(andNode, &use))
+    {
+        return nullptr;
+    }
+
+    GenTreeHWIntrinsic* andnNode =
+        comp->gtNewScalarHWIntrinsicNode(andNode->TypeGet(), notNode->AsUnOp()->gtGetOp1(), opNode, intrinsic);
+
+    JITDUMP("Lower: optimize AND(X, NOT(Y)))\n");
+    DISPNODE(andNode);
+    JITDUMP("to:\n");
+    DISPNODE(andnNode);
+
+    use.ReplaceWith(andnNode);
+
+    BlockRange().InsertBefore(andNode, andnNode);
+    BlockRange().Remove(andNode);
+    BlockRange().Remove(notNode);
+
+    ContainCheckHWIntrinsic(andnNode);
+
+    return andnNode;
+    
 }
 
 #endif // FEATURE_HW_INTRINSICS

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3848,7 +3848,7 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
 
     // We will avoid using "andn" when one of the operands is (likely to be) in memory:
     // "and"'s RMW form provides for a shorter instruction sequence in that case.
-    if (!opNode->OperIs(GT_LCL_VAR))
+    if (IsBinOpInRMWStoreInd(andNode))
     {
         return nullptr;
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -3846,8 +3846,8 @@ GenTree* Lowering::TryLowerAndOpToAndNot(GenTreeOp* andNode)
         return nullptr;
     }
 
-    // We will avoid using "andn" when one of the operands is (likely to be) in memory:
-    // "and"'s RMW form provides for a shorter instruction sequence in that case.
+    // We want to avoid using "andn" when one of the operands is both a source and the destination and is also coming
+    // from memory. In this scenario, we will get smaller and likely faster code by using the RMW encoding of `and`
     if (IsBinOpInRMWStoreInd(andNode))
     {
         return nullptr;


### PR DESCRIPTION
This adds a lowering for the pattern `AND(x, NOT(y))` and `AND(NOT(x),y))` using the existing arm specific logic as a base. 

The arm specific version is moved into arm specific lowering where it functions unchanged, it generates a GT_AND_NOT node which is later emitted as a BitClear instruction.

The xarch specific version has been added. It generates a new HWIntrinsic node for the `andn` instruction taking advantage of the support for the instruction already in place in the emitter. The instruction format needed to be added to the whitelist of formats that are recognised as setting the ZF flag to allow the best optimization.

Diffs are improvements. In all cases where the node is used the instruction count is reduced. In cases where the size has increased it is because the andn instruction plus 3 args encoding consumes one more byte than the combination of simpler and followed by not and their args.

## aspnet.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 21586326 (overridden on cmd)
Total bytes of diff: 21586263 (overridden on cmd)
Total bytes of delta: -63 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
           4 : 51520.dasm (3.03% of base)
           1 : 44444.dasm (0.04% of base)
           1 : 18515.dasm (0.04% of base)
           1 : 19658.dasm (0.04% of base)

Top file improvements (bytes):
         -16 : 54342.dasm (-4.28% of base)
          -4 : 9096.dasm (-0.58% of base)
          -4 : 4052.dasm (-8.00% of base)
          -2 : 53045.dasm (-0.55% of base)
          -1 : 12850.dasm (-3.45% of base)
          -1 : 41513.dasm (-0.06% of base)
          -1 : 61212.dasm (-3.45% of base)
          -1 : 10701.dasm (-1.14% of base)
          -1 : 64291.dasm (-1.79% of base)
          -1 : 18559.dasm (-3.45% of base)
          -1 : 50000.dasm (-1.79% of base)
          -1 : 59338.dasm (-0.04% of base)
          -1 : 18514.dasm (-0.04% of base)
          -1 : 41531.dasm (-3.45% of base)
          -1 : 59350.dasm (-3.45% of base)
          -1 : 63077.dasm (-0.04% of base)
          -1 : 19657.dasm (-0.04% of base)
          -1 : 29363.dasm (-0.04% of base)
          -1 : 63082.dasm (-3.45% of base)
          -1 : 18557.dasm (-1.79% of base)

52 total files with Code Size differences (48 improved, 4 regressed), 4 unchanged.

Top method regressions (bytes):
           4 ( 3.03% of base) : 51520.dasm - RegexParser:ScanOptions():this
           1 ( 0.04% of base) : 44444.dasm - HttpParser`1:ParseHeaders(Http1ParsingHandler,byref):bool:this
           1 ( 0.04% of base) : 18515.dasm - HttpParser`1:ParseHeaders(Http1ParsingHandler,byref):bool:this
           1 ( 0.04% of base) : 19658.dasm - HttpParser`1:ParseHeaders(Http1ParsingHandler,byref):bool:this

Top method improvements (bytes):
         -16 (-4.28% of base) : 54342.dasm - RBTree`1:GetIndexOfPageWithFreeSlot(bool):int:this
          -4 (-0.58% of base) : 9096.dasm - Sha1ForNonSecretPurposes:Drain():this
          -4 (-8.00% of base) : 4052.dasm - ThreadCounts:SetInt16Value(short,ubyte):this
          -2 (-0.55% of base) : 53045.dasm - ChainPal:GetChainStatusInformation(int):ref
          -1 (-0.04% of base) : 59338.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 18514.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 63077.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 19657.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 29363.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 61179.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 23857.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 44434.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 50012.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 57539.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 64284.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-0.04% of base) : 41526.dasm - Http1Connection:TakeMessageHeaders(byref,bool):bool:this
          -1 (-1.79% of base) : 64291.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this
          -1 (-1.79% of base) : 50000.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this
          -1 (-1.79% of base) : 18557.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this
          -1 (-1.79% of base) : 59349.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this

Top method regressions (percentages):
           4 ( 3.03% of base) : 51520.dasm - RegexParser:ScanOptions():this
           1 ( 0.04% of base) : 18515.dasm - HttpParser`1:ParseHeaders(Http1ParsingHandler,byref):bool:this
           1 ( 0.04% of base) : 19658.dasm - HttpParser`1:ParseHeaders(Http1ParsingHandler,byref):bool:this
           1 ( 0.04% of base) : 44444.dasm - HttpParser`1:ParseHeaders(Http1ParsingHandler,byref):bool:this

Top method improvements (percentages):
          -4 (-8.00% of base) : 4052.dasm - ThreadCounts:SetInt16Value(short,ubyte):this
         -16 (-4.28% of base) : 54342.dasm - RBTree`1:GetIndexOfPageWithFreeSlot(bool):int:this
          -1 (-3.45% of base) : 12850.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 61212.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 18559.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 41531.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 59350.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 63082.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 57535.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 29342.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 19667.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 50002.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 64293.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 23872.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-3.45% of base) : 44381.dasm - HttpRequestHeaders:OnHeadersComplete():this
          -1 (-1.79% of base) : 64291.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this
          -1 (-1.79% of base) : 50000.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this
          -1 (-1.79% of base) : 18557.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this
          -1 (-1.79% of base) : 59349.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this
          -1 (-1.79% of base) : 19666.dasm - Http1ParsingHandler:OnHeadersComplete(bool):this

52 total methods with Code Size differences (48 improved, 4 regressed), 4 unchanged.

```

</details>

--------------------------------------------------------------------------------

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 13177305 (overridden on cmd)
Total bytes of diff: 13177224 (overridden on cmd)
Total bytes of delta: -81 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
           4 : 1240.dasm (3.20% of base)
           2 : 36630.dasm (1.10% of base)
           1 : 35514.dasm (0.17% of base)
           1 : 35530.dasm (0.81% of base)

Top file improvements (bytes):
         -16 : 33641.dasm (-3.25% of base)
         -13 : 35515.dasm (-2.40% of base)
         -12 : 7250.dasm (-2.26% of base)
         -11 : 33688.dasm (-0.66% of base)
          -8 : 34512.dasm (-1.78% of base)
          -8 : 35570.dasm (-0.22% of base)
          -6 : 9736.dasm (-3.17% of base)
          -5 : 6916.dasm (-1.12% of base)
          -4 : 7375.dasm (-36.36% of base)
          -3 : 795.dasm (-0.46% of base)
          -2 : 6587.dasm (-0.57% of base)
          -1 : 4449.dasm (-0.88% of base)

16 total files with Code Size differences (12 improved, 4 regressed), 7 unchanged.

Top method regressions (bytes):
           4 ( 3.20% of base) : 1240.dasm - System.Text.RegularExpressions.RegexParser:ScanOptions():this
           2 ( 1.10% of base) : 36630.dasm - Microsoft.CodeAnalysis.BitVector:set_Item(int,bool):this
           1 ( 0.81% of base) : 35530.dasm - System.Reflection.PortableExecutable.ManagedTextSection:CalculateOffsetToMappedFieldDataStream():int:this
           1 ( 0.17% of base) : 35514.dasm - System.Reflection.PortableExecutable.PEBuilder:Serialize(System.Reflection.Metadata.BlobBuilder):System.Reflection.Metadata.BlobContentId:this

Top method improvements (bytes):
         -16 (-3.25% of base) : 33641.dasm - Microsoft.CodeAnalysis.CSharp.Imports:Complete(System.Threading.CancellationToken):this
         -13 (-2.40% of base) : 35515.dasm - System.Reflection.PortableExecutable.PEBuilder:SerializeSections():System.Collections.Immutable.ImmutableArray`1[SerializedSection]:this
         -12 (-2.26% of base) : 7250.dasm - System.Text.RegularExpressions.Symbolic.BDDAlgebra:CreateSetFromRangeImpl(int,int,int):System.Text.RegularExpressions.Symbolic.BDD:this
         -11 (-0.66% of base) : 33688.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ModifierUtils:CheckModifiers(int,int,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag,System.Nullable`1[SyntaxTokenList],byref):int
          -8 (-1.78% of base) : 34512.dasm - Microsoft.CodeAnalysis.CSharp.DiagnosticsPass:CheckForBitwiseOrSignExtend(Microsoft.CodeAnalysis.CSharp.BoundExpression,int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression):this
          -8 (-0.22% of base) : 35570.dasm - System.Reflection.PortableExecutable.PEBuilder:WritePEHeader(System.Reflection.Metadata.BlobBuilder,System.Reflection.PortableExecutable.PEDirectoriesBuilder,System.Collections.Immutable.ImmutableArray`1[SerializedSection]):this
          -6 (-3.17% of base) : 9736.dasm - System.Text.Json.BitStack:PushToArray(bool):this
          -5 (-1.12% of base) : 6916.dasm - System.Number:AssembleFloatingPointBits(byref,long,int,bool):long
          -4 (-36.36% of base) : 7375.dasm - System.Text.RegularExpressions.Symbolic.BV64Algebra:Not(long):long:this
          -3 (-0.46% of base) : 795.dasm - System.Sha1ForNonSecretPurposes:Drain():this
          -2 (-0.57% of base) : 6587.dasm - Internal.Cryptography.Pal.ChainPal:GetChainStatusInformation(int):System.Security.Cryptography.X509Certificates.X509ChainStatus[]
          -1 (-0.88% of base) : 4449.dasm - System.Threading.ManualResetEventSlim:UpdateStateAtomically(int,int):this

Top method regressions (percentages):
           4 ( 3.20% of base) : 1240.dasm - System.Text.RegularExpressions.RegexParser:ScanOptions():this
           2 ( 1.10% of base) : 36630.dasm - Microsoft.CodeAnalysis.BitVector:set_Item(int,bool):this
           1 ( 0.81% of base) : 35530.dasm - System.Reflection.PortableExecutable.ManagedTextSection:CalculateOffsetToMappedFieldDataStream():int:this
           1 ( 0.17% of base) : 35514.dasm - System.Reflection.PortableExecutable.PEBuilder:Serialize(System.Reflection.Metadata.BlobBuilder):System.Reflection.Metadata.BlobContentId:this

Top method improvements (percentages):
          -4 (-36.36% of base) : 7375.dasm - System.Text.RegularExpressions.Symbolic.BV64Algebra:Not(long):long:this
         -16 (-3.25% of base) : 33641.dasm - Microsoft.CodeAnalysis.CSharp.Imports:Complete(System.Threading.CancellationToken):this
          -6 (-3.17% of base) : 9736.dasm - System.Text.Json.BitStack:PushToArray(bool):this
         -13 (-2.40% of base) : 35515.dasm - System.Reflection.PortableExecutable.PEBuilder:SerializeSections():System.Collections.Immutable.ImmutableArray`1[SerializedSection]:this
         -12 (-2.26% of base) : 7250.dasm - System.Text.RegularExpressions.Symbolic.BDDAlgebra:CreateSetFromRangeImpl(int,int,int):System.Text.RegularExpressions.Symbolic.BDD:this
          -8 (-1.78% of base) : 34512.dasm - Microsoft.CodeAnalysis.CSharp.DiagnosticsPass:CheckForBitwiseOrSignExtend(Microsoft.CodeAnalysis.CSharp.BoundExpression,int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression):this
          -5 (-1.12% of base) : 6916.dasm - System.Number:AssembleFloatingPointBits(byref,long,int,bool):long
          -1 (-0.88% of base) : 4449.dasm - System.Threading.ManualResetEventSlim:UpdateStateAtomically(int,int):this
         -11 (-0.66% of base) : 33688.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ModifierUtils:CheckModifiers(int,int,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag,System.Nullable`1[SyntaxTokenList],byref):int
          -2 (-0.57% of base) : 6587.dasm - Internal.Cryptography.Pal.ChainPal:GetChainStatusInformation(int):System.Security.Cryptography.X509Certificates.X509ChainStatus[]
          -3 (-0.46% of base) : 795.dasm - System.Sha1ForNonSecretPurposes:Drain():this
          -8 (-0.22% of base) : 35570.dasm - System.Reflection.PortableExecutable.PEBuilder:WritePEHeader(System.Reflection.Metadata.BlobBuilder,System.Reflection.PortableExecutable.PEDirectoriesBuilder,System.Collections.Immutable.ImmutableArray`1[SerializedSection]):this

16 total methods with Code Size differences (12 improved, 4 regressed), 7 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 127515315 (overridden on cmd)
Total bytes of diff: 127483556 (overridden on cmd)
Total bytes of delta: -31759 (-0.02 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
           6 : 216048.dasm (0.04% of base)
           5 : 216026.dasm (45.45% of base)
           3 : 93376.dasm (0.20% of base)
           2 : 215427.dasm (0.43% of base)
           1 : 125315.dasm (5.00% of base)
           1 : 188830.dasm (5.00% of base)
           1 : 18932.dasm (5.00% of base)
           1 : 113879.dasm (5.00% of base)
           1 : 190634.dasm (5.00% of base)
           1 : 230347.dasm (0.43% of base)
           1 : 149367.dasm (5.00% of base)
           1 : 17497.dasm (5.00% of base)
           1 : 195009.dasm (5.00% of base)
           1 : 183258.dasm (5.00% of base)
           1 : 184141.dasm (5.00% of base)
           1 : 185786.dasm (5.00% of base)
           1 : 187439.dasm (5.00% of base)
           1 : 215202.dasm (0.75% of base)
           1 : 216083.dasm (2.17% of base)
           1 : 146747.dasm (5.00% of base)

Top file improvements (bytes):
         -21 : 227695.dasm (-3.55% of base)
         -21 : 227696.dasm (-3.55% of base)
         -21 : 227697.dasm (-3.55% of base)
         -21 : 227633.dasm (-3.25% of base)
         -21 : 227634.dasm (-3.25% of base)
         -21 : 227635.dasm (-3.25% of base)
         -16 : 227692.dasm (-5.50% of base)
         -16 : 227693.dasm (-5.57% of base)
         -16 : 227694.dasm (-5.57% of base)
         -16 : 227630.dasm (-5.57% of base)
         -16 : 227631.dasm (-5.59% of base)
         -16 : 227632.dasm (-5.59% of base)
         -14 : 52421.dasm (-3.27% of base)
         -14 : 52422.dasm (-3.27% of base)
         -14 : 52423.dasm (-3.27% of base)
         -14 : 52424.dasm (-3.27% of base)
         -14 : 48545.dasm (-3.27% of base)
         -14 : 48546.dasm (-3.27% of base)
         -13 : 198906.dasm (-2.89% of base)
         -13 : 198908.dasm (-2.89% of base)

17346 total files with Code Size differences (17303 improved, 43 regressed), 0 unchanged.

Top method regressions (bytes):
           6 ( 0.04% of base) : 216048.dasm - Internal.IL.ILImporter:ImportBasicBlock(BasicBlock):this
           5 (45.45% of base) : 216026.dasm - Internal.IL.ILImporter:ClearPendingPrefix(int):this
           3 ( 0.20% of base) : 93376.dasm - JitTest.Test:Main():int
           2 ( 0.43% of base) : 215427.dasm - Internal.TypeSystem.LayoutInt:AlignUp(Internal.TypeSystem.LayoutInt,Internal.TypeSystem.LayoutInt,Internal.TypeSystem.TargetDetails):Internal.TypeSystem.LayoutInt
           1 ( 2.17% of base) : 216083.dasm - Internal.IL.ILImporter:EndImportingInstruction():this
           1 ( 0.75% of base) : 215202.dasm - Internal.TypeSystem.AlignmentHelper:AlignUp(int,int):int
           1 ( 5.88% of base) : 12220.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(byte,byte):byte
           1 ( 5.00% of base) : 125315.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 188830.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 18932.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 113879.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 190634.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 149367.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 17497.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 195009.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 183258.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 184141.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 185786.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 187439.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 146747.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float

Top method improvements (bytes):
         -21 (-3.55% of base) : 227696.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunReflectionScenario_Load():this
         -21 (-3.55% of base) : 227697.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunReflectionScenario_LoadAligned():this
         -21 (-3.55% of base) : 227695.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunReflectionScenario_UnsafeRead():this
         -21 (-3.25% of base) : 227634.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunReflectionScenario_Load():this
         -21 (-3.25% of base) : 227635.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunReflectionScenario_LoadAligned():this
         -21 (-3.25% of base) : 227633.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunReflectionScenario_UnsafeRead():this
         -16 (-5.57% of base) : 227693.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunBasicScenario_Load():this
         -16 (-5.57% of base) : 227694.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunBasicScenario_LoadAligned():this
         -16 (-5.50% of base) : 227692.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunBasicScenario_UnsafeRead():this
         -16 (-5.59% of base) : 227631.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunBasicScenario_Load():this
         -16 (-5.59% of base) : 227632.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunBasicScenario_LoadAligned():this
         -16 (-5.57% of base) : 227630.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunBasicScenario_UnsafeRead():this
         -14 (-3.27% of base) : 48545.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadDouble):this
         -14 (-3.27% of base) : 52421.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadInt32):this
         -14 (-3.27% of base) : 52423.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadInt64):this
         -14 (-3.27% of base) : 48546.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadSingle):this
         -14 (-3.27% of base) : 52422.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadUInt32):this
         -14 (-3.27% of base) : 52424.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadUInt64):this
         -13 (-2.42% of base) : 227399.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpConvTest__ConvertScalarToVector128SingleSingle:RunReflectionScenario_Load():this
         -13 (-2.42% of base) : 227400.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpConvTest__ConvertScalarToVector128SingleSingle:RunReflectionScenario_LoadAligned():this

Top method regressions (percentages):
           5 (45.45% of base) : 216026.dasm - Internal.IL.ILImporter:ClearPendingPrefix(int):this
           1 ( 7.14% of base) : 12170.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(short,short):short
           1 ( 7.14% of base) : 12227.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(ubyte,ubyte):ubyte
           1 ( 7.14% of base) : 12177.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(ushort,ushort):ushort
           1 ( 5.88% of base) : 12220.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(byte,byte):byte
           1 ( 5.00% of base) : 125315.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 188830.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 18932.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 113879.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 190634.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 149367.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 17497.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 195009.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 183258.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 184141.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 185786.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 187439.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 146747.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 193326.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float
           1 ( 5.00% of base) : 12151.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(float,float):float

Top method improvements (percentages):
          -4 (-40.00% of base) : 12134.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(long,long):long
          -4 (-40.00% of base) : 12141.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(long,long):long
          -1 (-14.29% of base) : 12184.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(int,int):int
          -1 (-14.29% of base) : 12191.dasm - JIT.HardwareIntrinsics.Arm.Helpers:BitwiseClear(int,int):int
          -1 (-6.67% of base) : 12233.dasm - DataTable:Align(long,long):long
         -16 (-5.59% of base) : 227631.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunBasicScenario_Load():this
         -16 (-5.59% of base) : 227632.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunBasicScenario_LoadAligned():this
         -16 (-5.57% of base) : 227693.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunBasicScenario_Load():this
         -16 (-5.57% of base) : 227694.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunBasicScenario_LoadAligned():this
         -16 (-5.57% of base) : 227630.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MultipleSumAbsoluteDifferences:RunBasicScenario_UnsafeRead():this
         -16 (-5.50% of base) : 227692.dasm - JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__CompareGreaterThanInt64:RunBasicScenario_UnsafeRead():this
         -11 (-4.85% of base) : 218969.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadDouble):this
         -11 (-4.85% of base) : 196131.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadInt32):this
         -11 (-4.85% of base) : 196133.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadInt64):this
         -11 (-4.85% of base) : 218970.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadSingle):this
         -11 (-4.85% of base) : 196132.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadUInt32):this
         -11 (-4.85% of base) : 196134.dasm - TestStruct:RunStructFldScenario(JIT.HardwareIntrinsics.X86.SimpleBinaryOpTest__MaskLoadUInt64):this
          -4 (-4.65% of base) : 243015.dasm - FPBehaviorApp.Managed:Truncate(double):double
          -9 (-4.62% of base) : 198733.dasm - JIT.HardwareIntrinsics.X86.SimpleUnaryOpTest__ConvertToVector128Int16Byte:RunBasicScenario_Load():this
          -9 (-4.62% of base) : 198734.dasm - JIT.HardwareIntrinsics.X86.SimpleUnaryOpTest__ConvertToVector128Int16Byte:RunBasicScenario_LoadAligned():this

17346 total methods with Code Size differences (17303 improved, 43 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 47108531 (overridden on cmd)
Total bytes of diff: 47108360 (overridden on cmd)
Total bytes of delta: -171 (-0.00 % of base)
    diff is an improvement.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
           6 : 138026.dasm (20.69% of base)
           6 : 138025.dasm (20.69% of base)
           4 : 228858.dasm (3.20% of base)
           4 : 43388.dasm (23.53% of base)
           3 : 138087.dasm (1.21% of base)
           3 : 138110.dasm (5.17% of base)
           3 : 141565.dasm (0.29% of base)
           3 : 138105.dasm (11.54% of base)
           3 : 43384.dasm (30.00% of base)
           3 : 141330.dasm (0.54% of base)
           3 : 138152.dasm (1.70% of base)
           2 : 27741.dasm (0.26% of base)
           2 : 156738.dasm (0.43% of base)
           2 : 76046.dasm (1.10% of base)
           2 : 101984.dasm (0.15% of base)
           1 : 219907.dasm (0.41% of base)
           1 : 75723.dasm (0.54% of base)
           1 : 215047.dasm (0.13% of base)
           1 : 22935.dasm (0.76% of base)
           1 : 220174.dasm (4.00% of base)

Top file improvements (bytes):
         -18 : 237769.dasm (-1.09% of base)
         -17 : 75717.dasm (-2.11% of base)
         -16 : 42977.dasm (-0.65% of base)
         -16 : 110343.dasm (-4.91% of base)
         -13 : 215017.dasm (-2.40% of base)
         -12 : 110283.dasm (-3.59% of base)
         -12 : 229577.dasm (-2.26% of base)
         -11 : 42162.dasm (-1.60% of base)
          -8 : 151566.dasm (-2.33% of base)
          -8 : 215020.dasm (-0.22% of base)
          -8 : 28026.dasm (-1.74% of base)
          -6 : 147131.dasm (-3.17% of base)
          -6 : 191077.dasm (-0.38% of base)
          -6 : 140182.dasm (-0.12% of base)
          -5 : 126011.dasm (-0.49% of base)
          -5 : 53315.dasm (-0.12% of base)
          -4 : 126180.dasm (-0.51% of base)
          -4 : 179409.dasm (-0.22% of base)
          -4 : 183018.dasm (-8.16% of base)
          -4 : 81283.dasm (-8.16% of base)

89 total files with Code Size differences (50 improved, 39 regressed), 19 unchanged.

Top method regressions (bytes):
           6 (20.69% of base) : 138025.dasm - System.Xml.Xsl.XmlQueryType:get_MaybeEmpty():bool:this
           6 (20.69% of base) : 138026.dasm - System.Xml.Xsl.XmlQueryType:get_MaybeMany():bool:this
           4 (23.53% of base) : 43388.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SymbolCompletionState:get_NextIncompletePart():int:this
           4 ( 3.20% of base) : 228858.dasm - System.Text.RegularExpressions.RegexParser:ScanOptions():this
           3 ( 1.70% of base) : 138152.dasm - FloatingDecimal:InitFromDouble(double):this
           3 (30.00% of base) : 43384.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SymbolCompletionState:get_IncompleteParts():int:this
           3 ( 1.21% of base) : 138087.dasm - SequenceType:Create(System.Xml.Xsl.XmlQueryType,System.Xml.Xsl.XmlQueryCardinality):System.Xml.Xsl.XmlQueryType
           3 ( 0.54% of base) : 141330.dasm - System.Xml.Xsl.IlGen.TailCallAnalyzer:AnalyzeDefinition(System.Xml.Xsl.Qil.QilNode)
           3 ( 0.29% of base) : 141565.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:MatchesNodeKinds(System.Xml.Xsl.Qil.QilTargetType,System.Xml.Xsl.XmlQueryType,System.Xml.Xsl.XmlQueryType):bool:this
           3 ( 5.17% of base) : 138110.dasm - System.Xml.Xsl.XPathConvert:IsInteger(double,byref):bool
           3 (11.54% of base) : 138105.dasm - System.Xml.Xsl.XPathConvert:IsSpecial(double):bool
           2 ( 0.43% of base) : 156738.dasm - Internal.TypeSystem.LayoutInt:AlignUp(Internal.TypeSystem.LayoutInt,Internal.TypeSystem.LayoutInt,Internal.TypeSystem.TargetDetails):Internal.TypeSystem.LayoutInt
           2 ( 1.10% of base) : 76046.dasm - Microsoft.CodeAnalysis.BitVector:set_Item(int,bool):this
           2 ( 0.26% of base) : 27741.dasm - Microsoft.CodeAnalysis.CSharp.DataFlowPass:SetSlotUnassigned(int,byref):this
           2 ( 0.15% of base) : 101984.dasm - Microsoft.Diagnostics.Tracing.Ctf.CtfReader:ReadTypeIntoBuffer(Microsoft.Diagnostics.Tracing.Ctf.CtfStruct,Microsoft.Diagnostics.Tracing.Ctf.CtfMetadataType):this
           1 ( 0.13% of base) : 215047.dasm - <GetContentToSign>d__29:MoveNext():bool:this
           1 ( 0.10% of base) : 150850.dasm - ILCompiler.DependencyAnalysis.ReadyToRun.CopiedFieldRvaNode:GetRvaData(int):System.Byte[]:this
           1 ( 0.14% of base) : 150441.dasm - ILCompiler.PEWriter.R2RPEBuilder:UpdateSectionRVAs(System.IO.Stream):this
           1 ( 0.75% of base) : 156537.dasm - Internal.TypeSystem.AlignmentHelper:AlignUp(int,int):int
           1 ( 0.54% of base) : 75723.dasm - Microsoft.Cci.PeWriter:CalculateOffsetToMappedFieldDataStream(Microsoft.Cci.MetadataSizes):int:this

Top method improvements (bytes):
         -18 (-1.09% of base) : 237769.dasm - Xunit.Sdk.Sha1Digest:ProcessBlock():this
         -17 (-2.11% of base) : 75717.dasm - Microsoft.Cci.PeWriter:CreateSectionHeaders(Microsoft.Cci.MetadataSizes,int):System.Collections.Generic.List`1[[Microsoft.Cci.SectionHeader, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
         -16 (-0.65% of base) : 42977.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertySymbol:ForceComplete(Microsoft.CodeAnalysis.SourceLocation,System.Threading.CancellationToken):this
         -16 (-4.91% of base) : 110343.dasm - System.Data.RBTree`1[Byte][System.Byte]:GetIndexOfPageWithFreeSlot(bool):int:this
         -13 (-2.40% of base) : 215017.dasm - System.Reflection.PortableExecutable.PEBuilder:SerializeSections():System.Collections.Immutable.ImmutableArray`1[SerializedSection]:this
         -12 (-3.59% of base) : 110283.dasm - System.Data.RBTree`1[__Canon][System.__Canon]:GetIndexOfPageWithFreeSlot(bool):int:this
         -12 (-2.26% of base) : 229577.dasm - System.Text.RegularExpressions.Symbolic.BDDAlgebra:CreateSetFromRangeImpl(int,int,int):System.Text.RegularExpressions.Symbolic.BDD:this
         -11 (-1.60% of base) : 42162.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ModifierUtils:CheckModifiers(int,int,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag,byref):int
          -8 (-2.33% of base) : 151566.dasm - Internal.JitInterface.CorInfoImpl:getClassGClayout(long,long):int:this
          -8 (-1.74% of base) : 28026.dasm - Microsoft.CodeAnalysis.CSharp.DiagnosticsPass:CheckForBitwiseOrSignExtend(Microsoft.CodeAnalysis.CSharp.BoundExpression,int,Microsoft.CodeAnalysis.CSharp.BoundExpression,Microsoft.CodeAnalysis.CSharp.BoundExpression):this
          -8 (-0.22% of base) : 215020.dasm - System.Reflection.PortableExecutable.PEBuilder:WritePEHeader(System.Reflection.Metadata.BlobBuilder,System.Reflection.PortableExecutable.PEDirectoriesBuilder,System.Collections.Immutable.ImmutableArray`1[SerializedSection]):this
          -6 (-0.38% of base) : 191077.dasm - System.DirectoryServices.AccountManagement.SDSUtils:AccountControlToDirectoryEntry(System.DirectoryServices.AccountManagement.Principal,System.String,System.DirectoryServices.DirectoryEntry,System.String,bool,bool)
          -6 (-3.17% of base) : 147131.dasm - System.Text.Json.BitStack:PushToArray(bool):this
          -6 (-0.12% of base) : 140182.dasm - System.Xml.Xsl.Runtime.XmlCollation:Create(System.String,bool):System.Xml.Xsl.Runtime.XmlCollation
          -5 (-0.12% of base) : 53315.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceNamedTypeSymbol:CheckDeclarationModifiers(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Binder,Microsoft.CodeAnalysis.DiagnosticBag,int):int:this
          -5 (-0.49% of base) : 126011.dasm - System.Runtime.Serialization.DataContract:ComputeHash(System.Byte[]):System.Byte[]
          -4 (-0.44% of base) : 85636.dasm - Microsoft.Diagnostics.Tracing.Parsers.DynamicTraceEventData:PayloadString(int,System.IFormatProvider):System.String:this
          -4 (-8.16% of base) : 81283.dasm - Roslyn.Utilities.ThreadSafeFlagOperations:Clear(byref,int):bool
          -4 (-0.22% of base) : 179409.dasm - System.ComponentModel.EnumConverter:ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type):System.Object:this
          -4 (-12.90% of base) : 179644.dasm - System.ComponentModel.InterlockedBitVector32:DangerousSet(int,bool):this

Top method regressions (percentages):
           3 (30.00% of base) : 43384.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SymbolCompletionState:get_IncompleteParts():int:this
           4 (23.53% of base) : 43388.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SymbolCompletionState:get_NextIncompletePart():int:this
           6 (20.69% of base) : 138025.dasm - System.Xml.Xsl.XmlQueryType:get_MaybeEmpty():bool:this
           6 (20.69% of base) : 138026.dasm - System.Xml.Xsl.XmlQueryType:get_MaybeMany():bool:this
           3 (11.54% of base) : 138105.dasm - System.Xml.Xsl.XPathConvert:IsSpecial(double):bool
           1 (10.00% of base) : 77847.dasm - Microsoft.CodeAnalysis.SymbolDisplayFormat:RemoveKindOptions(int):Microsoft.CodeAnalysis.SymbolDisplayFormat:this
           1 (10.00% of base) : 77844.dasm - Microsoft.CodeAnalysis.SymbolDisplayFormat:RemoveMemberOptions(int):Microsoft.CodeAnalysis.SymbolDisplayFormat:this
           1 (10.00% of base) : 77816.dasm - Microsoft.CodeAnalysis.SymbolDisplayFormat:RemoveParameterOptions(int):Microsoft.CodeAnalysis.SymbolDisplayFormat:this
           1 ( 9.09% of base) : 83919.dasm - Microsoft.Diagnostics.Tracing.BPerfEventSource:AlignUp(int,int):int
           1 ( 9.09% of base) : 101885.dasm - Microsoft.Diagnostics.Tracing.Ctf.IntHelpers:AlignUp(int,int):int
           1 ( 6.67% of base) : 80848.dasm - Roslyn.Utilities.BitArithmeticUtilities:Align(int,int):int
           1 ( 6.67% of base) : 80847.dasm - Roslyn.Utilities.BitArithmeticUtilities:Align(int,int):int
           1 ( 6.67% of base) : 217940.dasm - System.Reflection.Internal.BitArithmetic:Align(int,int):int
           1 ( 6.67% of base) : 217939.dasm - System.Reflection.Internal.BitArithmetic:Align(int,int):int
           1 ( 5.26% of base) : 183253.dasm - System.Configuration.SimpleBitVector32:set_Item(int,bool):this
           3 ( 5.17% of base) : 138110.dasm - System.Xml.Xsl.XPathConvert:IsInteger(double,byref):bool
           1 ( 4.00% of base) : 220174.dasm - System.Security.AccessControl.CommonSecurityDescriptor:UpdateControlFlags(int,int):this
           4 ( 3.20% of base) : 228858.dasm - System.Text.RegularExpressions.RegexParser:ScanOptions():this
           3 ( 1.70% of base) : 138152.dasm - FloatingDecimal:InitFromDouble(double):this
           3 ( 1.21% of base) : 138087.dasm - SequenceType:Create(System.Xml.Xsl.XmlQueryType,System.Xml.Xsl.XmlQueryCardinality):System.Xml.Xsl.XmlQueryType

Top method improvements (percentages):
          -4 (-36.36% of base) : 229611.dasm - System.Text.RegularExpressions.Symbolic.BV64Algebra:Not(long):long:this
          -3 (-20.00% of base) : 237766.dasm - Xunit.Sdk.Sha1Digest:F(int,int,int):int
          -4 (-12.90% of base) : 179644.dasm - System.ComponentModel.InterlockedBitVector32:DangerousSet(int,bool):this
          -1 (-11.11% of base) : 101887.dasm - Microsoft.Diagnostics.Tracing.Ctf.IntHelpers:AlignDown(int,int):int
          -4 (-8.16% of base) : 81283.dasm - Roslyn.Utilities.ThreadSafeFlagOperations:Clear(byref,int):bool
          -4 (-8.16% of base) : 183018.dasm - System.Configuration.SafeBitVector32:set_Item(int,bool):this
          -4 (-8.16% of base) : 218579.dasm - System.Runtime.Caching.SafeBitVector32:set_Item(int,bool):this
          -1 (-7.69% of base) : 138009.dasm - System.Xml.Xsl.XmlQueryCardinality:op_GreaterThanOrEqual(System.Xml.Xsl.XmlQueryCardinality,System.Xml.Xsl.XmlQueryCardinality):bool
          -1 (-7.69% of base) : 138008.dasm - System.Xml.Xsl.XmlQueryCardinality:op_LessThanOrEqual(System.Xml.Xsl.XmlQueryCardinality,System.Xml.Xsl.XmlQueryCardinality):bool
          -4 (-6.06% of base) : 218580.dasm - System.Runtime.Caching.SafeBitVector32:ChangeValue(int,bool):bool:this
          -4 (-5.33% of base) : 144554.dasm - System.Speech.Recognition.RecognizerBase:RemoveEventInterest(long):this
         -16 (-4.91% of base) : 110343.dasm - System.Data.RBTree`1[Byte][System.Byte]:GetIndexOfPageWithFreeSlot(bool):int:this
          -1 (-4.35% of base) : 209982.dasm - System.Net.Sockets.SocketInformation:SetOption(int,bool):this
         -12 (-3.59% of base) : 110283.dasm - System.Data.RBTree`1[__Canon][System.__Canon]:GetIndexOfPageWithFreeSlot(bool):int:this
          -3 (-3.49% of base) : 110280.dasm - System.Data.RBTree`1[__Canon][System.__Canon]:MarkPageFree(TreePage[__Canon]):this
          -3 (-3.49% of base) : 110340.dasm - System.Data.RBTree`1[Byte][System.Byte]:MarkPageFree(TreePage[Byte]):this
          -2 (-3.45% of base) : 175115.dasm - System.Collections.Specialized.BitVector32:set_Item(Section,int):this
          -6 (-3.17% of base) : 147131.dasm - System.Text.Json.BitStack:PushToArray(bool):this
          -1 (-2.78% of base) : 160489.dasm - CacheEntryState:SetFlag(ubyte,bool):this
         -13 (-2.40% of base) : 215017.dasm - System.Reflection.PortableExecutable.PEBuilder:SerializeSections():System.Collections.Immutable.ImmutableArray`1[SerializedSection]:this

89 total methods with Code Size differences (50 improved, 39 regressed), 19 unchanged.

```

</details>

--------------------------------------------------------------------------------


Example:

```diff
; Assembly listing for method Microsoft.CodeAnalysis.CSharp.Symbols.SymbolCompletionState:get_NextIncompletePart():int:this
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; No matching PGO data
; 0 inlinees with PGO data; 1 single block inlinees; 0 inlinees without PGO data
; Final local variable assignments
;
;  V00 this         [V00,T01] (  3,  3   )   byref  ->  rcx         this single-def
;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+00H]   "OutgoingArgSpace"
;  V02 tmp1         [V02,T00] (  3,  6   )     int  ->  rax         "dup spill"
;
; Lcl frame size = 0

G_M56083_IG01:        ; gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG
						;; bbWeight=1    PerfScore 0.00
G_M56083_IG02:        ; gcrefRegs=00000000 {}, byrefRegs=00000002 {rcx}, byref
       ; byrRegs +[rcx]
       mov      eax, dword ptr [rcx]
       not      eax
       and      eax, 0x1FFFF
       lea      edx, [rax-1]
-      not      edx
-      and      eax, edx
+      andn     eax, edx, eax
                                                ;; bbWeight=1    PerfScore 3.50
 G_M56083_IG03:        ; , epilog, nogc, extend
        ret
                                                ;; bbWeight=1    PerfScore 1.00

-; Total bytes of code 17, prolog size 0, PerfScore 6.20, instruction count 7, allocated bytes for code 17 (MethodHash=781a24ec) for method Microsoft.CodeAnalysis.CSharp.Symbols.SymbolCompletionState:get_NextIncompletePart():int:this
+; Total bytes of code 18, prolog size 0, PerfScore 6.30, instruction count 6, allocated bytes for code 18 (MethodHash=781a24ec) for method Microsoft.CodeAnalysis.CSharp.Symbols.SymbolCompletionState:get_NextIncompletePart():int:this
; ============================================================

Unwind Info:
  >> Start offset   : 0x000000 (not in unwind data)
  >>   End offset   : 0xd1ffab1e (not in unwind data)
  Version           : 1
  Flags             : 0x00
  SizeOfProlog      : 0x00
  CountOfUnwindCodes: 0
  FrameRegister     : none (0)
  FrameOffset       : N/A (no FrameRegister) (Value=0)
  UnwindCodes       :

```
/cc @dotnet/jit-contrib 

