### PR TITLE
Remove command-line arguments from Main methods in ILPROJ projects

### DIFF
--- a/src/tests/JIT/Methodical/eh/basics/emptyfinally.il
+++ b/src/tests/JIT/Methodical/eh/basics/emptyfinally.il
@@ -48,7 +48,7 @@
 
 
     .method public hidebysig static int32
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/basics/tryfinallywith2endfinally.il
+++ b/src/tests/JIT/Methodical/eh/basics/tryfinallywith2endfinally.il
@@ -38,7 +38,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/basics/tryfinallywith2reachableendfinally.il
+++ b/src/tests/JIT/Methodical/eh/basics/tryfinallywith2reachableendfinally.il
@@ -44,7 +44,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadcodeincatch.il
@@ -113,7 +113,7 @@
     } // end of method Class1::inFinally
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet.il
@@ -66,7 +66,7 @@
          extends [mscorlib]System.Object
   {
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/finallyexec/catchrettoinnertry.il
+++ b/src/tests/JIT/Methodical/eh/finallyexec/catchrettoinnertry.il
@@ -66,7 +66,7 @@
       		ret
     } 
      .method private hidebysig static int32 
-             Main(string[] args) cil managed
+             Main() cil managed
      {
        .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
            01 00 00 00

--- a/src/tests/JIT/Methodical/eh/finallyexec/nonlocalexittonestedsibling.il
+++ b/src/tests/JIT/Methodical/eh/finallyexec/nonlocalexittonestedsibling.il
@@ -56,7 +56,7 @@
     } 
     
      .method public hidebysig static int32 
-             Main(string[] args) cil managed
+             Main() cil managed
      {
        .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
            01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/2branchesoutoftry.il
+++ b/src/tests/JIT/Methodical/eh/leaves/2branchesoutoftry.il
@@ -38,7 +38,7 @@
          extends [mscorlib]System.Object
   {
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/backwardleaveincatch.il
+++ b/src/tests/JIT/Methodical/eh/leaves/backwardleaveincatch.il
@@ -75,7 +75,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/branchbackwardswithcatch.il
+++ b/src/tests/JIT/Methodical/eh/leaves/branchbackwardswithcatch.il
@@ -74,7 +74,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/branchbackwardswithfinally.il
+++ b/src/tests/JIT/Methodical/eh/leaves/branchbackwardswithfinally.il
@@ -74,7 +74,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/branchoutofnestedtryfinally.il
+++ b/src/tests/JIT/Methodical/eh/leaves/branchoutofnestedtryfinally.il
@@ -83,7 +83,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/branchoutoftryfinally.il
+++ b/src/tests/JIT/Methodical/eh/leaves/branchoutoftryfinally.il
@@ -39,7 +39,7 @@
          extends [mscorlib]System.Object
   {
     .method public hidebysig static int32
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/forwardleaveincatch.il
+++ b/src/tests/JIT/Methodical/eh/leaves/forwardleaveincatch.il
@@ -74,7 +74,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/leaveinsameregion.il
+++ b/src/tests/JIT/Methodical/eh/leaves/leaveinsameregion.il
@@ -63,7 +63,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/leaveintotrybody.il
+++ b/src/tests/JIT/Methodical/eh/leaves/leaveintotrybody.il
@@ -55,7 +55,7 @@
     } 
 
     .method public hidebysig static int32
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/leaves/tryfinallyintrycatchwithleaveintotry.il
+++ b/src/tests/JIT/Methodical/eh/leaves/tryfinallyintrycatchwithleaveintotry.il
@@ -56,7 +56,7 @@
     } 
 
     .method public hidebysig static int32
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/mixedhandler/catchfiltercatch.il
+++ b/src/tests/JIT/Methodical/eh/mixedhandler/catchfiltercatch.il
@@ -54,7 +54,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/mixedhandler/filterfiltercatchcatch.il
+++ b/src/tests/JIT/Methodical/eh/mixedhandler/filterfiltercatchcatch.il
@@ -54,7 +54,7 @@
     } 
 
     .method public hidebysig static int32
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/eh/rethrow/rethrowinfinallyinsidecatch.il
+++ b/src/tests/JIT/Methodical/eh/rethrow/rethrowinfinallyinsidecatch.il
@@ -54,7 +54,7 @@
     } 
 
     .method public hidebysig static int32 
