### PR TITLE
Delete null comparisons of non-null arguments

### DIFF
--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -139,8 +139,8 @@ extern "C" void PopulateDebugHeaders()
     size_t currentDebugPos = 0;
     size_t currentGlobalPos = 0;
 
-    ZeroMemory(s_DebugEntries, DebugTypeEntriesArraySize);
-    ZeroMemory(s_GlobalEntries, GlobalEntriesArraySize);
+    ZeroMemory(s_DebugEntries, sizeof(s_DebugEntries));
+    ZeroMemory(s_GlobalEntries, sizeof(s_GlobalEntries));
 
     MAKE_SIZE_ENTRY(GcDacVars);
     MAKE_DEBUG_FIELD_ENTRY(GcDacVars, major_version_number);

--- a/src/coreclr/nativeaot/Runtime/MethodTable.cpp
+++ b/src/coreclr/nativeaot/Runtime/MethodTable.cpp
@@ -20,10 +20,6 @@ bool MethodTable::Validate(bool assertOnFail /* default: true */)
 {
 #define REPORT_FAILURE() do { if (assertOnFail) { ASSERT_UNCONDITIONALLY("MethodTable::Validate check failed"); } return false; } while (false)
 
-    // Deal with the most common case of a bad pointer without an exception.
-    if (this == NULL)
-        REPORT_FAILURE();
-
     // MethodTable structures should be at least pointer aligned.
     if (dac_cast<TADDR>(this) & (sizeof(TADDR)-1))
         REPORT_FAILURE();


### PR DESCRIPTION
`non-null` args comparisons were earlier deleted in coreclr, this is to fix remaining GCC warnings in NativeAOT.