### PR TITLE
Add/use ArgumentException.ThrowIfNullOrEmpty

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -314,14 +314,7 @@ namespace System.Reflection.Emit
 
         private ModuleBuilder DefineDynamicModuleInternalNoLock(string name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if (name[0] == '\0')
             {
                 throw new ArgumentException(SR.Argument_InvalidName, nameof(name));
@@ -467,14 +460,7 @@ namespace System.Reflection.Emit
         /// <param name="name">The name of module for the look up.</param>
         private ModuleBuilder? GetDynamicModuleNoLock(string name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             for (int i = 0; i < _assemblyData._moduleBuilderList.Count; i++)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/FieldBuilder.cs
@@ -20,17 +20,12 @@ namespace System.Reflection.Emit
         internal FieldBuilder(TypeBuilder typeBuilder, string fieldName, Type type,
             Type[]? requiredCustomModifiers, Type[]? optionalCustomModifiers, FieldAttributes attributes)
         {
-            if (fieldName == null)
-                throw new ArgumentNullException(nameof(fieldName));
-
-            if (fieldName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(fieldName));
+            ArgumentException.ThrowIfNullOrEmpty(fieldName);
 
             if (fieldName[0] == '\0')
                 throw new ArgumentException(SR.Argument_IllegalName, nameof(fieldName));
 
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
+            ArgumentNullException.ThrowIfNull(type);
 
             if (type == typeof(void))
                 throw new ArgumentException(SR.Argument_BadFieldType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -1273,11 +1273,7 @@ namespace System.Reflection.Emit
             // Specifying the namespace to be used in evaluating locals and watches
             // for the current active lexical scope.
 
-            if (usingNamespace == null)
-                throw new ArgumentNullException(nameof(usingNamespace));
-
-            if (usingNamespace.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(usingNamespace));
+            ArgumentException.ThrowIfNullOrEmpty(usingNamespace);
 
             MethodBuilder? methodBuilder = m_methodBuilder as MethodBuilder;
             if (methodBuilder == null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -61,24 +61,18 @@ namespace System.Reflection.Emit
             Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers,
             ModuleBuilder mod, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TypeBuilder type)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             if (name[0] == '\0')
                 throw new ArgumentException(SR.Argument_IllegalName, nameof(name));
 
-            if (mod == null)
-                throw new ArgumentNullException(nameof(mod));
+            ArgumentNullException.ThrowIfNull(mod);
 
             if (parameterTypes != null)
             {
                 foreach (Type t in parameterTypes)
                 {
-                    if (t == null)
-                        throw new ArgumentNullException(nameof(parameterTypes));
+                    ArgumentNullException.ThrowIfNull(t, nameof(parameterTypes));
                 }
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -948,14 +948,7 @@ namespace System.Reflection.Emit
             {
                 throw new InvalidOperationException(SR.InvalidOperation_GlobalsHaveBeenCreated);
             }
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if ((attributes & MethodAttributes.Static) == 0)
             {
                 throw new ArgumentException(SR.Argument_GlobalFunctionHasToBeStatic);
@@ -1352,18 +1345,8 @@ namespace System.Reflection.Emit
         private int GetArrayMethodTokenNoLock(Type arrayClass, string methodName, CallingConventions callingConvention,
             Type? returnType, Type[]? parameterTypes)
         {
-            if (arrayClass == null)
-            {
-                throw new ArgumentNullException(nameof(arrayClass));
-            }
-            if (methodName == null)
-            {
-                throw new ArgumentNullException(nameof(methodName));
-            }
-            if (methodName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(methodName));
-            }
+            ArgumentNullException.ThrowIfNull(arrayClass);
+            ArgumentException.ThrowIfNullOrEmpty(methodName);
             if (!arrayClass.IsArray)
             {
                 throw new ArgumentException(SR.Argument_HasToBeArrayClass);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/PropertyBuilder.cs
@@ -34,10 +34,7 @@ namespace System.Reflection.Emit
             int prToken, // the metadata token for this property
             TypeBuilder containingType) // the containing type
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if (name[0] == '\0')
                 throw new ArgumentException(SR.Argument_IllegalName, nameof(name));
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -480,11 +480,7 @@ namespace System.Reflection.Emit
             string fullname, TypeAttributes attr, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent, Type[]? interfaces, ModuleBuilder module,
             PackingSize iPackingSize, int iTypeSize, TypeBuilder? enclosingType)
         {
-            if (fullname == null)
-                throw new ArgumentNullException(nameof(fullname));
-
-            if (fullname.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(fullname));
+            ArgumentException.ThrowIfNullOrEmpty(fullname);
 
             if (fullname[0] == '\0')
                 throw new ArgumentException(SR.Argument_IllegalName, nameof(fullname));
@@ -581,11 +577,7 @@ namespace System.Reflection.Emit
             FieldBuilder fdBuilder;
             TypeAttributes typeAttributes;
 
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             if (size <= 0 || size >= 0x003f0000)
                 throw new ArgumentException(SR.Argument_BadSizeForData);
@@ -1282,11 +1274,7 @@ namespace System.Reflection.Emit
             Type? returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers,
             Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             AssemblyBuilder.CheckContext(returnType);
             AssemblyBuilder.CheckContext(returnTypeRequiredCustomModifiers, returnTypeOptionalCustomModifiers, parameterTypes);
@@ -1374,23 +1362,9 @@ namespace System.Reflection.Emit
 
             lock (SyncRoot)
             {
-                if (name == null)
-                    throw new ArgumentNullException(nameof(name));
-
-                if (name.Length == 0)
-                    throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
-
-                if (dllName == null)
-                    throw new ArgumentNullException(nameof(dllName));
-
-                if (dllName.Length == 0)
-                    throw new ArgumentException(SR.Argument_EmptyName, nameof(dllName));
-
-                if (importName == null)
-                    throw new ArgumentNullException(nameof(importName));
-
-                if (importName.Length == 0)
-                    throw new ArgumentException(SR.Argument_EmptyName, nameof(importName));
+                ArgumentException.ThrowIfNullOrEmpty(name);
+                ArgumentException.ThrowIfNullOrEmpty(dllName);
+                ArgumentException.ThrowIfNullOrEmpty(importName);
 
                 if ((attributes & MethodAttributes.Abstract) != 0)
                     throw new ArgumentException(SR.Argument_BadPInvokeMethod);
@@ -1792,10 +1766,7 @@ namespace System.Reflection.Emit
             Type returnType, Type[]? returnTypeRequiredCustomModifiers, Type[]? returnTypeOptionalCustomModifiers,
             Type[]? parameterTypes, Type[][]? parameterTypeRequiredCustomModifiers, Type[][]? parameterTypeOptionalCustomModifiers)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             AssemblyBuilder.CheckContext(returnType);
             AssemblyBuilder.CheckContext(returnTypeRequiredCustomModifiers, returnTypeOptionalCustomModifiers, parameterTypes);
@@ -1847,10 +1818,7 @@ namespace System.Reflection.Emit
 
         private EventBuilder DefineEventNoLock(string name, EventAttributes attributes, Type eventtype)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if (name[0] == '\0')
                 throw new ArgumentException(SR.Argument_IllegalName, nameof(name));
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -558,8 +558,7 @@ namespace System
 
         internal static RuntimeType GetTypeByNameUsingCARules(string name, RuntimeModule scope)
         {
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentException(null, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             RuntimeType? type = null;
             GetTypeByNameUsingCARules(name, new QCallModule(ref scope), ObjectHandleOnStack.Create(ref type));

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.Derive.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanAndroid.Derive.cs
@@ -23,10 +23,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 ThrowIfDisposed();
 
@@ -45,10 +43,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 ThrowIfDisposed();
 

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
@@ -76,10 +76,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 using (SafeNCryptSecretHandle secretAgreement = DeriveSecretAgreementHandle(otherPartyPublicKey))
                 {
@@ -99,10 +97,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 using (SafeNCryptSecretHandle secretAgreement = DeriveSecretAgreementHandle(otherPartyPublicKey))
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.Derive.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.Derive.cs
@@ -24,10 +24,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 ThrowIfDisposed();
 
@@ -46,10 +44,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 ThrowIfDisposed();
 

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
@@ -121,10 +121,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 ThrowIfDisposed();
 
@@ -143,10 +141,8 @@ namespace System.Security.Cryptography
                 byte[]? secretPrepend,
                 byte[]? secretAppend)
             {
-                if (otherPartyPublicKey == null)
-                    throw new ArgumentNullException(nameof(otherPartyPublicKey));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
                 ThrowIfDisposed();
 

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -678,12 +678,9 @@ namespace System.Security.Cryptography
 
             public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
             {
-                if (hash == null)
-                    throw new ArgumentNullException(nameof(hash));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw HashAlgorithmNameNullOrEmpty();
-                if (padding == null)
-                    throw new ArgumentNullException(nameof(padding));
+                ArgumentNullException.ThrowIfNull(hash);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(padding);
 
                 if (!TrySignHash(
                     hash,
@@ -708,14 +705,8 @@ namespace System.Security.Cryptography
                 RSASignaturePadding padding,
                 out int bytesWritten)
             {
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                {
-                    throw HashAlgorithmNameNullOrEmpty();
-                }
-                if (padding == null)
-                {
-                    throw new ArgumentNullException(nameof(padding));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(padding);
 
                 bool ret = TrySignHash(
                     hash,
@@ -817,14 +808,8 @@ namespace System.Security.Cryptography
 
             public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
             {
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                {
-                    throw HashAlgorithmNameNullOrEmpty();
-                }
-                if (padding == null)
-                {
-                    throw new ArgumentNullException(nameof(padding));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(padding);
                 if (padding != RSASignaturePadding.Pkcs1 && padding != RSASignaturePadding.Pss)
                 {
                     throw PaddingModeNotSupported();
@@ -894,9 +879,6 @@ namespace System.Security.Cryptography
 
             private static Exception PaddingModeNotSupported() =>
                 new CryptographicException(SR.Cryptography_InvalidPaddingMode);
-
-            private static Exception HashAlgorithmNameNullOrEmpty() =>
-                new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSACng.SignVerify.cs
@@ -52,14 +52,9 @@ namespace System.Security.Cryptography
             }
 
             string? hashAlgorithmName = hashAlgorithm.Name;
-            if (string.IsNullOrEmpty(hashAlgorithmName))
-            {
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-            }
-            if (padding == null)
-            {
-                throw new ArgumentNullException(nameof(padding));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithmName, nameof(hashAlgorithm));
+
+            ArgumentNullException.ThrowIfNull(padding);
 
             if (hash.Length != GetHashSizeInBytes(hashAlgorithm))
             {
@@ -99,14 +94,8 @@ namespace System.Security.Cryptography
         public override unsafe bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
         {
             string? hashAlgorithmName = hashAlgorithm.Name;
-            if (string.IsNullOrEmpty(hashAlgorithmName))
-            {
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-            }
-            if (padding == null)
-            {
-                throw new ArgumentNullException(nameof(padding));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithmName, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
             {
@@ -159,14 +148,8 @@ namespace System.Security.Cryptography
         public override unsafe bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
             string? hashAlgorithmName = hashAlgorithm.Name;
-            if (string.IsNullOrEmpty(hashAlgorithmName))
-            {
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-            }
-            if (padding == null)
-            {
-                throw new ArgumentNullException(nameof(padding));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithmName, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             using (SafeNCryptKeyHandle keyHandle = GetDuplicatedKeyHandle())
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -750,12 +750,9 @@ namespace System.Security.Cryptography
 
         public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
-            if (hash == null)
-                throw new ArgumentNullException(nameof(hash));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(hash);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             if (!TrySignHash(
                 hash,
@@ -780,14 +777,8 @@ namespace System.Security.Cryptography
             RSASignaturePadding padding,
             out int bytesWritten)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-            {
-                throw HashAlgorithmNameNullOrEmpty();
-            }
-            if (padding == null)
-            {
-                throw new ArgumentNullException(nameof(padding));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             bool ret = TrySignHash(
                 hash,
@@ -860,11 +851,7 @@ namespace System.Security.Cryptography
 
         public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-            {
-                throw HashAlgorithmNameNullOrEmpty();
-            }
-
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             ValidatePadding(padding);
 
             IntPtr digestAlgorithm = Interop.Crypto.HashAlgorithmToEvp(hashAlgorithm.Name);
@@ -951,9 +938,6 @@ namespace System.Security.Cryptography
 
         private static Exception PaddingModeNotSupported() =>
             new CryptographicException(SR.Cryptography_InvalidPaddingMode);
-
-        private static Exception HashAlgorithmNameNullOrEmpty() =>
-            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
     }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -386,12 +386,9 @@ namespace System.Security.Cryptography
 
             public override byte[] SignHash(byte[] hash, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
             {
-                if (hash == null)
-                    throw new ArgumentNullException(nameof(hash));
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                    throw HashAlgorithmNameNullOrEmpty();
-                if (padding == null)
-                    throw new ArgumentNullException(nameof(padding));
+                ArgumentNullException.ThrowIfNull(hash);
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(padding);
 
                 ThrowIfDisposed();
 
@@ -443,14 +440,8 @@ namespace System.Security.Cryptography
 
             public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
             {
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                {
-                    throw HashAlgorithmNameNullOrEmpty();
-                }
-                if (padding == null)
-                {
-                    throw new ArgumentNullException(nameof(padding));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(padding);
 
                 ThrowIfDisposed();
 
@@ -550,14 +541,8 @@ namespace System.Security.Cryptography
 
             public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
             {
-                if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                {
-                    throw HashAlgorithmNameNullOrEmpty();
-                }
-                if (padding == null)
-                {
-                    throw new ArgumentNullException(nameof(padding));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+                ArgumentNullException.ThrowIfNull(padding);
 
                 ThrowIfDisposed();
 
@@ -795,8 +780,5 @@ namespace System.Security.Cryptography
                 return true;
             }
         }
-
-        private static Exception HashAlgorithmNameNullOrEmpty() =>
-            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DsaFamilySignatureFormatTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DsaFamilySignatureFormatTests.cs
@@ -337,13 +337,21 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
             foreach (DSASignatureFormat format in Enum.GetValues(typeof(DSASignatureFormat)))
             {
-                AssertExtensions.Throws<ArgumentException>(
+                AssertExtensions.Throws<ArgumentNullException>(
                     "hashAlgorithm",
                     () => SignData(key, empty, default, format));
 
-                AssertExtensions.Throws<ArgumentException>(
+                AssertExtensions.Throws<ArgumentNullException>(
                     "hashAlgorithm",
                     () => VerifyData(key, empty, empty, default, format));
+
+                AssertExtensions.Throws<ArgumentException>(
+                    "hashAlgorithm",
+                    () => SignData(key, empty, new HashAlgorithmName(""), format));
+
+                AssertExtensions.Throws<ArgumentException>(
+                    "hashAlgorithm",
+                    () => VerifyData(key, empty, empty, new HashAlgorithmName(""), format));
             }
         }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -40,9 +40,9 @@ namespace System.Security.Cryptography.EcDsa.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.SignData(new byte[0], 0, -1, default(HashAlgorithmName)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.SignData(new byte[0], 0, 1, default(HashAlgorithmName)));
 
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new byte[0], default(HashAlgorithmName)));
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new byte[0], 0, 0, default(HashAlgorithmName)));
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new byte[0], 0, 0, default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.SignData(new byte[0], default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.SignData(new byte[0], 0, 0, default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.SignData(new byte[0], 0, 0, default(HashAlgorithmName)));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new byte[10], 0, 10, new HashAlgorithmName("")));
 
             Assert.ThrowsAny<CryptographicException>(() => ecdsa.SignData(new byte[0], new HashAlgorithmName(Guid.NewGuid().ToString("N"))));
@@ -64,8 +64,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.VerifyData(new byte[0], 0, -1, null, default(HashAlgorithmName)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.VerifyData(new byte[0], 0, 1, null, default(HashAlgorithmName)));
 
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[0], new byte[0], default(HashAlgorithmName)));
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[0], 0, 0, new byte[0], default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[0], new byte[0], default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[0], 0, 0, new byte[0], default(HashAlgorithmName)));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[10], new byte[0], new HashAlgorithmName("")));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[10], 0, 10, new byte[0], new HashAlgorithmName("")));
 
@@ -110,7 +110,8 @@ namespace System.Security.Cryptography.EcDsa.Tests
         public void SignData_InvalidArguments_Throws(ECDsa ecdsa)
         {
             AssertExtensions.Throws<ArgumentNullException>("data", () => ecdsa.SignData((Stream)null, default(HashAlgorithmName)));
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new MemoryStream(), default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.SignData(new MemoryStream(), default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new MemoryStream(), new HashAlgorithmName("")));
             Assert.ThrowsAny<CryptographicException>(() => ecdsa.SignData(new MemoryStream(), new HashAlgorithmName(Guid.NewGuid().ToString("N"))));
         }
 
@@ -119,7 +120,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("data", () => ecdsa.VerifyData((Stream)null, null, default(HashAlgorithmName)));
             AssertExtensions.Throws<ArgumentNullException>("signature", () => ecdsa.VerifyData(new MemoryStream(), null, default(HashAlgorithmName)));
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new MemoryStream(), new byte[0], default(HashAlgorithmName)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.VerifyData(new MemoryStream(), new byte[0], default(HashAlgorithmName)));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new MemoryStream(), new byte[0], new HashAlgorithmName("")));
             Assert.ThrowsAny<CryptographicException>(() => ecdsa.VerifyData(new MemoryStream(), new byte[0], new HashAlgorithmName(Guid.NewGuid().ToString("N"))));
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
@@ -28,7 +28,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         [Theory, MemberData(nameof(RealImplementations))]
         public void SignData_InvalidArguments_Throws(ECDsa ecdsa)
         {
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.TrySignData(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, new HashAlgorithmName(null), out int bytesWritten));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.TrySignData(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, new HashAlgorithmName(null), out int bytesWritten));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.TrySignData(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, new HashAlgorithmName(""), out int bytesWritten));
             Assert.ThrowsAny<CryptographicException>(() => ecdsa.TrySignData(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, new HashAlgorithmName(Guid.NewGuid().ToString("N")), out int bytesWritten));
         }
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         [Theory, MemberData(nameof(RealImplementations))]
         public void VerifyData_InvalidArguments_Throws(ECDsa ecdsa)
         {
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, new HashAlgorithmName(null)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.VerifyData(ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, new HashAlgorithmName(null)));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, new HashAlgorithmName("")));
             Assert.ThrowsAny<CryptographicException>(() => ecdsa.VerifyData(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, new HashAlgorithmName(Guid.NewGuid().ToString("N"))));
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -48,14 +48,18 @@ namespace System.Security.Cryptography.Rsa.Tests
         protected abstract bool VerifyData(RSA rsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding);
         protected abstract bool VerifyHash(RSA rsa, byte[] hash, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding);
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void InvalidHashAlgorithmName_Throws(string name)
+        [Fact]
+        public void InvalidHashAlgorithmName_Throws()
         {
             using (RSA rsa = RSAFactory.Create())
             {
-                var invalidName = new HashAlgorithmName(name);
+                var invalidName = new HashAlgorithmName(null);
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => SignData(rsa, new byte[1], invalidName, RSASignaturePadding.Pkcs1));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => SignHash(rsa, new byte[1], invalidName, RSASignaturePadding.Pkcs1));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => VerifyData(rsa, new byte[1], new byte[1], invalidName, RSASignaturePadding.Pkcs1));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => VerifyHash(rsa, new byte[1], new byte[1], invalidName, RSASignaturePadding.Pkcs1));
+
+                invalidName = new HashAlgorithmName("");
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => SignData(rsa, new byte[1], invalidName, RSASignaturePadding.Pkcs1));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => SignHash(rsa, new byte[1], invalidName, RSASignaturePadding.Pkcs1));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => VerifyData(rsa, new byte[1], new byte[1], invalidName, RSASignaturePadding.Pkcs1));

--- a/src/libraries/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
@@ -193,9 +193,6 @@
   <data name="MaskedTextProviderInvalidCharError" xml:space="preserve">
     <value>The specified character value is not allowed for this property.</value>
   </data>
-  <data name="MaskedTextProviderMaskNullOrEmpty" xml:space="preserve">
-    <value>The Mask value cannot be null or empty.</value>
-  </data>
   <data name="MaskedTextProviderMaskInvalidChar" xml:space="preserve">
     <value>The specified mask contains invalid characters.</value>
   </data>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MaskedTextProvider.cs
@@ -227,10 +227,7 @@ namespace System.ComponentModel
         /// </summary>
         public MaskedTextProvider(string mask, CultureInfo? culture, bool allowPromptAsInput, char promptChar, char passwordChar, bool restrictToAscii)
         {
-            if (string.IsNullOrEmpty(mask))
-            {
-                throw new ArgumentException(SR.MaskedTextProviderMaskNullOrEmpty, nameof(mask));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(mask);
 
             foreach (char c in mask)
             {

--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -215,9 +215,6 @@
   <data name="PendingAsyncOperation" xml:space="preserve">
     <value>An async read operation has already been started on the stream.</value>
   </data>
-  <data name="InvalidParameter" xml:space="preserve">
-    <value>Invalid value '{1}' for parameter '{0}'.</value>
-  </data>
   <data name="CategoryHelpCorrupt" xml:space="preserve">
     <value>Cannot load Category Help data because an invalid index '{0}' was read from the registry.</value>
   </data>

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.cs
@@ -10,11 +10,7 @@ namespace System.Diagnostics
         /// <returns>true if the machine is remote; false if it's local.</returns>
         public static bool IsRemoteMachine(string machineName)
         {
-            if (machineName == null)
-                throw new ArgumentNullException(nameof(machineName));
-
-            if (machineName.Length == 0)
-                throw new ArgumentException(SR.Format(SR.InvalidParameter, nameof(machineName), machineName));
+            ArgumentException.ThrowIfNullOrEmpty(machineName);
 
             return IsRemoteMachineCore(machineName);
         }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1147,7 +1147,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void GetProcesses_EmptyMachineName_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => Process.GetProcesses(""));
+            AssertExtensions.Throws<ArgumentException>("machineName", () => Process.GetProcesses(""));
         }
 
         [Fact]
@@ -1292,7 +1292,7 @@ namespace System.Diagnostics.Tests
         public void GetProcessesByName_EmptyMachineName_ThrowsArgumentException()
         {
             Process currentProcess = Process.GetCurrentProcess();
-            AssertExtensions.Throws<ArgumentException>(null, () => Process.GetProcessesByName(currentProcess.ProcessName, ""));
+            AssertExtensions.Throws<ArgumentException>("machineName", () => Process.GetProcessesByName(currentProcess.ProcessName, ""));
         }
 
         [Fact]

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -57,9 +58,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Generic_ArgCantBeEmptyString" xml:space="preserve">
-    <value>'{0}' can not be empty string.</value>
-  </data>
   <data name="TraceAsTraceSource" xml:space="preserve">
     <value>Trace</value>
   </data>

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/DelimitedListTraceListener.cs
@@ -63,11 +63,7 @@ namespace System.Diagnostics
             }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(Delimiter));
-
-                if (value.Length == 0)
-                    throw new ArgumentException(SR.Format(SR.Generic_ArgCantBeEmptyString, nameof(Delimiter)));
+                ArgumentException.ThrowIfNullOrEmpty(value, nameof(Delimiter));
 
                 lock (this)
                 {

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/CtorsDelimiterTests.cs
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/tests/CtorsDelimiterTests.cs
@@ -90,8 +90,8 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
         {
             var target = new DelimitedListTraceListener(FileStream.Null);
             Assert.Equal(DefaultDelimiter, target.Delimiter);
-            Assert.Throws<ArgumentNullException>(() => target.Delimiter = null);
-            AssertExtensions.Throws<ArgumentException>(null, () => target.Delimiter = string.Empty);
+            AssertExtensions.Throws<ArgumentNullException>("Delimiter", () => target.Delimiter = null);
+            AssertExtensions.Throws<ArgumentException>("Delimiter", () => target.Delimiter = string.Empty);
         }
 
         [Fact]

--- a/src/libraries/System.Diagnostics.TraceSource/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.TraceSource/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -86,8 +87,5 @@
   </data>
   <data name="TraceSwitchLevelTooHigh" xml:space="preserve">
     <value>Attempted to set {0} to a value that is too high.  Setting level to TraceLevel.Verbose</value>
-  </data>
-  <data name="InvalidNullEmptyArgument" xml:space="preserve">
-    <value>Argument {0} cannot be null or zero-length.</value>
   </data>
 </root>

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/SwitchAttribute.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/SwitchAttribute.cs
@@ -26,10 +26,7 @@ namespace System.Diagnostics
             [MemberNotNull(nameof(_name))]
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-                if (value.Length == 0)
-                    throw new ArgumentException(SR.Format(SR.InvalidNullEmptyArgument, nameof(value)), nameof(value));
+                ArgumentException.ThrowIfNullOrEmpty(value);
 
                 _name = value;
             }

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSource.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSource.cs
@@ -28,10 +28,7 @@ namespace System.Diagnostics
 
         public TraceSource(string name, SourceLevels defaultLevel)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Format(SR.InvalidNullEmptyArgument, nameof(name)), nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             _sourceName = name;
             _switchLevel = defaultLevel;

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/Resources/Strings.resx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -187,9 +188,6 @@
   </data>
   <data name="Argument_InvalidPathChars" xml:space="preserve">
     <value>Illegal characters in path '{0}'.</value>
-  </data>
-  <data name="Arg_PathEmpty" xml:space="preserve">
-    <value>The path is empty.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
     <value>Positive number required.</value>

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -244,20 +244,8 @@ namespace System.IO
         /// <remarks>This extension method was added to .NET Core to bring the functionality that was provided by the `System.IO.Directory.CreateDirectory(System.String,System.Security.AccessControl.DirectorySecurity)` .NET Framework method.</remarks>
         public static DirectoryInfo CreateDirectory(this DirectorySecurity directorySecurity, string path)
         {
-            if (directorySecurity == null)
-            {
-                throw new ArgumentNullException(nameof(directorySecurity));
-            }
-
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
-            if (path.Length == 0)
-            {
-                throw new ArgumentException(SR.Arg_PathEmpty);
-            }
+            ArgumentNullException.ThrowIfNull(directorySecurity);
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             DirectoryInfo dirInfo = new DirectoryInfo(path);
 

--- a/src/libraries/System.IO.IsolatedStorage/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.IsolatedStorage/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -92,9 +93,6 @@
   </data>
   <data name="IsolatedStorage_NotValidOnDesktop" xml:space="preserve">
     <value>The Site scope is currently not supported.</value>
-  </data>
-  <data name="Argument_EmptyPath" xml:space="preserve">
-    <value>Empty path name is not legal.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -288,13 +288,7 @@ namespace System.IO.IsolatedStorage
 
         public DateTimeOffset GetCreationTime(string path)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-
-            if (path.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             EnsureStoreIsValid();
 
@@ -310,13 +304,7 @@ namespace System.IO.IsolatedStorage
 
         public DateTimeOffset GetLastAccessTime(string path)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-
-            if (path.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             EnsureStoreIsValid();
 
@@ -332,13 +320,7 @@ namespace System.IO.IsolatedStorage
 
         public DateTimeOffset GetLastWriteTime(string path)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-
-            if (path.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             EnsureStoreIsValid();
 
@@ -354,42 +336,16 @@ namespace System.IO.IsolatedStorage
 
         public void CopyFile(string sourceFileName, string destinationFileName)
         {
-            if (sourceFileName == null)
-                throw new ArgumentNullException(nameof(sourceFileName));
-
-            if (destinationFileName == null)
-                throw new ArgumentNullException(nameof(destinationFileName));
-
-            if (sourceFileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(sourceFileName));
-            }
-
-            if (destinationFileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(destinationFileName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(sourceFileName);
+            ArgumentException.ThrowIfNullOrEmpty(destinationFileName);
 
             CopyFile(sourceFileName, destinationFileName, false);
         }
 
         public void CopyFile(string sourceFileName, string destinationFileName, bool overwrite)
         {
-            if (sourceFileName == null)
-                throw new ArgumentNullException(nameof(sourceFileName));
-
-            if (destinationFileName == null)
-                throw new ArgumentNullException(nameof(destinationFileName));
-
-            if (sourceFileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(sourceFileName));
-            }
-
-            if (destinationFileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(destinationFileName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(sourceFileName);
+            ArgumentException.ThrowIfNullOrEmpty(destinationFileName);
 
             EnsureStoreIsValid();
 
@@ -416,21 +372,8 @@ namespace System.IO.IsolatedStorage
 
         public void MoveFile(string sourceFileName, string destinationFileName)
         {
-            if (sourceFileName == null)
-                throw new ArgumentNullException(nameof(sourceFileName));
-
-            if (destinationFileName == null)
-                throw new ArgumentNullException(nameof(destinationFileName));
-
-            if (sourceFileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(sourceFileName));
-            }
-
-            if (destinationFileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(destinationFileName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(sourceFileName);
+            ArgumentException.ThrowIfNullOrEmpty(destinationFileName);
 
             EnsureStoreIsValid();
 
@@ -457,21 +400,8 @@ namespace System.IO.IsolatedStorage
 
         public void MoveDirectory(string sourceDirectoryName, string destinationDirectoryName)
         {
-            if (sourceDirectoryName == null)
-                throw new ArgumentNullException(nameof(sourceDirectoryName));
-
-            if (destinationDirectoryName == null)
-                throw new ArgumentNullException(nameof(destinationDirectoryName));
-
-            if (sourceDirectoryName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(sourceDirectoryName));
-            }
-
-            if (destinationDirectoryName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(destinationDirectoryName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(sourceDirectoryName);
+            ArgumentException.ThrowIfNullOrEmpty(destinationDirectoryName);
 
             EnsureStoreIsValid();
 

--- a/src/libraries/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <!-- 
     Microsoft ResX Schema 
     
@@ -169,9 +170,6 @@
   </data>
   <data name="Argument_NewMMFTruncateModeNotAllowed" xml:space="preserve">
     <value>FileMode.Truncate is not permitted when creating new memory mapped files.</value>
-  </data>
-  <data name="ArgumentNull_MapName" xml:space="preserve">
-    <value>Map name cannot be null.</value>
   </data>
   <data name="ArgumentNull_FileStream" xml:space="preserve">
     <value>fileStream cannot be null.</value>

--- a/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -60,15 +60,7 @@ namespace System.IO.MemoryMappedFiles
         public static MemoryMappedFile OpenExisting(string mapName, MemoryMappedFileRights desiredAccessRights,
                                                                     HandleInheritability inheritability)
         {
-            if (mapName == null)
-            {
-                throw new ArgumentNullException(nameof(mapName), SR.ArgumentNull_MapName);
-            }
-
-            if (mapName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_MapNameEmptyString);
-            }
+            ArgumentException.ThrowIfNullOrEmpty(mapName);
 
             if (inheritability < HandleInheritability.None || inheritability > HandleInheritability.Inheritable)
             {
@@ -319,15 +311,7 @@ namespace System.IO.MemoryMappedFiles
                                                     MemoryMappedFileAccess access, MemoryMappedFileOptions options,
                                                     HandleInheritability inheritability)
         {
-            if (mapName == null)
-            {
-                throw new ArgumentNullException(nameof(mapName), SR.ArgumentNull_MapName);
-            }
-
-            if (mapName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_MapNameEmptyString);
-            }
+            ArgumentException.ThrowIfNullOrEmpty(mapName);
 
             if (capacity <= 0)
             {

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateOrOpen.Tests.cs
@@ -20,9 +20,9 @@ namespace System.IO.MemoryMappedFiles.Tests
             AssertExtensions.Throws<ArgumentNullException>("mapName", () => MemoryMappedFile.CreateOrOpen(null, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None));
 
             // Empty string is always an invalid map name
-            AssertExtensions.Throws<ArgumentException>(null, () => MemoryMappedFile.CreateOrOpen(string.Empty, 4096));
-            AssertExtensions.Throws<ArgumentException>(null, () => MemoryMappedFile.CreateOrOpen(string.Empty, 4096, MemoryMappedFileAccess.ReadWrite));
-            AssertExtensions.Throws<ArgumentException>(null, () => MemoryMappedFile.CreateOrOpen(string.Empty, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None));
+            AssertExtensions.Throws<ArgumentException>("mapName", () => MemoryMappedFile.CreateOrOpen(string.Empty, 4096));
+            AssertExtensions.Throws<ArgumentException>("mapName", () => MemoryMappedFile.CreateOrOpen(string.Empty, 4096, MemoryMappedFileAccess.ReadWrite));
+            AssertExtensions.Throws<ArgumentException>("mapName", () => MemoryMappedFile.CreateOrOpen(string.Empty, 4096, MemoryMappedFileAccess.ReadWrite, MemoryMappedFileOptions.None, HandleInheritability.None));
         }
 
         /// <summary>

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.OpenExisting.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.OpenExisting.Tests.cs
@@ -18,7 +18,7 @@ namespace System.IO.MemoryMappedFiles.Tests
             AssertExtensions.Throws<ArgumentNullException>("mapName", () => MemoryMappedFile.OpenExisting(null));
 
             // Empty is never a valid map name
-            AssertExtensions.Throws<ArgumentException>(null, () => MemoryMappedFile.OpenExisting(string.Empty));
+            AssertExtensions.Throws<ArgumentException>("mapName", () => MemoryMappedFile.OpenExisting(string.Empty));
         }
 
         /// <summary>

--- a/src/libraries/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Pipes/src/Resources/Strings.resx
@@ -123,9 +123,6 @@
   <data name="ArgumentOutOfRange_NeedValidPipeAccessRights" xml:space="preserve">
     <value>Invalid PipeAccessRights value.</value>
   </data>
-  <data name="Argument_NeedNonemptyPipeName" xml:space="preserve">
-    <value>pipeName cannot be an empty string.</value>
-  </data>
   <data name="Argument_NonContainerInvalidAnyFlag" xml:space="preserve">
     <value>This flag may not be set on a pipe.</value>
   </data>

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -56,18 +56,8 @@ namespace System.IO.Pipes
             PipeOptions options, TokenImpersonationLevel impersonationLevel, HandleInheritability inheritability)
             : base(direction, 0)
         {
-            if (pipeName == null)
-            {
-                throw new ArgumentNullException(nameof(pipeName));
-            }
-            if (serverName == null)
-            {
-                throw new ArgumentNullException(nameof(serverName), SR.ArgumentNull_ServerName);
-            }
-            if (pipeName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_NeedNonemptyPipeName);
-            }
+            ArgumentException.ThrowIfNullOrEmpty(pipeName);
+            ArgumentNullException.ThrowIfNull(serverName);
             if (serverName.Length == 0)
             {
                 throw new ArgumentException(SR.Argument_EmptyServerName);

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -94,14 +94,7 @@ namespace System.IO.Pipes
             int outBufferSize,
             HandleInheritability inheritability)
         {
-            if (pipeName == null)
-            {
-                throw new ArgumentNullException(nameof(pipeName));
-            }
-            if (pipeName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_NeedNonemptyPipeName);
-            }
+            ArgumentException.ThrowIfNullOrEmpty(pipeName);
             if (direction < PipeDirection.In || direction > PipeDirection.InOut)
             {
                 throw new ArgumentOutOfRangeException(nameof(direction), SR.ArgumentOutOfRange_DirectionModeInOutOrInOut);

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
@@ -22,8 +22,8 @@ namespace System.IO.Pipes.Tests
         [Fact]
         public static void EmptyStringPipeName_Throws_ArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeClientStream(""));
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeClientStream(".", ""));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeClientStream(""));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeClientStream(".", ""));
         }
 
         [Theory]

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
@@ -31,12 +31,12 @@ namespace System.IO.Pipes.Tests
         [InlineData(PipeDirection.Out)]
         public static void ZeroLengthPipeName_Throws_ArgumentException(PipeDirection direction)
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeServerStream(""));
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeServerStream("", direction));
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeServerStream("", direction, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeServerStream("", direction, 3, PipeTransmissionMode.Byte));
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeServerStream("", direction, 3, PipeTransmissionMode.Byte, PipeOptions.None));
-            AssertExtensions.Throws<ArgumentException>(null, () => new NamedPipeServerStream("", direction, 3, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeServerStream(""));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeServerStream("", direction));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeServerStream("", direction, 2));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeServerStream("", direction, 3, PipeTransmissionMode.Byte));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeServerStream("", direction, 3, PipeTransmissionMode.Byte, PipeOptions.None));
+            AssertExtensions.Throws<ArgumentException>("pipeName", () => new NamedPipeServerStream("", direction, 3, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));
         }
 
         [Theory]

