### PR TITLE
Add vectorized paths for Span<T>.Reverse

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1742,44 +1742,7 @@ namespace System
             if (length <= 1)
                 return;
 
-            if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-            {
-                if (Unsafe.SizeOf<T>() == sizeof(byte))
-                {
-                    SpanHelpers.ReverseByteRef(ref Unsafe.As<T, byte>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index)), length);
-                    return;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(char))
-                {
-                    SpanHelpers.ReverseCharRef(ref Unsafe.As<T, char>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index)), length);
-                    return;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(int))
-                {
-                    SpanHelpers.ReverseInt32Ref(ref Unsafe.As<T, int>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index)), length);
-                    return;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(long))
-                {
-                    SpanHelpers.ReverseInt64Ref(ref Unsafe.As<T, long>(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index)), length);
-                    return;
-                }
-            }
-            ReverseInner(array, index, length);
-        }
-
-        private static void ReverseInner<T>(T[] array, int index, int length)
-        {
-            ref T first = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index);
-            ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, length), -1);
-            do
-            {
-                T temp = first;
-                first = last;
-                last = temp;
-                first = ref Unsafe.Add(ref first, 1);
-                last = ref Unsafe.Add(ref last, -1);
-            } while (Unsafe.IsAddressLessThan(ref first, ref last));
+            SpanHelpers.Reverse(ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), index), (nuint)length);
         }
 
         // Sorts the elements of an array. The sort compares the elements to each

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1637,7 +1637,6 @@ namespace System
         // located at index length - i - 1, where length is the
         // length of the array.
         //
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Reverse(Array array)
         {
             if (array == null)
@@ -1719,15 +1718,13 @@ namespace System
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Reverse<T>(T[] array)
         {
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            Reverse(array, 0, array.Length);
+            SpanHelpers.Reverse(ref MemoryMarshal.GetArrayDataReference(array), (nuint)array.Length);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Reverse<T>(T[] array, int index, int length)
         {
             if (array == null)

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1722,7 +1722,8 @@ namespace System
         {
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            SpanHelpers.Reverse(ref MemoryMarshal.GetArrayDataReference(array), (nuint)array.Length);
+            if (array.Length > 1)
+                SpanHelpers.Reverse(ref MemoryMarshal.GetArrayDataReference(array), (nuint)array.Length);
         }
 
         public static void Reverse<T>(T[] array, int index, int length)

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1545,13 +1545,11 @@ namespace System
         /// </summary>
         public static void Reverse<T>(this Span<T> span)
         {
-            if (span.Length <= 1)
+            if (span.Length > 1)
             {
-                return;
+                SpanHelpers.Reverse(ref MemoryMarshal.GetReference(span), (nuint)span.Length);
             }
-            SpanHelpers.Reverse(ref MemoryMarshal.GetReference(span), (nuint)span.Length);
         }
-
 
         /// <summary>
         /// Creates a new span over the target array.

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1543,6 +1543,7 @@ namespace System
         /// <summary>
         /// Reverses the sequence of the elements in the entire span.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Reverse<T>(this Span<T> span)
         {
             if (span.Length <= 1)
@@ -1573,7 +1574,11 @@ namespace System
                     return;
                 }
             }
+            ReverseInner<T>(span);
+        }
 
+        private static void ReverseInner<T>(this Span<T> span)
+        {
             ref T first = ref MemoryMarshal.GetReference(span);
             ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, span.Length), -1);
             do

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1550,46 +1550,9 @@ namespace System
             {
                 return;
             }
-
-            if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-            {
-                if (Unsafe.SizeOf<T>() == sizeof(byte))
-                {
-                    SpanHelpers.ReverseByteRef(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)), span.Length);
-                    return;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(char))
-                {
-                    SpanHelpers.ReverseCharRef(ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)), span.Length);
-                    return;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(int))
-                {
-                    SpanHelpers.ReverseInt32Ref(ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)), span.Length);
-                    return;
-                }
-                else if (Unsafe.SizeOf<T>() == sizeof(long))
-                {
-                    SpanHelpers.ReverseInt64Ref(ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)), span.Length);
-                    return;
-                }
-            }
-            ReverseInner<T>(span);
+            SpanHelpers.Reverse(ref MemoryMarshal.GetReference(span), (nuint)span.Length);
         }
 
-        private static void ReverseInner<T>(this Span<T> span)
-        {
-            ref T first = ref MemoryMarshal.GetReference(span);
-            ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, span.Length), -1);
-            do
-            {
-                T temp = first;
-                first = last;
-                last = temp;
-                first = ref Unsafe.Add(ref first, 1);
-                last = ref Unsafe.Add(ref last, -1);
-            } while (Unsafe.IsAddressLessThan(ref first, ref last));
-        }
 
         /// <summary>
         /// Creates a new span over the target array.

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1543,7 +1543,6 @@ namespace System
         /// <summary>
         /// Reverses the sequence of the elements in the entire span.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Reverse<T>(this Span<T> span)
         {
             if (span.Length <= 1)

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1550,14 +1550,30 @@ namespace System
                 return;
             }
 
-            if (RuntimeHelpers.IsBitwiseEquatable<T>())
+            if (typeof(T).IsValueType)
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
                     SpanHelpers.ReverseByteRef(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)), span.Length);
                     return;
                 }
+                else if (Unsafe.SizeOf<T>() == sizeof(char))
+                {
+                    SpanHelpers.ReverseCharRef(ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)), span.Length);
+                    return;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(int))
+                {
+                    SpanHelpers.ReverseInt32Ref(ref Unsafe.As<T, int>(ref MemoryMarshal.GetReference(span)), span.Length);
+                    return;
+                }
+                else if (Unsafe.SizeOf<T>() == sizeof(long))
+                {
+                    SpanHelpers.ReverseInt64Ref(ref Unsafe.As<T, long>(ref MemoryMarshal.GetReference(span)), span.Length);
+                    return;
+                }
             }
+
             ref T first = ref MemoryMarshal.GetReference(span);
             ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, span.Length), -1);
             do
@@ -1569,25 +1585,6 @@ namespace System
                 last = ref Unsafe.Add(ref last, -1);
             } while (Unsafe.IsAddressLessThan(ref first, ref last));
         }
