### PR TITLE
Delete custom cmake config cache mechanism on Unix

### DIFF
--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -96,19 +96,6 @@ if [[ "$build_arch" == "wasm" ]]; then
     cmake_command="emcmake $cmake_command"
 fi
 
-cmake_args_to_cache="$scan_build\n$SCAN_BUILD_COMMAND\n$generator\n$__UnprocessedCMakeArgs"
-cmake_args_cache_file="$2/cmake_cmd_line.txt"
-if [[ -z "$__ConfigureOnly" ]]; then
-    if [[ -e "$cmake_args_cache_file" ]]; then
-        cmake_args_cache=$(<"$cmake_args_cache_file")
-        if [[ "$cmake_args_cache" == "$cmake_args_to_cache" ]]; then
-            echo "CMake command line is unchanged. Reusing previous cache instead of regenerating."
-            exit 0
-        fi
-    fi
-    echo $cmake_args_to_cache > $cmake_args_cache_file
-fi
-
 # We have to be able to build with CMake 3.6.2, so we can't use the -S or -B options
 pushd "$2"
 


### PR DESCRIPTION
When cmake configuration fails due to missing dependency or manually terminated in the middle (Ctrl+C) for some reason, re-running the build command fails with these messages:
```
  CMake command line is unchanged. Reusing previous cache instead of regenerating.
  Unable to find generated build files for "native libraries component" project!
```
The workaround is to delete artifacts directory and rerun the build command, which is wasteful (as it repreforms all the previous steps including rebuilding the previous subsets). cmake has its own up-to-date caching mechanism which works well on Unix (it has some issues on Windows/MSBuild), so deleting the custom sentinel-based cache on Unix makes it more robust and saves some time. The one in `gen-buildsys.cmd` for Windows is kept intact.

cc @jkoritzinsky