--- a/src/libraries/System.IO/tests/StreamReader/StreamReader.StringCtorTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReader.StringCtorTests.cs
@@ -19,10 +19,10 @@ namespace System.IO.Tests
             AssertExtensions.Throws<ArgumentNullException>("path", () => new StreamReader((string)null, null, true));
             AssertExtensions.Throws<ArgumentNullException>("path", () => new StreamReader((string)null, null, true, null));
             AssertExtensions.Throws<ArgumentNullException>("path", () => new StreamReader((string)null, null, true, -1));
-            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("", (Encoding)null));
-            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("", null, true));
-            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("", null, true, null));
-            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("", null, true, -1));
+            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("path", (Encoding)null));
+            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("path", null, true));
+            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("path", null, true, null));
+            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamReader("path", null, true, -1));
             AssertExtensions.Throws<ArgumentNullException>("options", () => new StreamReader("path", (FileStreamOptions)null));
             AssertExtensions.Throws<ArgumentNullException>("options", () => new StreamReader("path", Encoding.UTF8, true, null));
 
@@ -32,12 +32,12 @@ namespace System.IO.Tests
         public static void EmptyPath_ThrowsArgumentException()
         {
             // No argument name for the empty path exception
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamReader(""));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamReader("", new FileStreamOptions()));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamReader("", Encoding.UTF8));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamReader("", Encoding.UTF8, true));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamReader("", Encoding.UTF8, true, new FileStreamOptions()));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamReader("", Encoding.UTF8, true, -1));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamReader(""));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamReader("", new FileStreamOptions()));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamReader("", Encoding.UTF8));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamReader("", Encoding.UTF8, true));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamReader("", Encoding.UTF8, true, new FileStreamOptions()));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamReader("", Encoding.UTF8, true, -1));
         }
 
         [Fact]

