### PR TITLE
Fix JIT rolling build issue with non-JIT changes

### DIFF
--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -118,7 +118,7 @@ jobs:
       - script: $(PipScript) install --user --upgrade pip && $(PipScript) install --user azure.storage.blob==12.5.0 --force-reinstall
         displayName: Upgrade Pip to latest and install azure-storage-blob Python package
 
-      - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/jitrollingbuild.py upload -build_type $(buildConfig) -arch $(archType) -host_os $(osGroup) -git_hash $(Build.SourceVersion)
+      - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/jitrollingbuild.py upload -build_type $(buildConfig) -arch $(archType) -host_os $(osGroup) -git_hash $(Build.SourceVersion) --use_latest_jit_change
         displayName: Upload JIT to Azure Storage
         env:
           CLRJIT_AZ_KEY: $(clrjit_key1) # secret key stored as variable in pipeline


### PR DESCRIPTION
When uploading a JIT rolling build, use the git hash of the most recent
JIT change, not the git hash that was actually built. This handles the case
where a JIT change kicked off an AzDO pipeline, but the pipeline didn't start
until after one or more additional changes were merged.

The AzDO pipelines appear to fetch with `-depth=20`, which should provide
enough history for almost any case.

Fixes #64392