### PR TITLE
Local heap optimizations  on Arm64

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2311,34 +2311,66 @@ void CodeGen::genLclHeap(GenTree* tree)
         // We should reach here only for non-zero, constant size allocations.
         assert(amount > 0);
 
+        const int storePairRegsWritesBytes = 2 * REGSIZE_BYTES;
+
         // For small allocations we will generate up to four stp instructions, to zero 16 to 64 bytes.
-        static_assert_no_msg(STACK_ALIGN == (REGSIZE_BYTES * 2));
-        assert(amount % (REGSIZE_BYTES * 2) == 0); // stp stores two registers at a time
-        size_t stpCount = amount / (REGSIZE_BYTES * 2);
-        if (stpCount <= 4)
+        static_assert_no_msg(STACK_ALIGN == storePairRegsWritesBytes);
+        assert(amount % storePairRegsWritesBytes == 0); // stp stores two registers at a time
+
+        if (compiler->info.compInitMem)
         {
-            while (stpCount != 0)
+            if (amount <= LCLHEAP_UNROLL_LIMIT)
             {
-                // We can use pre-indexed addressing.
-                // stp ZR, ZR, [SP, #-16]!   // STACK_ALIGN is 16
-                GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_PTRSIZE, REG_ZR, REG_ZR, REG_SPBASE, -16, INS_OPTS_PRE_INDEX);
-                stpCount -= 1;
+                // The following zeroes the last 16 bytes and probes the page containing [sp, #16] address.
+                // stp xzr, xzr, [sp, #-16]!
+                GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_8BYTE, REG_ZR, REG_ZR, REG_SPBASE, -storePairRegsWritesBytes,
+                                              INS_OPTS_PRE_INDEX);
+
+                if (amount > storePairRegsWritesBytes)
+                {
+                    // The following sets SP to its final value and zeroes the first 16 bytes of the allocated space.
+                    // stp xzr, xzr, [sp, #-amount+16]!
+                    const ssize_t finalSpDelta = (ssize_t)amount - storePairRegsWritesBytes;
+                    GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_8BYTE, REG_ZR, REG_ZR, REG_SPBASE, -finalSpDelta,
+                                                  INS_OPTS_PRE_INDEX);
+
+                    // The following zeroes the remaining space in [finalSp+16, initialSp-16) interval
+                    // using a sequence of stp instruction with unsigned offset.
+                    for (ssize_t offset = storePairRegsWritesBytes; offset < (ssize_t)amount - storePairRegsWritesBytes;
+                         offset += storePairRegsWritesBytes)
+                    {
+                        // stp xzr, xzr, [sp, #offset]
+                        GetEmitter()->emitIns_R_R_R_I(INS_stp, EA_8BYTE, REG_ZR, REG_ZR, REG_SPBASE, offset);
+                    }
+                }
+
+                lastTouchDelta = 0;
+
+                goto ALLOC_DONE;
             }
-
-            lastTouchDelta = 0;
-
-            goto ALLOC_DONE;
         }
