### PR TITLE
JIT: Don't avoid LEA for byrefs (Fixes rolling builds)

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4906,7 +4906,7 @@ bool Lowering::TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* par
     }
 
 #ifdef TARGET_ARM64
-    if (parent->OperIsIndir() && parent->AsIndir()->IsVolatile())
+    if (parent->OperIsIndir() && parent->AsIndir()->IsVolatile() && !varTypeIsGC(addr))
     {
         // For Arm64 we avoid using LEA for volatile INDs
         // because we won't be able to use ldar/star


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/64418 and https://github.com/dotnet/runtime/issues/64417

Introduced in https://github.com/dotnet/runtime/pull/64354 (this PR basically reverts that change for byrefs - gcinfo is not happy that it got rid of LEA)

@dotnet/jit-contrib  PTAL