### PR TITLE
fix some test for FreeBSD

### DIFF
--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -359,6 +359,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(InvalidPrefix_TestData))]
+        [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD accepts some as valid and test hangs")]
         public void Add_InvalidPrefixNotStarted_ThrowsHttpListenerExceptionOnStart(string uriPrefix)
         {
             var listener = new HttpListener();
@@ -371,6 +372,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(InvalidPrefix_TestData))]
+        [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD accepts some as valid and test hangs")]
         public void Add_InvalidPrefixAlreadyStarted_ThrowsHttpListenerExceptionOnAdd(string uriPrefix)
         {
             using (var factory = new HttpListenerFactory())

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -359,7 +359,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(InvalidPrefix_TestData))]
-        [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD accepts some as valid and test hangs")]
+        [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD accepts some inputs as valid and test hangs")]
         public void Add_InvalidPrefixNotStarted_ThrowsHttpListenerExceptionOnStart(string uriPrefix)
         {
             var listener = new HttpListener();
@@ -372,7 +372,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(InvalidPrefix_TestData))]
-        [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD accepts some as valid and test hangs")]
+        [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD accepts some inputs as valid and test hangs")]
         public void Add_InvalidPrefixAlreadyStarted_ThrowsHttpListenerExceptionOnAdd(string uriPrefix)
         {
             using (var factory = new HttpListenerFactory())

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -436,6 +436,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.FreeBSD, "unreliable on FreeBSD")]
         public async Task AddLongHeader_DoesNotThrow()
         {
             string longString = new string('a', 65536);

--- a/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -498,7 +498,7 @@ namespace System.Net.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/21022", platforms: TestPlatforms.Windows)] // Indeterminate failure - socket not always fully disconnected.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/21590", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/21590", TestPlatforms.OSX | TestPlatforms.FreeBSD)]
         public async Task Write_ContentToClosedConnectionSynchronously_ThrowsHttpListenerException(bool ignoreWriteExceptions)
         {
             const string Text = "Some-String";

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -115,7 +115,6 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [MemberData(nameof(Loopbacks))]
         [SkipOnPlatform(TestPlatforms.Android, "Unsupported on Android")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64416", TestPlatforms.FreeBSD)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
@@ -141,7 +140,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64416", TestPlatforms.FreeBSD)]
         [PlatformSpecific(~(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.Android))]
         [MemberData(nameof(Loopbacks))]
         public async Task IPGlobalProperties_TcpActiveConnections_Succeed(IPAddress address)

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -115,6 +115,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [MemberData(nameof(Loopbacks))]
         [SkipOnPlatform(TestPlatforms.Android, "Unsupported on Android")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64416", TestPlatforms.FreeBSD)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
@@ -140,6 +141,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/64416", TestPlatforms.FreeBSD)]
         [PlatformSpecific(~(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.Android))]
         [MemberData(nameof(Loopbacks))]
         public async Task IPGlobalProperties_TcpActiveConnections_Succeed(IPAddress address)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -27,7 +27,7 @@ namespace System.Net.Security.Tests
         public const string NtlmUserFilePath = "/var/tmp/ntlm_user_file";
 
         public static bool SupportsNullEncryption { get { return s_supportsNullEncryption.Value; } }
-        public static bool SupportsHandshakeAlerts { get { return OperatingSystem.IsLinux() || OperatingSystem.IsWindows(); } }
+        public static bool SupportsHandshakeAlerts { get { return OperatingSystem.IsLinux() || OperatingSystem.IsWindows() || OperatingSystem.IsFreeBSD(); } }
         public static bool SupportsRenegotiation { get { return (OperatingSystem.IsWindows() && !PlatformDetection.IsWindows7) || ((OperatingSystem.IsLinux() || OperatingSystem.IsFreeBSD()) && PlatformDetection.OpenSslVersion >= new Version(1, 1, 1)); } }
 
         public static Task WhenAllOrAnyFailedWithTimeout(params Task[] tasks)

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendTo.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendTo.cs
@@ -84,6 +84,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD allows sendto() to broadcast")]
         public async Task Datagram_UDP_AccessDenied_Throws_DoesNotBind()
         {
             IPEndPoint invalidEndpoint = new IPEndPoint(IPAddress.Broadcast, 1234);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -504,7 +504,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50568", TestPlatforms.Android)]
@@ -515,6 +515,7 @@ namespace System.Net.Sockets.Tests
             int SO_RCVBUF;
 
             if (OperatingSystem.IsWindows() ||
+                OperatingSystem.IsFreeBSD() ||
                 OperatingSystem.IsMacOS())
             {
                 SOL_SOCKET = 0xffff;
@@ -558,7 +559,7 @@ namespace System.Net.Sockets.Tests
                 s.Bind(new IPEndPoint(IPAddress.Loopback, 0));
                 s.Listen();
 
-                Assert.Equal(1, s.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.AcceptConnection));
+                Assert.NotEqual(0, s.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.AcceptConnection));
             }
         }
 


### PR DESCRIPTION
contributes to #14537 and fixes some test sets reported as broken:

- System.Net.HttpListener.Tests 
 I just disabled failing tests. When the code does not throws as expected whole set hangs. I see no reason investing into HttpListener
- System.Net.NetworkInformation.Functional.Tests
I opened separate issue for tracing and disabled two tests with ActiveIssue. We are lacking ability to get listening connections at the moment.
- System.Net.Security.Tests
Adjusted expectation around Alerts - We use OpenSSL so the behavior is same as Linux. 
- System.Net.Sockets.Tests
This is the curious one. The test expects we would throw when sending to broadcast without SO_BROADCAST.
The documentation has references to it as well but that is not what I see happening
```
16448: socket(PF_INET,SOCK_DGRAM|SOCK_CLOEXEC,IPPROTO_UDP) = 175 (0xaf)
16448: fcntl(175,F_GETFL,)                       = 2 (0x2)
16448: fcntl(175,F_SETFL,O_RDWR|O_NONBLOCK)      = 0 (0x0)
16448: sendmsg(175,{{ AF_INET 255.255.255.255:1234 },16,[{"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"...,32}],1,{},0,0},0) = 32 (0x20)
16448: close(175)                                = 0 (0x0)
```
Since this does not seems critical, I simply disabled `Datagram_UDP_AccessDenied_Throws_DoesNotBind`

and `Get_AcceptConnection_Succeeds` was expecting value of one. The man page did mentioned something about boolean and the implementation really just returns the flag if set:
```
/usr/include/sys/socketvar.h:#define	SOLISTENING(sol)	(((sol)->so_options & SO_ACCEPTCONN) != 0)
/usr/include/sys/socket.h:#define	SO_ACCEPTCONN	0x00000002	/* socket has had listen() */
```
and the test was failing because it would get 2 instead of 1. Since the value is really not meaningful as counter I adjusted the test to expect non-zero value. (e.g true vs 0 -> false)

And the `SkipTestException` in GetSetRawSocketOption_Roundtrips makes the test fail if we do not use `ConditionalTheory` attribute. Since the fix was simple, I also added values for FreeBSD

All the networking tests are passing now

```
   Discovering: System.Net.Sockets.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Sockets.Tests (found 1215 of 1685 test cases)
    Starting:    System.Net.Sockets.Tests (parallel test collections = on, max threads = 2)
      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Supported_Success [SKIP]
        Condition(s) not met: "SupportsRawSockets"
    Finished:    System.Net.Sockets.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Sockets.Tests  Total: 1908, Errors: 0, Failed: 0, Skipped: 1, Time: 17.084s
```


