### PR TITLE
[WIP] [ILVerify] Recognize type equivalence of two types with `System.Runtime.InteropServices.TypeIdentifierAttribute`

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -26,9 +26,7 @@ namespace Internal.TypeSystem
             // Its only valid to compare two TypeDescs in the same context
             Debug.Assert(o is not TypeDesc || object.ReferenceEquals(((TypeDesc)o).Context, this.Context));
             if (o is TypeDesc)
-            {
                 return this.IsEquivalentTo((TypeDesc)o);
-            }
             return object.ReferenceEquals(this, o);
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -25,6 +25,10 @@ namespace Internal.TypeSystem
         {
             // Its only valid to compare two TypeDescs in the same context
             Debug.Assert(o is not TypeDesc || object.ReferenceEquals(((TypeDesc)o).Context, this.Context));
+            if (o is TypeDesc)
+            {
+                return this.IsEquivalentTo((TypeDesc)o);
+            }
             return object.ReferenceEquals(this, o);
         }
 
@@ -33,14 +37,18 @@ namespace Internal.TypeSystem
         {
             // Its only valid to compare two TypeDescs in the same context
             Debug.Assert(left is null || right is null || object.ReferenceEquals(left.Context, right.Context));
-            return object.ReferenceEquals(left, right);
+            if (left is null)
+                return object.ReferenceEquals(left, right);
+            return left.IsEquivalentTo(right);
         }
 
         public static bool operator !=(TypeDesc left, TypeDesc right)
         {
             // Its only valid to compare two TypeDescs in the same context
             Debug.Assert(left is null || right is null || object.ReferenceEquals(left.Context, right.Context));
-            return !object.ReferenceEquals(left, right);
+            if (left is null)
+                return !object.ReferenceEquals(left, right);
+            return !left.IsEquivalentTo(right);
         }
 #endif
 
@@ -691,6 +699,16 @@ namespace Internal.TypeSystem
             {
                 return (GetTypeFlags(TypeFlags.IsIDynamicInterfaceCastable | TypeFlags.IsIDynamicInterfaceCastableComputed) & TypeFlags.IsIDynamicInterfaceCastable) != 0;
             }
+        }
+
+        /// <summary>
+        /// Determines whether two types have the same identity and are eligible for type equivalence.
+        /// </summary>
+        public virtual bool IsEquivalentTo(TypeDesc typeDesc)
+        {
+            // Its only valid to compare two TypeDescs in the same context
+            Debug.Assert(typeDesc is null || object.ReferenceEquals(this.Context, typeDesc.Context));
+            return object.ReferenceEquals(this, typeDesc);
         }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -611,13 +611,11 @@ namespace Internal.TypeSystem.Ecma
                 return true;
 
             if (typeDesc is EcmaType)
-            {
-                return IsPossiblyEquivalent(this, (EcmaType)typeDesc);
-            }
+                return CheckEquivalence(this, (EcmaType)typeDesc);
 
             return false;
 
-            static bool IsPossiblyEquivalent(EcmaType type1, EcmaType type2)
+            static bool CheckEquivalence(EcmaType type1, EcmaType type2)
             {
                 if (!type1.HasCustomAttribute("System.Runtime.InteropServices", "TypeIdentifierAttribute"))
                     return false;


### PR DESCRIPTION
Resolves this: https://github.com/dotnet/runtime/issues/62732

**Description**

ILVerify would fail verification of an assembly when two types, one in the assembly and one in a different assembly, had equivalent `TypeIdentifierAttribute` data.

**Acceptance Criteria**

- [ ] Add Tests


