### PR TITLE
AltTrailingSlash tests should actually use AltDirectorySeparatorChar

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
@@ -79,7 +79,7 @@ namespace System.IO.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void PathEndsInAltTrailingSlash_Windows()
         {
-            string path = GetTestFilePath() + Path.DirectorySeparatorChar;
+            string path = GetTestFilePath() + Path.AltDirectorySeparatorChar;
             Assert.False(Exists(path));
         }
 
@@ -97,7 +97,7 @@ namespace System.IO.Tests
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
-            Assert.False(Exists(path + Path.DirectorySeparatorChar));
+            Assert.False(Exists(path + Path.AltDirectorySeparatorChar));
         }
 
         [Fact]


### PR DESCRIPTION
While I was reviewing #64347 I've realized that the tests are not doing what they were supposed to: using `Path.AltDirectorySeparatorChar` instead `Path.DirectorySeparatorChar`