### PR TITLE
Small optimizations in `System.Net.NetworkInformation`

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
@@ -379,8 +379,8 @@ namespace System.Net.NetworkInformation
         public override async Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
         {
             // Wait for the address table to stabilize.
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            if (!TeredoHelper.UnsafeNotifyStableUnicastIpAddressTable(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (!TeredoHelper.UnsafeNotifyStableUnicastIpAddressTable(s => ((TaskCompletionSource)s).TrySetResult(), tcs))
             {
                 await tcs.Task.ConfigureAwait(false);
             }


### PR DESCRIPTION
This PR does two small optimizations:

* ~~In the `TeredoHelper` class, we used to queue a callback to the thread pool by using the good old `ThreadPool.QueueUserWorkItem` method. I changed it by implementing the `IThreadPoolWorkItem` interface in `TeredoHelper`, and queueing it directly to the thread pool, saving an allocation, and avoiding needlessly flowing the `ExecutionContext` (judging from the name `TeredoHelper.UnsafeNotifyStableUnicastIpAddressTable`).~~
* The `SystemIPGlobalProperties.GetUnicastAddressesAsync` was creating a `TaskCompletionSource<bool>`, while the newer non-generic `TaskCompletionSource` class is more appropriate and has a tiny bit smaller footprint. I changed it.