-
-
-        // private static readonly short[] ReverseMaskAvx2Short =
-        // {
-        //     0, 1, 2, 3, 4, 5, 6, 7,  // first 128-bit lane
-        //     0, 1, 2, 3, 4, 5, 6, 7,  // second 128-bit lane
-        // };
-
-        // private static readonly int[] ReverseMaskAvx2Int32 =
-        // {
-        //     0, 1, 2, 3, // first 128-bit lane
-        //     0, 1, 2, 3  // second 128-bit lane
-        // };
-
-        // private static readonly long[] ReverseMaskAvx2Int64 =
-        // {
-        //     0, 1, // first 128-bit lane
-        //     0, 1  // second 128-bit lane
-        // };
 
         /// <summary>
         /// Creates a new span over the target array.

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1550,7 +1550,7 @@ namespace System
                 return;
             }
 
-            if (typeof(T).IsValueType)
+            if (!RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2238,5 +2238,59 @@ namespace System
             // Find the first lane that is set inside compareResult.
             return (uint)BitOperations.TrailingZeroCount(selectedLanes) >> 2;
         }
+
+        public static void ReverseByteRef(ref byte buf, nint length)
+        {
+            ref byte first = ref buf;
+            ref byte last = ref Unsafe.Add(ref Unsafe.Add(ref first, length), -1);
+            int numBytesWritten = 0;
+            if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= length)
+            {
+                Vector256<byte> ReverseMask = Vector256.Create((byte)0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, // first 128-bit lane
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);  // second 128-bit lane
+                last = ref Unsafe.Add(ref Unsafe.Add(ref first, length), -Vector256<byte>.Count);
+                do
+                {
+                    Vector256<byte> tempFirst = Unsafe.As<byte, Vector256<byte>>(ref first);
+                    Vector256<byte> tempLast = Unsafe.As<byte, Vector256<byte>>(ref last);
+                    tempFirst = Avx2.Shuffle(tempFirst, ReverseMask);
+                    tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
+                    tempLast = Avx2.Shuffle(tempLast, ReverseMask);
+                    tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
+                    Unsafe.As<byte, Vector256<byte>>(ref first) = tempLast;
+                    Unsafe.As<byte, Vector256<byte>>(ref last) = tempFirst;
+                    first = ref Unsafe.Add(ref first, Vector256<byte>.Count);
+                    last = ref Unsafe.Add(ref last, -Vector256<byte>.Count);
+                    numBytesWritten += Vector256<byte>.Count * 2;
+                } while ((length - numBytesWritten) >= Vector256<byte>.Count * 2);
+            }
+            else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= length)
+            {
+                Vector128<byte> ReverseMask = Vector128.Create((byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+                last = ref Unsafe.Add(ref Unsafe.Add(ref first, length), -Vector128<byte>.Count);
+                do
+                {
+                    Vector128<byte> tempFirst = Unsafe.As<byte, Vector128<byte>>(ref first);
+                    Vector128<byte> tempLast = Unsafe.As<byte, Vector128<byte>>(ref last);
+                    tempFirst = Ssse3.Shuffle(tempFirst, ReverseMask);
+                    tempLast = Ssse3.Shuffle(tempLast, ReverseMask);
+                    Unsafe.As<byte, Vector128<byte>>(ref first) = tempLast;
+                    Unsafe.As<byte, Vector128<byte>>(ref last) = tempFirst;
+                    first = ref Unsafe.Add(ref first, Vector128<byte>.Count);
+                    last = ref Unsafe.Add(ref last, -Vector128<byte>.Count);
+                    numBytesWritten += Vector128<byte>.Count * 2;
+                } while ((length - numBytesWritten) >= Vector128<byte>.Count * 2);
+            }
+            last = ref Unsafe.Add(ref first, (length - numBytesWritten) - 1);
+            while ((length - numBytesWritten) > 1)
+            {
+                byte temp = first;
+                first = last;
+                last = temp;
+                first = ref Unsafe.Add(ref first, 1);
+                last = ref Unsafe.Add(ref last, -1);
+                numBytesWritten += 2;
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2277,13 +2277,13 @@ namespace System
                     //     | P1 | O1 | N1 | M1 | L1 | K1 | J1 | I1 | H1 | G1 | F1 | E1 | D1 | C1 | B1 | A1 |
                     //     +-------------------------------------------------------------------------------+
                     tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
-                    tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
+                    tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 0b00_01);
                     tempLast = Avx2.Shuffle(tempLast, reverseMask);
-                    tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
+                    tempLast = Avx2.Permute2x128(tempLast, tempLast, 0b00_01);
 
                     // Store the reversed vectors
-                    Vector256.StoreUnsafe(tempLast, ref buf, firstOffset);
-                    Vector256.StoreUnsafe(tempFirst, ref buf, lastOffset);
+                    tempLast.StoreUnsafe(ref buf, firstOffset);
+                    tempFirst.StoreUnsafe(ref buf, lastOffset);
                 }
                 buf = ref Unsafe.Add(ref buf, numIters * numElements);
                 length -= numIters * numElements * 2;
@@ -2314,8 +2314,8 @@ namespace System
                     tempLast = Ssse3.Shuffle(tempLast, reverseMask);
 
                     // Store the reversed vectors
-                    Vector128.StoreUnsafe(tempLast, ref buf, firstOffset);
-                    Vector128.StoreUnsafe(tempFirst, ref buf, lastOffset);
+                    tempLast.StoreUnsafe(ref buf, firstOffset);
+                    tempFirst.StoreUnsafe(ref buf, lastOffset);
                 }
                 buf = ref Unsafe.Add(ref buf, numIters * numElements);
                 length -= numIters * numElements * 2;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2247,8 +2247,9 @@ namespace System
             int numBytesWritten = 0;
             if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= numBytes)
             {
-                Vector256<byte> reverseMask = Vector256.Create((byte)0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, // first 128-bit lane
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);  // second 128-bit lane
+                Vector256<byte> reverseMask = Vector256.Create(
+                    (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // first 128-bit lane
+                    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0); // first 128-bit lane
                 last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector256<byte>.Count);
                 do
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2245,7 +2245,7 @@ namespace System
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // first 128-bit lane
-                    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0); // first 128-bit lane
+                    15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0); // second 128-bit lane
                 nuint numElements = (nuint)Vector256<byte>.Count;
                 nuint numIters = (length / numElements) / 2;
                 for (nuint i = 0; i < numIters; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -2239,7 +2239,7 @@ namespace System
             return (uint)BitOperations.TrailingZeroCount(selectedLanes) >> 2;
         }
 