-            Main(string[] args) cil managed
+            Main() cil managed
     {
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00

--- a/src/tests/JIT/Methodical/flowgraph/bug619534/twoEndFinallys.il
+++ b/src/tests/JIT/Methodical/flowgraph/bug619534/twoEndFinallys.il
@@ -50,7 +50,7 @@
   } // end of method Test::.ctor
 
   .method private hidebysig static int32 
-          Main(string[] args) cil managed
+          Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
@@ -59,7 +59,8 @@
     // Code size       23 (0x17)
     .maxstack  2
     .locals init (class Test_twoEndFinallys V_0)
-    IL_0000:  ldarg.0
+              ldc.i4.s   0
+    IL_0000:  newarr     [mscorlib]System.String
     IL_0001:  call       class Test_twoEndFinallys Test_twoEndFinallys::TwoEndFinallys(string[])
     IL_0006:  stloc.0
     IL_0007:  ldloc.0

--- a/src/tests/JIT/Methodical/inlining/dev10_bug719093/variancesmall.il
+++ b/src/tests/JIT/Methodical/inlining/dev10_bug719093/variancesmall.il
@@ -290,7 +290,7 @@
   } 
 
   .method private hidebysig static int32 
-          Main(string[] args) cil managed
+          Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00

--- a/src/tests/JIT/Methodical/nonvirtualcall/classic.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/classic.il
@@ -681,7 +681,7 @@
     IL_000e:  ret
   } // end of method Program::CallFromInsideGrandChild
 
-  .method public hidebysig static int32  Main(string[] args) cil managed
+  .method public hidebysig static int32  Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00

--- a/src/tests/JIT/Methodical/nonvirtualcall/delegate.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/delegate.il
@@ -566,7 +566,7 @@
     IL_007f:  ret
   } // end of method Program::CallDelegateFromGrandChild
 
-  .method public hidebysig static int32  Main(string[] args) cil managed
+  .method public hidebysig static int32  Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00

--- a/src/tests/JIT/Methodical/nonvirtualcall/generics.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/generics.il
@@ -693,7 +693,7 @@
     IL_000e:  ret
   } // end of method Program::CallFromInsideGrandChild
 
-  .method public hidebysig static int32  Main(string[] args) cil managed
+  .method public hidebysig static int32  Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00

--- a/src/tests/JIT/Methodical/nonvirtualcall/generics2.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/generics2.il
@@ -728,7 +728,7 @@
     IL_000e:  ret
   } // end of method Program::CallFromInsideGrandChild
 
-  .method public hidebysig static int32  Main(string[] args) cil managed
+  .method public hidebysig static int32  Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00

--- a/src/tests/JIT/Methodical/nonvirtualcall/tailcall.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/tailcall.il
@@ -601,7 +601,7 @@
     IL_000e:  ret
   } // end of method Program::CallFromInsideGrandChild
 
-  .method public hidebysig static int32  Main(string[] args) cil managed
+  .method public hidebysig static int32  Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00

--- a/src/tests/JIT/Methodical/nonvirtualcall/valuetype.il
+++ b/src/tests/JIT/Methodical/nonvirtualcall/valuetype.il
@@ -114,7 +114,7 @@
     IL_0037:  ret
   } // end of method Program::CallDummy
 
-  .method public hidebysig static int32  Main(string[] args) cil managed
+  .method public hidebysig static int32  Main() cil managed
   {
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00


### PR DESCRIPTION
In my recent change I fixed C# test projects to stop using
command-line arguments. This follow-up change complements it by
applying the same transformation to IL projects. In most cases
the arguments were ignored so the transformation was trivial; in
the special case of twoEndFinallys.il the argument array is
passed to the method TwoEndFinallys so I patched it to allocate
a zero-sized string array instead (there are no tests passing
actual command-line arguments to the test app).

Thanks

Tomas

/cc @dotnet/jit-contrib 