### PR TITLE
Add support for byref fields in NativeAOT/crossgen2

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2193,7 +2193,7 @@ namespace Internal.JitInterface
         {
             int result = 0;
 
-            if (type.IsByReferenceOfT || type.IsByRef)
+            if (type.IsByReferenceOfT)
             {
                 return MarkGcField(gcPtrs, CorInfoGCType.TYPE_GC_BYREF);
             }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2193,7 +2193,7 @@ namespace Internal.JitInterface
         {
             int result = 0;
 
-            if (type.IsByReferenceOfT)
+            if (type.IsByReferenceOfT || type.IsByRef)
             {
                 return MarkGcField(gcPtrs, CorInfoGCType.TYPE_GC_BYREF);
             }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -37,12 +37,8 @@ namespace Internal.TypeSystem
 
                 TypeDesc fieldType = field.FieldType;
 
-                // ByRef instance fields are not allowed.
-                if (fieldType.IsByRef)
-                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
-
-                // ByRef-like instance fields on non-byref-like types are not allowed.
-                if (fieldType.IsByRefLike && !type.IsByRefLike)
+                // ByRef and byref-like instance fields on non-byref-like types are not allowed.
+                if ((fieldType.IsByRef || fieldType.IsByRefLike) && !type.IsByRefLike)
                     ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
 
                 numInstanceFields++;
@@ -481,7 +477,7 @@ namespace Internal.TypeSystem
                 }
                 else
                 {
-                    Debug.Assert(fieldType.IsPrimitive || fieldType.IsPointer || fieldType.IsFunctionPointer || fieldType.IsEnum);
+                    Debug.Assert(fieldType.IsPrimitive || fieldType.IsPointer || fieldType.IsFunctionPointer || fieldType.IsEnum || fieldType.IsByRef);
 
                     var fieldSizeAndAlignment = ComputeFieldSizeAndAlignment(fieldType, hasLayout, packingSize, out bool _, out bool _);
                     instanceNonGCPointerFieldsCount[CalculateLog2(fieldSizeAndAlignment.Size.AsInt)]++;
@@ -815,7 +811,7 @@ namespace Internal.TypeSystem
             }
             else
             {
-                Debug.Assert(fieldType.IsPointer || fieldType.IsFunctionPointer);
+                Debug.Assert(fieldType.IsPointer || fieldType.IsFunctionPointer || fieldType.IsByRef);
                 result.Size = fieldType.Context.Target.LayoutPointerSize;
                 result.Alignment = fieldType.Context.Target.LayoutPointerSize;
             }

--- a/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
+++ b/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
@@ -107,7 +107,7 @@
         ldarg.0
         ldarga.s 1
         mkrefany !T
-        stfld typedref class InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        stfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
         ret
     }
 
@@ -115,7 +115,7 @@
         instance class [System.Runtime]System.Type GetFieldType () cil managed
     {
         ldarg.0
-        ldfld typedref class InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        ldfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
         refanytype
         call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle )
         ret

--- a/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
+++ b/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
@@ -107,7 +107,7 @@
         ldarg.0
         ldarga.s 1
         mkrefany !T
-        stfld typedref InvalidCSharp.WithTypedReferenceField`1::Field
+        stfld typedref class InvalidCSharp.WithTypedReferenceField`1<!T>::Field
         ret
     }
 
@@ -115,7 +115,7 @@
         instance class [System.Runtime]System.Type GetFieldType () cil managed
     {
         ldarg.0
-        ldfld typedref InvalidCSharp.WithTypedReferenceField`1::Field
+        ldfld typedref class InvalidCSharp.WithTypedReferenceField`1<!T>::Field
         refanytype
         call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle )
         ret


### PR DESCRIPTION
The only necessary changes at this point were in code shared between crossgen2 and NativeAOT.

Cc @dotnet/crossgen-contrib 