### PR TITLE
Add array-fast path in Enumerable.Min/Max(int/long)

### DIFF
--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -98,6 +98,7 @@
   <ItemGroup>
     <Reference Include="System.Collections" />
     <Reference Include="System.Memory" />
+    <Reference Include="System.Numerics.Vectors" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
   </ItemGroup>

--- a/src/libraries/System.Linq/tests/MaxTests.cs
+++ b/src/libraries/System.Linq/tests/MaxTests.cs
@@ -40,6 +40,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().Max());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().Max(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<int>().Max());
+            Assert.Throws<InvalidOperationException>(() => new List<int>().Max());
         }
 
         public static IEnumerable<object[]> Max_Int_TestData()
@@ -55,6 +57,12 @@ namespace System.Linq.Tests
             yield return new object[] { new int[] { 16, 9, 10, 7, 8 }, 16 };
             yield return new object[] { new int[] { 6, 9, 10, 0, 50 }, 50 };
             yield return new object[] { new int[] { -6, 0, -9, 0, -10, 0 }, 0 };
+
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length)), length + length - 1 };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).ToArray()), length + length - 1 };
+            }
         }
 
         [Theory]
@@ -78,6 +86,12 @@ namespace System.Linq.Tests
             yield return new object[] { new long[] { 250, 49, 130, 47, 28 }, 250L };
             yield return new object[] { new long[] { 6, 9, 10, 0, int.MaxValue + 50L }, int.MaxValue + 50L };
             yield return new object[] { new long[] { 6, 50, 9, 50, 10, 50 }, 50L };
+
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i)), (long)(length + length - 1) };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i).ToArray()), (long)(length + length - 1) };
+            }
         }
 
         [Theory]
@@ -100,6 +114,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<long>().Max());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<long>().Max(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<long>().Max());
+            Assert.Throws<InvalidOperationException>(() => new List<long>().Max());
         }
 
         public static IEnumerable<object[]> Max_Float_TestData()

--- a/src/libraries/System.Linq/tests/MinTests.cs
+++ b/src/libraries/System.Linq/tests/MinTests.cs
@@ -42,6 +42,12 @@ namespace System.Linq.Tests
             yield return new object[] { new int[] { 6, 9, 10, 7, 8 }, 6 };
             yield return new object[] { new int[] { 6, 9, 10, 0, -5 }, -5 };
             yield return new object[] { new int[] { 6, 0, 9, 0, 10, 0 }, 0 };
+
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length)), length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).ToArray()), length };
+            }
         }
 
         [Theory]
@@ -64,6 +70,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().Min());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<int>().Min(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<int>().Min());
+            Assert.Throws<InvalidOperationException>(() => new List<int>().Min());
         }
 
         public static IEnumerable<object[]> Min_Long_TestData()
@@ -79,6 +87,12 @@ namespace System.Linq.Tests
             yield return new object[] { new long[] { -250, 49, 130, 47, 28 }, -250L };
             yield return new object[] { new long[] { 6, 9, 10, 0, -int.MaxValue - 50L }, -int.MaxValue - 50L };
             yield return new object[] { new long[] { 6, -5, 9, -5, 10, -5 }, -5 };
+
+            for (int length = 2; length < 33; length++)
+            {
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i)), (long)length };
+                yield return new object[] { Shuffler.Shuffle(Enumerable.Range(length, length).Select(i => (long)i).ToArray()), (long)length };
+            }
         }
 
         [Theory]
@@ -101,6 +115,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<long>().Min());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<long>().Min(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<long>().Min());
+            Assert.Throws<InvalidOperationException>(() => new List<long>().Min());
         }
 
         public static IEnumerable<object[]> Min_Float_TestData()
@@ -160,6 +176,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<float>().Min());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<float>().Min(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<float>().Min());
+            Assert.Throws<InvalidOperationException>(() => new List<float>().Min());
         }
 
         public static IEnumerable<object[]> Min_Double_TestData()
@@ -218,6 +236,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<double>().Min());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<double>().Min(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<double>().Min());
+            Assert.Throws<InvalidOperationException>(() => new List<double>().Min());
         }
 
         public static IEnumerable<object[]> Min_Decimal_TestData()
@@ -248,6 +268,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<decimal>().Min());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<decimal>().Min(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<decimal>().Min());
+            Assert.Throws<InvalidOperationException>(() => new List<decimal>().Min());
         }
 
         [Fact]