-        public static void ReverseRef(ref byte buf, nuint length)
+        public static void Reverse(ref byte buf, nuint length)
         {
             int numBytes = (int)length;
             ref byte first = ref buf;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -2018,21 +2018,23 @@ namespace System
 
         public static void Reverse(ref char buf, nuint length)
         {
-            nint numBytes = (int)length * sizeof(char);
-            int numBytesWritten = 0;
-            ref byte first = ref Unsafe.As<char, byte>(ref buf);
-            ref byte last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), sizeof(char));
-            if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= numBytes)
+            ref byte bufByte = ref Unsafe.As<char, byte>(ref buf);
+            nuint byteLength = length * sizeof(char);
+            if (Avx2.IsSupported && (nuint)Vector256<short>.Count * 2 <= length)
             {
                 Vector256<byte> reverseMask = Vector256.Create(
                     (byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1, // first 128-bit lane
                     14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1); // second 128-bit lane
-                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector256<byte>.Count);
-                do
+                nuint numElements = (nuint)Vector256<byte>.Count;
+                nuint numIters = (byteLength / numElements) / 2;
+                for (nuint i = 0; i < numIters; i++)
                 {
+                    nuint firstOffset = i * numElements;
+                    nuint lastOffset = byteLength - ((1 + i) * numElements);
+
                     // Load in values from beginning and end of the array.
-                    Vector256<byte> tempFirst = Unsafe.As<byte, Vector256<byte>>(ref first);
-                    Vector256<byte> tempLast = Unsafe.As<byte, Vector256<byte>>(ref last);
+                    Vector256<byte> tempFirst = Vector256.LoadUnsafe(ref bufByte, firstOffset);
+                    Vector256<byte> tempLast = Vector256.LoadUnsafe(ref bufByte, lastOffset);
 
                     // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
                     // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
@@ -2053,24 +2055,25 @@ namespace System
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
 
                     // Store the reversed vectors
-                    Unsafe.As<byte, Vector256<byte>>(ref first) = tempLast;
-                    Unsafe.As<byte, Vector256<byte>>(ref last) = tempFirst;
-
-                    // Adjust the references to point to the next vector
-                    first = ref Unsafe.Add(ref first, Vector256<byte>.Count);
-                    last = ref Unsafe.Subtract(ref last, Vector256<byte>.Count);
-                    numBytesWritten += Vector256<byte>.Count * 2;
-                } while (numBytes - numBytesWritten >= Vector256<byte>.Count * 2);
+                    Vector256.StoreUnsafe(tempLast, ref bufByte, firstOffset);
+                    Vector256.StoreUnsafe(tempFirst, ref bufByte, lastOffset);
+                }
+                bufByte = ref Unsafe.Add(ref bufByte, numIters * numElements);
+                length -= numIters * (nuint)Vector256<short>.Count * 2;
             }
-            else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
+            else if (Sse2.IsSupported && (nuint)Vector128<short>.Count * 2 <= length)
             {
                 Vector128<byte> reverseMask = Vector128.Create((byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
-                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector128<byte>.Count);
-                do
+                nuint numElements = (nuint)Vector128<byte>.Count;
+                nuint numIters = ((length * sizeof(char)) / numElements) / 2;
+                for (nuint i = 0; i < numIters; i++)
                 {
+                    nuint firstOffset = i * numElements;
+                    nuint lastOffset = byteLength - ((1 + i) * numElements);
+
                     // Load in values from beginning and end of the array.
-                    Vector128<byte> tempFirst = Unsafe.As<byte, Vector128<byte>>(ref first);
-                    Vector128<byte> tempLast = Unsafe.As<byte, Vector128<byte>>(ref last);
+                    Vector128<byte> tempFirst = Vector128.LoadUnsafe(ref bufByte, firstOffset);
+                    Vector128<byte> tempLast = Vector128.LoadUnsafe(ref bufByte, lastOffset);
 
                     // Shuffle to reverse each vector:
                     //     +-------------------------------+
@@ -2084,26 +2087,20 @@ namespace System
                     tempLast = Ssse3.Shuffle(tempLast, reverseMask);
 
                     // Store the reversed vectors
-                    Unsafe.As<byte, Vector128<byte>>(ref first) = tempLast;
-                    Unsafe.As<byte, Vector128<byte>>(ref last) = tempFirst;
-
-                    // Adjust the references to point to the next vector
-                    first = ref Unsafe.Add(ref first, Vector128<byte>.Count);
-                    last = ref Unsafe.Subtract(ref last, Vector128<byte>.Count);
-                    numBytesWritten += Vector128<byte>.Count * 2;
-                } while ((numBytes - numBytesWritten) >= Vector128<byte>.Count * 2);
+                    Vector128.StoreUnsafe(tempLast, ref bufByte, firstOffset);
+                    Vector128.StoreUnsafe(tempFirst, ref bufByte, lastOffset);
+                }
+                bufByte = ref Unsafe.Add(ref bufByte, numIters * numElements);
+                length -= numIters * (nuint)Vector128<short>.Count * 2;
             }
 
             // Store any remaining values one-by-one
-            last = ref Unsafe.Add(ref first, (numBytes - numBytesWritten) - sizeof(char));
-            ref char firstChar = ref Unsafe.As<byte, char>(ref first);
-            ref char lastChar = ref Unsafe.As<byte, char>(ref last);
-            while (numBytes - numBytesWritten > sizeof(char))
+            buf = ref Unsafe.As<byte, char>(ref bufByte);
+            for (nuint i = 0; i < (length / 2); i++)
             {
-                (lastChar, firstChar) = (firstChar, lastChar);
-                firstChar = ref Unsafe.Add(ref firstChar, 1);
-                lastChar = ref Unsafe.Subtract(ref lastChar, 1);
-                numBytesWritten += sizeof(char) * 2;
+                ref char first = ref Unsafe.Add(ref buf, i);
+                ref char last = ref Unsafe.Add(ref buf, length - 1 - i);
+                (last, first) = (first, last);
             }
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -2016,9 +2016,9 @@ namespace System
             return BitOperations.TrailingZeroCount(selectedLanes) >> 3;
         }
 
-        public static void ReverseCharRef(ref char buf, nint length)
+        public static void ReverseCharRef(ref char buf, nuint length)
         {
-            nint numBytes = length * sizeof(char);
+            nint numBytes = (int)length * sizeof(char);
             int numBytesWritten = 0;
             ref byte first = ref Unsafe.As<char, byte>(ref buf);
             ref byte last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -sizeof(char));
