### PR TITLE
Temporarily disable test Runtime_60035 failing with Crossgen2

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -820,6 +820,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/v2.1/DDB/B168384/LdfldaHack/*">
             <Issue>https://github.com/dotnet/runtime/issues/615</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_60035/Runtime_60035/*">
+            <Issue>https://github.com/dotnet/runtime/issues/64419</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
             <Issue>Not compatible with crossgen2</Issue>
         </ExcludeList>


### PR DESCRIPTION
cf: https://github.com/dotnet/runtime/issues/64419
