### PR TITLE
Set language specific flags appropriately in mono

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -490,19 +490,23 @@ if(GCC)
   # We rely on signed overflow to behave
   append("-fwrapv" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
-  set(WARNINGS "-Wall -Wunused -Wmissing-declarations -Wpointer-arith -Wno-cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes -Wmissing-prototypes -Wstrict-prototypes -Wnested-externs -Wno-format-zero-length -Wno-unused-function")
+  set(WARNINGS "-Wall -Wunused -Wmissing-declarations -Wpointer-arith -Wno-cast-qual -Wwrite-strings -Wno-switch -Wno-switch-enum -Wno-unused-value -Wno-attributes -Wno-format-zero-length -Wno-unused-function")
+  set(WARNINGS_C "-Wmissing-prototypes -Wstrict-prototypes -Wnested-externs")
 
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(WARNINGS "${WARNINGS} -Qunused-arguments -Wno-tautological-compare -Wno-parentheses-equality -Wno-self-assign -Wno-return-stack-address -Wno-constant-logical-operand -Wno-zero-length-array")
   endif()
 
+  set(WERROR "-Werror=return-type")
+  set(WERROR_C "-Werror=implicit-function-declaration")
+
   check_c_compiler_flag("-Werror=incompatible-pointer-types" WERROR_INCOMPATIBLE_POINTER_TYPES)
   if(WERROR_INCOMPATIBLE_POINTER_TYPES)
-    set(WERROR "-Werror=incompatible-pointer-types")
+    set(WERROR_C "${WERROR_C} -Werror=incompatible-pointer-types")
   endif()
-  set(WERROR "-Werror=return-type -Werror-implicit-function-declaration")
 
-  append("${WARNINGS} ${WERROR}" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  append("${WARNINGS} ${WARNINGS_C} ${WERROR} ${WERROR_C}" CMAKE_C_FLAGS)
+  append("${WARNINGS} ${WERROR}" CMAKE_CXX_FLAGS)
 
   set(MONO_ZERO_LEN_ARRAY 0)
 

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1692,9 +1692,6 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 #if defined(ALLOW_METHOD_ADD) || defined(ALLOW_FIELD_ADD)
 	MonoClass *add_member_klass = NULL;
 #endif
-#ifdef ALLOW_METHOD_ADD
-	uint32_t add_param_method_index = 0;
-#endif
 
 	gboolean assemblyref_updated = FALSE;
 	for (int i = 0; i < rows ; ++i) {
@@ -1731,7 +1728,6 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 
 		case ENC_FUNC_ADD_PARAM: {
 			g_assert (token_table == MONO_TABLE_METHOD);
-			add_param_method_index = token_index;
 			break;
 		}
 #endif


### PR DESCRIPTION
Fix two set of warnings:
```
cc1plus: warning: command line option ‘-Wmissing-prototypes’ is valid for C/ObjC but not for C++
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
cc1plus: warning: command line option ‘-Wnested-externs’ is valid for C/ObjC but not for C++
cc1plus: warning: ‘-Werror=’ argument ‘-Werror=implicit-function-declaration’ is not valid for C++
```
and
```
/__w/1/s/src/mono/mono/component/hot_reload.c:1696:18: warning: variable ‘add_param_method_index’ set but not used [-Wunused-but-set-variable]
1696 |         uint32_t add_param_method_index = 0;
     |                  ^~~~~~~~~~~~~~~~~~~~~~
```