### PR TITLE
Add support for `TYP_BYREF` `LCL_FLD`s to VN

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17806,15 +17806,6 @@ void Compiler::fgAddFieldSeqForZeroOffset(GenTree* addr, FieldSeqNode* fieldSeqZ
             fieldSeqRecorded             = true;
             break;
 
-        case GT_LCL_FLD:
-        {
-            GenTreeLclFld* lclFld = addr->AsLclFld();
-            fieldSeqUpdate        = GetFieldSeqStore()->Append(lclFld->GetFieldSeq(), fieldSeqZero);
-            lclFld->SetFieldSeq(fieldSeqUpdate);
-            fieldSeqRecorded = true;
-            break;
-        }
-
         case GT_ADDR:
             if (addr->AsOp()->gtOp1->OperGet() == GT_LCL_FLD)
             {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12591,28 +12591,20 @@ DONE_MORPHING_CHILDREN:
                         lclFld->SetLclOffs(lclFld->GetLclOffs() + static_cast<unsigned>(ival1));
                         lclFld->SetFieldSeq(GetFieldSeqStore()->Append(lclFld->GetFieldSeq(), fieldSeq));
                     }
-                    else // we have a GT_LCL_VAR
+                    else // We have a GT_LCL_VAR.
                     {
                         assert(temp->OperGet() == GT_LCL_VAR);
-                        temp->ChangeOper(GT_LCL_FLD); // Note that this typically makes the gtFieldSeq "NotAField",
-                        // unless there is a zero filed offset associated with 'temp'.
+                        temp->ChangeOper(GT_LCL_FLD); // Note that this makes the gtFieldSeq "NotAField".
                         lclFld = temp->AsLclFld();
                         lclFld->SetLclOffs(static_cast<unsigned>(ival1));
 
-                        if (lclFld->GetFieldSeq() == FieldSeqStore::NotAField())
+                        if (fieldSeq != nullptr)
                         {
-                            if (fieldSeq != nullptr)
-                            {
-                                // If it does represent a field, note that.
-                                lclFld->SetFieldSeq(fieldSeq);
-                            }
-                        }
-                        else
-                        {
-                            // Append 'fieldSeq' to the existing one
-                            lclFld->SetFieldSeq(GetFieldSeqStore()->Append(lclFld->GetFieldSeq(), fieldSeq));
+                            // If it does represent a field, note that.
+                            lclFld->SetFieldSeq(fieldSeq);
                         }
                     }
+
                     temp->gtType      = tree->gtType;
                     foldAndReturnTemp = true;
                 }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8449,6 +8449,17 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                     {
                         ValueNumPair lclVNPair = varDsc->GetPerSsaData(ssaNum)->m_vnPair;
                         tree->gtVNPair = vnStore->VNPairApplySelectors(lclVNPair, lclFld->GetFieldSeq(), indType);
+
+                        // If we have byref field, we may have a zero-offset sequence to add.
+                        FieldSeqNode* zeroOffsetFldSeq = nullptr;
+                        if ((typ == TYP_BYREF) && GetZeroOffsetFieldMap()->Lookup(lclFld, &zeroOffsetFldSeq))
+                        {
+                            ValueNum addrExtended = vnStore->ExtendPtrVN(lclFld, zeroOffsetFldSeq);
+                            if (addrExtended != ValueNumStore::NoVN)
+                            {
+                                lclFld->gtVNPair.SetBoth(addrExtended);
+                            }
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
First, the code in `fgAddFieldSeqForZeroOffset` that was adding zero-offset sequence to `LCL_FLD` directly was incorrect, because `fgAddFieldSeqForZeroOffset` adds a sequence for the address that the passed-in node represents, while adding a field sequence to `LCL_FLD` directly means adding it to the "implicit" `LCL_FLD_ADDR` it indirects. One can reproduce this issue via code like the following (with `JitNoStructPromotion=1`):
```cs
private static int Problem(StructWithRawFldPtr p)
{
    return ((StructWithIndex*)p.RawFldPtr)->Index;
}

struct StructWithRawFldPtr
{
    public nint RawFldPtr;
}

struct StructWithIndex
{
    public int Index;
    public int Value;
}
```
```scala
LCL_FLD   long   V00 arg0         u:1[+0] Fseq[RawFldPtr, Index] (last use)
```
The first two commits fix this issue, in `fgAddFieldSeqForZeroOffset` and similar code in `ChangeOper` and we now get the lovely combination of `LCL_FLD` + zero-offset sequence in the map.
```scala
LCL_FLD   long   V00 arg0         u:1[+0] Fseq[RawFldPtr] (last use) Zero Fseq[Index]
```
That opens a possibility for another bug of course: partial sequences, that is cases where we will have `ADD((LCL_FLD PtrToStatic [Zero FldSeq]), OFFSET FldSeq)` and fail to incorporate the `Zero FldSeq` into the `PtrToStatic`'s VN. This is fixed in the third commit.

Part of #58312.
Contributes to #63768.

[No diffs](https://dev.azure.com/dnceng/public/_build/results?buildId=1580735&view=ms.vss-build-web.run-extensions-tab) as expected.