--- a/src/libraries/System.IO/tests/StreamWriter/StreamWriter.StringCtorTests.cs
+++ b/src/libraries/System.IO/tests/StreamWriter/StreamWriter.StringCtorTests.cs
@@ -22,21 +22,18 @@ namespace System.IO.Tests
             AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamWriter("path", true, null));
             AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamWriter("path", null, null));
             AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamWriter("path", true, null, -1));
-            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamWriter("", true, null));
-            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamWriter("", null, null));
-            AssertExtensions.Throws<ArgumentNullException>("encoding", () => new StreamWriter("", true, null, -1));
         }
 
         [Fact]
         public static void EmptyPath_ThrowsArgumentException()
         {
             // No argument name for the empty path exception
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamWriter(""));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamWriter("", new FileStreamOptions()));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamWriter("", true));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamWriter("", true, Encoding.UTF8));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamWriter("", Encoding.UTF8, new FileStreamOptions()));
-            AssertExtensions.Throws<ArgumentException>(null, () => new StreamWriter("", true, Encoding.UTF8, -1));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamWriter(""));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamWriter("", new FileStreamOptions()));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamWriter("", true));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamWriter("", true, Encoding.UTF8));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamWriter("", Encoding.UTF8, new FileStreamOptions()));
+            AssertExtensions.Throws<ArgumentException>("path", () => new StreamWriter("", true, Encoding.UTF8, -1));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Mail/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Mail/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -57,18 +58,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-
-  <data name="net_emptystringcall" xml:space="preserve">
-    <value>The parameter '{0}' cannot be an empty string.</value>
-  </data>
   <data name="net_io_invalidasyncresult" xml:space="preserve">
     <value>The IAsyncResult object was not returned from the corresponding asynchronous method on this class.</value>
   </data>
   <data name="net_io_invalidendcall" xml:space="preserve">
     <value>{0} can only be called once for each asynchronous operation.</value>
-  </data>
-  <data name="net_emptystringset" xml:space="preserve">
-    <value>This property cannot be set to an empty string.</value>
   </data>
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/Attachment.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/Attachment.cs
@@ -68,15 +68,7 @@ namespace System.Net.Mail
 
         internal void SetContentFromFile(string fileName, ContentType? contentType)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
-
-            if (fileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(fileName)), nameof(fileName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(fileName);
 
             Stream stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
             _part.SetContent(stream, contentType);
@@ -84,15 +76,7 @@ namespace System.Net.Mail
 
         internal void SetContentFromFile(string fileName, string? mediaType)
         {
-            if (fileName == null)
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
-
-            if (fileName.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(fileName)), nameof(fileName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(fileName);
 
             Stream stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
             _part.SetContent(stream, null, mediaType);

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
@@ -119,15 +119,12 @@ namespace System.Net.Mail
 
         private static bool TryParse(string address, string? displayName, Encoding? displayNameEncoding, out (string displayName, string user, string host, Encoding displayNameEncoding) parsedData, bool throwExceptionIfFail)
         {
-            if (string.IsNullOrEmpty(address))
+            if (throwExceptionIfFail)
             {
-                if (throwExceptionIfFail)
-                {
-                    throw address is null ?
-                        new ArgumentNullException(nameof(address)) :
-                        new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(address)), nameof(address));
-                }
-
+                ArgumentException.ThrowIfNullOrEmpty(address);
+            }
+            else if (string.IsNullOrEmpty(address))
+            {
                 parsedData = default;
                 return false;
             }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
@@ -18,14 +18,7 @@ namespace System.Net.Mail
 
         public void Add(string addresses)
         {
-            if (addresses == null)
-            {
-                throw new ArgumentNullException(nameof(addresses));
-            }
-            if (addresses.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(addresses)), nameof(addresses));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(addresses);
 
             ParseValue(addresses);
         }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
@@ -37,17 +37,8 @@ namespace System.Net.Mail
 
         public MailMessage(string from, string to)
         {
-            if (from == null)
-                throw new ArgumentNullException(nameof(from));
-
-            if (to == null)
-                throw new ArgumentNullException(nameof(to));
-
-            if (from.Length == 0)
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(from)), nameof(from));
-
-            if (to.Length == 0)
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(to)), nameof(to));
+            ArgumentException.ThrowIfNullOrEmpty(from);
+            ArgumentException.ThrowIfNullOrEmpty(to);
 
             _message = new Message(from, to);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _message);

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
@@ -44,17 +44,8 @@ namespace System.Net.Mail
 
         internal Message(string from, string to) : this()
         {
-            if (from == null)
-                throw new ArgumentNullException(nameof(from));
-
-            if (to == null)
-                throw new ArgumentNullException(nameof(to));
-
-            if (from.Length == 0)
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(from)), nameof(from));
-
-            if (to.Length == 0)
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(to)), nameof(to));
+            ArgumentException.ThrowIfNullOrEmpty(from);
+            ArgumentException.ThrowIfNullOrEmpty(to);
 
             _from = new MailAddress(from);
             MailAddressCollection collection = new MailAddressCollection();

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -168,15 +168,7 @@ namespace System.Net.Mail
                     throw new InvalidOperationException(SR.SmtpInvalidOperationDuringSend);
                 }
 
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                if (value.Length == 0)
-                {
-                    throw new ArgumentException(SR.net_emptystringset, nameof(value));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(value);
 
                 value = value.Trim();
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentDisposition.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentDisposition.cs
@@ -79,14 +79,7 @@ namespace System.Net.Mime
             get { return _dispositionType; }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-                if (value.Length == 0)
-                {
-                    throw new ArgumentException(SR.net_emptystringset, nameof(value));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(value);
 
                 _isChanged = true;
                 _dispositionType = value;

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentType.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/ContentType.cs
@@ -45,14 +45,7 @@ namespace System.Net.Mime
         /// <param name="contentType">Unparsed value of the Content-Type header.</param>
         public ContentType(string contentType)
         {
-            if (contentType == null)
-            {
-                throw new ArgumentNullException(nameof(contentType));
-            }
-            if (contentType.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(contentType)), nameof(contentType));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(contentType);
 
             _isChanged = true;
             _type = contentType;
@@ -99,15 +92,7 @@ namespace System.Net.Mime
             get { return _mediaType + "/" + _subType; }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                if (value.Length == 0)
-                {
-                    throw new ArgumentException(SR.net_emptystringset, nameof(value));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(value);
 
                 int offset = 0;
                 _mediaType = MailBnfHelper.ReadToken(value, ref offset, null);

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/HeaderCollection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/HeaderCollection.cs
@@ -22,15 +22,7 @@ namespace System.Net.Mime
         public override void Remove(string name)
 #pragma warning restore CS8765
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(name)), nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             base.Remove(name);
         }
@@ -40,15 +32,7 @@ namespace System.Net.Mime
         public override string? Get(string name)
 #pragma warning restore CS8765
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(name)), nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             return base.Get(name);
         }
@@ -57,15 +41,7 @@ namespace System.Net.Mime
         public override string[]? GetValues(string name)
 #pragma warning restore CS8765
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(name)), nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             return base.GetValues(name);
         }