@@ -2043,7 +2043,7 @@ namespace System
                     numBytesWritten += Vector256<byte>.Count * 2;
                 } while (numBytes - numBytesWritten >= Vector256<byte>.Count * 2);
             }
-            else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= length)
+            else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
             {
                 Vector128<byte> ReverseMask = Vector128.Create((byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
                 last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -Vector128<byte>.Count);
@@ -2065,9 +2065,7 @@ namespace System
             ref char lastChar = ref Unsafe.As<byte, char>(ref last);
             while (numBytes - numBytesWritten > sizeof(char))
             {
-                char temp = firstChar;
-                firstChar = lastChar;
-                lastChar = temp;
+                (lastChar, firstChar) = (firstChar, lastChar);
                 firstChar = ref Unsafe.Add(ref firstChar, 1);
                 lastChar = ref Unsafe.Add(ref lastChar, -1);
                 numBytesWritten += sizeof(char) * 2;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -2016,7 +2016,7 @@ namespace System
             return BitOperations.TrailingZeroCount(selectedLanes) >> 3;
         }
 
-        public static void ReverseRef(ref char buf, nuint length)
+        public static void Reverse(ref char buf, nuint length)
         {
             nint numBytes = (int)length * sizeof(char);
             int numBytesWritten = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -2021,13 +2021,13 @@ namespace System
             nint numBytes = (int)length * sizeof(char);
             int numBytesWritten = 0;
             ref byte first = ref Unsafe.As<char, byte>(ref buf);
-            ref byte last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -sizeof(char));
+            ref byte last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), sizeof(char));
             if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= numBytes)
             {
-                Vector256<byte> ReverseMask = Vector256.Create(
+                Vector256<byte> reverseMask = Vector256.Create(
                     (byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1, // first 128-bit lane
                     14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1); // second 128-bit lane
-                last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -Vector256<byte>.Count);
+                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector256<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
@@ -2047,9 +2047,9 @@ namespace System
                     //     +---------------------------------------------------------------+
                     //     | P | O | N | M | L | K | J | I | H | G | F | E | D | C | B | A |
                     //     +---------------------------------------------------------------+
-                    tempFirst = Avx2.Shuffle(tempFirst, ReverseMask);
+                    tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
                     tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
-                    tempLast = Avx2.Shuffle(tempLast, ReverseMask);
+                    tempLast = Avx2.Shuffle(tempLast, reverseMask);
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
 
                     // Store the reversed vectors
@@ -2058,14 +2058,14 @@ namespace System
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector256<byte>.Count);
-                    last = ref Unsafe.Add(ref last, -Vector256<byte>.Count);
+                    last = ref Unsafe.Subtract(ref last, Vector256<byte>.Count);
                     numBytesWritten += Vector256<byte>.Count * 2;
                 } while (numBytes - numBytesWritten >= Vector256<byte>.Count * 2);
             }
             else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
             {
-                Vector128<byte> ReverseMask = Vector128.Create((byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
-                last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -Vector128<byte>.Count);
+                Vector128<byte> reverseMask = Vector128.Create((byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector128<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
@@ -2080,8 +2080,8 @@ namespace System
                     //     +-------------------------------+
                     //     | H | G | F | E | D | C | B | A |
                     //     +-------------------------------+
-                    tempFirst = Ssse3.Shuffle(tempFirst, ReverseMask);
-                    tempLast = Ssse3.Shuffle(tempLast, ReverseMask);
+                    tempFirst = Ssse3.Shuffle(tempFirst, reverseMask);
+                    tempLast = Ssse3.Shuffle(tempLast, reverseMask);
 
                     // Store the reversed vectors
                     Unsafe.As<byte, Vector128<byte>>(ref first) = tempLast;
@@ -2089,7 +2089,7 @@ namespace System
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector128<byte>.Count);
-                    last = ref Unsafe.Add(ref last, -Vector128<byte>.Count);
+                    last = ref Unsafe.Subtract(ref last, Vector128<byte>.Count);
                     numBytesWritten += Vector128<byte>.Count * 2;
                 } while ((numBytes - numBytesWritten) >= Vector128<byte>.Count * 2);
             }
@@ -2102,7 +2102,7 @@ namespace System
             {
                 (lastChar, firstChar) = (firstChar, lastChar);
                 firstChar = ref Unsafe.Add(ref firstChar, 1);
-                lastChar = ref Unsafe.Add(ref lastChar, -1);
+                lastChar = ref Unsafe.Subtract(ref lastChar, 1);
                 numBytesWritten += sizeof(char) * 2;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -2050,13 +2050,13 @@ namespace System
                     //     | P | O | N | M | L | K | J | I | H | G | F | E | D | C | B | A |
                     //     +---------------------------------------------------------------+
                     tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
-                    tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
+                    tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 0b00_01);
                     tempLast = Avx2.Shuffle(tempLast, reverseMask);
-                    tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
+                    tempLast = Avx2.Permute2x128(tempLast, tempLast, 0b00_01);
 
                     // Store the reversed vectors
-                    Vector256.StoreUnsafe(tempLast, ref bufByte, firstOffset);
-                    Vector256.StoreUnsafe(tempFirst, ref bufByte, lastOffset);
+                    tempLast.StoreUnsafe(ref bufByte, firstOffset);
+                    tempFirst.StoreUnsafe(ref bufByte, lastOffset);
                 }
                 bufByte = ref Unsafe.Add(ref bufByte, numIters * numElements);
                 length -= numIters * (nuint)Vector256<short>.Count * 2;
@@ -2087,8 +2087,8 @@ namespace System
                     tempLast = Ssse3.Shuffle(tempLast, reverseMask);
 
                     // Store the reversed vectors
-                    Vector128.StoreUnsafe(tempLast, ref bufByte, firstOffset);
-                    Vector128.StoreUnsafe(tempFirst, ref bufByte, lastOffset);
+                    tempLast.StoreUnsafe(ref bufByte, firstOffset);
+                    tempFirst.StoreUnsafe(ref bufByte, lastOffset);
                 }
                 bufByte = ref Unsafe.Add(ref bufByte, numIters * numElements);
                 length -= numIters * (nuint)Vector128<short>.Count * 2;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -423,8 +423,7 @@ namespace System
                     Vector256<int> tempFirst = Vector256.LoadUnsafe(ref buf, firstOffset);
                     Vector256<int> tempLast = Vector256.LoadUnsafe(ref buf, lastOffset);
 
