### PR TITLE
Use const enums in typescript since regular enums generate extremely bad code

### DIFF
--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -195,7 +195,7 @@ export function assert(condition: unknown, messsage: string): asserts condition 
 }
 
 // see src/mono/wasm/driver.c MARSHAL_TYPE_xxx and Runtime.cs MarshalType
-export enum MarshalType {
+export const enum MarshalType {
     NULL = 0,
     INT = 1,
     FP64 = 2,
@@ -230,7 +230,7 @@ export enum MarshalType {
 }
 
 // see src/mono/wasm/driver.c MARSHAL_ERROR_xxx and Runtime.cs
-export enum MarshalError {
+export const enum MarshalError {
     BUFFER_TOO_SMALL = 512,
     NULL_CLASS_POINTER = 513,
     NULL_TYPE_POINTER = 514,


### PR DESCRIPTION
To get good behavior in typescript, your enums need to be 'const enum', otherwise it generates some really gross JS with runtime overhead. I didn't know this (thanks to @pavelsavara for the tip)