### PR TITLE
Implement operator delete on ThreadStressLog

### DIFF
--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -740,6 +740,7 @@ public:
 
 #if defined(MEMORY_MAPPED_STRESSLOG) && !defined(STRESS_LOG_ANALYZER)
     void* __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT;
+    void __cdecl operator delete (void * chunk);
 #endif
 
     ~ThreadStressLog ()

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -965,6 +965,19 @@ void* __cdecl ThreadStressLog::operator new(size_t n, const NoThrow&) NOEXCEPT
     return malloc(n);
 #endif //HOST_WINDOWS
 }
+
+void __cdecl ThreadStressLog::operator delete(void* p) 
+{
+    if (StressLogChunk::s_memoryMapped)
+        return; // Giving up, we will just leak it instead of building a sophisticated allocator
+#ifdef HOST_WINDOWS
+    _ASSERTE(StressLogChunk::s_LogChunkHeap);
+    HeapFree(StressLogChunk::s_LogChunkHeap, 0, p);
+#else
+    free(p);
+#endif //HOST_WINDOWS
+}
+
 #endif //MEMORY_MAPPED_STRESSLOG
 
 #endif // STRESS_LOG


### PR DESCRIPTION
On rare occasions, we do delete `ThreadStressLog` objects [here](https://github.com/dotnet/runtime/blob/c7adf5598f27e59644030ddae4e382cbda74e41e/src/coreclr/utilcode/stresslog.cpp#L559). We have to be fairly unlucky when that happens, but it is annoying enough when they become false positive when we wanted to reproduce a stress bug.

If we do not override the delete operator, it will use [this](https://github.com/dotnet/runtime/blob/c7adf5598f27e59644030ddae4e382cbda74e41e/src/coreclr/utilcode/clrhost_nodependencies.cpp#L392) implementation of the delete operator and hit [this](https://github.com/dotnet/runtime/blob/c7adf5598f27e59644030ddae4e382cbda74e41e/src/coreclr/utilcode/clrhost_nodependencies.cpp#L295) assertion.

This change simply leaks the object when we are allocating from the memory-mapped file. I think that is okay given this condition should not happen often.