### PR TITLE
Fix DateOnly and TimeOnly Formatting using interpolated strings

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
@@ -817,15 +817,13 @@ namespace System
                         return DateTimeFormat.TryFormat(GetEquivalentDateTime(), destination, out charsWritten, format, provider);
 
                     default:
-                        charsWritten = 0;
-                        return false;
+                        throw new FormatException(SR.Argument_BadFormatSpecifier);
                 }
             }
 
             if (!DateTimeFormat.IsValidCustomDateFormat(format, throwOnError: false))
             {
-                charsWritten = 0;
-                return false;
+                throw new FormatException(SR.Format(SR.Format_DateTimeOnlyContainsNoneDateParts, format.ToString(), nameof(DateOnly)));
             }
 
             return DateTimeFormat.TryFormat(GetEquivalentDateTime(), destination, out charsWritten, format, provider);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
@@ -62,8 +62,8 @@ namespace System
         "M"     "0"         month w/o leading zero                2
         "MM"    "00"        month with leading zero               02
         "MMM"               short month name (abbreviation)       Feb
-        "MMMM"              full month name                       Febuary
-        "MMMM*"             full month name                       Febuary
+        "MMMM"              full month name                       February
+        "MMMM*"             full month name                       February
 
         "y"     "0"         two digit year (year % 100) w/o leading zero           0
         "yy"    "00"        two digit year (year % 100) with leading zero          00
@@ -734,7 +734,7 @@ namespace System
                         break;
                     case '\\':
                         // Escaped character.  Can be used to insert a character into the format string.
-                        // For exmple, "\d" will insert the character 'd' into the string.
+                        // For example, "\d" will insert the character 'd' into the string.
                         //
                         // NOTENOTE : we can remove this format character if we enforce the enforced quote
                         // character rule.
@@ -966,7 +966,7 @@ namespace System
                         // This format is not supported by DateTimeOffset
                         throw new FormatException(SR.Format_InvalidString);
                     }
-                    // Universal time is always in Greogrian calendar.
+                    // Universal time is always in Gregorian calendar.
                     //
                     // Change the Calendar to be Gregorian Calendar.
                     //

--- a/src/libraries/System.Private.CoreLib/src/System/ISpanFormattable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ISpanFormattable.cs
@@ -15,6 +15,7 @@ namespace System
         /// <remarks>
         /// An implementation of this interface should produce the same string of characters as an implementation of <see cref="IFormattable.ToString(string?, IFormatProvider?)"/>
         /// on the same type.
+        /// TryFormat should return false only if there is not enough space in the destination buffer. Any other failures should throw an exception.
         /// </remarks>
         bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
     }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -892,15 +892,13 @@ namespace System
                         return DateTimeFormat.TryFormat(ToDateTime(), destination, out charsWritten, format, provider);
 
                     default:
-                        charsWritten = 0;
-                        return false;
+                        throw new FormatException(SR.Argument_BadFormatSpecifier);
                 }
             }
 
             if (!DateTimeFormat.IsValidCustomTimeFormat(format, throwOnError: false))
             {
-                charsWritten = 0;
-                return false;
+                throw new FormatException(SR.Format(SR.Format_DateTimeOnlyContainsNoneDateParts, format.ToString(), nameof(TimeOnly)));
             }
 
             return DateTimeFormat.TryFormat(ToDateTime(), destination, out charsWritten, format, provider);

--- a/src/libraries/System.Runtime/tests/System/DateOnlyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateOnlyTests.cs
@@ -513,12 +513,14 @@ namespace System.Tests
             Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out charsWritten));
             Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "r"));
             Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "O"));
-        }
-
-        [Fact]
-        public static void InvalidFormattingWithInterpolatedStringTest()
-        {
-            DateOnly dateOnly = DateOnly.FromDateTime(DateTime.Today);
+            Assert.Throws<FormatException>(() => {
+                    Span<char> buff = stackalloc char[100];
+                    dateOnly.TryFormat(buff, out charsWritten, "u");
+                });
+            Assert.Throws<FormatException>(() => {
+                    Span<char> buff = stackalloc char[100];
+                    dateOnly.TryFormat(buff, out charsWritten, "hh-ss");
+                });
             Assert.Throws<FormatException>(() => $"{dateOnly:u}");
             Assert.Throws<FormatException>(() => $"{dateOnly:hh-ss}");
         }

--- a/src/libraries/System.Runtime/tests/System/DateOnlyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateOnlyTests.cs
@@ -514,5 +514,13 @@ namespace System.Tests
             Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "r"));
             Assert.False(dateOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "O"));
         }
+
+        [Fact]
+        public static void InvalidFormattingWithInterpolatedStringTest()
+        {
+            DateOnly dateOnly = DateOnly.FromDateTime(DateTime.Today);
+            Assert.Throws<FormatException>(() => $"{dateOnly:u}");
+            Assert.Throws<FormatException>(() => $"{dateOnly:hh-ss}");
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/TimeOnlyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeOnlyTests.cs
@@ -483,12 +483,15 @@ namespace System.Tests
             Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out charsWritten));
             Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "r"));
             Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "O"));
-        }
 
-        [Fact]
-        public static void InvalidFormattingWithInterpolatedStringTest()
-        {
-            TimeOnly timeOnly = TimeOnly.FromDateTime(DateTime.Now);
+            Assert.Throws<FormatException>(() => {
+                    Span<char> buff = stackalloc char[100];
+                    timeOnly.TryFormat(buff, out charsWritten, "u");
+                });
+            Assert.Throws<FormatException>(() => {
+                    Span<char> buff = stackalloc char[100];
+                    timeOnly.TryFormat(buff, out charsWritten, "dd-yyyy");
+                });
             Assert.Throws<FormatException>(() => $"{timeOnly:u}");
             Assert.Throws<FormatException>(() => $"{timeOnly:dd-yyyy}");
         }

--- a/src/libraries/System.Runtime/tests/System/TimeOnlyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeOnlyTests.cs
@@ -484,5 +484,13 @@ namespace System.Tests
             Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "r"));
             Assert.False(timeOnly.TryFormat(buffer.Slice(0, 3), out charsWritten, "O"));
         }
+
+        [Fact]
+        public static void InvalidFormattingWithInterpolatedStringTest()
+        {
+            TimeOnly timeOnly = TimeOnly.FromDateTime(DateTime.Now);
+            Assert.Throws<FormatException>(() => $"{timeOnly:u}");
+            Assert.Throws<FormatException>(() => $"{timeOnly:dd-yyyy}");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/64292