@@ -486,6 +508,8 @@ namespace System.Linq.Tests
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<DateTime>().Min());
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<DateTime>().Min(x => x));
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<DateTime>().Min());
+            Assert.Throws<InvalidOperationException>(() => new List<DateTime>().Min());
         }
 
         public static IEnumerable<object[]> Min_String_TestData()

--- a/src/libraries/System.Linq/tests/Shuffler.cs
+++ b/src/libraries/System.Linq/tests/Shuffler.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -9,6 +8,17 @@ namespace System.Linq.Tests
 {
     public static class Shuffler
     {
+        public static T[] Shuffle<T>(T[] array)
+        {
+            int i = array.Length;
+            while (i > 1)
+            {
+                int j = Random.Shared.Next(i--);
+                (array[i], array[j]) = (array[j], array[i]);
+            }
+            return array;
+        }
+
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source, int seed)
         {
             return new ShuffledEnumerable<T>(source, seed);


### PR DESCRIPTION
In looking through usage data, it's pretty common to call Enumerable.Min/Max with an array.  At the cost of a type check when the source isn't an array, we can speed up the cases where it is, at a minimum by avoiding interface dispatch and in the best case by vectorizing.  I've done so for int/long.  We could look at doing so for float/double as well, but I wasn't sure about the impact of the NaN-related logic on vectorization.

| Method |         Toolchain | Length | Array |         Mean |      Error | Ratio |
|------- |------------------ |------- |------ |-------------:|-----------:|------:|
|    Min | \main\corerun.exe |      1 | False |    31.444 ns |  0.6275 ns |  1.00 |
|    Min |   \pr\corerun.exe |      1 | False |    31.211 ns |  0.3926 ns |  0.99 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |      1 |  True |    14.049 ns |  0.0917 ns |  1.00 |
|    Min |   \pr\corerun.exe |      1 |  True |     1.912 ns |  0.0116 ns |  0.14 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |      4 | False |    44.083 ns |  0.5091 ns |  1.00 |
|    Min |   \pr\corerun.exe |      4 | False |    44.900 ns |  0.4524 ns |  1.02 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |      4 |  True |    24.681 ns |  0.1511 ns |  1.00 |
|    Min |   \pr\corerun.exe |      4 |  True |     3.553 ns |  0.0647 ns |  0.14 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |     16 | False |   108.921 ns |  1.0189 ns |  1.00 |
|    Min |   \pr\corerun.exe |     16 | False |   112.215 ns |  0.5962 ns |  1.03 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |     16 |  True |    74.743 ns |  0.4251 ns |  1.00 |
|    Min |   \pr\corerun.exe |     16 |  True |     4.557 ns |  0.0403 ns |  0.06 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |     64 | False |   333.232 ns |  1.3208 ns |  1.00 |
|    Min |   \pr\corerun.exe |     64 | False |   331.662 ns |  6.6332 ns |  0.99 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |     64 |  True |   251.663 ns |  5.0050 ns |  1.00 |
|    Min |   \pr\corerun.exe |     64 |  True |     7.923 ns |  0.0847 ns |  0.03 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |    256 | False | 1,275.711 ns | 25.5032 ns |  1.00 |
|    Min |   \pr\corerun.exe |    256 | False | 1,220.111 ns | 24.3144 ns |  0.96 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |    256 |  True |   932.077 ns |  2.8967 ns |  1.00 |
|    Min |   \pr\corerun.exe |    256 |  True |    21.124 ns |  0.1536 ns |  0.02 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |   1024 | False | 4,951.882 ns | 92.7338 ns |  1.00 |
|    Min |   \pr\corerun.exe |   1024 | False | 4,673.227 ns | 41.3033 ns |  0.94 |
|        |                   |        |       |              |            |       |
|    Min | \main\corerun.exe |   1024 |  True | 3,753.438 ns | 50.7476 ns |  1.00 |
|    Min |   \pr\corerun.exe |   1024 |  True |    86.373 ns |  0.3499 ns |  0.02 |

```C#
using System;
using System.Collections.Generic;
using System.Linq;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    [Params(1, 4, 16, 64, 256, 1024)]
    public int Length { get; set; }

    [Params(false, true)]
    public bool Array { get; set; }

    private IEnumerable<int> _source;

    [GlobalSetup]
    public void Setup()
    {
        _source = Enumerable.Range(1, Length).Reverse();
        if (Array)
        {
            _source = _source.ToArray();
        }
    }

    [Benchmark]
    public int Min() => _source.Min();
}
```