@@ -93,25 +69,8 @@ namespace System.Net.Mime
         public override void Set(string name, string value)
 #pragma warning restore CS8765
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(name)), nameof(name));
-            }
-
-            if (value.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(value)), nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
+            ArgumentException.ThrowIfNullOrEmpty(value);
 
             if (!MimeBasePart.IsAscii(name, false))
             {
@@ -131,22 +90,8 @@ namespace System.Net.Mime
         public override void Add(string name, string value)
 #pragma warning restore CS8765
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(name)), nameof(name));
-            }
-            if (value.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(value)), nameof(value));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
+            ArgumentException.ThrowIfNullOrEmpty(value);
 
             MailBnfHelper.ValidateHeaderName(name);
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -57,20 +57,8 @@ namespace System.Net
 
         public void Add(string host, int port, string authenticationType, NetworkCredential credential)
         {
-            if (host == null)
-            {
-                throw new ArgumentNullException(nameof(host));
-            }
-
-            if (authenticationType == null)
-            {
-                throw new ArgumentNullException(nameof(authenticationType));
-            }
-
-            if (host.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(host)), nameof(host));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(host);
+            ArgumentNullException.ThrowIfNull(authenticationType);
 
             if (port < 0)
             {
@@ -200,18 +188,8 @@ namespace System.Net
 
         public NetworkCredential? GetCredential(string host, int port, string authenticationType)
         {
-            if (host == null)
-            {
-                throw new ArgumentNullException(nameof(host));
-            }
-            if (authenticationType == null)
-            {
-                throw new ArgumentNullException(nameof(authenticationType));
-            }
-            if (host.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(host)), nameof(host));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(host);
+            ArgumentNullException.ThrowIfNull(authenticationType);
             if (port < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(port));

--- a/src/libraries/System.Net.Primitives/src/System/Net/DnsEndPoint.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/DnsEndPoint.cs
@@ -16,15 +16,7 @@ namespace System.Net
 
         public DnsEndPoint(string host, int port, AddressFamily addressFamily)
         {
-            if (host == null)
-            {
-                throw new ArgumentNullException(nameof(host));
-            }
-
-            if (string.IsNullOrEmpty(host))
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(host)));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(host);
 
             if (port < IPEndPoint.MinPort || port > IPEndPoint.MaxPort)
             {

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/DnsEndPointTest.cs
@@ -30,8 +30,8 @@ namespace System.Net.Primitives.Functional.Tests
         [Fact]
         public static void Ctor_HostPortAddressFamily_Invalid()
         {
-            Assert.Throws<ArgumentNullException>(() => new DnsEndPoint(null, 500, AddressFamily.InterNetwork)); //Null host
-            AssertExtensions.Throws<ArgumentException>(null, () => new DnsEndPoint("", 500, AddressFamily.InterNetwork)); //Empty host
+            AssertExtensions.Throws<ArgumentNullException>("host", () => new DnsEndPoint(null, 500, AddressFamily.InterNetwork)); //Null host
+            AssertExtensions.Throws<ArgumentException>("host", () => new DnsEndPoint("", 500, AddressFamily.InterNetwork)); //Empty host
 
             Assert.Throws<ArgumentOutOfRangeException>(() => new DnsEndPoint("host", IPEndPoint.MinPort - 1, AddressFamily.InterNetwork)); //Port < min port (0)
             Assert.Throws<ArgumentOutOfRangeException>(() => new DnsEndPoint("host", IPEndPoint.MaxPort + 1, AddressFamily.InterNetwork)); //Port > max port (65535)

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -266,9 +266,6 @@
   <data name="security_ExtendedProtectionPolicy_NoEmptyServiceNameCollection" xml:space="preserve">
     <value>The ServiceNameCollection must contain at least one service name.</value>
   </data>
-  <data name="security_ServiceNameCollection_EmptyServiceName" xml:space="preserve">
-    <value>A service name must not be null or empty.</value>
-  </data>
   <data name="net_allocate_ssl_context_failed" xml:space="preserve">
     <value>Failed to allocate SSL/TLS context, OpenSSL error - {0}.</value>
   </data>

--- a/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ServiceNameCollection.cs
+++ b/src/libraries/System.Net.Security/src/System/Security/Authentication/ExtendedProtection/ServiceNameCollection.cs
@@ -135,10 +135,7 @@ namespace System.Security.Authentication.ExtendedProtection
         /// </summary>
         private void AddIfNew(string serviceName)
         {
-            if (string.IsNullOrEmpty(serviceName))
-            {
-                throw new ArgumentException(SR.security_ServiceNameCollection_EmptyServiceName);
-            }
+            ArgumentException.ThrowIfNullOrEmpty(serviceName);
 
             serviceName = NormalizeServiceName(serviceName);
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServiceNameCollectionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServiceNameCollectionTest.cs
@@ -17,14 +17,16 @@ namespace System.Security.Authentication.ExtendedProtection.Tests
             Assert.Throws<ArgumentNullException>(() => new ServiceNameCollection(null));
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void Constructor_CollectionContainsNullOrEmpty_Throws(string item)
+        [Fact]
+        public void Constructor_CollectionContainsNullOrEmpty_Throws()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new ServiceNameCollection(new[] { item }));
-            AssertExtensions.Throws<ArgumentException>(null, () => new ServiceNameCollection(new[] { "first", item }));
-            AssertExtensions.Throws<ArgumentException>(null, () => new ServiceNameCollection(new[] { item, "second" }));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => new ServiceNameCollection(new[] { (string)null }));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => new ServiceNameCollection(new[] { "first", null }));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => new ServiceNameCollection(new[] { null, "second" }));
+
+            AssertExtensions.Throws<ArgumentException>("serviceName", () => new ServiceNameCollection(new[] { "" }));
+            AssertExtensions.Throws<ArgumentException>("serviceName", () => new ServiceNameCollection(new[] { "first", "" }));
+            AssertExtensions.Throws<ArgumentException>("serviceName", () => new ServiceNameCollection(new[] { "", "second" }));
         }
 
         [Fact]
@@ -184,8 +186,8 @@ namespace System.Security.Authentication.ExtendedProtection.Tests
         public void Merge_NullOrEmptyString_Throws()
         {
             var collection = new ServiceNameCollection(new[] { "first", "second" });
-            AssertExtensions.Throws<ArgumentException>(null, () => collection.Merge((string)null));
-            AssertExtensions.Throws<ArgumentException>(null, () => collection.Merge(string.Empty));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => collection.Merge((string)null));
+            AssertExtensions.Throws<ArgumentException>("serviceName", () => collection.Merge(string.Empty));
         }
 
         [Fact]
@@ -220,22 +222,22 @@ namespace System.Security.Authentication.ExtendedProtection.Tests
             Assert.Throws<NullReferenceException>(() => collection.Merge((IEnumerable)null));
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void Merge_EnumerableContainingNullOrEmpty_Throws(string item)
+        [Fact]
+        public void Merge_EnumerableContainingNullOrEmpty_Throws()
         {
             var collection = new ServiceNameCollection(new[] { "first", "second" });
-            AssertExtensions.Throws<ArgumentException>(null, () => collection.Merge(new[] { item }));
-            AssertExtensions.Throws<ArgumentException>(null, () => collection.Merge(new[] { "third", item }));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => collection.Merge(new[] { (string)null }));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => collection.Merge(new[] { "third", null }));
+            AssertExtensions.Throws<ArgumentException>("serviceName", () => collection.Merge(new[] { "" }));
+            AssertExtensions.Throws<ArgumentException>("serviceName", () => collection.Merge(new[] { "third", "" }));
         }
 
         [Fact]
         public void Merge_NonStringEnumerable_Throws()
         {
             var collection = new ServiceNameCollection(new[] { "first", "second" });
-            AssertExtensions.Throws<ArgumentException>(null, () => collection.Merge(new[] { 3 }));
-            AssertExtensions.Throws<ArgumentException>(null, () => collection.Merge(new[] { new object() }));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => collection.Merge(new[] { 3 }));
+            AssertExtensions.Throws<ArgumentNullException>("serviceName", () => collection.Merge(new[] { new object() }));
         }
 
         public static object[][] MergeCollectionsTestData =

--- a/src/libraries/System.Net.WebHeaderCollection/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebHeaderCollection/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -62,9 +63,6 @@
   </data>
   <data name="net_headers_rsp" xml:space="preserve">
     <value>This collection holds request headers and cannot contain the specified response header.</value>
-  </data>
-  <data name="net_emptyStringCall" xml:space="preserve">
-    <value>The parameter '{0}' cannot be an empty string.</value>
   </data>
   <data name="net_WebHeaderInvalidControlChars" xml:space="preserve">
     <value>Specified value has invalid Control characters.</value>

--- a/src/libraries/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
+++ b/src/libraries/System.Net.WebHeaderCollection/src/System/Net/WebHeaderCollection.cs
@@ -344,14 +344,7 @@ namespace System.Net
         public override void Add(string name, string? value)
 #pragma warning restore CS8765
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Format(SR.net_emptyStringCall, nameof(name)), nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             name = HttpValidationHelpers.CheckBadHeaderNameChars(name);
             value = HttpValidationHelpers.CheckBadHeaderValueChars(value);

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1002,17 +1002,11 @@
   <data name="Argument_EmitWriteLineType" xml:space="preserve">
     <value>EmitWriteLine does not support this field or local type.</value>
   </data>
-  <data name="Argument_EmptyDecString" xml:space="preserve">
-    <value>Decimal separator cannot be the empty string.</value>
-  </data>
   <data name="Argument_EmptyFileName" xml:space="preserve">
     <value>Empty file name is not legal.</value>
   </data>
   <data name="Argument_EmptyName" xml:space="preserve">
     <value>Empty name is not legal.</value>
-  </data>
-  <data name="Argument_EmptyPath" xml:space="preserve">
-    <value>Empty path name is not legal.</value>
   </data>
   <data name="Argument_EmptyWaithandleArray" xml:space="preserve">
     <value>Waithandle array may not be empty.</value>
@@ -1479,9 +1473,6 @@
   </data>
   <data name="Argument_StringFirstCharIsZero" xml:space="preserve">
     <value>The first char in the string is the null character.</value>
-  </data>
-  <data name="Argument_StringZeroLength" xml:space="preserve">
-    <value>String cannot be of zero length.</value>
   </data>
   <data name="Argument_StructMustNotBeValueClass" xml:space="preserve">
     <value>The structure must not be a value class.</value>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2141,7 +2141,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\DebugProvider.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Stopwatch.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Tracing\RuntimeEventSourceHelper.Unix.cs" Condition="'$(FeaturePerfTracing)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Android.cs" Condition="'$(TargetsAndroid)' == 'true'"/>
+    <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Android.cs" Condition="'$(TargetsAndroid)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.NoRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.UnixOrBrowser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.OSVersion.OSX.cs" Condition="'$(IsOSXLike)' == 'true' AND '$(TargetsMacCatalyst)' != 'true'" />
@@ -2186,10 +2186,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStatus.SetTimes.OtherUnix.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetEUid.cs"
-             Link="Common\Interop\Unix\Interop.GetEUid.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IsMemberOfGroup.cs"
-             Link="Common\Interop\Unix\Interop.IsMemberOfGroup.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetEUid.cs" Link="Common\Interop\Unix\Interop.GetEUid.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IsMemberOfGroup.cs" Link="Common\Interop\Unix\Interop.IsMemberOfGroup.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetPwUid.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.GetPwUid.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -94,10 +94,7 @@ namespace System
         /// <returns>A return value of true represents that the switch was set and <paramref name="isEnabled"/> contains the value of the switch</returns>
         public static bool TryGetSwitch(string switchName, out bool isEnabled)
         {
-            if (switchName == null)
-                throw new ArgumentNullException(nameof(switchName));
-            if (switchName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(switchName));
+            ArgumentException.ThrowIfNullOrEmpty(switchName);
 
             if (s_switches != null)
             {
@@ -124,10 +121,7 @@ namespace System
         /// <param name="isEnabled">The value to assign</param>
         public static void SetSwitch(string switchName, bool isEnabled)
         {
-            if (switchName == null)
-                throw new ArgumentNullException(nameof(switchName));
-            if (switchName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(switchName));
+            ArgumentException.ThrowIfNullOrEmpty(switchName);
 
             if (s_switches == null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -80,13 +80,10 @@ namespace System
 
         public string ApplyPolicy(string assemblyName)
         {
-            if (assemblyName == null)
+            ArgumentException.ThrowIfNullOrEmpty(assemblyName);
+            if (assemblyName[0] == '\0')
             {
-                throw new ArgumentNullException(nameof(assemblyName));
-            }
-            if (assemblyName.Length == 0 || assemblyName[0] == '\0')
-            {
-                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(assemblyName));
+                throw new ArgumentException(SR.Argument_EmptyString, nameof(assemblyName));
             }
 
             return assemblyName;

--- a/src/libraries/System.Private.CoreLib/src/System/ApplicationId.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ApplicationId.cs
@@ -12,10 +12,9 @@ namespace System
 
         public ApplicationId(byte[] publicKeyToken, string name, Version version, string? processorArchitecture, string? culture)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0) throw new ArgumentException(SR.Argument_EmptyString, nameof(name));
-            if (version == null) throw new ArgumentNullException(nameof(version));
-            if (publicKeyToken == null) throw new ArgumentNullException(nameof(publicKeyToken));
+            ArgumentException.ThrowIfNullOrEmpty(name);
+            ArgumentNullException.ThrowIfNull(version);
+            ArgumentNullException.ThrowIfNull(publicKeyToken);
 
             _publicKeyToken = (byte[])publicKeyToken.Clone();
             Name = name;

--- a/src/libraries/System.Private.CoreLib/src/System/ArgumentException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ArgumentException.cs
@@ -10,6 +10,8 @@
 **
 =============================================================================*/
 
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
 namespace System
@@ -97,5 +99,24 @@ namespace System
         }
 
         public virtual string? ParamName => _paramName;
+
+        /// <summary>Throws an exception if <paramref name="argument"/> is null or empty.</summary>
+        /// <param name="argument">The string argument to validate as non-null and non-empty.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="argument"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="argument"/> is empty.</exception>
+        public static void ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        {
+            if (string.IsNullOrEmpty(argument))
+            {
+                ThrowNullOrEmptyException(argument, paramName);
+            }
+        }
+
+        [DoesNotReturn]
+        private static void ThrowNullOrEmptyException(string? argument, string? paramName) =>
+            throw (argument is null ?
+                new ArgumentNullException(paramName) :
+                new ArgumentException(SR.Argument_EmptyString, paramName));
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -77,12 +77,7 @@ namespace System
             get => CurrentDirectoryCore;
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (value.Length == 0)
-                    throw new ArgumentException(SR.Argument_PathEmpty, nameof(value));
-
+                ArgumentException.ThrowIfNullOrEmpty(value);
                 CurrentDirectoryCore = value;
             }
         }
@@ -239,11 +234,7 @@ namespace System
 
         private static void ValidateVariableAndValue(string variable, ref string? value)
         {
-            if (variable == null)
-                throw new ArgumentNullException(nameof(variable));
-
-            if (variable.Length == 0)
-                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(variable));
+            ArgumentException.ThrowIfNullOrEmpty(variable);
 
             if (variable[0] == '\0')
                 throw new ArgumentException(SR.Argument_StringFirstCharIsZero, nameof(variable));

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -80,27 +80,6 @@ namespace System.Globalization
         {
         }
 
-        private static void VerifyDecimalSeparator(string decSep, string propertyName)
-        {
-            if (decSep == null)
-            {
-                throw new ArgumentNullException(propertyName);
-            }
-
-            if (decSep.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyDecString, propertyName);
-            }
-        }
-
-        private static void VerifyGroupSeparator(string groupSep, string propertyName)
-        {
-            if (groupSep == null)
-            {
-                throw new ArgumentNullException(propertyName);
-            }
-        }
-
         private static void VerifyNativeDigits(string[] nativeDig, string propertyName)
         {
             if (nativeDig == null)
@@ -264,7 +243,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, nameof(value));
+                ArgumentException.ThrowIfNullOrEmpty(value);
                 _currencyDecimalSeparator = value;
             }
         }
@@ -355,7 +334,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyGroupSeparator(value, nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
                 _currencyGroupSeparator = value;
             }
         }
@@ -542,7 +521,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, nameof(value));
+                ArgumentException.ThrowIfNullOrEmpty(value);
                 _numberDecimalSeparator = value;
             }
         }
@@ -553,7 +532,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyGroupSeparator(value, nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
                 _numberGroupSeparator = value;
             }
         }
@@ -631,7 +610,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyDecimalSeparator(value, nameof(value));
+                ArgumentException.ThrowIfNullOrEmpty(value);
                 _percentDecimalSeparator = value;
             }
         }
@@ -642,7 +621,7 @@ namespace System.Globalization
             set
             {
                 VerifyWritable();
-                VerifyGroupSeparator(value, nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
                 _percentGroupSeparator = value;
             }
         }
@@ -652,11 +631,7 @@ namespace System.Globalization
             get => _percentSymbol;
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
+                ArgumentNullException.ThrowIfNull(value);
                 VerifyWritable();
                 _percentSymbol = value;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -13,11 +13,7 @@ namespace System.IO
     {
         public static DirectoryInfo? GetParent(string path)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_PathEmpty, nameof(path));
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             string fullPath = Path.GetFullPath(path);
 
@@ -29,10 +25,7 @@ namespace System.IO
 
         public static DirectoryInfo CreateDirectory(string path)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_PathEmpty, nameof(path));
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             string fullPath = Path.GetFullPath(path);
 
@@ -228,25 +221,15 @@ namespace System.IO
 
         public static void SetCurrentDirectory(string path)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_PathEmpty, nameof(path));
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             Environment.CurrentDirectory = Path.GetFullPath(path);
         }
 
         public static void Move(string sourceDirName, string destDirName)
         {
-            if (sourceDirName == null)
-                throw new ArgumentNullException(nameof(sourceDirName));
-            if (sourceDirName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(sourceDirName));
-
-            if (destDirName == null)
-                throw new ArgumentNullException(nameof(destDirName));
-            if (destDirName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destDirName));
+            ArgumentException.ThrowIfNullOrEmpty(sourceDirName);
+            ArgumentException.ThrowIfNullOrEmpty(destDirName);
 
             string fullsourceDirName = Path.GetFullPath(sourceDirName);
             string sourcePath = PathInternal.EnsureTrailingSeparator(fullsourceDirName);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs
@@ -188,10 +188,7 @@ namespace System.IO
 
         public void MoveTo(string destDirName)
         {
-            if (destDirName == null)
-                throw new ArgumentNullException(nameof(destDirName));
-            if (destDirName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destDirName));
+            ArgumentException.ThrowIfNullOrEmpty(destDirName);
 
             string destination = Path.GetFullPath(destDirName);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -49,14 +49,8 @@ namespace System.IO
         /// </summary>
         public static void Copy(string sourceFileName, string destFileName, bool overwrite)
         {
-            if (sourceFileName == null)
-                throw new ArgumentNullException(nameof(sourceFileName), SR.ArgumentNull_FileName);
-            if (destFileName == null)
-                throw new ArgumentNullException(nameof(destFileName), SR.ArgumentNull_FileName);
-            if (sourceFileName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(sourceFileName));
-            if (destFileName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destFileName));
+            ArgumentException.ThrowIfNullOrEmpty(sourceFileName);
+            ArgumentException.ThrowIfNullOrEmpty(destFileName);
 
             FileSystem.CopyFile(Path.GetFullPath(sourceFileName), Path.GetFullPath(destFileName), overwrite);
         }
@@ -292,12 +286,8 @@ namespace System.IO
 
         public static void WriteAllBytes(string path, byte[] bytes)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path), SR.ArgumentNull_Path);
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
-            if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes));
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(bytes);
 
             using SafeFileHandle sfh = OpenHandle(path, FileMode.Create, FileAccess.Write, FileShare.Read);
             RandomAccess.WriteAtOffset(sfh, bytes, 0);
@@ -418,14 +408,8 @@ namespace System.IO
 
         public static void Move(string sourceFileName, string destFileName, bool overwrite)
         {
-            if (sourceFileName == null)
-                throw new ArgumentNullException(nameof(sourceFileName), SR.ArgumentNull_FileName);
-            if (destFileName == null)
-                throw new ArgumentNullException(nameof(destFileName), SR.ArgumentNull_FileName);
-            if (sourceFileName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(sourceFileName));
-            if (destFileName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destFileName));
+            ArgumentException.ThrowIfNullOrEmpty(sourceFileName);
+            ArgumentException.ThrowIfNullOrEmpty(destFileName);
 
             string fullSourceFileName = Path.GetFullPath(sourceFileName);
             string fullDestFileName = Path.GetFullPath(destFileName);
@@ -609,12 +593,8 @@ namespace System.IO
 
         public static Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path), SR.ArgumentNull_Path);
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
-            if (bytes == null)
-                throw new ArgumentNullException(nameof(bytes));
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(bytes);
 
             return cancellationToken.IsCancellationRequested
                 ? Task.FromCanceled(cancellationToken)
@@ -764,12 +744,8 @@ namespace System.IO
 
         private static void Validate(string path, Encoding encoding)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-            if (encoding == null)
-                throw new ArgumentNullException(nameof(encoding));
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(encoding);
         }
 
         private static byte[] ReadAllBytesUnknownLength(SafeFileHandle sfh)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -89,10 +89,7 @@ namespace System.IO
 
         public FileInfo CopyTo(string destFileName, bool overwrite)
         {
-            if (destFileName == null)
-                throw new ArgumentNullException(nameof(destFileName), SR.ArgumentNull_FileName);
-            if (destFileName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destFileName));
+            ArgumentException.ThrowIfNullOrEmpty(destFileName);
 
             string destinationPath = Path.GetFullPath(destFileName);
             FileSystem.CopyFile(FullPath, destinationPath, overwrite);
@@ -139,10 +136,7 @@ namespace System.IO
         // This method does work across volumes.
         public void MoveTo(string destFileName, bool overwrite)
         {
-            if (destFileName == null)
-                throw new ArgumentNullException(nameof(destFileName));
-            if (destFileName.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName, nameof(destFileName));
+            ArgumentException.ThrowIfNullOrEmpty(destFileName);
 
             string fullDestFileName = Path.GetFullPath(destFileName);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -173,19 +173,9 @@ namespace System.IO
         /// <exception cref="T:System.IO.PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length. </exception>
         public FileStream(string path, FileStreamOptions options)
         {
-            if (path is null)
-            {
-                throw new ArgumentNullException(nameof(path), SR.ArgumentNull_Path);
-            }
-            else if (path.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
-            }
-            else if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-            else if ((options.Access & FileAccess.Read) != 0 && options.Mode == FileMode.Append)
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(options);
+            if ((options.Access & FileAccess.Read) != 0 && options.Mode == FileMode.Append)
             {
                 throw new ArgumentException(SR.Argument_InvalidAppendMode, nameof(options));
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.cs
@@ -7,15 +7,8 @@ namespace System.IO
     {
         internal static void VerifyValidPath(string path, string argName)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(argName);
-            }
-            else if (path.Length == 0)
-            {
-                throw new ArgumentException(SR.Arg_PathEmpty, argName);
-            }
-            else if (path.Contains('\0'))
+            ArgumentException.ThrowIfNullOrEmpty(path, argName);
+            if (path.Contains('\0'))
             {
                 throw new ArgumentException(SR.Argument_InvalidPathChars, argName);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -16,11 +16,7 @@ namespace System.IO
         // Expands the given path to a fully qualified path.
         public static string GetFullPath(string path)
         {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             if (path.Contains('\0'))
                 throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path));

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -53,14 +53,7 @@ namespace System.IO.Strategies
 
         internal static void ValidateArguments(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options, long preallocationSize)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path), SR.ArgumentNull_Path);
-            }
-            else if (path.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(path));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(path);
 
             // don't include inheritable in our bounds check for share
             FileShare tempshare = share & ~FileShare.Inheritable;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs
@@ -210,12 +210,9 @@ namespace System.IO
 
         private static Stream ValidateArgsAndOpenPath(string path, Encoding encoding, FileStreamOptions options)
         {
-            ValidateArgs(path, encoding);
-
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(encoding);
+            ArgumentNullException.ThrowIfNull(options);
             if ((options.Access & FileAccess.Read) == 0)
             {
                 throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(options));
@@ -226,21 +223,14 @@ namespace System.IO
 
         private static Stream ValidateArgsAndOpenPath(string path, Encoding encoding, int bufferSize)
         {
-            ValidateArgs(path, encoding);
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(encoding);
             if (bufferSize <= 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+            }
 
             return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultFileStreamBufferSize);
-        }
-
-        private static void ValidateArgs(string path, Encoding encoding)
-        {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-            if (encoding == null)
-                throw new ArgumentNullException(nameof(encoding));
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyPath);
         }
 
         public override void Close()

--- a/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/StreamWriter.cs
@@ -166,12 +166,9 @@ namespace System.IO
 
         private static Stream ValidateArgsAndOpenPath(string path, Encoding encoding, FileStreamOptions options)
         {
-            ValidateArgs(path, encoding);
-
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(encoding);
+            ArgumentNullException.ThrowIfNull(options);
             if ((options.Access & FileAccess.Write) == 0)
             {
                 throw new ArgumentException(SR.Argument_StreamNotWritable, nameof(options));
@@ -182,21 +179,14 @@ namespace System.IO
 
         private static Stream ValidateArgsAndOpenPath(string path, bool append, Encoding encoding, int bufferSize)
         {
-            ValidateArgs(path, encoding);
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(encoding);
             if (bufferSize <= 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_NeedPosNum);
+            }
 
             return new FileStream(path, append ? FileMode.Append : FileMode.Create, FileAccess.Write, FileShare.Read, DefaultFileStreamBufferSize);
-        }
-
-        private static void ValidateArgs(string path, Encoding encoding)
-        {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-            if (encoding == null)
-                throw new ArgumentNullException(nameof(encoding));
-            if (path.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyPath);
         }
 
         public override void Close()

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/OSPlatform.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/OSPlatform.cs
@@ -19,9 +19,7 @@ namespace System.Runtime.InteropServices
 
         private OSPlatform(string osPlatform)
         {
-            if (osPlatform == null) throw new ArgumentNullException(nameof(osPlatform));
-            if (osPlatform.Length == 0) throw new ArgumentException(SR.Argument_EmptyString, nameof(osPlatform));
-
+            ArgumentException.ThrowIfNullOrEmpty(osPlatform);
             Name = osPlatform;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -422,15 +422,7 @@ namespace System.Runtime.Loader
         // platform-independent way. The DLL is loaded with default load flags.
         protected IntPtr LoadUnmanagedDllFromPath(string unmanagedDllPath)
         {
-            if (unmanagedDllPath == null)
-            {
-                throw new ArgumentNullException(nameof(unmanagedDllPath));
-            }
-
-            if (unmanagedDllPath.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyPath, nameof(unmanagedDllPath));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(unmanagedDllPath);
 
             if (PathInternal.IsPartiallyQualified(unmanagedDllPath))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/FrameworkName.cs
@@ -96,20 +96,9 @@ namespace System.Runtime.Versioning
 
         public FrameworkName(string identifier, Version version, string? profile)
         {
-            if (identifier == null)
-            {
-                throw new ArgumentNullException(nameof(identifier));
-            }
-
-            identifier = identifier.Trim();
-            if (identifier.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyString, nameof(identifier));
-            }
-            if (version == null)
-            {
-                throw new ArgumentNullException(nameof(version));
-            }
+            identifier = identifier?.Trim()!;
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
+            ArgumentNullException.ThrowIfNull(version);
 
             _identifier = identifier;
             _version = version;
@@ -122,14 +111,7 @@ namespace System.Runtime.Versioning
         //  - The version string must be in the System.Version format; an optional "v" or "V" prefix is allowed
         public FrameworkName(string frameworkName)
         {
-            if (frameworkName == null)
-            {
-                throw new ArgumentNullException(nameof(frameworkName));
-            }
-            if (frameworkName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyString, nameof(frameworkName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(frameworkName);
 
             string[] components = frameworkName.Split(ComponentSeparator);
 

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -925,15 +925,7 @@ namespace System
 
         private string ReplaceCore(string oldValue, string? newValue, CompareInfo? ci, CompareOptions options)
         {
-            if (oldValue is null)
-            {
-                throw new ArgumentNullException(nameof(oldValue));
-            }
-
-            if (oldValue.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(oldValue));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(oldValue);
 
             // If they asked to replace oldValue with a null, replace all occurrences
             // with the empty string. AsSpan() will normalize appropriately.
@@ -1054,14 +1046,7 @@ namespace System
 
         public string Replace(string oldValue, string? newValue)
         {
-            if (oldValue is null)
-            {
-                throw new ArgumentNullException(nameof(oldValue));
-            }
-            if (oldValue.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(oldValue));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(oldValue);
 
             // If newValue is null, treat it as an empty string.  Callers use this to remove the oldValue.
             newValue ??= Empty;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -1959,14 +1959,7 @@ namespace System.Text
             {
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_Index);
             }
-            if (oldValue == null)
-            {
-                throw new ArgumentNullException(nameof(oldValue));
-            }
-            if (oldValue.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(oldValue));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(oldValue);
 
             newValue ??= string.Empty;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Windows.cs
@@ -44,10 +44,7 @@ namespace System.Threading
         private static OpenExistingResult OpenExistingWorker(string name, out EventWaitHandle? result)
         {
 #if TARGET_WINDOWS
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             result = null;
             SafeWaitHandle myHandle = Interop.Kernel32.OpenEvent(AccessRights, false, name);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
@@ -29,15 +29,7 @@ namespace System.Threading
 
         private static OpenExistingResult OpenExistingWorker(string name, out Mutex? result)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             OpenExistingResult status = WaitSubsystem.OpenNamedMutex(name, out SafeWaitHandle? safeWaitHandle);
             result = status == OpenExistingResult.Success ? new Mutex(safeWaitHandle!) : null;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs
@@ -41,15 +41,7 @@ namespace System.Threading
 
         private static OpenExistingResult OpenExistingWorker(string name, out Mutex? result)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             result = null;
             // To allow users to view & edit the ACL's, call OpenMutex

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Windows.cs
@@ -45,10 +45,7 @@ namespace System.Threading
         private static OpenExistingResult OpenExistingWorker(string name, out Semaphore? result)
         {
 #if TARGET_WINDOWS
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             // Pass false to OpenSemaphore to prevent inheritedHandles
             SafeWaitHandle myHandle = Interop.Kernel32.OpenSemaphore(AccessRights, false, name);

--- a/src/libraries/System.Private.Xml.Linq/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml.Linq/src/Resources/Strings.resx
@@ -1,4 +1,5 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -74,9 +75,6 @@
   </data>
   <data name="Argument_InvalidPIName" xml:space="preserve">
     <value>'{0}' is an invalid name for a processing instruction.</value>
-  </data>
-  <data name="Argument_InvalidPrefix" xml:space="preserve">
-    <value>'{0}' is an invalid prefix.</value>
   </data>
   <data name="Argument_MustBeDerivedFrom" xml:space="preserve">
     <value>The argument must be derived from {0}.</value>

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -478,8 +478,7 @@ namespace System.Xml.Linq
         /// <returns>An <see cref="XNamespace"/> for the namespace bound to the prefix</returns>
         public XNamespace? GetNamespaceOfPrefix(string prefix)
         {
-            if (prefix == null) throw new ArgumentNullException(nameof(prefix));
-            if (prefix.Length == 0) throw new ArgumentException(SR.Format(SR.Argument_InvalidPrefix, prefix));
+            ArgumentException.ThrowIfNullOrEmpty(prefix);
             if (prefix == "xmlns") return XNamespace.Xmlns;
             string? namespaceName = GetNamespaceOfPrefixInScope(prefix, null);
             if (namespaceName != null) return XNamespace.Get(namespaceName);

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XName.cs
@@ -71,8 +71,7 @@ namespace System.Xml.Linq
         /// </returns>
         public static XName Get(string expandedName)
         {
-            if (expandedName == null) throw new ArgumentNullException(nameof(expandedName));
-            if (expandedName.Length == 0) throw new ArgumentException(SR.Format(SR.Argument_InvalidExpandedName, expandedName));
+            ArgumentException.ThrowIfNullOrEmpty(expandedName);
             if (expandedName[0] == '{')
             {
                 int i = expandedName.LastIndexOf('}');

--- a/src/libraries/System.Private.Xml.Linq/tests/SDMSample/SDMElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/SDMSample/SDMElement.cs
@@ -784,7 +784,7 @@ namespace XDocumentTests.SDMSample
             XElement e = new XElement(ns + "foo");
 
             Assert.Throws<ArgumentNullException>(() => e.GetNamespaceOfPrefix(null));
-            AssertExtensions.Throws<ArgumentException>(null, () => e.GetNamespaceOfPrefix(string.Empty));
+            AssertExtensions.Throws<ArgumentException>("prefix", () => e.GetNamespaceOfPrefix(string.Empty));
 
             XNamespace n = e.GetNamespaceOfPrefix("xmlns");
             Assert.Equal("http://www.w3.org/2000/xmlns/", n.NamespaceName);

--- a/src/libraries/System.Private.Xml.Linq/tests/SDMSample/SDMXName.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/SDMSample/SDMXName.cs
@@ -29,7 +29,7 @@ namespace XDocumentTests.SDMSample
             Assert.Throws<ArgumentNullException>(() => XName.Get(null));
             Assert.Throws<ArgumentNullException>(() => XName.Get(null, "foo"));
             Assert.Throws<ArgumentNullException>(() => XName.Get(string.Empty, "foo"));
-            AssertExtensions.Throws<ArgumentException>(null, () => XName.Get(string.Empty));
+            AssertExtensions.Throws<ArgumentException>("expandedName", () => XName.Get(string.Empty));
             AssertExtensions.Throws<ArgumentException>(null, () => XName.Get("{}"));
             AssertExtensions.Throws<ArgumentException>(null, () => XName.Get("{foo}"));
         }

--- a/src/libraries/System.Private.Xml.Linq/tests/Streaming/StreamingOutput.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/Streaming/StreamingOutput.cs
@@ -60,7 +60,7 @@ namespace XDocumentTests.Streaming
         [Fact]
         public void XNameAsEmptyStringConstructor()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new XStreamingElement(string.Empty));
+            AssertExtensions.Throws<ArgumentException>("expandedName", () => new XStreamingElement(string.Empty));
             Assert.Throws<XmlException>(() => new XStreamingElement(" "));
         }
 

--- a/src/libraries/System.Private.Xml.Linq/tests/axes/InvalidParamValidation.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/axes/InvalidParamValidation.cs
@@ -50,9 +50,9 @@ namespace System.Xml.Linq.Tests
         public static void InvalidXNameTest()
         {
             Assert.Throws<XmlException>(() => { TestData.GetDocumentWithContacts().Root.Attribute("*&^%_#@!"); });
-            AssertExtensions.Throws<ArgumentException>(null, () => { TestData.GetDocumentWithContacts().Root.Attribute(""); });
+            AssertExtensions.Throws<ArgumentException>("expandedName", () => { TestData.GetDocumentWithContacts().Root.Attribute(""); });
             Assert.Throws<XmlException>(() => { TestData.GetDocumentWithContacts().Root.Attributes("*&^%_#@!"); });
-            AssertExtensions.Throws<ArgumentException>(null, () => { TestData.GetDocumentWithContacts().Root.Attributes(""); });
+            AssertExtensions.Throws<ArgumentException>("expandedName", () => { TestData.GetDocumentWithContacts().Root.Attributes(""); });
         }
     }
 

--- a/src/libraries/System.Private.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Xml/src/Resources/Strings.resx
@@ -390,9 +390,6 @@
   <data name="Xml_NotEnoughSpaceForSurrogatePair" xml:space="preserve">
     <value>The buffer is not large enough to fit a surrogate pair. Please provide a buffer of size at least 2 characters.</value>
   </data>
-  <data name="Xml_EmptyUrl" xml:space="preserve">
-    <value>The URL cannot be empty.</value>
-  </data>
   <data name="Xml_UnexpectedNodeInSimpleContent" xml:space="preserve">
     <value>Unexpected node type {0}. {1} method can only be called on elements with simple or empty content.</value>
   </data>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReader.cs
@@ -1635,12 +1635,7 @@ namespace System.Xml
         // Creates an XmlReader for parsing XML from the given Uri.
         public static XmlReader Create(string inputUri)
         {
-            ArgumentNullException.ThrowIfNull(inputUri);
-
-            if (inputUri.Length == 0)
-            {
-                throw new ArgumentException(SR.XmlConvert_BadUri, nameof(inputUri));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(inputUri);
 
             // Avoid using XmlReader.Create(string, XmlReaderSettings), as it references a lot of types
             // that then can't be trimmed away.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
@@ -318,12 +318,7 @@ namespace System.Xml
 
         internal XmlReader CreateReader(string inputUri, XmlParserContext? inputContext)
         {
-            ArgumentNullException.ThrowIfNull(inputUri);
-
-            if (inputUri.Length == 0)
-            {
-                throw new ArgumentException(SR.XmlConvert_BadUri, nameof(inputUri));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(inputUri);
 
             // resolve and open the url
             XmlResolver tmpResolver = GetXmlResolver() ?? new XmlUrlResolver();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -567,15 +567,7 @@ namespace System.Xml
 
         public XmlTextReaderImpl(string url, XmlNameTable nt) : this(nt)
         {
-            if (url == null)
-            {
-                throw new ArgumentNullException(nameof(url));
-            }
-
-            if (url.Length == 0)
-            {
-                throw new ArgumentException(SR.Xml_EmptyUrl, nameof(url));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(url);
 
             _namespaceManager = new XmlNamespaceManager(nt);
 

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -161,7 +161,7 @@ namespace System.Reflection.Tests
             if (asm.Location.Length > 0)
             {
                 Assert.Throws<ArgumentNullException>(() => asm.GetFile(null));
-                AssertExtensions.Throws<ArgumentException>(null, () => asm.GetFile(""));
+                Assert.Throws<ArgumentException>(() => asm.GetFile(""));
                 Assert.Null(asm.GetFile("NonExistentfile.dll"));
                 Assert.NotNull(asm.GetFile("System.Reflection.Tests.dll"));
 

--- a/src/libraries/System.Reflection/tests/GetTypeTests.cs
+++ b/src/libraries/System.Reflection/tests/GetTypeTests.cs
@@ -39,27 +39,27 @@ namespace System.Reflection.Tests
             AssertExtensions.Throws<ArgumentException>("typeName@0", () => Type.GetType(aqn, throwOnError: true, ignoreCase: true));
 
             // Assembly.GetType
-            AssertExtensions.Throws<ArgumentException>(null, () => a.GetType(typeName));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName));
             Assert.Null(a.GetType(aqn));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: false, ignoreCase: false));
-            AssertExtensions.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: false, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: false, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: false, ignoreCase: true));
             Assert.Null(a.GetType(aqn, throwOnError: false, ignoreCase: false));
             Assert.Null(a.GetType(aqn, throwOnError: false, ignoreCase: true));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: true, ignoreCase: false));
-            AssertExtensions.Throws<ArgumentException>(null, () => a.GetType(typeName, throwOnError: true, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: true, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => a.GetType(typeName, throwOnError: true, ignoreCase: true));
             AssertExtensions.Throws<ArgumentException>("typeName@0", () => a.GetType(aqn, throwOnError: true, ignoreCase: false));
             AssertExtensions.Throws<ArgumentException>("typeName@0", () => a.GetType(aqn, throwOnError: true, ignoreCase: true));
 
             // Module.GetType
-            AssertExtensions.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: false, ignoreCase: false));
-            AssertExtensions.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: false, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: false, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: false, ignoreCase: true));
             Assert.Null(m.GetType(aqn, throwOnError: false, ignoreCase: false));
             Assert.Null(m.GetType(aqn, throwOnError: false, ignoreCase: true));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: true, ignoreCase: false));
-            AssertExtensions.Throws<ArgumentException>(null, () => m.GetType(typeName, throwOnError: true, ignoreCase: true));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: true, ignoreCase: false));
+            Assert.Throws<ArgumentException>(() => m.GetType(typeName, throwOnError: true, ignoreCase: true));
             AssertExtensions.Throws<ArgumentException>("typeName@0", () => m.GetType(aqn, throwOnError: true, ignoreCase: false));
             AssertExtensions.Throws<ArgumentException>("typeName@0", () => m.GetType(aqn, throwOnError: true, ignoreCase: true));
         }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -277,6 +277,7 @@ namespace System
         public override string Message { get { throw null; } }
         public virtual string? ParamName { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public static void ThrowIfNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNullAttribute] string? argument, [System.Runtime.CompilerServices.CallerArgumentExpression("argument")] string? paramName = null) { throw null; }
     }
     public partial class ArgumentNullException : System.ArgumentException
     {

--- a/src/libraries/System.Runtime/tests/System/ArgumentExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArgumentExceptionTests.cs
@@ -60,5 +60,32 @@ namespace System.Tests
             Assert.Contains(message, exception.Message);
             Assert.Contains(argumentName, exception.Message);
         }