-        else if (!compiler->info.compInitMem && (amount < compiler->eeGetPageSize())) // must be < not <=
+        else if (amount < compiler->eeGetPageSize()) // must be < not <=
         {
             // Since the size is less than a page, simply adjust the SP value.
             // The SP might already be in the guard page, so we must touch it BEFORE
             // the alloc, not after.
 
-            // ldr wz, [SP, #0]
-            GetEmitter()->emitIns_R_R_I(INS_ldr, EA_4BYTE, REG_ZR, REG_SP, 0);
-
-            genInstrWithConstant(INS_sub, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, amount, rsGetRsvdReg());
+            if (emitter::canEncodeLoadOrStorePairOffset(amount, EA_8BYTE))
+            {
+                // The following probes the page and allocates the local heap.
+                // ldp tmpReg, xzr, [sp], #-amount
+                // Note that behaviour of ldp where two source registers are the same is unpredictable.
+                const regNumber tmpReg = targetReg;
+                GetEmitter()->emitIns_R_R_R_I(INS_ldp, EA_8BYTE, tmpReg, REG_ZR, REG_SPBASE, -(ssize_t)amount,
+                                              INS_OPTS_POST_INDEX);
+            }
+            else
+            {
+                // ldr wzr, [sp]
+                // sub, sp, #amount
+                GetEmitter()->emitIns_R_R_I(INS_ldr, EA_4BYTE, REG_ZR, REG_SPBASE, amount);
+                genInstrWithConstant(INS_sub, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, amount, rsGetRsvdReg());
+            }
 
             lastTouchDelta = amount;
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2368,7 +2368,8 @@ void CodeGen::genLclHeap(GenTree* tree)
             {
                 // The following probes the page and allocates the local heap.
                 // ldp tmpReg, xzr, [sp], #-amount
-                // Note that behaviour of ldp where two source registers are the same is unpredictable.
+                // Note that we cannot use ldp xzr, xzr since
+                // the behaviour of ldp where two source registers are the same is unpredictable.
                 const regNumber tmpReg = targetReg;
                 GetEmitter()->emitIns_R_R_R_I(INS_ldp, EA_8BYTE, tmpReg, REG_ZR, REG_SPBASE, -(ssize_t)amount,
                                               INS_OPTS_POST_INDEX);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2336,7 +2336,7 @@ void CodeGen::genLclHeap(GenTree* tree)
 
                     // The following zeroes the remaining space in [finalSp+16, initialSp-16) interval
                     // using a sequence of stp instruction with unsigned offset.
-                    for (ssize_t offset = storePairRegsWritesBytes; offset < (ssize_t)amount - storePairRegsWritesBytes;
+                    for (ssize_t offset = storePairRegsWritesBytes; offset < finalSpDelta;
                          offset += storePairRegsWritesBytes)
                     {
                         // stp xzr, xzr, [sp, #offset]

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -543,14 +543,14 @@ int LinearScan::BuildNode(GenTree* tree)
         {
             assert(dstCount == 1);
 
-            // Need a variable number of temp regs (see genLclHeap() in codegenamd64.cpp):
+            // Need a variable number of temp regs (see genLclHeap() in codegenarm64.cpp):
             // Here '-' means don't care.
             //
             //  Size?                   Init Memory?    # temp regs
             //   0                          -               0
-            //   const and <=6 ptr words    -               0
+            //   const and <=UnrollLimit    -               0
             //   const and <PageSize        No              0
-            //   >6 ptr words               Yes             0
+            //   >UnrollLimit               Yes             0
             //   Non-const                  Yes             0
             //   Non-const                  No              2
             //
@@ -569,12 +569,9 @@ int LinearScan::BuildNode(GenTree* tree)
                     // Note: The Gentree node is not updated here as it is cheap to recompute stack aligned size.
                     // This should also help in debugging as we can examine the original size specified with
                     // localloc.
-                    sizeVal         = AlignUp(sizeVal, STACK_ALIGN);
-                    size_t stpCount = sizeVal / (REGSIZE_BYTES * 2);
+                    sizeVal = AlignUp(sizeVal, STACK_ALIGN);
 
-                    // For small allocations up to 4 'stp' instructions (i.e. 16 to 64 bytes of localloc)
-                    //
-                    if (stpCount <= 4)
+                    if (sizeVal <= LCLHEAP_UNROLL_LIMIT)
                     {
                         // Need no internal registers
                     }

--- a/src/coreclr/jit/targetarm64.h
+++ b/src/coreclr/jit/targetarm64.h
@@ -15,6 +15,7 @@
   #define CPBLK_LCL_UNROLL_LIMIT   128    // Upper bound to let the code generator to loop unroll CpBlk (when both srcAddr and dstAddr point to the stack)
   #define INITBLK_UNROLL_LIMIT     64     // Upper bound to let the code generator to loop unroll InitBlk
   #define INITBLK_LCL_UNROLL_LIMIT 128    // Upper bound to let the code generator to loop unroll InitBlk (when dstAddr points to the stack)
+  #define LCLHEAP_UNROLL_LIMIT     128    // Upper bound to let the code generator to loop unroll LclHeap (when zeroing is required)
 
 #ifdef FEATURE_SIMD
   #define ALIGN_SIMD_TYPES         1       // whether SIMD type locals are to be aligned


### PR DESCRIPTION
1. When not required to zero the allocated space for local heap (for sizes up to 64 bytes) - do not zero:

```diff
-            stp     xzr, xzr, [sp,#-16]!
-            stp     xzr, xzr, [sp,#-16]!
-            stp     xzr, xzr, [sp,#-16]!
-            stp     xzr, xzr, [sp,#-16]!
+            ldr     wzr, [sp],#-64
```

2. For sizes less than one `PAGE_SIZE` use `ldr wzr, [sp], #-amount` that does probing at `[sp]` and allocates the space at the same time:

```diff
-            ldr     wzr, [sp]
-            sub     sp, sp, #208
+            ldr     wzr, [sp],#-208
```
or use `ldp tmpReg, xzr, [sp], #-amount` (when it's not encodable by post-index variant of `ldr`)
```diff
-            ldr     wzr, [sp]
-            sub     sp, sp, #512
+            ldp     x0, xzr, [sp],#-512
```


3. Allow non-loop zeroing (i.e. unrolled sequence) for sizes up to 128 bytes (i.e. up to `LCLHEAP_UNROLL_LIMIT`). This has also allowed to free up two internal integer registers for such cases. 

```diff
-            mov     w11, #128
-                                               ;; bbWeight=0.50 PerfScore 0.25
-G_M44913_IG19:        ; gcrefRegs=00F9 {x0 x3 x4 x5 x6 x7}, byrefRegs=0000 {}, byref, isz
             stp     xzr, xzr, [sp,#-16]!
-            subs    x11, x11, #16
-            bne     G_M44913_IG19
+            stp     xzr, xzr, [sp,#-112]!
+            stp     xzr, xzr, [sp,#16]
+            stp     xzr, xzr, [sp,#32]
+            stp     xzr, xzr, [sp,#48]
+            stp     xzr, xzr, [sp,#64]
+            stp     xzr, xzr, [sp,#80]
+            stp     xzr, xzr, [sp,#96]
```

This will show up as a code size regression.

4. Do zeroing in ascending order of the effective address:

```diff
-            mov     w7, #96
-G_M49279_IG13:
             stp     xzr, xzr, [sp,#-16]!
-            subs    x7, x7, #16
-            bne     G_M49279_IG13
+            stp     xzr, xzr, [sp,#-80]!
+            stp     xzr, xzr, [sp,#16]
+            stp     xzr, xzr, [sp,#32]
+            stp     xzr, xzr, [sp,#48]
+            stp     xzr, xzr, [sp,#64]
```

In the last example, the zeroing is done at `[initialSp-16], [initialSp-96], [initialSp-80], [initialSp-64], [initialSp-48], [initialSp-32]` order. The idea here is to allow a CPU to detect the sequential `memset` to `0` and switch into write streaming mode.


## benchmarks.run.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 14725324 (overridden on cmd)
Total bytes of diff: 14724648 (overridden on cmd)
Total bytes of delta: -676 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          16 : 38461.dasm (2.38% of base)
           8 : 38793.dasm (1.64% of base)

Top file improvements (bytes):
         -48 : 35301.dasm (-1.21% of base)
         -32 : 34927.dasm (-0.73% of base)
         -28 : 8891.dasm (-6.73% of base)
         -20 : 9058.dasm (-1.24% of base)
         -16 : 12699.dasm (-0.72% of base)
         -16 : 31025.dasm (-1.15% of base)
         -16 : 35409.dasm (-1.21% of base)
         -16 : 6709.dasm (-1.19% of base)
         -12 : 11525.dasm (-1.85% of base)
         -12 : 36920.dasm (-1.85% of base)
         -12 : 6786.dasm (-2.16% of base)
         -12 : 472.dasm (-1.46% of base)
         -12 : 11461.dasm (-1.34% of base)
         -12 : 13254.dasm (-1.76% of base)
         -12 : 4500.dasm (-4.76% of base)
         -12 : 5824.dasm (-1.22% of base)
         -12 : 7846.dasm (-2.04% of base)
         -12 : 7978.dasm (-1.03% of base)
         -12 : 12328.dasm (-2.17% of base)
         -12 : 8884.dasm (-1.07% of base)

84 total files with Code Size differences (82 improved, 2 regressed), 48 unchanged.

Top method regressions (bytes):
          16 ( 2.38% of base) : 38461.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:MessageJson(int,int,System.String,int,System.String,System.String,System.String,System.String):this
           8 ( 1.64% of base) : 38793.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:FormattedMessage(int,int,System.String,int,System.String,System.String):this

Top method improvements (bytes):
         -48 (-1.21% of base) : 35301.dasm - ILStubClass:IL_STUB_StructMarshal(byref,long,int,byref)
         -32 (-0.73% of base) : 34927.dasm - ILStubClass:IL_STUB_StructMarshal(byref,long,int,byref)
         -28 (-6.73% of base) : 8891.dasm - System.Net.Security.SslStreamPal:DecryptMessage(System.Net.Security.SafeDeleteSslContext,System.Span`1[Byte],byref,byref):System.Net.SecurityStatusPal
         -20 (-1.24% of base) : 9058.dasm - System.Numerics.BigInteger:Multiply(System.ReadOnlySpan`1[UInt32],int,System.ReadOnlySpan`1[UInt32],int):System.Numerics.BigInteger
         -16 (-1.21% of base) : 35409.dasm - System.Numerics.BigInteger:Add(System.ReadOnlySpan`1[UInt32],int,System.ReadOnlySpan`1[UInt32],int):System.Numerics.BigInteger
         -16 (-1.19% of base) : 6709.dasm - System.Numerics.BigInteger:Subtract(System.ReadOnlySpan`1[UInt32],int,System.ReadOnlySpan`1[UInt32],int):System.Numerics.BigInteger
         -16 (-0.72% of base) : 12699.dasm - System.Numerics.BigIntegerCalculator:PowCore(System.Span`1[UInt32],int,System.ReadOnlySpan`1[UInt32],System.ReadOnlySpan`1[UInt32],System.Span`1[UInt32],System.Span`1[UInt32])
         -16 (-1.15% of base) : 31025.dasm - System.Numerics.BigNumber:FormatBigIntegerToHex(bool,System.Numerics.BigInteger,ushort,int,System.Globalization.NumberFormatInfo,System.Span`1[Char],byref,byref):System.String
         -12 (-3.19% of base) : 7325.dasm - System.Environment:get_SystemDirectory():System.String
         -12 (-5.00% of base) : 7714.dasm - System.Globalization.TimeSpanFormat:FormatC(System.TimeSpan):System.String
         -12 (-1.85% of base) : 11525.dasm - System.Net.NameResolutionPal:TryGetNameInfo(System.Net.IPAddress,byref,byref):System.String
         -12 (-0.46% of base) : 8820.dasm - System.Net.Security.SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -12 (-1.07% of base) : 8884.dasm - System.Net.Security.SslStreamPal:EncryptMessage(System.Net.Security.SafeDeleteSslContext,System.ReadOnlyMemory`1[Byte],int,int,byref,byref):System.Net.SecurityStatusPal
         -12 (-1.22% of base) : 5824.dasm - System.Number:<FormatInt32>g__FormatInt32Slow|40_0(int,int,System.String,System.IFormatProvider):System.String
         -12 (-1.52% of base) : 3856.dasm - System.Number:<FormatInt64>g__FormatInt64Slow|44_0(long,System.String,System.IFormatProvider):System.String
         -12 (-1.46% of base) : 472.dasm - System.Number:<FormatUInt32>g__FormatUInt32Slow|42_0(int,System.String,System.IFormatProvider):System.String
         -12 (-1.76% of base) : 13254.dasm - System.Number:<FormatUInt64>g__FormatUInt64Slow|46_0(long,System.String,System.IFormatProvider):System.String
         -12 (-1.03% of base) : 7978.dasm - System.Number:<TryFormatInt32>g__TryFormatInt32Slow|41_0(int,int,System.ReadOnlySpan`1[Char],System.IFormatProvider,System.Span`1[Char],byref):bool
         -12 (-1.18% of base) : 39456.dasm - System.Number:<TryFormatInt64>g__TryFormatInt64Slow|45_0(long,System.ReadOnlySpan`1[Char],System.IFormatProvider,System.Span`1[Char],byref):bool
         -12 (-1.34% of base) : 11461.dasm - System.Number:<TryFormatUInt64>g__TryFormatUInt64Slow|47_0(long,System.ReadOnlySpan`1[Char],System.IFormatProvider,System.Span`1[Char],byref):bool

Top method regressions (percentages):
          16 ( 2.38% of base) : 38461.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:MessageJson(int,int,System.String,int,System.String,System.String,System.String,System.String):this
           8 ( 1.64% of base) : 38793.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:FormattedMessage(int,int,System.String,int,System.String,System.String):this

Top method improvements (percentages):
         -28 (-6.73% of base) : 8891.dasm - System.Net.Security.SslStreamPal:DecryptMessage(System.Net.Security.SafeDeleteSslContext,System.Span`1[Byte],byref,byref):System.Net.SecurityStatusPal
         -12 (-5.00% of base) : 7714.dasm - System.Globalization.TimeSpanFormat:FormatC(System.TimeSpan):System.String
         -12 (-4.76% of base) : 726.dasm - System.Number:FormatDouble(double,System.String,System.Globalization.NumberFormatInfo):System.String
         -12 (-4.76% of base) : 4500.dasm - System.Number:FormatSingle(float,System.String,System.Globalization.NumberFormatInfo):System.String
          -8 (-4.26% of base) : 4687.dasm - System.Diagnostics.Tracing.EventSource:WriteEvent(int,int,int,int):this
          -8 (-3.28% of base) : 11488.dasm - System.Diagnostics.Tracing.EventSource:WriteEvent(int,System.String,int,int):this
         -12 (-3.19% of base) : 7325.dasm - System.Environment:get_SystemDirectory():System.String
         -12 (-3.00% of base) : 8281.dasm - System.Number:FormatDecimal(System.Decimal,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo):System.String
          -4 (-2.86% of base) : 1223.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindCaseSensitivePrefix(System.Text.RegularExpressions.RegexNode):System.String
          -8 (-2.27% of base) : 7119.dasm - System.Text.Json.JsonWriterHelper:WriteDateTimeTrimmed(System.Span`1[Byte],System.DateTime,byref)
          -8 (-2.22% of base) : 9746.dasm - System.Text.Json.JsonWriterHelper:WriteDateTimeOffsetTrimmed(System.Span`1[Byte],System.DateTimeOffset,byref)
         -12 (-2.17% of base) : 12328.dasm - System.Number:TryFormatDouble(double,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo,System.Span`1[Char],byref):bool
         -12 (-2.17% of base) : 36918.dasm - System.Number:TryFormatSingle(float,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo,System.Span`1[Char],byref):bool
         -12 (-2.16% of base) : 6786.dasm - System.Text.Encodings.Web.DefaultUrlEncoder:.ctor(System.Text.Encodings.Web.TextEncoderSettings):this
         -12 (-2.04% of base) : 7846.dasm - UTF8EncodingSealed:GetStringForSmallInput(System.Byte[]):System.String:this
         -12 (-1.85% of base) : 11525.dasm - System.Net.NameResolutionPal:TryGetNameInfo(System.Net.IPAddress,byref,byref):System.String
         -12 (-1.85% of base) : 36920.dasm - System.Number:TryFormatDecimal(System.Decimal,System.ReadOnlySpan`1[Char],System.Globalization.NumberFormatInfo,System.Span`1[Char],byref):bool
         -12 (-1.76% of base) : 13254.dasm - System.Number:<FormatUInt64>g__FormatUInt64Slow|46_0(long,System.String,System.IFormatProvider):System.String
          -8 (-1.64% of base) : 1210.dasm - System.Text.RegularExpressions.RegexWriter:Write(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexCode
          -4 (-1.54% of base) : 3316.dasm - System.Version:ToString(int):System.String:this

84 total methods with Code Size differences (82 improved, 2 regressed), 48 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 167802056 (overridden on cmd)
Total bytes of diff: 167801244 (overridden on cmd)
Total bytes of delta: -812 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          36 : 260300.dasm (5.45% of base)
          16 : 256946.dasm (15.38% of base)
          16 : 259740.dasm (4.44% of base)
          16 : 256945.dasm (15.38% of base)
          12 : 88993.dasm (5.17% of base)
          12 : 97247.dasm (11.54% of base)
          12 : 227386.dasm (1.78% of base)

Top file improvements (bytes):
         -40 : 234409.dasm (-2.94% of base)
         -40 : 234410.dasm (-2.94% of base)
         -32 : 234408.dasm (-2.68% of base)
         -24 : 234401.dasm (-2.41% of base)
         -24 : 234399.dasm (-2.47% of base)
         -24 : 234400.dasm (-2.41% of base)
         -24 : 234398.dasm (-2.44% of base)
         -24 : 234397.dasm (-2.44% of base)
         -24 : 234402.dasm (-2.44% of base)
         -16 : 234384.dasm (-2.31% of base)
         -16 : 242734.dasm (-1.84% of base)
         -16 : 234385.dasm (-2.37% of base)
          -8 : 224176.dasm (-1.35% of base)
          -8 : 224195.dasm (-1.52% of base)
          -8 : 234356.dasm (-1.46% of base)
          -8 : 234392.dasm (-1.37% of base)
          -8 : 242189.dasm (-1.21% of base)
          -8 : 242731.dasm (-1.28% of base)
          -8 : 242759.dasm (-1.45% of base)
          -8 : 234337.dasm (-1.50% of base)

103 total files with Code Size differences (96 improved, 7 regressed), 20 unchanged.

Top method regressions (bytes):
          36 ( 5.45% of base) : 260300.dasm - JitTest.Test:Main():int
          16 ( 4.44% of base) : 259740.dasm - BringUpTest_LocallocCnstB117_PSP:LocallocCnstB117_PSP():int
          16 (15.38% of base) : 256945.dasm - ShowLocallocAlignment.App:SnapLocallocBufferAddress1(int,int,int,int,int,int):long
          16 (15.38% of base) : 256946.dasm - ShowLocallocAlignment.App:SnapLocallocBufferAddress2(int,int,int,int,int,int):long
          12 ( 5.17% of base) : 88993.dasm - BringUpTest_LocallocCnstB117:LocallocCnstB117():int
          12 (11.54% of base) : 97247.dasm - Test2A.TestClass:TestFunc2():int
          12 ( 1.78% of base) : 227386.dasm - Vector256ArrayTest`1[Byte][System.Byte]:Vector256Array():int

Top method improvements (bytes):
         -40 (-2.94% of base) : 234410.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,System.Object,System.Boolean[],int):bool
         -40 (-2.94% of base) : 234409.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,System.Object,System.Char[],int):bool
         -32 (-2.68% of base) : 234408.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,System.Object,System.SByte[],int):bool
         -24 (-2.47% of base) : 234399.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object):bool
         -24 (-2.44% of base) : 234398.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object):bool
         -24 (-2.44% of base) : 234397.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object):bool
         -24 (-2.41% of base) : 234401.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,bool):bool
         -24 (-2.41% of base) : 234400.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,bool):bool
         -24 (-2.44% of base) : 234402.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,bool):bool
         -16 (-2.31% of base) : 234384.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+S2[],int,ArrayMarshal+S2[]):bool
         -16 (-2.37% of base) : 234385.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+S2[],int,ArrayMarshal+S2[]):bool
         -16 (-1.84% of base) : 242734.dasm - ILStubClass:IL_STUB_PInvoke(byref,byref,byref):bool
          -8 (-1.50% of base) : 234368.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+S2[],int):bool
          -8 (-1.48% of base) : 234336.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+TestStruct[],int):bool
          -8 (-1.44% of base) : 234358.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+TestStruct[],int):bool
          -8 (-1.48% of base) : 234364.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+TestStruct[],int):bool
          -8 (-1.35% of base) : 224176.dasm - ILStubClass:IL_STUB_PInvoke(byref):bool
          -8 (-1.52% of base) : 224195.dasm - ILStubClass:IL_STUB_PInvoke(byref):bool
          -8 (-1.52% of base) : 224140.dasm - ILStubClass:IL_STUB_PInvoke(byref):bool
          -8 (-1.34% of base) : 224199.dasm - ILStubClass:IL_STUB_PInvoke(byref):bool

