### PR TITLE
[wasm][debugger] Move the breakpoint line after applying changes

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -1126,7 +1126,7 @@ namespace DebuggerTests
         }
 
         [Fact]
-        public async Task DebugHotReloadMethodAddBreakpointUsingSDBChangeBreakpointPosition()
+        public async Task DebugHotReloadMethod_CheckBreakpointLineUpdated_ByVS_Simulated()
         {
             string asm_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll");
             string pdb_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb");

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -1124,5 +1124,26 @@ namespace DebuggerTests
                 }
             );
         }
+
+        [Fact]
+        public async Task DebugHotReloadMethodAddBreakpointUsingSDBChangeBreakpointPosition()
+        {
+            string asm_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll");
+            string pdb_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb");
+            string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll");
+
+            var bp = await SetBreakpoint(".*/MethodBody1.cs$", 48, 12, use_regex: true);
+            var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
+                    asm_file, pdb_file, "MethodBody5", "StaticMethod1");
+
+            //apply first update
+            pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
+                    asm_file_hot_reload, "MethodBody5", "StaticMethod1", 1, bp.Value["breakpointId"].Value<string>(), 49, 12);
+
+            JToken top_frame = pause_location["callFrames"]?[0];
+            AssertEqual("StaticMethod1", top_frame?["functionName"]?.Value<string>(), top_frame?.ToString());
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 49, 12, scripts, top_frame["location"]);
+
+        }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -1138,7 +1138,12 @@ namespace DebuggerTests
 
             //apply first update
             pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
-                    asm_file_hot_reload, "MethodBody5", "StaticMethod1", 1, bp.Value["breakpointId"].Value<string>(), 49, 12);
+                    asm_file_hot_reload, "MethodBody5", "StaticMethod1", 1, 
+                    rebindBreakpoint : async () =>
+                    {
+                        await RemoveBreakpoint(bp.Value["breakpointId"].Value<string>());
+                        await SetBreakpoint(".*/MethodBody1.cs$", 49, 12, use_regex: true);
+                    });
 
             JToken top_frame = pause_location["callFrames"]?[0];
             AssertEqual("StaticMethod1", top_frame?["functionName"]?.Value<string>(), top_frame?.ToString());

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1215,7 +1215,7 @@ namespace DebuggerTests
             return await insp.WaitFor(Inspector.PAUSE);
         }
 
-        internal async Task<JObject> LoadAssemblyAndTestHotReloadUsingSDB(string asm_file_hot_reload, string class_name, string method_name, int id)
+        internal async Task<JObject> LoadAssemblyAndTestHotReloadUsingSDB(string asm_file_hot_reload, string class_name, string method_name, int id, string bpId = null, int newLine = 0, int newColumn = 0)
         {
             await cli.SendCommand("Debugger.resume", null, token);
             var bytes = File.ReadAllBytes($"{asm_file_hot_reload}.{id}.dmeta");
@@ -1245,6 +1245,13 @@ namespace DebuggerTests
                 dpdb = dpdb1
             });
             await cli.SendCommand("DotnetDebugger.applyUpdates", applyUpdates, token);
+
+            if (bpId != null)
+            {
+                await RemoveBreakpoint(bpId);
+                await SetBreakpoint(".*/MethodBody1.cs$", 49, 12, use_regex: true);
+            }
+
             run_method = JObject.FromObject(new
             {
                 expression = "window.setTimeout(function() { invoke_static_method('[debugger-test] TestHotReloadUsingSDB:RunMethod', '" + class_name + "', '" + method_name + "'); }, 1);"

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1215,7 +1215,7 @@ namespace DebuggerTests
             return await insp.WaitFor(Inspector.PAUSE);
         }
 
-        internal async Task<JObject> LoadAssemblyAndTestHotReloadUsingSDB(string asm_file_hot_reload, string class_name, string method_name, int id, string bpId = null, int newLine = 0, int newColumn = 0)
+        internal async Task<JObject> LoadAssemblyAndTestHotReloadUsingSDB(string asm_file_hot_reload, string class_name, string method_name, int id, Func<Task> rebindBreakpoint = null)
         {
             await cli.SendCommand("Debugger.resume", null, token);
             var bytes = File.ReadAllBytes($"{asm_file_hot_reload}.{id}.dmeta");
@@ -1246,11 +1246,8 @@ namespace DebuggerTests
             });
             await cli.SendCommand("DotnetDebugger.applyUpdates", applyUpdates, token);
 
-            if (bpId != null)
-            {
-                await RemoveBreakpoint(bpId);
-                await SetBreakpoint(".*/MethodBody1.cs$", newLine, newColumn, use_regex: true);
-            }
+            if (rebindBreakpoint != null)
+                await rebindBreakpoint();
 
             run_method = JObject.FromObject(new
             {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1249,7 +1249,7 @@ namespace DebuggerTests
             if (bpId != null)
             {
                 await RemoveBreakpoint(bpId);
-                await SetBreakpoint(".*/MethodBody1.cs$", 49, 12, use_regex: true);
+                await SetBreakpoint(".*/MethodBody1.cs$", newLine, newColumn, use_regex: true);
             }
 
             run_method = JObject.FromObject(new

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
@@ -38,4 +38,15 @@ namespace ApplyUpdateReferencedAssembly
         public static void StaticMethod4 () {
         }
     }
+
+
+
+
+
+
+    public class MethodBody5 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("original");
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics;
 using System;
-
+//keep the same line number for class in the original file and the updates ones
 namespace ApplyUpdateReferencedAssembly
 {
     public class MethodBody1 {

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
@@ -43,4 +43,11 @@ namespace ApplyUpdateReferencedAssembly
             Console.WriteLine(a + b);
         }
     }
+
+    public class MethodBody5 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("beforeoriginal");
+            Console.WriteLine("original");
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics;
 using System;
-
+//keep the same line number for class in the original file and the updates ones
 namespace ApplyUpdateReferencedAssembly
 {
     public class MethodBody1 {

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Diagnostics;
 using System;
-
+//keep the same line number for class in the original file and the updates ones
 namespace ApplyUpdateReferencedAssembly
 {
     public class MethodBody1 {

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
@@ -38,4 +38,16 @@ namespace ApplyUpdateReferencedAssembly
         public static void StaticMethod4 () {
         }
     }
+
+
+
+
+
+
+    public class MethodBody5 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("beforeoriginal");
+            Console.WriteLine("original");
+        }
+    }
 }


### PR DESCRIPTION
When hot-reloading code with new lines added, VS automatically updates the breakpoints by sending Remove/SetBreakpoint commands. 

Add a test case for the reload, with simulated VS part.