-                    // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
-                    // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
+                    // Permute to reverse each vector:
                     //     +-------------------------------+
                     //     | A | B | C | D | E | F | G | H |
                     //     +-------------------------------+
@@ -497,8 +496,7 @@ namespace System
                     Vector256<long> tempFirst = Vector256.LoadUnsafe(ref buf, firstOffset);
                     Vector256<long> tempLast = Vector256.LoadUnsafe(ref buf, lastOffset);
 
-                    // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
-                    // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
+                    // Permute to reverse each vector:
                     //     +---------------+
                     //     | A | B | C | D |
                     //     +---------------+

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -436,8 +436,8 @@ namespace System
                     tempLast = Avx2.PermuteVar8x32(tempLast, reverseMask);
 
                     // Store the values into final location
-                    Vector256.StoreUnsafe(tempLast, ref buf, firstOffset);
-                    Vector256.StoreUnsafe(tempFirst, ref buf, lastOffset);
+                    tempLast.StoreUnsafe(ref buf, firstOffset);
+                    tempFirst.StoreUnsafe(ref buf, lastOffset);
                 }
                 buf = ref Unsafe.Add(ref buf, numIters * numElements);
                 length -= numIters * numElements * 2;
@@ -467,8 +467,8 @@ namespace System
                     tempLast = Sse2.Shuffle(tempLast, 0b00_01_10_11);
 
                     // Store the values into final location
-                    Vector128.StoreUnsafe(tempLast, ref buf, firstOffset);
-                    Vector128.StoreUnsafe(tempFirst, ref buf, lastOffset);
+                    tempLast.StoreUnsafe(ref buf, firstOffset);
+                    tempFirst.StoreUnsafe(ref buf, lastOffset);
                 }
                 buf = ref Unsafe.Add(ref buf, numIters * numElements);
                 length -= numIters * numElements * 2;
@@ -510,8 +510,8 @@ namespace System
                     tempLast = Avx2.Permute4x64(tempLast, 0b00_01_10_11);
 
                     // Store the values into final location
-                    Vector256.StoreUnsafe(tempLast, ref buf, firstOffset);
-                    Vector256.StoreUnsafe(tempFirst, ref buf, lastOffset);
+                    tempLast.StoreUnsafe(ref buf, firstOffset);
+                    tempFirst.StoreUnsafe(ref buf, lastOffset);
                 }
                 buf = ref Unsafe.Add(ref buf, numIters * numElements);
                 length -= numIters * numElements * 2;
@@ -542,8 +542,8 @@ namespace System
                     tempLast = Sse2.Shuffle(tempLast, 0b0100_1110);
 
                     // Store the values into final location
-                    Vector128.StoreUnsafe(tempLast, ref bufInt, firstOffset);
-                    Vector128.StoreUnsafe(tempFirst, ref bufInt, lastOffset);
+                    tempLast.StoreUnsafe(ref bufInt, firstOffset);
+                    tempFirst.StoreUnsafe(ref bufInt, lastOffset);
                 }
                 bufInt = ref Unsafe.Add(ref bufInt, numIters * numElements);
                 buf = ref Unsafe.As<int, long>(ref bufInt);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -520,6 +520,7 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Reverse<T>(ref T elements, nuint length)
         {
             Debug.Assert(length > 0);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -413,13 +413,13 @@ namespace System
             int numBytes = (int)length * sizeof(int);
             int numBytesWritten = 0;
             ref byte first = ref Unsafe.As<int, byte>(ref buf);
-            ref byte last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -sizeof(int));
+            ref byte last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), sizeof(int));
             if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= numBytes)
             {
-                Vector256<byte> ReverseMask = Vector256.Create(
+                Vector256<byte> reverseMask = Vector256.Create(
                     (byte)12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3, // first 128-bit lane
                     12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3); // second 128-bit lane
-                last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -Vector256<byte>.Count);
+                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector256<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
@@ -439,9 +439,9 @@ namespace System
                     //     +-------------------------------+
                     //     | H | G | F | E | D | C | B | A |
                     //     +-------------------------------+
-                    tempFirst = Avx2.Shuffle(tempFirst, ReverseMask);
+                    tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
                     tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
-                    tempLast = Avx2.Shuffle(tempLast, ReverseMask);
+                    tempLast = Avx2.Shuffle(tempLast, reverseMask);
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
 
                     // Store the reversed vectors
@@ -450,14 +450,14 @@ namespace System
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector256<byte>.Count);
-                    last = ref Unsafe.Add(ref last, -Vector256<byte>.Count);
+                    last = ref Unsafe.Subtract(ref last, Vector256<byte>.Count);
                     numBytesWritten += Vector256<byte>.Count * 2;
                 } while (numBytes - numBytesWritten >= Vector256<byte>.Count * 2);
             }
             else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
             {
-                Vector128<byte> ReverseMask = Vector128.Create((byte)12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
-                last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -Vector128<byte>.Count);
+                Vector128<byte> reverseMask = Vector128.Create((byte)12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
+                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector128<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
@@ -472,8 +472,8 @@ namespace System
                     //     +---------------+
                     //     | D | C | B | A |
                     //     +---------------+
-                    tempFirst = Ssse3.Shuffle(tempFirst, ReverseMask);
-                    tempLast = Ssse3.Shuffle(tempLast, ReverseMask);
+                    tempFirst = Ssse3.Shuffle(tempFirst, reverseMask);
+                    tempLast = Ssse3.Shuffle(tempLast, reverseMask);
 
                     // Store the reversed vectors
                     Unsafe.As<byte, Vector128<byte>>(ref first) = tempLast;
@@ -481,7 +481,7 @@ namespace System
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector128<byte>.Count);
-                    last = ref Unsafe.Add(ref last, -Vector128<byte>.Count);
+                    last = ref Unsafe.Subtract(ref last, Vector128<byte>.Count);
                     numBytesWritten += Vector128<byte>.Count * 2;
                 } while ((numBytes - numBytesWritten) >= Vector128<byte>.Count * 2);
             }
@@ -494,7 +494,7 @@ namespace System
             {
                 (lastInt, firstInt) = (firstInt, lastInt);
                 firstInt = ref Unsafe.Add(ref firstInt, 1);
-                lastInt = ref Unsafe.Add(ref lastInt, -1);
+                lastInt = ref Unsafe.Subtract(ref lastInt, 1);
                 numBytesWritten += sizeof(int) * 2;
             }
         }