Top method regressions (percentages):
          16 (15.38% of base) : 256945.dasm - ShowLocallocAlignment.App:SnapLocallocBufferAddress1(int,int,int,int,int,int):long
          16 (15.38% of base) : 256946.dasm - ShowLocallocAlignment.App:SnapLocallocBufferAddress2(int,int,int,int,int,int):long
          12 (11.54% of base) : 97247.dasm - Test2A.TestClass:TestFunc2():int
          36 ( 5.45% of base) : 260300.dasm - JitTest.Test:Main():int
          12 ( 5.17% of base) : 88993.dasm - BringUpTest_LocallocCnstB117:LocallocCnstB117():int
          16 ( 4.44% of base) : 259740.dasm - BringUpTest_LocallocCnstB117_PSP:LocallocCnstB117_PSP():int
          12 ( 1.78% of base) : 227386.dasm - Vector256ArrayTest`1[Byte][System.Byte]:Vector256Array():int

Top method improvements (percentages):
          -4 (-3.23% of base) : 97248.dasm - Test2A.TestClass:TestFunc1():int
         -40 (-2.94% of base) : 234410.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,System.Object,System.Boolean[],int):bool
         -40 (-2.94% of base) : 234409.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,System.Object,System.Char[],int):bool
          -4 (-2.86% of base) : 69.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindCaseSensitivePrefix(System.Text.RegularExpressions.RegexNode):System.String
         -32 (-2.68% of base) : 234408.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,System.Object,System.SByte[],int):bool
         -24 (-2.47% of base) : 234399.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object):bool
         -24 (-2.44% of base) : 234398.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object):bool
         -24 (-2.44% of base) : 234397.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object):bool
         -24 (-2.44% of base) : 234402.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,bool):bool
         -24 (-2.41% of base) : 234401.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,bool):bool
         -24 (-2.41% of base) : 234400.dasm - ILStubClass:IL_STUB_PInvoke(System.Object,System.Object,System.Object,bool):bool
         -16 (-2.37% of base) : 234385.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+S2[],int,ArrayMarshal+S2[]):bool
         -16 (-2.31% of base) : 234384.dasm - ILStubClass:IL_STUB_PInvoke(ArrayMarshal+S2[],int,ArrayMarshal+S2[]):bool
         -16 (-1.84% of base) : 242734.dasm - ILStubClass:IL_STUB_PInvoke(byref,byref,byref):bool
          -8 (-1.63% of base) : 59.dasm - System.Text.RegularExpressions.RegexWriter:Write(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexCode
          -8 (-1.54% of base) : 224158.dasm - ILStubClass:IL_STUB_PInvoke(System.String[]):bool
          -8 (-1.53% of base) : 224159.dasm - ILStubClass:IL_STUB_PInvoke(byref):bool
          -8 (-1.53% of base) : 238314.dasm - ILStubClass:IL_STUB_PInvoke(System.Numerics.Vector3[]):float
          -8 (-1.53% of base) : 224174.dasm - ILStubClass:IL_STUB_PInvoke(System.String[]):bool
          -8 (-1.53% of base) : 224194.dasm - ILStubClass:IL_STUB_PInvoke(System.String[]):bool

103 total methods with Code Size differences (96 improved, 7 regressed), 20 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 45560808 (overridden on cmd)
Total bytes of diff: 45559728 (overridden on cmd)
Total bytes of delta: -1080 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          16 : 193559.dasm (1.93% of base)
          16 : 193562.dasm (0.54% of base)
          12 : 108646.dasm (0.27% of base)

Top file improvements (bytes):
         -24 : 55583.dasm (-0.99% of base)
         -20 : 197197.dasm (-0.87% of base)
         -16 : 197231.dasm (-0.87% of base)
         -16 : 197318.dasm (-0.91% of base)
         -16 : 197151.dasm (-1.13% of base)
         -16 : 197317.dasm (-0.91% of base)
         -16 : 197233.dasm (-0.88% of base)
         -12 : 197310.dasm (-0.55% of base)
         -12 : 73145.dasm (-2.50% of base)
         -12 : 197207.dasm (-0.71% of base)
         -12 : 64509.dasm (-5.26% of base)
         -12 : 64741.dasm (-4.11% of base)
         -12 : 69528.dasm (-1.33% of base)
         -12 : 69529.dasm (-1.11% of base)
         -12 : 69642.dasm (-3.66% of base)
         -12 : 69643.dasm (-4.11% of base)
         -12 : 197208.dasm (-0.72% of base)
         -12 : 69645.dasm (-3.06% of base)
         -12 : 69646.dasm (-3.33% of base)
         -12 : 158049.dasm (-1.52% of base)

159 total files with Code Size differences (156 improved, 3 regressed), 111 unchanged.

Top method regressions (bytes):
          16 ( 0.54% of base) : 193562.dasm - System.Security.Cryptography.PasswordBasedEncryption:Decrypt(byref,System.ReadOnlySpan`1[System.Char],System.ReadOnlySpan`1[System.Byte],System.ReadOnlySpan`1[System.Byte],System.Span`1[System.Byte]):int
          16 ( 1.93% of base) : 193559.dasm - System.Security.Cryptography.PasswordBasedEncryption:Pbes2Decrypt(System.Nullable`1[System.ReadOnlyMemory`1[System.Byte]],System.ReadOnlySpan`1[System.Char],System.ReadOnlySpan`1[System.Byte],System.ReadOnlySpan`1[System.Byte],System.Span`1[System.Byte]):int
          12 ( 0.27% of base) : 108646.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventSession:EnableProvider(System.Guid,int,long,Microsoft.Diagnostics.Tracing.Session.TraceEventProviderOptions):bool:this

Top method improvements (bytes):
         -24 (-0.99% of base) : 55583.dasm - System.IO.Enumeration.FileSystemName:MatchPattern(System.ReadOnlySpan`1[System.Char],System.ReadOnlySpan`1[System.Char],bool,bool):bool
         -20 (-0.87% of base) : 197197.dasm - System.Numerics.BigInteger:Multiply(System.ReadOnlySpan`1[System.UInt32],int,System.ReadOnlySpan`1[System.UInt32],int):System.Numerics.BigInteger
         -16 (-0.88% of base) : 197233.dasm - System.Numerics.BigInteger:Add(System.ReadOnlySpan`1[System.UInt32],int,System.ReadOnlySpan`1[System.UInt32],int):System.Numerics.BigInteger
         -16 (-0.87% of base) : 197231.dasm - System.Numerics.BigInteger:Subtract(System.ReadOnlySpan`1[System.UInt32],int,System.ReadOnlySpan`1[System.UInt32],int):System.Numerics.BigInteger
         -16 (-0.91% of base) : 197317.dasm - System.Numerics.BigIntegerCalculator:PowCore(System.Span`1[System.UInt32],int,int,System.ReadOnlySpan`1[System.UInt32],System.Span`1[System.UInt32],System.Span`1[System.UInt32])
         -16 (-0.91% of base) : 197318.dasm - System.Numerics.BigIntegerCalculator:PowCore(System.Span`1[System.UInt32],int,System.ReadOnlySpan`1[System.UInt32],System.ReadOnlySpan`1[System.UInt32],System.Span`1[System.UInt32],System.Span`1[System.UInt32])
         -16 (-1.13% of base) : 197151.dasm - System.Numerics.BigNumber:FormatBigIntegerToHex(bool,System.Numerics.BigInteger,ushort,int,System.Globalization.NumberFormatInfo,System.Span`1[System.Char],byref,byref):System.String
         -12 (-1.02% of base) : 180717.dasm - <>c:<OpenProcessor>b__15_0(System.Security.Cryptography.HashAlgorithmName):System.Security.Cryptography.RsaPaddingProcessor:this
         -12 (-1.23% of base) : 181438.dasm - NCrypt:DeriveKeyMaterial(Microsoft.Win32.SafeHandles.SafeNCryptSecretHandle,System.String,System.String,System.Byte[],System.Byte[],System.Byte[],int):System.Byte[]
         -12 (-5.26% of base) : 64509.dasm - System.Buffers.ArrayPoolEventSource:BufferRented(int,int,int,int):this
         -12 (-2.50% of base) : 73145.dasm - System.Environment:get_SystemDirectory():System.String
         -12 (-1.21% of base) : 73156.dasm - System.Environment:get_UserDomainName():System.String
         -12 (-2.44% of base) : 159084.dasm - System.Formats.Asn1.AsnDecoder:ReadGeneralizedTime(System.ReadOnlySpan`1[System.Byte],int,byref,System.Nullable`1[System.Formats.Asn1.Asn1Tag]):System.DateTimeOffset
         -12 (-4.11% of base) : 64741.dasm - System.Globalization.TimeSpanFormat:FormatC(System.TimeSpan):System.String
         -12 (-1.17% of base) : 55586.dasm - System.IO.Enumeration.FileSystemName:TranslateWin32Expression(System.String):System.String
         -12 (-1.52% of base) : 158049.dasm - System.Net.NameResolutionPal:TryGetNameInfo(System.Net.IPAddress,byref,byref):System.String
         -12 (-0.31% of base) : 152661.dasm - System.Net.Security.SafeDeleteContext:AcceptSecurityContext(byref,byref,int,int,System.Net.Security.InputSecurityBuffers,byref,byref):int
         -12 (-1.09% of base) : 69530.dasm - System.Number:<FormatInt32>g__FormatInt32Slow|40_0(int,int,System.String,System.IFormatProvider):System.String
         -12 (-1.37% of base) : 69526.dasm - System.Number:<FormatInt64>g__FormatInt64Slow|44_0(long,System.String,System.IFormatProvider):System.String
         -12 (-1.33% of base) : 69528.dasm - System.Number:<FormatUInt32>g__FormatUInt32Slow|42_0(int,System.String,System.IFormatProvider):System.String

Top method regressions (percentages):
          16 ( 1.93% of base) : 193559.dasm - System.Security.Cryptography.PasswordBasedEncryption:Pbes2Decrypt(System.Nullable`1[System.ReadOnlyMemory`1[System.Byte]],System.ReadOnlySpan`1[System.Char],System.ReadOnlySpan`1[System.Byte],System.ReadOnlySpan`1[System.Byte],System.Span`1[System.Byte]):int
          16 ( 0.54% of base) : 193562.dasm - System.Security.Cryptography.PasswordBasedEncryption:Decrypt(byref,System.ReadOnlySpan`1[System.Char],System.ReadOnlySpan`1[System.Byte],System.ReadOnlySpan`1[System.Byte],System.Span`1[System.Byte]):int
          12 ( 0.27% of base) : 108646.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventSession:EnableProvider(System.Guid,int,long,Microsoft.Diagnostics.Tracing.Session.TraceEventProviderOptions):bool:this

Top method improvements (percentages):
         -12 (-5.26% of base) : 64509.dasm - System.Buffers.ArrayPoolEventSource:BufferRented(int,int,int,int):this
         -12 (-4.11% of base) : 64741.dasm - System.Globalization.TimeSpanFormat:FormatC(System.TimeSpan):System.String
         -12 (-4.11% of base) : 69643.dasm - System.Number:FormatDouble(double,System.String,System.Globalization.NumberFormatInfo):System.String
         -12 (-4.11% of base) : 69636.dasm - System.Number:FormatHalf(System.Half,System.String,System.Globalization.NumberFormatInfo):System.String
         -12 (-4.11% of base) : 69639.dasm - System.Number:FormatSingle(float,System.String,System.Globalization.NumberFormatInfo):System.String
          -8 (-3.92% of base) : 54986.dasm - System.Diagnostics.Tracing.EventSource:WriteEvent(int,int,int,int):this
          -8 (-3.92% of base) : 54983.dasm - System.Diagnostics.Tracing.EventSource:WriteEvent(int,long,long,long):this
         -12 (-3.85% of base) : 161386.dasm - System.Security.Cryptography.SHA512CryptoServiceProvider:Initialize():this
         -12 (-3.75% of base) : 62350.dasm - System.Threading.Tasks.TplEventSource:TaskCompleted(int,int,int,bool):this
         -12 (-3.66% of base) : 69642.dasm - System.Number:TryFormatDouble(double,System.ReadOnlySpan`1[System.Char],System.Globalization.NumberFormatInfo,System.Span`1[System.Char],byref):bool
         -12 (-3.66% of base) : 69638.dasm - System.Number:TryFormatSingle(float,System.ReadOnlySpan`1[System.Char],System.Globalization.NumberFormatInfo,System.Span`1[System.Char],byref):bool
         -12 (-3.57% of base) : 69634.dasm - System.Number:TryFormatHalf(System.Half,System.ReadOnlySpan`1[System.Char],System.Globalization.NumberFormatInfo,System.Span`1[System.Char],byref):bool
         -12 (-3.33% of base) : 69646.dasm - System.Number:FormatDecimal(System.Decimal,System.ReadOnlySpan`1[System.Char],System.Globalization.NumberFormatInfo):System.String
          -8 (-3.08% of base) : 54978.dasm - System.Diagnostics.Tracing.EventSource:WriteEvent(int,System.String,int,int):this
          -8 (-3.08% of base) : 54746.dasm - System.Diagnostics.Tracing.FrameworkEventSource:WriteEvent(int,long,int,System.String):this
         -12 (-3.06% of base) : 69645.dasm - System.Number:TryFormatDecimal(System.Decimal,System.ReadOnlySpan`1[System.Char],System.Globalization.NumberFormatInfo,System.Span`1[System.Char],byref):bool
          -8 (-2.63% of base) : 62344.dasm - System.Threading.Tasks.TplEventSource:TraceOperationBegin(int,System.String,long):this
          -8 (-2.60% of base) : 161393.dasm - System.Security.Cryptography.SHA384CryptoServiceProvider:Initialize():this
         -12 (-2.50% of base) : 73145.dasm - System.Environment:get_SystemDirectory():System.String
         -12 (-2.44% of base) : 159084.dasm - System.Formats.Asn1.AsnDecoder:ReadGeneralizedTime(System.ReadOnlySpan`1[System.Byte],int,byref,System.Nullable`1[System.Formats.Asn1.Asn1Tag]):System.DateTimeOffset

159 total methods with Code Size differences (156 improved, 3 regressed), 111 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 52982220 (overridden on cmd)
Total bytes of diff: 52980812 (overridden on cmd)
Total bytes of delta: -1408 (-0.00 % of base)
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          28 : 85241.dasm (0.67% of base)
          16 : 201530.dasm (3.51% of base)
          16 : 221946.dasm (0.46% of base)
          16 : 221949.dasm (2.12% of base)
          16 : 154233.dasm (2.38% of base)
           8 : 154229.dasm (1.64% of base)
           4 : 201531.dasm (0.91% of base)

Top file improvements (bytes):
         -24 : 208916.dasm (-5.45% of base)
         -20 : 225908.dasm (-1.59% of base)
         -20 : 218710.dasm (-1.24% of base)
         -20 : 226441.dasm (-0.94% of base)
         -16 : 218734.dasm (-1.21% of base)
         -16 : 218822.dasm (-1.10% of base)
         -16 : 218624.dasm (-0.73% of base)
         -16 : 218701.dasm (-1.19% of base)
         -16 : 218623.dasm (-0.72% of base)
         -16 : 218736.dasm (-1.19% of base)
         -12 : 200629.dasm (-2.48% of base)
         -12 : 218631.dasm (-0.64% of base)
         -12 : 220189.dasm (-1.49% of base)
         -12 : 225516.dasm (-2.61% of base)
         -12 : 225567.dasm (-0.95% of base)
         -12 : 200626.dasm (-3.41% of base)
         -12 : 200847.dasm (-0.46% of base)
         -12 : 205108.dasm (-2.21% of base)
         -12 : 208942.dasm (-0.46% of base)
         -12 : 209177.dasm (-2.33% of base)

226 total files with Code Size differences (219 improved, 7 regressed), 84 unchanged.

Top method regressions (bytes):
          28 ( 0.67% of base) : 85241.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventSession:EnableProvider(System.Guid,int,long,Microsoft.Diagnostics.Tracing.Session.TraceEventProviderOptions):bool:this
          16 ( 2.38% of base) : 154233.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:MessageJson(int,int,System.String,int,System.String,System.String,System.String,System.String):this
          16 ( 3.51% of base) : 201530.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 0.46% of base) : 221946.dasm - System.Security.Cryptography.PasswordBasedEncryption:Decrypt(byref,System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.Span`1[Byte]):int
          16 ( 2.12% of base) : 221949.dasm - System.Security.Cryptography.PasswordBasedEncryption:Pbes2Decrypt(System.Nullable`1[ReadOnlyMemory`1],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.Span`1[Byte]):int
           8 ( 1.64% of base) : 154229.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:FormattedMessage(int,int,System.String,int,System.String,System.String):this
           4 ( 0.91% of base) : 201531.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,System.String,int,int,int):this

