### PR TITLE
Fix layout and GCInfo for ByRef fields.

### DIFF
--- a/src/coreclr/inc/sigparser.h
+++ b/src/coreclr/inc/sigparser.h
@@ -864,6 +864,21 @@ public:
         return (GetGCType_NoThrow(type) == TYPE_GC_REF);
     }
 
+    static BOOL IsByRef(CorElementType type)
+    {
+        WRAPPER_NO_CONTRACT;
+        SUPPORTS_DAC;
+
+        return (GetGCType(type) == TYPE_GC_BYREF);
+    }
+    static BOOL IsByRef_NoThrow(CorElementType type)
+    {
+        WRAPPER_NO_CONTRACT;
+        SUPPORTS_DAC;
+
+        return (GetGCType_NoThrow(type) == TYPE_GC_BYREF);
+    }
+
     FORCEINLINE static BOOL IsGenericVariable(CorElementType type)
     {
         WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/field.cpp
+++ b/src/coreclr/vm/field.cpp
@@ -97,6 +97,14 @@ BOOL FieldDesc::IsObjRef()
     return CorTypeInfo::IsObjRef_NoThrow(GetFieldType());
 }
 
+// Return whether the field is a GC ref type
+BOOL FieldDesc::IsByRef()
+{
+    WRAPPER_NO_CONTRACT;
+    SUPPORTS_DAC;
+    return CorTypeInfo::IsByRef_NoThrow(GetFieldType());
+}
+
 BOOL FieldDesc::MightHaveName(ULONG nameHashValue)
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/field.h
+++ b/src/coreclr/vm/field.h
@@ -353,6 +353,8 @@ public:
 
     BOOL IsObjRef();
 
+    BOOL IsByRef();
+
     UINT LoadSize();
 
     // Return -1 if the type isn't loaded yet (i.e. if LookupFieldTypeHandle() would return null)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -2029,53 +2029,53 @@ bool CEEInfo::checkMethodModifier(CORINFO_METHOD_HANDLE hMethod,
     return result;
 }
 