@@ -504,13 +504,13 @@ namespace System
             nint numBytes = (int)length * sizeof(long);
             int numBytesWritten = 0;
             ref byte first = ref Unsafe.As<long, byte>(ref buf);
-            ref byte last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -sizeof(long));
+            ref byte last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), sizeof(long));
             if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= numBytes)
             {
-                Vector256<byte> ReverseMask = Vector256.Create(
+                Vector256<byte> reverseMask = Vector256.Create(
                     (byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, // first 128-bit lane
                      8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7); // second 128-bit lane
-                last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -Vector256<byte>.Count);
+                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector256<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
@@ -530,9 +530,9 @@ namespace System
                     //     +---------------+
                     //     | D | C | B | A |
                     //     +---------------+
-                    tempFirst = Avx2.Shuffle(tempFirst, ReverseMask);
+                    tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
                     tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
-                    tempLast = Avx2.Shuffle(tempLast, ReverseMask);
+                    tempLast = Avx2.Shuffle(tempLast, reverseMask);
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
 
                     // Store the reversed vectors
@@ -541,14 +541,14 @@ namespace System
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector256<byte>.Count);
-                    last = ref Unsafe.Add(ref last, -Vector256<byte>.Count);
+                    last = ref Unsafe.Subtract(ref last, Vector256<byte>.Count);
                     numBytesWritten += Vector256<byte>.Count * 2;
                 } while (numBytes - numBytesWritten >= Vector256<byte>.Count * 2);
             }
             else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
             {
-                Vector128<byte> ReverseMask = Vector128.Create((byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7);
-                last = ref Unsafe.Add(ref Unsafe.Add(ref first, numBytes), -Vector128<byte>.Count);
+                Vector128<byte> reverseMask = Vector128.Create((byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7);
+                last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector128<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
@@ -563,8 +563,8 @@ namespace System
                     //     +-------+
                     //     | B | A |
                     //     +-------+
-                    tempFirst = Ssse3.Shuffle(tempFirst, ReverseMask);
-                    tempLast = Ssse3.Shuffle(tempLast, ReverseMask);
+                    tempFirst = Ssse3.Shuffle(tempFirst, reverseMask);
+                    tempLast = Ssse3.Shuffle(tempLast, reverseMask);
 
                     // Store the reversed vectors
                     Unsafe.As<byte, Vector128<byte>>(ref first) = tempLast;
@@ -572,7 +572,7 @@ namespace System
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector128<byte>.Count);
-                    last = ref Unsafe.Add(ref last, -Vector128<byte>.Count);
+                    last = ref Unsafe.Subtract(ref last, Vector128<byte>.Count);
                     numBytesWritten += Vector128<byte>.Count * 2;
                 } while ((numBytes - numBytesWritten) >= Vector128<byte>.Count * 2);
             }
@@ -585,7 +585,7 @@ namespace System
             {
                 (lastLong, firstLong) = (firstLong, lastLong);
                 firstLong = ref Unsafe.Add(ref firstLong, 1);
-                lastLong = ref Unsafe.Add(ref lastLong, -1);
+                lastLong = ref Unsafe.Subtract(ref lastLong, 1);
                 numBytesWritten += sizeof(long) * 2;
             }
         }
@@ -624,12 +624,12 @@ namespace System
         {
             Debug.Assert(length > 0);
             ref T first = ref elements;
-            ref T last = ref Unsafe.Add(ref Unsafe.Add(ref first, (int)length), -1);
+            ref T last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, (int)length), 1);
             do
             {
                 (last, first) = (first, last);
                 first = ref Unsafe.Add(ref first, 1);
-                last = ref Unsafe.Add(ref last, -1);
+                last = ref Unsafe.Subtract(ref last, 1);
             } while (Unsafe.IsAddressLessThan(ref first, ref last));
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
-using Internal.Runtime.CompilerServices;
 
 namespace System
 {
@@ -416,15 +415,12 @@ namespace System
             ref byte last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), sizeof(int));
             if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= numBytes)
             {
-                Vector256<byte> reverseMask = Vector256.Create(
-                    (byte)12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3, // first 128-bit lane
-                    12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3); // second 128-bit lane
                 last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector256<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
-                    Vector256<byte> tempFirst = Unsafe.As<byte, Vector256<byte>>(ref first);
-                    Vector256<byte> tempLast = Unsafe.As<byte, Vector256<byte>>(ref last);
+                    Vector256<int> tempFirst = Unsafe.As<byte, Vector256<int>>(ref first);
+                    Vector256<int> tempLast = Unsafe.As<byte, Vector256<int>>(ref last);
 
                     // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
                     // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
@@ -439,14 +435,14 @@ namespace System
                     //     +-------------------------------+
                     //     | H | G | F | E | D | C | B | A |
                     //     +-------------------------------+
-                    tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
+                    tempFirst = Avx2.Shuffle(tempFirst, 0b00011011);
                     tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
-                    tempLast = Avx2.Shuffle(tempLast, reverseMask);
+                    tempLast = Avx2.Shuffle(tempLast, 0b00011011);
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
 
                     // Store the reversed vectors
-                    Unsafe.As<byte, Vector256<byte>>(ref first) = tempLast;
-                    Unsafe.As<byte, Vector256<byte>>(ref last) = tempFirst;
+                    Unsafe.As<byte, Vector256<int>>(ref first) = tempLast;
+                    Unsafe.As<byte, Vector256<int>>(ref last) = tempFirst;
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector256<byte>.Count);
@@ -454,15 +450,14 @@ namespace System
                     numBytesWritten += Vector256<byte>.Count * 2;
                 } while (numBytes - numBytesWritten >= Vector256<byte>.Count * 2);
             }