+
+        [Fact]
+        public static void ThrowIfNullOrEmpty_ThrowsForInvalidInput()
+        {
+            AssertExtensions.Throws<ArgumentNullException>(null, () => ArgumentException.ThrowIfNullOrEmpty(null, null));
+            AssertExtensions.Throws<ArgumentNullException>("something", () => ArgumentException.ThrowIfNullOrEmpty(null, "something"));
+
+            AssertExtensions.Throws<ArgumentException>(null, () => ArgumentException.ThrowIfNullOrEmpty("", null));
+            AssertExtensions.Throws<ArgumentException>("something", () => ArgumentException.ThrowIfNullOrEmpty("", "something"));
+
+            ArgumentException.ThrowIfNullOrEmpty(" ");
+            ArgumentException.ThrowIfNullOrEmpty(" ", "something");
+            ArgumentException.ThrowIfNullOrEmpty("abc", "something");
+        }
+
+        [Fact]
+        public static void ThrowIfNullOrEmpty_UsesArgumentExpression_ParameterNameMatches()
+        {
+            string someString = null;
+            AssertExtensions.Throws<ArgumentNullException>(nameof(someString), () => ArgumentException.ThrowIfNullOrEmpty(someString));
+
+            someString = "";
+            AssertExtensions.Throws<ArgumentException>(nameof(someString), () => ArgumentException.ThrowIfNullOrEmpty(someString));
+
+            someString = "abc";
+            ArgumentException.ThrowIfNullOrEmpty(someString);
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -117,15 +117,6 @@
   <data name="Cryptography_Encryption_MessageTooLong" xml:space="preserve">
     <value>The message exceeds the maximum allowable length for the chosen options ({0}).</value>
   </data>
-  <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
-    <value>The hash algorithm name cannot be null or empty.</value>
-  </data>
-  <data name="Cryptography_InvalidAlgorithmGroup" xml:space="preserve">
-    <value>The algorithm group '{0}' is invalid.</value>
-  </data>
-  <data name="Cryptography_InvalidAlgorithmName" xml:space="preserve">
-    <value>The algorithm name '{0}' is invalid.</value>
-  </data>
   <data name="Cryptography_InvalidCipherMode" xml:space="preserve">
     <value>Specified cipher mode is not valid for this algorithm.</value>
   </data>
@@ -159,17 +150,11 @@
   <data name="Cryptography_InvalidIVSize" xml:space="preserve">
     <value>Specified initialization vector (IV) does not match the block size for this algorithm.</value>
   </data>
-  <data name="Cryptography_InvalidKeyBlobFormat" xml:space="preserve">
-    <value>The key blob format '{0}' is invalid.</value>
-  </data>
   <data name="Cryptography_InvalidKeySize" xml:space="preserve">
     <value>Specified key is not a valid size for this algorithm.</value>
   </data>
   <data name="Cryptography_InvalidPadding" xml:space="preserve">
     <value>Padding is invalid and cannot be removed.</value>
-  </data>
-  <data name="Cryptography_InvalidProviderName" xml:space="preserve">
-    <value>The provider name '{0}' is invalid.</value>
   </data>
   <data name="Cryptography_InvalidRsaParameters" xml:space="preserve">
     <value>The specified RSA parameters are not valid. Exponent and Modulus are required. If D is present, it must have the same length as Modulus. If D is present, P, Q, DP, DQ, and InverseQ are required and must have half the length of Modulus, rounded up, otherwise they must be omitted.</value>

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngAlgorithm.cs
@@ -17,11 +17,7 @@ namespace System.Security.Cryptography
     {
         public CngAlgorithm(string algorithm)
         {
-            if (algorithm == null)
-                throw new ArgumentNullException(nameof(algorithm));
-            if (algorithm.Length == 0)
-                throw new ArgumentException(SR.Format(SR.Cryptography_InvalidAlgorithmName, algorithm), nameof(algorithm));
-
+            ArgumentException.ThrowIfNullOrEmpty(algorithm);
             _algorithm = algorithm;
         }
 

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngAlgorithmGroup.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngAlgorithmGroup.cs
@@ -18,11 +18,7 @@ namespace System.Security.Cryptography
     {
         public CngAlgorithmGroup(string algorithmGroup)
         {
-            if (algorithmGroup == null)
-                throw new ArgumentNullException(nameof(algorithmGroup));
-            if (algorithmGroup.Length == 0)
-                throw new ArgumentException(SR.Format(SR.Cryptography_InvalidAlgorithmGroup, algorithmGroup), nameof(algorithmGroup));
-
+            ArgumentException.ThrowIfNullOrEmpty(algorithmGroup);
             _algorithmGroup = algorithmGroup;
         }
 

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKeyBlobFormat.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKeyBlobFormat.cs
@@ -18,11 +18,7 @@ namespace System.Security.Cryptography
     {
         public CngKeyBlobFormat(string format)
         {
-            if (format == null)
-                throw new ArgumentNullException(nameof(format));
-            if (format.Length == 0)
-                throw new ArgumentException(SR.Format(SR.Cryptography_InvalidKeyBlobFormat, format), nameof(format));
-
+            ArgumentException.ThrowIfNullOrEmpty(format);
             _format = format;
         }
 

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProvider.cs
@@ -17,11 +17,7 @@ namespace System.Security.Cryptography
     {
         public CngProvider(string provider)
         {
-            if (provider == null)
-                throw new ArgumentNullException(nameof(provider));
-            if (provider.Length == 0)
-                throw new ArgumentException(SR.Format(SR.Cryptography_InvalidProviderName, provider), nameof(provider));
-
+            ArgumentException.ThrowIfNullOrEmpty(provider);
             _provider = provider;
         }
 

--- a/src/libraries/System.Security.Cryptography.Csp/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Csp/src/Resources/Strings.resx
@@ -143,9 +143,6 @@
   <data name="Cryptography_CSP_WrongKeySpec" xml:space="preserve">
     <value>The specified cryptographic service provider (CSP) does not support this key algorithm: {0}.</value>
   </data>
-  <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
-    <value>The hash algorithm name cannot be null or empty.</value>
-  </data>
   <data name="Cryptography_InvalidDSASignatureSize" xml:space="preserve">
     <value>Length of the DSA signature was not 40 bytes.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
@@ -678,12 +678,9 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             RSASignaturePadding padding)
         {
-            if (hash == null)
-                throw new ArgumentNullException(nameof(hash));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(hash);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
             if (padding != RSASignaturePadding.Pkcs1)
                 throw PaddingModeNotSupported();
 
@@ -696,14 +693,10 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             RSASignaturePadding padding)
         {
-            if (hash == null)
-                throw new ArgumentNullException(nameof(hash));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(hash);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
             if (padding != RSASignaturePadding.Pkcs1)
                 throw PaddingModeNotSupported();
 
@@ -733,11 +726,6 @@ namespace System.Security.Cryptography
         private static Exception PaddingModeNotSupported()
         {
             return new CryptographicException(SR.Cryptography_InvalidPaddingMode);
-        }
-
-        private static Exception HashAlgorithmNameNullOrEmpty()
-        {
-            return new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
         }
 
         private void ThrowIfDisposed()

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
@@ -137,9 +137,6 @@
   <data name="Cryptography_Encryption_MessageTooLong" xml:space="preserve">
     <value>The message exceeds the maximum allowable length for the chosen options ({0}).</value>
   </data>
-  <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
-    <value>The hash algorithm name cannot be null or empty.</value>
-  </data>
   <data name="Cryptography_CurveNotSupported" xml:space="preserve">
     <value>The specified curve '{0}' or its parameters are not valid for this platform.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -169,9 +169,6 @@
   <data name="Cryptography_Der_Invalid_Encoding" xml:space="preserve">
     <value>ASN1 corrupted data.</value>
   </data>
-  <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
-    <value>The hash algorithm name cannot be null or empty.</value>
-  </data>
   <data name="Cryptography_InvalidECCharacteristic2Curve" xml:space="preserve">
     <value>The specified Characteristic2 curve parameters are not valid. Polynomial, A, B, G.X, G.Y, and Order are required. A, B, G.X, G.Y must be the same length, and the same length as Q.X, Q.Y and D if those are specified. Seed, Cofactor and Hash are optional. Other parameters are not allowed.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/CertificateRequest.cs
@@ -58,12 +58,9 @@ namespace System.Security.Cryptography.X509Certificates
         /// <seealso cref="X500DistinguishedName(string)"/>
         public CertificateRequest(string subjectName, ECDsa key, HashAlgorithmName hashAlgorithm)
         {
-            if (subjectName == null)
-                throw new ArgumentNullException(nameof(subjectName));
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             SubjectName = new X500DistinguishedName(subjectName);
 
@@ -88,12 +85,9 @@ namespace System.Security.Cryptography.X509Certificates
         /// </param>
         public CertificateRequest(X500DistinguishedName subjectName, ECDsa key, HashAlgorithmName hashAlgorithm)
         {
-            if (subjectName == null)
-                throw new ArgumentNullException(nameof(subjectName));
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             SubjectName = subjectName;
 
@@ -122,14 +116,10 @@ namespace System.Security.Cryptography.X509Certificates
         /// <seealso cref="X500DistinguishedName(string)"/>
         public CertificateRequest(string subjectName, RSA key, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
-            if (subjectName == null)
-                throw new ArgumentNullException(nameof(subjectName));
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             SubjectName = new X500DistinguishedName(subjectName);
 
@@ -162,14 +152,10 @@ namespace System.Security.Cryptography.X509Certificates
             HashAlgorithmName hashAlgorithm,
             RSASignaturePadding padding)
         {
-            if (subjectName == null)
-                throw new ArgumentNullException(nameof(subjectName));
-            if (key == null)
-                throw new ArgumentNullException(nameof(key));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             SubjectName = subjectName;
 
@@ -194,12 +180,9 @@ namespace System.Security.Cryptography.X509Certificates
         /// </param>
         public CertificateRequest(X500DistinguishedName subjectName, PublicKey publicKey, HashAlgorithmName hashAlgorithm)
         {
-            if (subjectName == null)
-                throw new ArgumentNullException(nameof(subjectName));
-            if (publicKey == null)
-                throw new ArgumentNullException(nameof(publicKey));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(subjectName);
+            ArgumentNullException.ThrowIfNull(publicKey);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             SubjectName = subjectName;
             PublicKey = publicKey;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestApiTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestApiTests.cs
@@ -91,25 +91,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         {
             string subjectName = null;
             ECDsa key = null;
-            HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName)));
 
             subjectName = "";
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "key",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName)));
 
             key = ECDsa.Create(EccTestData.Secp384r1Data.KeyParameters);
 
             using (key)
             {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "hashAlgorithm",
+                    () => new CertificateRequest(subjectName, key, default(HashAlgorithmName)));
+
                 AssertExtensions.Throws<ArgumentException>(
                     "hashAlgorithm",
-                    () => new CertificateRequest(subjectName, key, hashAlgorithm));
+                    () => new CertificateRequest(subjectName, key, new HashAlgorithmName("")));
             }
         }
 
@@ -118,25 +121,27 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         {
             X500DistinguishedName subjectName = null;
             ECDsa key = null;
-            HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName)));
 
             subjectName = new X500DistinguishedName("");
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "key",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName)));
 
             key = ECDsa.Create(EccTestData.Secp384r1Data.KeyParameters);
 
             using (key)
             {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "hashAlgorithm",
+                    () => new CertificateRequest(subjectName, key, default(HashAlgorithmName)));
                 AssertExtensions.Throws<ArgumentException>(
                     "hashAlgorithm",
-                    () => new CertificateRequest(subjectName, key, hashAlgorithm));
+                    () => new CertificateRequest(subjectName, key, new HashAlgorithmName("")));
             }
         }
 
