### PR TITLE
JIT: fix x86 codegen issue

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1972,6 +1972,7 @@ void CodeGen::genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode)
             inst_Mov(TYP_FLOAT, tempXmm, reg1, /* canSkip */ false);
             GetEmitter()->emitIns_SIMD_R_R_R(INS_punpckldq, size, targetReg, targetReg, tempXmm);
         }
+        genProduceReg(lclNode);
     }
 #elif defined(TARGET_AMD64)
     assert(!TargetOS::IsWindows || !"Multireg store to SIMD reg not supported on Windows x64");


### PR DESCRIPTION
We were not calling `genProduceReg` in one case, leading to a missing
def and liveness assert. Normally this would have been a temp assign
followed by a copy to a local; evidently we don't track liveness for
temps and so don't notice the missing def, and the subsequent copy defs
the local and all seems well.

Forward sub gets rid of the copy and exposes the issue under jit stress.