-            else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
+            else if (Sse2.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
             {
-                Vector128<byte> reverseMask = Vector128.Create((byte)12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
                 last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector128<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
-                    Vector128<byte> tempFirst = Unsafe.As<byte, Vector128<byte>>(ref first);
-                    Vector128<byte> tempLast = Unsafe.As<byte, Vector128<byte>>(ref last);
+                    Vector128<int> tempFirst = Unsafe.As<byte, Vector128<int>>(ref first);
+                    Vector128<int> tempLast = Unsafe.As<byte, Vector128<int>>(ref last);
 
                     // Shuffle to reverse each vector:
                     //     +---------------+
@@ -472,12 +467,12 @@ namespace System
                     //     +---------------+
                     //     | D | C | B | A |
                     //     +---------------+
-                    tempFirst = Ssse3.Shuffle(tempFirst, reverseMask);
-                    tempLast = Ssse3.Shuffle(tempLast, reverseMask);
+                    tempFirst = Sse2.Shuffle(tempFirst, 0b00011011);
+                    tempLast = Sse2.Shuffle(tempLast, 0b00011011);
 
                     // Store the reversed vectors
-                    Unsafe.As<byte, Vector128<byte>>(ref first) = tempLast;
-                    Unsafe.As<byte, Vector128<byte>>(ref last) = tempFirst;
+                    Unsafe.As<byte, Vector128<int>>(ref first) = tempLast;
+                    Unsafe.As<byte, Vector128<int>>(ref last) = tempFirst;
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector128<byte>.Count);
@@ -507,15 +502,12 @@ namespace System
             ref byte last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), sizeof(long));
             if (Avx2.IsSupported && Vector256<byte>.Count * 2 <= numBytes)
             {
-                Vector256<byte> reverseMask = Vector256.Create(
-                    (byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, // first 128-bit lane
-                     8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7); // second 128-bit lane
                 last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector256<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
-                    Vector256<byte> tempFirst = Unsafe.As<byte, Vector256<byte>>(ref first);
-                    Vector256<byte> tempLast = Unsafe.As<byte, Vector256<byte>>(ref last);
+                    Vector256<int> tempFirst = Unsafe.As<byte, Vector256<int>>(ref first);
+                    Vector256<int> tempLast = Unsafe.As<byte, Vector256<int>>(ref last);
 
                     // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
                     // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
@@ -530,14 +522,14 @@ namespace System
                     //     +---------------+
                     //     | D | C | B | A |
                     //     +---------------+
-                    tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
+                    tempFirst = Avx2.Shuffle(tempFirst, 0b01001110);
                     tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 1);
-                    tempLast = Avx2.Shuffle(tempLast, reverseMask);
+                    tempLast = Avx2.Shuffle(tempLast, 0b01001110);
                     tempLast = Avx2.Permute2x128(tempLast, tempLast, 1);
 
                     // Store the reversed vectors
-                    Unsafe.As<byte, Vector256<byte>>(ref first) = tempLast;
-                    Unsafe.As<byte, Vector256<byte>>(ref last) = tempFirst;
+                    Unsafe.As<byte, Vector256<int>>(ref first) = tempLast;
+                    Unsafe.As<byte, Vector256<int>>(ref last) = tempFirst;
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector256<byte>.Count);
@@ -545,15 +537,14 @@ namespace System
                     numBytesWritten += Vector256<byte>.Count * 2;
                 } while (numBytes - numBytesWritten >= Vector256<byte>.Count * 2);
             }
-            else if (Ssse3.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
+            else if (Sse2.IsSupported && Vector128<byte>.Count * 2 <= numBytes)
             {
-                Vector128<byte> reverseMask = Vector128.Create((byte)8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7);
                 last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, numBytes), Vector128<byte>.Count);
                 do
                 {
                     // Load in values from beginning and end of the array.
-                    Vector128<byte> tempFirst = Unsafe.As<byte, Vector128<byte>>(ref first);
-                    Vector128<byte> tempLast = Unsafe.As<byte, Vector128<byte>>(ref last);
+                    Vector128<int> tempFirst = Unsafe.As<byte, Vector128<int>>(ref first);
+                    Vector128<int> tempLast = Unsafe.As<byte, Vector128<int>>(ref last);
 
                     // Shuffle to reverse each vector:
                     //     +-------+
@@ -563,12 +554,12 @@ namespace System
                     //     +-------+
                     //     | B | A |
                     //     +-------+
-                    tempFirst = Ssse3.Shuffle(tempFirst, reverseMask);
-                    tempLast = Ssse3.Shuffle(tempLast, reverseMask);
+                    tempFirst = Sse2.Shuffle(tempFirst, 0b01001110);
+                    tempLast = Sse2.Shuffle(tempLast, 0b01001110);
 
                     // Store the reversed vectors
-                    Unsafe.As<byte, Vector128<byte>>(ref first) = tempLast;
-                    Unsafe.As<byte, Vector128<byte>>(ref last) = tempFirst;
+                    Unsafe.As<byte, Vector128<int>>(ref first) = tempLast;
+                    Unsafe.As<byte, Vector128<int>>(ref last) = tempFirst;
 
                     // Adjust the references to point to the next vector
                     first = ref Unsafe.Add(ref first, Vector128<byte>.Count);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -594,7 +594,9 @@ namespace System
             ref T last = ref Unsafe.Subtract(ref Unsafe.Add(ref first, (int)length), 1);
             do
             {
-                (last, first) = (first, last);
+                T temp = first;
+                first = last;
+                last = temp;
                 first = ref Unsafe.Add(ref first, 1);
                 last = ref Unsafe.Subtract(ref last, 1);
             } while (Unsafe.IsAddressLessThan(ref first, ref last));

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -408,7 +408,7 @@ namespace System
             ip = default;
         }
 
-        public static void ReverseRef(ref int buf, nuint length)
+        public static void Reverse(ref int buf, nuint length)
         {
             int numBytes = (int)length * sizeof(int);
             int numBytesWritten = 0;
@@ -499,7 +499,7 @@ namespace System
             }
         }
 
