### PR TITLE
Remove workarounds for RemoteExecutor (dotnet/arcade#5865)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
@@ -106,10 +106,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                     })
                     .RunConsoleAsync();
             }, new RemoteInvokeOptions() { ExpectedExitCode = 124 });
-
-            // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
-            remoteHandle.Process.WaitForExit();
-            Assert.Equal(124, remoteHandle.Process.ExitCode);
         }
 
         private class EnsureEnvironmentExitCodeWorker : BackgroundService
@@ -143,11 +139,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                     })
                     .RunConsoleAsync();
             }, new RemoteInvokeOptions() { TimeOut = 30_000, ExpectedExitCode = expectedExitCode }); // give a 30 second time out, so if this does hang, it doesn't hang for the full timeout
-
-            Assert.True(remoteHandle.Process.WaitForExit(30_000), "The hosted process should have exited within 30 seconds");
-
-            // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
-            Assert.Equal(expectedExitCode, remoteHandle.Process.ExitCode);
         }
 
         private class EnsureEnvironmentExitDoesntHangWorker : BackgroundService

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/MessageSendTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/MessageSendTests.cs
@@ -71,11 +71,6 @@ namespace System.Runtime.InteropServices.Tests
                 var (msgSend, func) = msgSendOverrides[0];
                 ObjectiveCMarshal.SetMessageSendCallback(msgSend, func);
                 Assert.Throws<InvalidOperationException>(() => ObjectiveCMarshal.SetMessageSendCallback(msgSend, func));
-
-                // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
-                // RemoteExecutor currently only checks the expected exit code if the invoked function returns an int.
-                // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
-                return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
 
@@ -102,11 +97,6 @@ namespace System.Runtime.InteropServices.Tests
                 }
 
                 SetMessageSendCallbackImpl(msgSendArray);
-
-                // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
-                // RemoteExecutor currently only checks the expected exit code if the invoked function returns an int.
-                // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
-                return RemoteExecutor.SuccessExitCode;
             }, string.Join(';', funcsToOverride)).Dispose();
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/PendingExceptionTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ObjectiveC/PendingExceptionTests.cs
@@ -59,11 +59,6 @@ namespace System.Runtime.InteropServices.Tests
                 Assert.True(Enum.IsDefined<MessageSendFunction>(msgSend));
 
                 ValidateSetMessageSendPendingExceptionImpl(msgSend);
-
-                // TODO: Remove once https://github.com/dotnet/arcade/issues/5865 is resolved
-                // RemoteExecutor currently only checks the expected exit code if the invoked function returns an int.
-                // Check the exit code to ensure the test will fail if there was a crash that could not be caught by the executor.
-                return RemoteExecutor.SuccessExitCode;
             }, func.ToString()).Dispose();
         }
 

--- a/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -2268,8 +2268,6 @@ namespace System.Text.Tests
                     string s = new string('x', 500_000_000);
                     sb.Append(s); // This should throw, not AV
                 });
-
-                return RemoteExecutor.SuccessExitCode; // workaround https://github.com/dotnet/arcade/issues/5865
             }).Dispose();
         }
     }


### PR DESCRIPTION
The fix for https://github.com/dotnet/arcade/issues/5865 should have flowed into runtime with https://github.com/dotnet/runtime/pull/64331