Top method improvements (bytes):
         -24 (-5.45% of base) : 208916.dasm - System.Net.Security.SslStreamPal:DecryptMessage(System.Net.Security.SafeDeleteSslContext,System.Span`1[Byte],byref,byref):System.Net.SecurityStatusPal
         -20 (-1.24% of base) : 218710.dasm - System.Numerics.BigInteger:Multiply(System.ReadOnlySpan`1[UInt32],int,System.ReadOnlySpan`1[UInt32],int):System.Numerics.BigInteger
         -20 (-0.94% of base) : 226441.dasm - System.Security.Cryptography.Pbkdf2Implementation:FillKeyDerivation(System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],int,System.String,System.Span`1[Byte])
         -20 (-1.59% of base) : 225908.dasm - System.Security.Cryptography.Rfc2898DeriveBytes:Func():this
         -16 (-1.21% of base) : 218734.dasm - System.Numerics.BigInteger:Add(System.ReadOnlySpan`1[UInt32],int,System.ReadOnlySpan`1[UInt32],int):System.Numerics.BigInteger
         -16 (-1.19% of base) : 218701.dasm - System.Numerics.BigInteger:op_ExclusiveOr(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -16 (-1.19% of base) : 218736.dasm - System.Numerics.BigInteger:Subtract(System.ReadOnlySpan`1[UInt32],int,System.ReadOnlySpan`1[UInt32],int):System.Numerics.BigInteger
         -16 (-0.73% of base) : 218624.dasm - System.Numerics.BigIntegerCalculator:PowCore(System.Span`1[UInt32],int,int,System.ReadOnlySpan`1[UInt32],System.Span`1[UInt32],System.Span`1[UInt32])
         -16 (-0.72% of base) : 218623.dasm - System.Numerics.BigIntegerCalculator:PowCore(System.Span`1[UInt32],int,System.ReadOnlySpan`1[UInt32],System.ReadOnlySpan`1[UInt32],System.Span`1[UInt32],System.Span`1[UInt32])
         -16 (-1.10% of base) : 218822.dasm - System.Numerics.BigNumber:FormatBigIntegerToHex(bool,System.Numerics.BigInteger,ushort,int,System.Globalization.NumberFormatInfo,System.Span`1[Char],byref,byref):System.String
         -12 (-1.25% of base) : 225054.dasm - <>c:<OpenProcessor>b__15_0(System.Security.Cryptography.HashAlgorithmName):System.Security.Cryptography.RsaPaddingProcessor:this
         -12 (-1.28% of base) : 220898.dasm - <>c:<OpenProcessor>b__15_0(System.Security.Cryptography.HashAlgorithmName):System.Security.Cryptography.RsaPaddingProcessor:this
         -12 (-1.49% of base) : 220189.dasm - NCrypt:DeriveKeyMaterial(Microsoft.Win32.SafeHandles.SafeNCryptSecretHandle,System.String,System.String,System.Byte[],System.Byte[],System.Byte[],int):System.Byte[]
         -12 (-1.49% of base) : 224634.dasm - NCrypt:DeriveKeyMaterial(Microsoft.Win32.SafeHandles.SafeNCryptSecretHandle,System.String,System.String,System.Byte[],System.Byte[],System.Byte[],int):System.Byte[]
         -12 (-3.09% of base) : 185807.dasm - System.Formats.Asn1.AsnDecoder:ReadGeneralizedTime(System.ReadOnlySpan`1[Byte],int,byref,System.Nullable`1[Asn1Tag]):System.DateTimeOffset
         -12 (-1.85% of base) : 206111.dasm - System.Net.NameResolutionPal:TryGetNameInfo(System.Net.IPAddress,byref,byref):System.String
         -12 (-3.41% of base) : 200626.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this
         -12 (-3.41% of base) : 205109.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this
         -12 (-3.41% of base) : 208299.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this
         -12 (-3.41% of base) : 202164.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this

Top method regressions (percentages):
          16 ( 3.51% of base) : 201530.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 2.38% of base) : 154233.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:MessageJson(int,int,System.String,int,System.String,System.String,System.String,System.String):this
          16 ( 2.12% of base) : 221949.dasm - System.Security.Cryptography.PasswordBasedEncryption:Pbes2Decrypt(System.Nullable`1[ReadOnlyMemory`1],System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.Span`1[Byte]):int
           8 ( 1.64% of base) : 154229.dasm - Microsoft.Extensions.Logging.EventSource.LoggingEventSource:FormattedMessage(int,int,System.String,int,System.String,System.String):this
           4 ( 0.91% of base) : 201531.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,System.String,int,int,int):this
          28 ( 0.67% of base) : 85241.dasm - Microsoft.Diagnostics.Tracing.Session.TraceEventSession:EnableProvider(System.Guid,int,long,Microsoft.Diagnostics.Tracing.Session.TraceEventProviderOptions):bool:this
          16 ( 0.46% of base) : 221946.dasm - System.Security.Cryptography.PasswordBasedEncryption:Decrypt(byref,System.ReadOnlySpan`1[Char],System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.Span`1[Byte]):int

Top method improvements (percentages):
         -12 (-6.12% of base) : 221259.dasm - System.Security.Cryptography.SHA512CryptoServiceProvider:Initialize():this
         -24 (-5.45% of base) : 208916.dasm - System.Net.Security.SslStreamPal:DecryptMessage(System.Net.Security.SafeDeleteSslContext,System.Span`1[Byte],byref,byref):System.Net.SecurityStatusPal
         -12 (-4.23% of base) : 237896.dasm - System.Threading.Tasks.ParallelEtwProvider:ParallelLoopEnd(int,int,int,long):this
          -8 (-4.17% of base) : 221252.dasm - System.Security.Cryptography.SHA384CryptoServiceProvider:Initialize():this
          -8 (-4.08% of base) : 202745.dasm - System.Net.Http.HttpTelemetry:WriteEvent(int,double,ubyte,ubyte):this
         -12 (-3.41% of base) : 200626.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this
         -12 (-3.41% of base) : 205109.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this
         -12 (-3.41% of base) : 208299.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this
         -12 (-3.41% of base) : 202164.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int):this
          -8 (-3.12% of base) : 208529.dasm - System.Net.Security.NetSecurityTelemetry:WriteEvent(int,bool,double,System.String):this
         -12 (-3.09% of base) : 185807.dasm - System.Formats.Asn1.AsnDecoder:ReadGeneralizedTime(System.ReadOnlySpan`1[Byte],int,byref,System.Nullable`1[Asn1Tag]):System.DateTimeOffset
          -4 (-2.86% of base) : 69.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindCaseSensitivePrefix(System.Text.RegularExpressions.RegexNode):System.String
         -12 (-2.68% of base) : 210521.dasm - System.Net.WebSockets.WebSocketHandle:CreateSecKeyAndSecWebSocketAccept():System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -12 (-2.61% of base) : 225516.dasm - System.Security.Cryptography.ECDsa:VerifyDataCore(System.ReadOnlySpan`1[Byte],System.ReadOnlySpan`1[Byte],System.Security.Cryptography.HashAlgorithmName,int):bool:this
         -12 (-2.48% of base) : 200629.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,System.String,System.String,int):this
         -12 (-2.48% of base) : 202167.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,System.String,System.String,int):this
         -12 (-2.48% of base) : 205112.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,System.String,System.String,int):this
         -12 (-2.48% of base) : 208302.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,System.String,System.String,int):this
          -4 (-2.44% of base) : 202746.dasm - System.Net.Http.HttpTelemetry:WriteEvent(int,ubyte,ubyte):this
         -12 (-2.33% of base) : 209177.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,System.String,System.Byte[]):this

