### PR TITLE
Avoid CreateThreadStressLog under SpinLock

### DIFF
--- a/src/coreclr/vm/object.cpp
+++ b/src/coreclr/vm/object.cpp
@@ -1917,6 +1917,13 @@ void ExceptionObject::SetStackTrace(I1ARRAYREF stackTrace, PTRARRAYREF dynamicMe
     }
     CONTRACTL_END;
 
+#ifdef STRESS_LOG
+    if (StressLog::StressLogOn(~0u, 0))
+    {
+        StressLog::CreateThreadStressLog();
+    }
+#endif
+
     SpinLock::AcquireLock(&g_StackTraceArrayLock);
 
     SetObjectReference((OBJECTREF*)&_stackTrace, (OBJECTREF)stackTrace);

--- a/src/coreclr/vm/spinlock.cpp
+++ b/src/coreclr/vm/spinlock.cpp
@@ -283,6 +283,7 @@ void SpinLock::dbg_PreEnterLock()
         // SpinLock can not be nested.
         _ASSERTE ((pThread->m_StateNC & Thread::TSNC_OwnsSpinLock) == 0);
 
+        IncCantAllocCount();
         pThread->SetThreadStateNC(Thread::TSNC_OwnsSpinLock);
 
         if (!pThread->PreemptiveGCDisabled())
@@ -321,6 +322,7 @@ void SpinLock::dbg_LeaveLock()
     if (pThread)
     {
         _ASSERTE ((pThread->m_StateNC & Thread::TSNC_OwnsSpinLock) != 0);
+        DecCantAllocCount();
         pThread->ResetThreadStateNC(Thread::TSNC_OwnsSpinLock);
         INCONTRACT(pThread->EndNoTriggerGC());
     }


### PR DESCRIPTION
This change fixes a case where we are currently holding a `SpinLock`, writing a stress log message, and need to take a critical session because of [CreateThreadStressLog](https://github.com/dotnet/runtime/blob/5f72148e033b887ede8436fcdefdbec6cda83190/src/coreclr/utilcode/stresslog.cpp#L442), which will fail [this](https://github.com/dotnet/runtime/blob/5f72148e033b887ede8436fcdefdbec6cda83190/src/coreclr/vm/crst.cpp#L408) assertion.

Right now, the situation happens routinely under OSX ARM64 during exception dispatch, and this is blocking us from using the stress log to investigate issues.

Just before we take the `SpinLock` in the exception dispatch, the change preemptively makes sure we have some ThreadStressLog space to use. Experiments show us that this change is insufficient, as we might be at end of the previous chunk. The `CantAllocCount` change then makes sure even if we are unlucky, we are going to skip the message, instead of failing.

Note that my change to `CantAllocCount` might also change the behavior of `IBCLogger`. I am assuming that is fine and desired, it would be great if @davidwrighton can confirm that.