@@ -145,32 +150,29 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         {
             string subjectName = null;
             RSA key = null;
-            HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
             RSASignaturePadding padding = null;
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
 
             subjectName = "";
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "key",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
 
             key = RSA.Create(TestData.RsaBigExponentParams);
 
             using (key)
             {
-                AssertExtensions.Throws<ArgumentException>(
+                AssertExtensions.Throws<ArgumentNullException>(
                     "hashAlgorithm",
-                    () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
-
-                hashAlgorithm = HashAlgorithmName.SHA256;
+                    () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
 
                 AssertExtensions.Throws<ArgumentNullException>(
                     "padding",
-                    () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
+                    () => new CertificateRequest(subjectName, key, HashAlgorithmName.SHA256, padding));
             }
         }
 
@@ -179,32 +181,33 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         {
             X500DistinguishedName subjectName = null;
             RSA key = null;
-            HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
             RSASignaturePadding padding = null;
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
 
             subjectName = new X500DistinguishedName("");
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "key",
-                () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
+                () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
 
             key = RSA.Create(TestData.RsaBigExponentParams);
 
             using (key)
             {
+                AssertExtensions.Throws<ArgumentNullException>(
+                    "hashAlgorithm",
+                    () => new CertificateRequest(subjectName, key, default(HashAlgorithmName), padding));
+
                 AssertExtensions.Throws<ArgumentException>(
                     "hashAlgorithm",
-                    () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
-
-                hashAlgorithm = HashAlgorithmName.SHA256;
+                    () => new CertificateRequest(subjectName, key, new HashAlgorithmName(""), padding));
 
                 AssertExtensions.Throws<ArgumentNullException>(
                     "padding",
-                    () => new CertificateRequest(subjectName, key, hashAlgorithm, padding));
+                    () => new CertificateRequest(subjectName, key, HashAlgorithmName.SHA256, padding));
             }
         }
 
@@ -213,17 +216,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         {
             X500DistinguishedName subjectName = null;
             PublicKey publicKey = null;
-            HashAlgorithmName hashAlgorithm = default(HashAlgorithmName);
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "subjectName",
-                () => new CertificateRequest(subjectName, publicKey, hashAlgorithm));
+                () => new CertificateRequest(subjectName, publicKey, default(HashAlgorithmName)));
 
             subjectName = new X500DistinguishedName("");
 
             AssertExtensions.Throws<ArgumentNullException>(
                 "publicKey",
-                () => new CertificateRequest(subjectName, publicKey, hashAlgorithm));
+                () => new CertificateRequest(subjectName, publicKey, default(HashAlgorithmName)));
 
             using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp384r1Data.KeyParameters))
             {
@@ -231,9 +233,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 publicKey = generator.PublicKey;
             }
 
+            AssertExtensions.Throws<ArgumentNullException>(
+                "hashAlgorithm",
+                () => new CertificateRequest(subjectName, publicKey, default(HashAlgorithmName)));
+
             AssertExtensions.Throws<ArgumentException>(
                 "hashAlgorithm",
-                () => new CertificateRequest(subjectName, publicKey, hashAlgorithm));
+                () => new CertificateRequest(subjectName, publicKey, new HashAlgorithmName("")));
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSA.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/DSA.cs
@@ -127,10 +127,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm, DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -139,14 +137,12 @@ namespace System.Security.Cryptography
 
         public virtual byte[] SignData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return CreateSignature(hash);
@@ -195,14 +191,12 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -242,10 +236,8 @@ namespace System.Security.Cryptography
 
         public virtual byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, hashAlgorithm);
             return CreateSignature(hash);
@@ -274,10 +266,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm, DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -314,16 +304,13 @@ namespace System.Security.Cryptography
 
         public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return VerifySignature(hash, signature);
@@ -374,16 +361,13 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -392,12 +376,9 @@ namespace System.Security.Cryptography
 
         public virtual bool VerifyData(Stream data, byte[] signature, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, hashAlgorithm);
             return VerifySignature(hash, signature);
@@ -544,8 +525,7 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             out int bytesWritten)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             if (TryHashData(data, destination, hashAlgorithm, out int hashLength) &&
                 TryCreateSignature(destination.Slice(0, hashLength), destination, out bytesWritten))
@@ -589,8 +569,7 @@ namespace System.Security.Cryptography
             DSASignatureFormat signatureFormat,
             out int bytesWritten)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -634,8 +613,7 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> signature,
             HashAlgorithmName hashAlgorithm)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             return VerifyDataCore(data, signature, hashAlgorithm, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
         }
@@ -668,12 +646,9 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -708,12 +683,9 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -765,8 +737,7 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -932,9 +903,6 @@ namespace System.Security.Cryptography
 
         private static Exception DerivedClassMustOverride() =>
             new NotImplementedException(SR.NotSupported_SubclassOverride);
-
-        internal static Exception HashAlgorithmNameNullOrEmpty() =>
-            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
 
         public override bool TryExportEncryptedPkcs8PrivateKey(
             ReadOnlySpan<byte> passwordBytes,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsa.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ECDsa.cs
@@ -51,14 +51,12 @@ namespace System.Security.Cryptography
 
         public virtual byte[] SignData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return SignHash(hash);
@@ -107,14 +105,12 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -200,10 +196,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm, DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -233,10 +227,8 @@ namespace System.Security.Cryptography
         /// </exception>
         public byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm, DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -349,8 +341,7 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             out int bytesWritten)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             Span<byte> hashTmp = stackalloc byte[HashBufferStackSize];
             ReadOnlySpan<byte> hash = HashSpanToTmp(data, hashAlgorithm, hashTmp);
@@ -389,8 +380,7 @@ namespace System.Security.Cryptography
             DSASignatureFormat signatureFormat,
             out int bytesWritten)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -431,10 +421,8 @@ namespace System.Security.Cryptography
 
         public virtual byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, hashAlgorithm);
             return SignHash(hash);
@@ -450,16 +438,13 @@ namespace System.Security.Cryptography
 
         public virtual bool VerifyData(byte[] data, int offset, int count, byte[] signature, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return VerifyHash(hash, signature);
@@ -510,16 +495,13 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -554,12 +536,9 @@ namespace System.Security.Cryptography
         /// </exception>
         public bool VerifyData(byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm, DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -568,8 +547,7 @@ namespace System.Security.Cryptography
 
         public virtual bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             Span<byte> hashTmp = stackalloc byte[HashBufferStackSize];
             ReadOnlySpan<byte> hash = HashSpanToTmp(data, hashAlgorithm, hashTmp);
@@ -598,8 +576,7 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 
@@ -644,12 +621,9 @@ namespace System.Security.Cryptography
 
         public bool VerifyData(Stream data, byte[] signature, HashAlgorithmName hashAlgorithm)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             byte[] hash = HashData(data, hashAlgorithm);
             return VerifyHash(hash, signature);
@@ -683,12 +657,9 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             DSASignatureFormat signatureFormat)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
             if (!signatureFormat.IsKnownValue())
                 throw DSASignatureFormatHelpers.CreateUnknownValueException(signatureFormat);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/IncrementalHash.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/IncrementalHash.cs
@@ -319,8 +319,7 @@ namespace System.Security.Cryptography
         /// <exception cref="CryptographicException"><paramref name="hashAlgorithm"/> is not a known hash algorithm.</exception>
         public static IncrementalHash CreateHash(HashAlgorithmName hashAlgorithm)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             return new IncrementalHash(hashAlgorithm, HashProviderDispenser.CreateHashProvider(hashAlgorithm.Name));
         }
@@ -381,8 +380,7 @@ namespace System.Security.Cryptography
         [UnsupportedOSPlatform("browser")]
         public static IncrementalHash CreateHMAC(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> key)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             return new IncrementalHash(hashAlgorithm, new HMACCommon(hashAlgorithm.Name, key, -1));
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSA.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSA.cs
@@ -168,16 +168,13 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             RSASignaturePadding padding)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return SignHash(hash, hashAlgorithm, padding);
@@ -185,12 +182,9 @@ namespace System.Security.Cryptography
 
         public virtual byte[] SignData(Stream data, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             byte[] hash = HashData(data, hashAlgorithm);
             return SignHash(hash, hashAlgorithm, padding);
@@ -198,14 +192,8 @@ namespace System.Security.Cryptography
 
         public virtual bool TrySignData(ReadOnlySpan<byte> data, Span<byte> destination, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding, out int bytesWritten)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-            {
-                throw HashAlgorithmNameNullOrEmpty();
-            }
-            if (padding == null)
-            {
-                throw new ArgumentNullException(nameof(padding));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             if (TryHashData(data, destination, hashAlgorithm, out int hashLength) &&
                 TrySignHash(destination.Slice(0, hashLength), destination, hashAlgorithm, padding, out bytesWritten))
@@ -233,18 +221,14 @@ namespace System.Security.Cryptography
             HashAlgorithmName hashAlgorithm,
             RSASignaturePadding padding)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
+            ArgumentNullException.ThrowIfNull(data);
             if (offset < 0 || offset > data.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0 || count > data.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             byte[] hash = HashData(data, offset, count, hashAlgorithm);
             return VerifyHash(hash, signature, hashAlgorithm, padding);
@@ -252,14 +236,10 @@ namespace System.Security.Cryptography
 
         public bool VerifyData(Stream data, byte[] signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
-            if (data == null)
-                throw new ArgumentNullException(nameof(data));
-            if (signature == null)
-                throw new ArgumentNullException(nameof(signature));
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw HashAlgorithmNameNullOrEmpty();
-            if (padding == null)
-                throw new ArgumentNullException(nameof(padding));
+            ArgumentNullException.ThrowIfNull(data);
+            ArgumentNullException.ThrowIfNull(signature);
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             byte[] hash = HashData(data, hashAlgorithm);
             return VerifyHash(hash, signature, hashAlgorithm, padding);
@@ -267,14 +247,8 @@ namespace System.Security.Cryptography
 
         public virtual bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-            {
-                throw HashAlgorithmNameNullOrEmpty();
-            }
-            if (padding == null)
-            {
-                throw new ArgumentNullException(nameof(padding));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
+            ArgumentNullException.ThrowIfNull(padding);
 
             for (int i = 256; ; i = checked(i * 2))
             {
@@ -1015,8 +989,5 @@ namespace System.Security.Cryptography
 
         public override string? KeyExchangeAlgorithm => "RSA";
         public override string SignatureAlgorithm => "RSA";
-
-        private static Exception HashAlgorithmNameNullOrEmpty() =>
-            new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, "hashAlgorithm");
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAEncryptionPadding.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSAEncryptionPadding.cs
@@ -56,10 +56,7 @@ namespace System.Security.Cryptography
         /// </summary>
         public static RSAEncryptionPadding CreateOaep(HashAlgorithmName hashAlgorithm)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-            {
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithm.Name, nameof(hashAlgorithm));
 
             return new RSAEncryptionPadding(RSAEncryptionPaddingMode.Oaep, hashAlgorithm);
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.OneShot.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Rfc2898DeriveBytes.OneShot.cs
@@ -329,10 +329,8 @@ namespace System.Security.Cryptography
 
         private static void ValidateHashAlgorithm(HashAlgorithmName hashAlgorithm)
         {
-            if (string.IsNullOrEmpty(hashAlgorithm.Name))
-                throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
-
-            string hashAlgorithmName = hashAlgorithm.Name;
+            string? hashAlgorithmName = hashAlgorithm.Name;
+            ArgumentException.ThrowIfNullOrEmpty(hashAlgorithmName, nameof(hashAlgorithm));
 
             // MD5 intentionally left out.
             if (hashAlgorithmName != HashAlgorithmName.SHA1.Name &&

--- a/src/libraries/System.Security.Cryptography/tests/DSATests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DSATests.cs
@@ -55,9 +55,9 @@ namespace System.Security.Cryptography.Tests
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => wrapperDsa.SignData(new byte[1], 2, 0, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.SignData(new byte[1], 0, -1, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.SignData(new byte[1], 0, 2, HashAlgorithmName.SHA1));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => wrapperDsa.SignData(new byte[1], new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new byte[1], new HashAlgorithmName("")));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => wrapperDsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName("")));
             }
         }
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.Tests
                 byte[] initialSig = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);
                 byte[] actualSig = new byte[initialSig.Length];
 
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(null), out int _));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => wrapperDsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(null), out int _));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(""), out int _));
 
                 Assert.False(wrapperDsa.TrySignData(input, new Span<byte>(actualSig, 0, 1), HashAlgorithmName.SHA1, out bytesWritten));
@@ -102,7 +102,7 @@ namespace System.Security.Cryptography.Tests
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.VerifyData(new byte[1], 0, -1, null, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => wrapperDsa.VerifyData(new byte[1], 0, 2, null, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentNullException>("signature", () => wrapperDsa.VerifyData(new byte[1], 0, 1, null, HashAlgorithmName.SHA1));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new byte[1], new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => wrapperDsa.VerifyData(new byte[1], new byte[1], new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new byte[1], new byte[1], new HashAlgorithmName("")));
 
                 byte[] signature = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);