226 total methods with Code Size differences (219 improved, 7 regressed), 84 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 118249828 (overridden on cmd)
Total bytes of diff: 118250192 (overridden on cmd)
Total bytes of delta: 364 (0.00 % of base)
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          16 : 327271.dasm (1.40% of base)
          16 : 297449.dasm (3.51% of base)
          16 : 327299.dasm (3.03% of base)
          16 : 290685.dasm (3.51% of base)
          16 : 58443.dasm (3.51% of base)
          16 : 170650.dasm (3.92% of base)
          16 : 291922.dasm (3.51% of base)
          16 : 304605.dasm (2.94% of base)
          16 : 327329.dasm (3.20% of base)
          16 : 172680.dasm (3.51% of base)
          16 : 293773.dasm (3.51% of base)
          16 : 179073.dasm (3.51% of base)
          16 : 289330.dasm (3.51% of base)
          16 : 218507.dasm (5.33% of base)
          16 : 304604.dasm (1.72% of base)
          16 : 327266.dasm (3.01% of base)
          16 : 327267.dasm (4.40% of base)
          16 : 218554.dasm (3.51% of base)
          16 : 192989.dasm (0.80% of base)
          16 : 327297.dasm (10.53% of base)

Top file improvements (bytes):
          -8 : 59.dasm (-1.63% of base)
          -4 : 24.dasm (-0.76% of base)
          -4 : 69.dasm (-2.86% of base)
          -4 : 88.dasm (-1.06% of base)
          -4 : 133821.dasm (-0.66% of base)
          -4 : 92.dasm (-0.20% of base)
          -4 : 219327.dasm (-1.14% of base)