+static unsigned MarkGCField(BYTE* gcPtrs, CorInfoGCType type)
+{
+    STANDARD_VM_CONTRACT;
+
+    // Ensure that if we have multiple fields with the same offset,
+    // that we don't double count the data in the gc layout.
+    if (*gcPtrs == TYPE_GC_NONE)
+    {
+        *gcPtrs = type;
+        return 1;
+    }
+    else if (*gcPtrs != type)
+    {
+        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+    }
+
+    return 0;
+}
+
 /*********************************************************************/
 static unsigned ComputeGCLayout(MethodTable * pMT, BYTE* gcPtrs)
 {
     STANDARD_VM_CONTRACT;
 
-    unsigned result = 0;
-
     _ASSERTE(pMT->IsValueType());
 
     if (pMT->HasSameTypeDefAs(g_pByReferenceClass))
-    {
-        if (gcPtrs[0] == TYPE_GC_NONE)
-        {
-            gcPtrs[0] = TYPE_GC_BYREF;
-            result++;
-        }
-        else if (gcPtrs[0] != TYPE_GC_BYREF)
-        {
-            COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
-        }
-        return result;
-    }
+        return MarkGCField(gcPtrs, TYPE_GC_BYREF);
 
+    unsigned result = 0;
     ApproxFieldDescIterator fieldIterator(pMT, ApproxFieldDescIterator::INSTANCE_FIELDS);
     for (FieldDesc *pFD = fieldIterator.Next(); pFD != NULL; pFD = fieldIterator.Next())
     {
         int fieldStartIndex = pFD->GetOffset() / TARGET_POINTER_SIZE;
 
-        if (pFD->GetFieldType() != ELEMENT_TYPE_VALUETYPE)
-        {
-            if (pFD->IsObjRef())
-            {
-                if (gcPtrs[fieldStartIndex] == TYPE_GC_NONE)
-                {
-                    gcPtrs[fieldStartIndex] = TYPE_GC_REF;
-                    result++;
-                }
-                else if (gcPtrs[fieldStartIndex] != TYPE_GC_REF)
-                {
-                    COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
-                }
-            }
-        }
-        else
+        if (pFD->GetFieldType() == ELEMENT_TYPE_VALUETYPE)
         {
             MethodTable * pFieldMT = pFD->GetApproxFieldTypeHandleThrowing().AsMethodTable();
             result += ComputeGCLayout(pFieldMT, gcPtrs + fieldStartIndex);
+        }
+        else if (pFD->IsObjRef())
+        {
+            result += MarkGCField(gcPtrs + fieldStartIndex, TYPE_GC_REF);
+        }
+        else if (pFD->IsByRef())
+        {
+            result += MarkGCField(gcPtrs + fieldStartIndex, TYPE_GC_BYREF);
         }
     }
     return result;

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -3991,7 +3991,6 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
             {
                 Module * pTokenModule;
                 dwByValueClassToken = fsig.GetArgProps().PeekValueTypeTokenClosed(GetModule(), &bmtGenerics->typeContext, &pTokenModule);
-                fIsByValue = TRUE;
 
                 // By-value class
                 BAD_FORMAT_NOTHROW_ASSERT(dwByValueClassToken != 0);
@@ -4067,6 +4066,8 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
             // TypedReference shares the rest of the code here
 IS_VALUETYPE:
             {
+                fIsByValue = TRUE;
+
                 // It's not self-referential so try to load it
                 if (pByValueClass == NULL)
                 {

--- a/src/coreclr/vm/object.inl
+++ b/src/coreclr/vm/object.inl
@@ -272,38 +272,4 @@ inline TypeHandle Object::GetGCSafeTypeHandle() const
     return TypeHandle(pMT);
 }
 
-template<class F>
-inline void FindByRefPointerOffsetsInByRefLikeObject(PTR_MethodTable pMT, SIZE_T baseOffset, const F processPointerOffset)
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(pMT != nullptr);
-    _ASSERTE(pMT->IsByRefLike());
-
-    if (pMT->HasSameTypeDefAs(g_pByReferenceClass))
-    {
-        processPointerOffset(baseOffset);
-        return;
-    }
-
-    ApproxFieldDescIterator fieldIterator(pMT, ApproxFieldDescIterator::INSTANCE_FIELDS);
-    for (FieldDesc *pFD = fieldIterator.Next(); pFD != NULL; pFD = fieldIterator.Next())
-    {
-        if (pFD->GetFieldType() != ELEMENT_TYPE_VALUETYPE)
-        {
-            continue;
-        }
-
-        // TODO: GetApproxFieldTypeHandleThrowing may throw. This is a potential stress problem for fragile NGen of non-CoreLib
-        // assemblies. It won't ever throw for CoreCLR with R2R. Figure out if anything needs to be done to deal with the
-        // exception.
-        PTR_MethodTable pFieldMT = pFD->GetApproxFieldTypeHandleThrowing().AsMethodTable();
-        if (!pFieldMT->IsByRefLike())
-        {
-            continue;
-        }
-
-        FindByRefPointerOffsetsInByRefLikeObject(pFieldMT, baseOffset + pFD->GetOffset(), processPointerOffset);
-    }
-}
-
 #endif  // _OBJECT_INL_

--- a/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
+++ b/src/tests/Loader/classloader/RefFields/InvalidCSharp.il
@@ -101,11 +101,11 @@
 
     .method public hidebysig specialname rtspecialname
         instance void .ctor (
-            !T
+            !T&
         ) cil managed
     {
         ldarg.0
-        ldarga.s 1
+        ldarg.1
         mkrefany !T
         stfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
         ret
@@ -118,6 +118,20 @@
         ldfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
         refanytype
         call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle )
+        ret
+    }
+
+    .method public hidebysig
+        instance bool ConfirmFieldInstance (
+            !T
+        ) cil managed
+    {
+        ldarg.0
+        ldfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        refanyval !T
+        ldind.ref
+        ldarg.1
+        ceq
         ret
     }
 }

