### PR TITLE
[mono][windows] Disable Microsoft.Extensions.Logging.Generators.TestsLoggerMessageGeneratorEmitterTests with ActiveIssue

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 namespace Microsoft.Extensions.Logging.Generators.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/52062", TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsMonoRuntime))]
     public class LoggerMessageGeneratorEmitterTests
     {
         [Fact]

--- a/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineInitializedData.cs
+++ b/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderDefineInitializedData.cs
@@ -61,7 +61,7 @@ namespace System.Reflection.Emit.Tests
             Assert.Throws<InvalidOperationException>(() => module.DefineInitializedData("MyField2", new byte[] { 1, 0, 1 }, FieldAttributes.Public));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public void DefineInitializedData_EnsureAlignmentIsMinimumNeededForUseOfCreateSpan()
         {
             ModuleBuilder module = Helpers.DynamicModule();


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/pull/64344#issuecomment-1023966451

... and skips `System.Reflection.Emit.Tests.ModuleBuilderDefineInitializedData.DefineInitializedData_EnsureAlignmentIsMinimumNeededForUseOfCreateSpan` test which requires reflection emit and fails on tvOS arm64 leg.