40 total files with Code Size differences (7 improved, 33 regressed), 131 unchanged.

Top method regressions (bytes):
          16 ( 1.22% of base) : 170647.dasm - System.Buffers.Text.Tests.RealFormatterTests:InvariantToStringSingle(float,System.String):System.String:this
          16 ( 3.92% of base) : 170650.dasm - System.Buffers.Text.Tests.RealParserTests:InvariantToStringSingle(float):System.String:this
          16 ( 3.51% of base) : 297449.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 290685.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 58443.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 291922.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 172680.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 293773.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 179073.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 289330.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 218554.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 0.80% of base) : 192989.dasm - System.Security.Cryptography.Tests.HashAlgorithmTestDriver:Verify_OneShot(System.Byte[],System.String):this
          16 ( 1.85% of base) : 327104.dasm - System.Text.RegularExpressions.RegexCharClass:MakeCaseSensitiveIfPossible(System.String,System.Globalization.CultureInfo):System.String
          16 ( 3.01% of base) : 327266.dasm - System.Text.RegularExpressions.RegexParser:Parse(System.String,int,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexTree
          16 ( 4.40% of base) : 327267.dasm - System.Text.RegularExpressions.RegexParser:ParseReplacement(System.String,int,System.Collections.Hashtable,int,System.Collections.Hashtable):System.Text.RegularExpressions.RegexReplacement
          16 ( 1.40% of base) : 327271.dasm - System.Text.RegularExpressions.RegexParser:UnescapeImpl(System.String,int):System.String
          16 (10.53% of base) : 327297.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindCaseSensitivePrefix(System.Text.RegularExpressions.RegexNode):System.String
          16 ( 3.03% of base) : 327299.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindFirstCharClass(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Nullable`1[[System.ValueTuple`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Boolean, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
          16 ( 3.20% of base) : 327329.dasm - System.Text.RegularExpressions.RegexWriter:Write(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexCode
          16 ( 5.33% of base) : 218507.dasm - System.Text.Tests.ValueStringBuilderTests:EnsureCapacity_NoAllocIfNotNeeded():this

Top method improvements (bytes):
          -8 (-1.63% of base) : 59.dasm - System.Text.RegularExpressions.RegexWriter:Write(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexCode
          -4 (-1.14% of base) : 219327.dasm - DllImportGenerator.IntegrationTests.NativeExportsNE:ReturnStringLength(System.String):int
          -4 (-0.66% of base) : 133821.dasm - ILStubClass:IL_STUB_PInvoke(long,System.Guid,WINTRUST_DATA):int
          -4 (-0.76% of base) : 24.dasm - System.Text.RegularExpressions.RegexParser:Parse(System.String,int,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexTree
          -4 (-1.06% of base) : 88.dasm - System.Text.RegularExpressions.RegexParser:ParseReplacement(System.String,int,System.Collections.Hashtable,int,System.Collections.Hashtable):System.Text.RegularExpressions.RegexReplacement
          -4 (-2.86% of base) : 69.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindCaseSensitivePrefix(System.Text.RegularExpressions.RegexNode):System.String
          -4 (-0.20% of base) : 92.dasm - System.Text.RegularExpressions.RegexReplacement:.ctor(System.String,System.Text.RegularExpressions.RegexNode,System.Collections.Hashtable):this

Top method regressions (percentages):
          16 (10.53% of base) : 327297.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindCaseSensitivePrefix(System.Text.RegularExpressions.RegexNode):System.String
          16 ( 5.33% of base) : 218507.dasm - System.Text.Tests.ValueStringBuilderTests:EnsureCapacity_NoAllocIfNotNeeded():this
          16 ( 4.40% of base) : 327267.dasm - System.Text.RegularExpressions.RegexParser:ParseReplacement(System.String,int,System.Collections.Hashtable,int,System.Collections.Hashtable):System.Text.RegularExpressions.RegexReplacement
          16 ( 3.92% of base) : 170650.dasm - System.Buffers.Text.Tests.RealParserTests:InvariantToStringSingle(float):System.String:this
          16 ( 3.51% of base) : 297449.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 290685.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 58443.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 291922.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 172680.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 293773.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 179073.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 289330.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.51% of base) : 218554.dasm - System.Net.NetEventSource:WriteEvent(int,System.String,int,int,int,int,int,int,int):this
          16 ( 3.20% of base) : 327329.dasm - System.Text.RegularExpressions.RegexWriter:Write(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexCode
          16 ( 3.03% of base) : 327299.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindFirstCharClass(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Nullable`1[[System.ValueTuple`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Boolean, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
          16 ( 3.01% of base) : 327266.dasm - System.Text.RegularExpressions.RegexParser:Parse(System.String,int,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexTree
          16 ( 2.94% of base) : 304605.dasm - System.UriHelper:EscapeString(System.ReadOnlySpan`1[Char],byref,bool,ushort,ushort)
          16 ( 1.85% of base) : 327104.dasm - System.Text.RegularExpressions.RegexCharClass:MakeCaseSensitiveIfPossible(System.String,System.Globalization.CultureInfo):System.String
          16 ( 1.72% of base) : 304604.dasm - System.UriHelper:EscapeString(System.String,bool,System.ReadOnlySpan`1[Boolean],ushort,ushort):System.String
          16 ( 1.40% of base) : 327271.dasm - System.Text.RegularExpressions.RegexParser:UnescapeImpl(System.String,int):System.String

Top method improvements (percentages):
          -4 (-2.86% of base) : 69.dasm - System.Text.RegularExpressions.RegexPrefixAnalyzer:FindCaseSensitivePrefix(System.Text.RegularExpressions.RegexNode):System.String
          -8 (-1.63% of base) : 59.dasm - System.Text.RegularExpressions.RegexWriter:Write(System.Text.RegularExpressions.RegexTree,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexCode
          -4 (-1.14% of base) : 219327.dasm - DllImportGenerator.IntegrationTests.NativeExportsNE:ReturnStringLength(System.String):int
          -4 (-1.06% of base) : 88.dasm - System.Text.RegularExpressions.RegexParser:ParseReplacement(System.String,int,System.Collections.Hashtable,int,System.Collections.Hashtable):System.Text.RegularExpressions.RegexReplacement
          -4 (-0.76% of base) : 24.dasm - System.Text.RegularExpressions.RegexParser:Parse(System.String,int,System.Globalization.CultureInfo):System.Text.RegularExpressions.RegexTree
          -4 (-0.66% of base) : 133821.dasm - ILStubClass:IL_STUB_PInvoke(long,System.Guid,WINTRUST_DATA):int
          -4 (-0.20% of base) : 92.dasm - System.Text.RegularExpressions.RegexReplacement:.ctor(System.String,System.Text.RegularExpressions.RegexNode,System.Collections.Hashtable):this

40 total methods with Code Size differences (7 improved, 33 regressed), 131 unchanged.

```

</details>

--------------------------------------------------------------------------------