@@ -121,7 +121,7 @@ namespace System.Security.Cryptography.Tests
             {
                 AssertExtensions.Throws<ArgumentNullException>("data", () => wrapperDsa.VerifyData((Stream)null, null, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentNullException>("signature", () => wrapperDsa.VerifyData(new MemoryStream(new byte[1]), null, HashAlgorithmName.SHA1));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => wrapperDsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName("")));
 
                 byte[] signature = wrapperDsa.SignData(new MemoryStream(input), HashAlgorithmName.SHA1);
@@ -138,7 +138,7 @@ namespace System.Security.Cryptography.Tests
 
             using (var wrapperDsa = new OverrideAbstractDSA(DSA.Create(1024)))
             {
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData((Span<byte>)new byte[1], new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => wrapperDsa.VerifyData((Span<byte>)new byte[1], new byte[1], new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => wrapperDsa.VerifyData((Span<byte>)new byte[1], new byte[1], new HashAlgorithmName("")));
 
                 byte[] signature = wrapperDsa.SignData(input, HashAlgorithmName.SHA1);

--- a/src/libraries/System.Security.Cryptography/tests/ECDsaTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ECDsaTests.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.Tests
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => ecdsa.SignData(new byte[1], 2, 0, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.SignData(new byte[1], 0, -1, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.SignData(new byte[1], 0, 2, HashAlgorithmName.SHA1));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new byte[1], 0, 1, new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.SignData(new byte[1], 0, 1, new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new byte[1], 0, 1, new HashAlgorithmName("")));
 
                 AssertExtensions.Throws<ArgumentNullException>("data", () => ecdsa.VerifyData((byte[])null, null, HashAlgorithmName.SHA1));
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.Tests
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.VerifyData(new byte[1], 0, -1, null, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => ecdsa.VerifyData(new byte[1], 0, 2, null, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentNullException>("signature", () => ecdsa.VerifyData(new byte[1], 0, 1, null, HashAlgorithmName.SHA1));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[1], 0, 1, new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[1], 0, 1, new byte[1], new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new byte[1], 0, 1, new byte[1], new HashAlgorithmName("")));
 
                 var input = new byte[1024];
@@ -95,12 +95,12 @@ namespace System.Security.Cryptography.Tests
             using (var ecdsa = new OverrideAbstractECDsa(ECDsaFactory.Create()))
             {
                 AssertExtensions.Throws<ArgumentNullException>("data", () => ecdsa.SignData((Stream)null, HashAlgorithmName.SHA1));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.SignData(new MemoryStream(new byte[1]), new HashAlgorithmName("")));
 
                 AssertExtensions.Throws<ArgumentNullException>("data", () => ecdsa.VerifyData((Stream)null, null, HashAlgorithmName.SHA1));
                 AssertExtensions.Throws<ArgumentNullException>("signature", () => ecdsa.VerifyData(new MemoryStream(new byte[1]), null, HashAlgorithmName.SHA1));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName(null)));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData(new MemoryStream(new byte[1]), new byte[1], new HashAlgorithmName("")));
 
                 var input = new byte[1024];
@@ -120,10 +120,10 @@ namespace System.Security.Cryptography.Tests
         {
             using (var ecdsa = new OverrideAbstractECDsa(ECDsaFactory.Create()))
             {
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(null), out int bytesWritten));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(null), out int bytesWritten));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.TrySignData(new byte[1], new byte[1], new HashAlgorithmName(""), out int bytesWritten));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => ecdsa.VerifyData((ReadOnlySpan<byte>)new byte[1], new byte[1], new HashAlgorithmName(null)));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData((ReadOnlySpan<byte>)new byte[1], new byte[1], new HashAlgorithmName("")));
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => ecdsa.VerifyData((ReadOnlySpan<byte>)new byte[1], new byte[1], new HashAlgorithmName(null)));
 
                 var input = new byte[1024];
                 Random.Shared.NextBytes(input);

--- a/src/libraries/System.Security.Cryptography/tests/IncrementalHashTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/IncrementalHashTests.cs
@@ -42,13 +42,13 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public static void InvalidArguments_Throw()
         {
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHash(new HashAlgorithmName(null)));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => IncrementalHash.CreateHash(new HashAlgorithmName(null)));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHash(new HashAlgorithmName("")));
 
             if (PlatformDetection.IsNotBrowser)
             {
                 // HMAC is not supported on Browser
-                AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHMAC(new HashAlgorithmName(null), new byte[1]));
+                AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => IncrementalHash.CreateHMAC(new HashAlgorithmName(null), new byte[1]));
                 AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => IncrementalHash.CreateHMAC(new HashAlgorithmName(""), new byte[1]));
 
                 AssertExtensions.Throws<ArgumentNullException>("key", () => IncrementalHash.CreateHMAC(HashAlgorithmName.SHA512, null));

--- a/src/libraries/System.Security.Cryptography/tests/RSATests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/RSATests.cs
@@ -145,7 +145,7 @@ namespace System.Security.Cryptography.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => rsa.SignData(new byte[1], 0, -1, HashAlgorithmName.SHA256, null));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => rsa.SignData(new byte[1], 0, 2, HashAlgorithmName.SHA256, null));
 
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(new byte[1], 0, 1, new HashAlgorithmName(null), null));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => rsa.SignData(new byte[1], 0, 1, new HashAlgorithmName(null), null));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(new byte[1], 0, 1, new HashAlgorithmName(""), null));
 
             AssertExtensions.Throws<ArgumentNullException>("padding", () => rsa.SignData(new byte[1], 0, 1, new HashAlgorithmName("abc"), null));
@@ -163,7 +163,7 @@ namespace System.Security.Cryptography.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("data", () => rsa.SignData((Stream)null, HashAlgorithmName.SHA256, null));
 
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(Stream.Null, new HashAlgorithmName(null), null));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => rsa.SignData(Stream.Null, new HashAlgorithmName(null), null));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.SignData(Stream.Null, new HashAlgorithmName(""), null));
 
             AssertExtensions.Throws<ArgumentNullException>("padding", () => rsa.SignData(Stream.Null, new HashAlgorithmName("abc"), null));
@@ -182,7 +182,7 @@ namespace System.Security.Cryptography.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("signature", () => rsa.VerifyData(Stream.Null, null, HashAlgorithmName.SHA256, null));
 
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.VerifyData(Stream.Null, new byte[1], new HashAlgorithmName(null), null));
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () => rsa.VerifyData(Stream.Null, new byte[1], new HashAlgorithmName(null), null));
             AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () => rsa.VerifyData(Stream.Null, new byte[1], new HashAlgorithmName(""), null));
 
             AssertExtensions.Throws<ArgumentNullException>("padding", () => rsa.VerifyData(Stream.Null, new byte[1], new HashAlgorithmName("abc"), null));

--- a/src/libraries/System.Security.Cryptography/tests/Rfc2898OneShotTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/Rfc2898OneShotTests.cs
@@ -75,9 +75,13 @@ namespace System.Security.Cryptography
         [Fact]
         public static void Pbkdf2_PasswordBytes_NullHashName()
         {
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () =>
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () =>
                 Rfc2898DeriveBytes.Pbkdf2(
                     s_passwordBytes, s_salt, iterations: 1, default(HashAlgorithmName), s_extractLength)
+            );
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () =>
+                Rfc2898DeriveBytes.Pbkdf2(
+                    s_passwordBytes, s_salt, iterations: 1, new HashAlgorithmName(""), s_extractLength)
             );
         }
 
@@ -147,9 +151,13 @@ namespace System.Security.Cryptography
         [Fact]
         public static void Pbkdf2_PasswordString_NullHashName()
         {
-            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () =>
+            AssertExtensions.Throws<ArgumentNullException>("hashAlgorithm", () =>
                 Rfc2898DeriveBytes.Pbkdf2(
                     Password, s_salt, iterations: 1, default(HashAlgorithmName), s_extractLength)
+            );
+            AssertExtensions.Throws<ArgumentException>("hashAlgorithm", () =>
+                Rfc2898DeriveBytes.Pbkdf2(
+                    Password, s_salt, iterations: 1, new HashAlgorithmName(""), s_extractLength)
             );
         }
 

--- a/src/libraries/System.Security.Principal.Windows/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Principal.Windows/src/Resources/Strings.resx
@@ -84,9 +84,6 @@
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
-  <data name="Argument_StringZeroLength" xml:space="preserve">
-    <value>String cannot be of zero length.</value>
-  </data>
   <data name="IdentityReference_AccountNameTooLong" xml:space="preserve">
     <value>Account name is too long.</value>
   </data>

--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
@@ -33,15 +33,7 @@ namespace System.Security.Principal
 
         public NTAccount(string domainName, string accountName)
         {
-            if (accountName == null)
-            {
-                throw new ArgumentNullException(nameof(accountName));
-            }
-
-            if (accountName.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(accountName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(accountName);
 
             if (accountName.Length > MaximumAccountNameLength)
             {
@@ -65,15 +57,7 @@ namespace System.Security.Principal
 
         public NTAccount(string name)
         {
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            if (name.Length == 0)
-            {
-                throw new ArgumentException(SR.Argument_StringZeroLength, nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             if (name.Length > (MaximumDomainNameLength + 1 /* '\' */ + MaximumAccountNameLength))
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
@@ -47,16 +47,7 @@ namespace System.Text.RegularExpressions
             [MemberNotNull(nameof(_name))]
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(Name));
-                }
-
-                if (value.Length == 0)
-                {
-                    throw new ArgumentException(SR.Format(SR.InvalidEmptyArgument, nameof(Name)), nameof(Name));
-                }
-
+                ArgumentException.ThrowIfNullOrEmpty(value, nameof(Name));
                 _name = value;
             }
         }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.Mono.cs
@@ -258,10 +258,7 @@ namespace System.Reflection.Emit
 
         public ModuleBuilder DefineDynamicModule(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException("Empty name is not legal.", nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if (name[0] == '\0')
                 throw new ArgumentException(SR.Argument_InvalidName, nameof(name));
 
@@ -273,15 +270,13 @@ namespace System.Reflection.Emit
 
         public ModuleBuilder? GetDynamicModule(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException("Empty name is not legal.", nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             if (modules != null)
                 for (int i = 0; i < modules.Length; ++i)
                     if (modules[i].name == name)
                         return modules[i];
+
             return null;
         }
 
@@ -326,10 +321,7 @@ namespace System.Reflection.Emit
         [RequiresUnreferencedCode("Types might be removed")]
         public override Type? GetType(string name, bool throwOnError, bool ignoreCase)
         {
-            if (name == null)
-                throw new ArgumentNullException(name);
-            if (name.Length == 0)
-                throw new ArgumentException("Name cannot be empty", nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             Type res = InternalGetType(null, name, throwOnError, ignoreCase);
             if (res is TypeBuilder)
@@ -343,10 +335,7 @@ namespace System.Reflection.Emit
 
         public override Module? GetModule(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException("Name can't be empty");
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             if (modules == null)
                 return null;

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
@@ -148,10 +148,7 @@ namespace System.Reflection.Emit
             Justification = "Reflection.Emit is not subject to trimming")]
         private FieldBuilder DefineDataImpl(string name, int size, FieldAttributes attributes)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException("name cannot be empty", nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if (global_type_created != null)
                 throw new InvalidOperationException("global fields already created");
             if ((size <= 0) || (size >= 0x3f0000))
@@ -408,10 +405,7 @@ namespace System.Reflection.Emit
         [ComVisible(true)]
         public override Type? GetType(string className, bool throwOnError, bool ignoreCase)
         {
-            if (className == null)
-                throw new ArgumentNullException(nameof(className));
-            if (className.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyName, nameof(className));
+            ArgumentException.ThrowIfNullOrEmpty(className);
 
             TypeBuilder? result = null;
 

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.Mono.cs
@@ -408,8 +408,7 @@ namespace System.Reflection.Emit
             {
                 foreach (Type iface in interfaces)
                 {
-                    if (iface == null)
-                        throw new ArgumentNullException(nameof(interfaces));
+                    ArgumentNullException.ThrowIfNull(iface, nameof(interfaces));
                     if (iface.IsByRef)
                         throw new ArgumentException(nameof(interfaces));
                 }
@@ -1593,10 +1592,7 @@ namespace System.Reflection.Emit
 
         public FieldBuilder DefineUninitializedData(string name, int size, FieldAttributes attributes)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException("Empty name is not legal", nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if ((size <= 0) || (size > 0x3f0000))
                 throw new ArgumentException("Data size must be > 0 and < 0x3f0000");
             check_not_created();
@@ -1698,9 +1694,8 @@ namespace System.Reflection.Emit
 
         private static void check_name(string argName, string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(argName);
-            if (name.Length == 0 || name[0] == ((char)0))
+            ArgumentException.ThrowIfNullOrEmpty(name, argName);
+            if (name[0] == '\0')
                 throw new ArgumentException(SR.Argument_EmptyName, argName);
         }
 

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -228,10 +228,8 @@ namespace System.Reflection
 
         public override ManifestResourceInfo? GetManifestResourceInfo(string resourceName)
         {
-            if (resourceName == null)
-                throw new ArgumentNullException(nameof(resourceName));
-            if (resourceName.Length == 0)
-                throw new ArgumentException("String cannot have zero length.");
+            ArgumentException.ThrowIfNullOrEmpty(resourceName);
+
             ManifestResourceInfo result = new ManifestResourceInfo(null, null, 0);
             var this_assembly = this;
             bool found = GetManifestResourceInfoInternal(new QCallAssembly(ref this_assembly), resourceName, result);
@@ -243,12 +241,7 @@ namespace System.Reflection
 
         public override Stream? GetManifestResourceStream(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            if (name.Length == 0)
-                throw new ArgumentException("String cannot have zero length.",
-                    nameof(name));
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             unsafe
             {
@@ -292,11 +285,7 @@ namespace System.Reflection
         [RequiresUnreferencedCode("Types might be removed")]
         public override Type GetType(string name, bool throwOnError, bool ignoreCase)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-
-            if (name.Length == 0)
-                throw new ArgumentException("Name cannot be empty");
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             return InternalGetType(null, name, throwOnError, ignoreCase);
         }
@@ -323,10 +312,7 @@ namespace System.Reflection
 
         public override Module? GetModule(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0)
-                throw new ArgumentException("Name can't be empty");
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             Module[] modules = GetModules(true);
             foreach (Module module in modules)
@@ -450,10 +436,7 @@ namespace System.Reflection
         [RequiresAssemblyFiles(ThrowingMessageInRAF)]
         public override FileStream? GetFile(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name), SR.ArgumentNull_FileName);
-            if (name.Length == 0)
-                throw new ArgumentException(SR.Argument_EmptyFileName);
+            ArgumentException.ThrowIfNullOrEmpty(name);
             if (Location.Length == 0)
             {
                 // Throw if the assembly was loaded from memory, indicated by Location returning an empty string

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -207,10 +207,7 @@ namespace System.Reflection
         public override
         Type GetType(string className, bool throwOnError, bool ignoreCase)
         {
-            if (className == null)
-                throw new ArgumentNullException(nameof(className));
-            if (className.Length == 0)
-                throw new ArgumentException("Type name can't be empty");
+            ArgumentException.ThrowIfNullOrEmpty(className);
             return assembly.InternalGetType(this, className, throwOnError, ignoreCase);
         }
 


### PR DESCRIPTION
Adds ArgumentException.ThrowIfNullOrEmpty and then uses it in a bunch of places around the tree.  Most of the replaced places used a resource string for the message, and I used it in places where it didn't feel like we were losing any meaningful information by centralizing on the single shared string, but I didn't use it in places where the resource string message used in the empty case conveyed something that seemed useful, e.g. a recommendation on what to use instead of an empty string.

There are a few places where I allowed for order of exception throws to change in the case where there were multiple user errors and the validation for a single argument was split, e.g. I changed a few cases of:
```C#
if (arg1 is null) throw new ArgumentNullException(...);
if (arg2 is null) throw new ArgumentNullException(...);
if (arg1.Length == 0) throw new ArgumentException(...);
if (arg2.Length == 0) throw new ArgumentException(...);
```
to:
```C#
ArgumentException.ThrowIfNullOrEmpty(arg1);
ArgumentException.ThrowIfNullOrEmpty(arg2);
```
even though it'll produce a different exception for `M("", null)` than it would previously.  Technically a breaking change, but given this is a case of multiple usage errors and all the exceptions are ArgumentException-based, I think it's acceptable.

I wanted to get this in before we do the massive !! conversion, as I expect !! auto-fixes will make it a bit harder to roll this out.  I explicitly did not do anything to roll out use of ArgumentNullException.ThrowIfNull, except in cases where I was modifying a method to use ArgumentException.ThrowIfNullOrEmpty, in which case for consistency I changed anything else in the function that could have been using ThrowIfNull to do so.

Fixes https://github.com/dotnet/runtime/issues/62628