### PR TITLE
Fix UnobservedTaskException on Http2's SendPingAsync

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -2038,7 +2038,7 @@ namespace System.Net.Http
                         _keepAlivePingTimeoutTimestamp = now + _keepAlivePingTimeout;
 
                         long pingPayload = Interlocked.Increment(ref _keepAlivePingPayload);
-                        SendPingAsync(pingPayload);
+                        LogExceptions(SendPingAsync(pingPayload));
                         return;
                     }
                     break;


### PR DESCRIPTION
### Description

Fix #64450

Wrap the SendPingAsync function with LogExceptions in Http2Connection.cs
to avoid any exception here being caught as an UnobservedTaskException.

