### PR TITLE
Fix ExitDetectionNotBlockedByHandler test

### DIFF
--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -76,8 +76,9 @@ public partial class CancelKeyPressTests
                 Assert.Equal(RemoteExecutor.SuccessExitCode, handle.ExitCode);
             }
 
-            // Release CancelKeyPress
+            // Release CancelKeyPress, and give it time to return and tear down the app
             mre.Set();
+            Thread.Sleep(WaitFailTestTimeoutSeconds * 1000);
         }, new RemoteInvokeOptions() { ExpectedExitCode = 130 }).Dispose();
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/64364 (hopefully)
I believe what's happening is there's a race condition between the main thread exiting with exit code 42 and the CancelKeyPress handler returning and allowing cancellation to propagate and tear down the app with exit code 130.

cc: @danmoseley, @elinor-fung 