-        public static void ReverseRef(ref long buf, nuint length)
+        public static void Reverse(ref long buf, nuint length)
         {
             nint numBytes = (int)length * sizeof(long);
             int numBytesWritten = 0;
@@ -598,22 +598,22 @@ namespace System
             {
                 if (Unsafe.SizeOf<T>() == sizeof(byte))
                 {
-                    ReverseRef(ref Unsafe.As<T, byte>(ref elements), length);
+                    Reverse(ref Unsafe.As<T, byte>(ref elements), length);
                     return;
                 }
                 else if (Unsafe.SizeOf<T>() == sizeof(char))
                 {
-                    ReverseRef(ref Unsafe.As<T, char>(ref elements), length);
+                    Reverse(ref Unsafe.As<T, char>(ref elements), length);
                     return;
                 }
                 else if (Unsafe.SizeOf<T>() == sizeof(int))
                 {
-                    ReverseRef(ref Unsafe.As<T, int>(ref elements), length);
+                    Reverse(ref Unsafe.As<T, int>(ref elements), length);
                     return;
                 }
                 else if (Unsafe.SizeOf<T>() == sizeof(long))
                 {
-                    ReverseRef(ref Unsafe.As<T, long>(ref elements), length);
+                    Reverse(ref Unsafe.As<T, long>(ref elements), length);
                     return;
                 }
             }


### PR DESCRIPTION
Adds vectorized paths to `Span<T>.Reverse` for types that are supported. Falls back to previous behavior if `T` is not a value type or too big for a vector.

Compared against 65a5d0e8a3027f2b240d098f47327ba3e1f743b1.

Using [this](https://github.com/dotnet/performance/blob/36ea5c39c75ee2ca82a01a2eed22688f9eb98aed/src/benchmarks/micro/libraries/System.Memory/Span.cs#L42) microbenchmark to compare performance, modified to use more buffer sizes and types:

<details>
<summary>Microbenchmark changes</summary>

```
diff --git a/src/benchmarks/micro/libraries/System.Memory/Span.cs b/src/benchmarks/micro/libraries/System.Memory/Span.cs
index e696e141..75d28d7d 100644
--- a/src/benchmarks/micro/libraries/System.Memory/Span.cs
+++ b/src/benchmarks/micro/libraries/System.Memory/Span.cs
@@ -14,11 +14,20 @@ namespace System.Memory
     [GenericTypeArguments(typeof(byte))]
     [GenericTypeArguments(typeof(char))]
     [GenericTypeArguments(typeof(int))]
+    [GenericTypeArguments(typeof(long))]
+    [GenericTypeArguments(typeof(float))]
+    [GenericTypeArguments(typeof(double))]
     [BenchmarkCategory(Categories.Runtime, Categories.Libraries, Categories.Span)]
     public class Span<T>
         where T : struct, IComparable<T>, IEquatable<T>
     {
-        [Params(Utils.DefaultCollectionSize)]
+        [Params(
+            8 /* No vectorization */,
+            34 /* SSSE3 with leftover */,
+            68 /* AVX2 path with leftover bytes */,
+            Utils.DefaultCollectionSize,
+            Utils.DefaultCollectionSize * 2
+            )]
         public int Size;

         private T[] _array, _same, _emptyWithSingleValue;
```

</details>

Performance results:

```
$ py .\scripts\benchmarks_ci.py -c Release -f net7.0 --filter *Span*Reverse* --corerun C:\Users\acovingt\source\repos\runtime-master\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe --bdn-artifacts C:\Users\acovingt\Documents\vectorize-span-reverse-base
$ py .\scripts\benchmarks_ci.py -c Release -f net7.0 --filter *Span*Reverse* --corerun C:\Users\acovingt\source\repos\runtime\artifacts\bin\testhost\net7.0-windows-Release-x64\shared\Microsoft.NETCore.App\7.0.0\corerun.exe --bdn-artifacts C:\Users\acovingt\Documents\vectorize-span-reverse-diff
$ cd .\src\tools\ResultsComparer\ 
$ dotnet run -- --base C:\Users\acovingt\Documents\vectorize-span-reverse-base\ --diff C:\Users\acovingt\Documents\vectorize-span-reverse-diff\ --threshold 3% --noise 5ns
summary:
better: 23, geomean: 3.946
total diff: 23

No Slower results for the provided threshold = 3% and noise filter = 5ns.

| Faster                                         | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ---------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Memory.Span<Byte>.Reverse(Size: 1024)   |     33.45 |           616.32 |            18.42 |         |
| System.Memory.Span<Byte>.Reverse(Size: 512)    |     28.16 |           306.00 |            10.87 |         |
| System.Memory.Span<Char>.Reverse(Size: 512)    |     16.26 |           300.26 |            18.47 |         |
| System.Memory.Span<Char>.Reverse(Size: 1024)   |     14.25 |           609.56 |            42.77 |         |
| System.Memory.Span<Byte>.Reverse(Size: 68)     |      5.75 |            33.59 |             5.84 |         |
| System.Memory.Span<Char>.Reverse(Size: 68)     |      5.54 |            39.56 |             7.14 | bimodal |
| System.Memory.Span<Single>.Reverse(Size: 512)  |      4.57 |           152.19 |            33.33 |         |
| System.Memory.Span<Char>.Reverse(Size: 34)     |      4.13 |            21.56 |             5.22 | bimodal |
| System.Memory.Span<Single>.Reverse(Size: 1024) |      3.93 |           303.01 |            77.20 |         |
| System.Memory.Span<Int32>.Reverse(Size: 1024)  |      3.88 |           307.61 |            79.20 |         |
| System.Memory.Span<Int32>.Reverse(Size: 512)   |      3.67 |           154.75 |            42.20 |         |
| System.Memory.Span<Byte>.Reverse(Size: 34)     |      3.03 |            15.56 |             5.14 | several?|
| System.Memory.Span<Int32>.Reverse(Size: 68)    |      2.59 |            23.28 |             8.98 |         |
| System.Memory.Span<Single>.Reverse(Size: 68)   |      2.45 |            19.77 |             8.06 |         |
| System.Memory.Span<Single>.Reverse(Size: 34)   |      2.21 |            12.41 |             5.62 | several?|
| System.Memory.Span<Int64>.Reverse(Size: 1024)  |      2.01 |           302.07 |           150.24 |         |
| System.Memory.Span<Int32>.Reverse(Size: 34)    |      1.99 |            15.11 |             7.61 |         |
| System.Memory.Span<Int64>.Reverse(Size: 512)   |      1.98 |           153.95 |            77.64 |         |
| System.Memory.Span<Double>.Reverse(Size: 512)  |      1.97 |           152.21 |            77.18 |         |
| System.Memory.Span<Double>.Reverse(Size: 1024) |      1.93 |           301.68 |           156.33 |         |
| System.Memory.Span<Int64>.Reverse(Size: 68)    |      1.91 |            23.54 |            12.35 |         |
| System.Memory.Span<Int64>.Reverse(Size: 34)    |      1.76 |            14.90 |             8.49 |         |
| System.Memory.Span<Double>.Reverse(Size: 68)   |      1.64 |            19.80 |            12.08 |         |
```

Please let me know if I can provide any other information. Thanks!