--- a/src/tests/Loader/classloader/RefFields/Validate.cs
+++ b/src/tests/Loader/classloader/RefFields/Validate.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using InvalidCSharp;
 
 using Xunit;
@@ -23,6 +24,7 @@ class Validate
         var t = typeof(WithRefField);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void Create_RefField_Worker(string str, int depth)
     {
         if (depth == 5)
@@ -46,6 +48,7 @@ class Validate
         Create_RefField_Worker(str, 1);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void Create_RefStructField_Worker(string str, int depth)
     {
         if (depth == 5)
@@ -68,6 +71,7 @@ class Validate
         Create_RefStructField_Worker(str, 1);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void Create_TypedReferenceRefField_Worker(Validate v, int depth)
     {
         if (depth == 5)

--- a/src/tests/Loader/classloader/RefFields/Validate.cs
+++ b/src/tests/Loader/classloader/RefFields/Validate.cs
@@ -23,17 +23,41 @@ class Validate
         var t = typeof(WithRefField);
     }
 
+    private static void Create_RefField_Worker(string str, int depth)
+    {
+        if (depth == 5)
+        {
+            return;
+        }
+
+        WithRefField s = new(ref str);
+        string newStr = new(str);
+
+        Create_RefField_Worker(str + $" {depth}", depth + 1);
+        Assert.False(s.ConfirmFieldInstance(newStr));
+        Assert.True(s.ConfirmFieldInstance(str));
+    }
+
     [Fact]
     public static void Validate_Create_RefField()
     {
         var str = nameof(Validate_Create_RefField);
         Console.WriteLine($"{str}...");
+        Create_RefField_Worker(str, 1);
+    }
+
+    private static void Create_RefStructField_Worker(string str, int depth)
+    {
+        if (depth == 5)
+        {
+            return;
+        }
 
         WithRefField s = new(ref str);
-        Assert.True(s.ConfirmFieldInstance(str));
+        WithRefStructField t = new(ref s);
 
-        string newStr = new(str);
-        Assert.False(s.ConfirmFieldInstance(newStr));
+        Create_RefStructField_Worker(str + $" {depth}", depth + 1);
+        Assert.True(t.ConfirmFieldInstance(ref s));
     }
 
     [Fact]
@@ -41,10 +65,21 @@ class Validate
     {
         var str = nameof(Validate_Create_RefStructField);
         Console.WriteLine($"{str}...");
+        Create_RefStructField_Worker(str, 1);
+    }
 
-        WithRefField s = new(ref str);
-        WithRefStructField t = new(ref s);
-        Assert.True(t.ConfirmFieldInstance(ref s));
+    private static void Create_TypedReferenceRefField_Worker(Validate v, int depth)
+    {
+        if (depth == 5)
+        {
+            return;
+        }
+
+        WithTypedReferenceField<Validate> s = new(ref v);
+
+        Create_TypedReferenceRefField_Worker(v, depth + 1);
+        Assert.Equal(typeof(Validate), s.GetFieldType());
+        Assert.True(s.ConfirmFieldInstance(v));
     }
 
     [Fact]
@@ -53,7 +88,6 @@ class Validate
         Console.WriteLine($"{nameof(Validate_Create_TypedReferenceRefField)}...");
 
         Validate v = new();
-        WithTypedReferenceField<Validate> s = new(v);
-        Assert.Equal(typeof(Validate), s.GetFieldType());
+        Create_TypedReferenceRefField_Worker(v, 1);
     }
 }


### PR DESCRIPTION
Update tests to use recursion and validate GCStress scenarios.

Related NativeAOT/CrossGen2 change - https://github.com/dotnet/runtime/pull/64366

Fixes https://github.com/dotnet/runtime/issues/64465
Fixes https://github.com/dotnet/runtime/issues/64466

/cc @MichalStrehovsky @dotnet/interop-contrib 