### PR TITLE
[Jit] Delete Statement::m_compilerAdded .

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -6420,7 +6420,6 @@ public:
         , m_lastILOffset(BAD_IL_OFFSET)
         , m_stmtID(stmtID)
 #endif
-        , m_compilerAdded(false)
     {
     }
 
@@ -6507,16 +6506,6 @@ public:
         m_prev = prevStmt;
     }
 
-    bool IsCompilerAdded() const
-    {
-        return m_compilerAdded;
-    }
-
-    void SetCompilerAdded()
-    {
-        m_compilerAdded = true;
-    }
-
     bool IsPhiDefnStmt() const
     {
         return m_rootNode->IsPhiDefn();
@@ -6553,8 +6542,6 @@ private:
     IL_OFFSET m_lastILOffset; // The instr offset at the end of this statement.
     unsigned  m_stmtID;
 #endif
-
-    bool m_compilerAdded; // Was the statement created by optimizer?
 };
 
 // StatementList: adapter class for forward iteration of the statement linked list using range-based `for`,

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1159,7 +1159,7 @@ bool Compiler::optExtractInitTestIncr(
     noway_assert(initStmt != nullptr && (initStmt->GetNextStmt() == nullptr));
 
     // If it is a duplicated loop condition, skip it.
-    if (initStmt->IsCompilerAdded())
+    if (initStmt->GetRootNode()->OperIs(GT_JTRUE))
     {
         bool doGetPrev = true;
 #ifdef DEBUG
@@ -3771,10 +3771,9 @@ PhaseStatus Compiler::optUnrollLoops()
         Statement* incrStmt = testStmt->GetPrevStmt();
         noway_assert(incrStmt != nullptr);
 
-        if (initStmt->IsCompilerAdded())
+        if (initStmt->GetRootNode()->OperIs(GT_JTRUE))
         {
             // Must be a duplicated loop condition.
-            noway_assert(initStmt->GetRootNode()->gtOper == GT_JTRUE);
 
             dupCond  = true;
             initStmt = initStmt->GetPrevStmt();
@@ -4601,8 +4600,6 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
         {
             clonedStmt->SetDebugInfo(stmt->GetDebugInfo());
         }
-
-        clonedStmt->SetCompilerAdded();
     }
 
     assert(foundCondTree);
@@ -5835,12 +5832,9 @@ void Compiler::optPerformHoistExpr(GenTree* origExpr, BasicBlock* exprBb, unsign
     preHead->bbFlags |= (exprBb->bbFlags & (BBF_HAS_IDX_LEN | BBF_HAS_NULLCHECK));
 
     Statement* hoistStmt = gtNewStmt(hoist);
-    hoistStmt->SetCompilerAdded();
 
-    /* simply append the statement at the end of the preHead's list */
-
+    // Simply append the statement at the end of the preHead's list.
     Statement* firstStmt = preHead->firstStmt();
-
     if (firstStmt != nullptr)
     {
         /* append after last statement */


### PR DESCRIPTION
Delete `Statement::m_compilerAdded` field to save some memory during compilation:
```diff
--class Statement	size(56):
++class Statement	size(48):
	+---
 0	| m_rootNode
 8	| m_treeList
16	| m_next
24	| m_prev
32	| DebugInfo m_debugInfo
--48	| m_compilerAdded
--  	| <alignment member> (size=7)
```

and size on crossgen2 SPC:
```diff
--alloc size :   2035068447 (avg   71183 per method)
++alloc size :   2031246799 (avg   71049 per method)
```
around 0.2% improvement.

no diffs with jit-diff, no diff with spmi, but there are some missing data failures, because in the past we:
1. did not mark some compiler added as compiler added;
2. did not recognize natural loops with both pre-condition and post-condition.

<details>
  <summary>SPMI example</summary>

```
****** START compiling Lookup`2:System.Linq.IIListProvider<System.Linq.IGrouping<TKey,TElement>>.ToArray():ref:this (MethodHash=aa8d7d85)
IL_000f  7b e7 03 00 0a    ldfld        0xA0003E7
IL_0014  0c                stloc.2
IL_0015  08                ldloc.2
IL_0016  2c 18             brfalse.s    24 (IL_0030) <- pre loop check
IL_0018  08                ldloc.2
IL_0019  7b e8 03 00 0a    ldfld        0xA0003E8
IL_001e  0c                stloc.2
IL_001f  06                ldloc.0
IL_0020  07                ldloc.1
IL_0021  08                ldloc.2
IL_0022  a2                stelem.ref
IL_0023  07                ldloc.1
IL_0024  17                ldc.i4.1
IL_0025  58                add
IL_0026  0b                stloc.1
IL_0027  08                ldloc.2
IL_0028  02                ldarg.0
IL_0029  7b e7 03 00 0a    ldfld        0xA0003E7
IL_002e  33 e8             bne.un.s     -24 (IL_0018) <- post loop check

***** BB01
STMT00003 ( 0x015[E-] ... 0x016 )
               [000019] ------------              *  JTRUE     void
               [000018] ------------              \--*  EQ        int
               [000016] ------------                 +--*  LCL_VAR   ref    V03 loc2
               [000017] ------------                 \--*  CNS_INT   ref    null

------------ BB02 [018..030) -> BB02 (cond), preds={} succs={BB03,BB02}

***** BB02
STMT00005 ( 0x018[E-] ... 0x01E )
               [000025] -A-XG-------              *  ASG       ref
               [000024] D------N----              +--*  LCL_VAR   ref    V03 loc2
               [000023] ---XG-------              \--*  FIELD     ref    hackishFieldName
               [000022] ------------                 \--*  LCL_VAR   ref    V03 loc2

***** BB02
STMT00006 ( 0x01F[E-] ... 0x022 )
               [000029] --CXG-------              *  CALL help void   HELPER.CORINFO_HELP_ARRADDR_ST
               [000026] ------------ arg0         +--*  LCL_VAR   ref    V01 loc0
               [000027] ------------ arg1         +--*  LCL_VAR   int    V02 loc1
               [000028] ------------ arg2         \--*  LCL_VAR   ref    V03 loc2

***** BB02
STMT00007 ( 0x023[E-] ... 0x026 )
               [000034] -A----------              *  ASG       int
               [000033] D------N----              +--*  LCL_VAR   int    V02 loc1
               [000032] ------------              \--*  ADD       int
               [000030] ------------                 +--*  LCL_VAR   int    V02 loc1
               [000031] ------------                 \--*  CNS_INT   int    1

***** BB02
STMT00008 ( 0x027[E-] ... 0x02E )
               [000039] ---XG-------              *  JTRUE     void
               [000038] N--XG----U--              \--*  NE        int
               [000035] ------------                 +--*  LCL_VAR   ref    V03 loc2
               [000037] ---XG-------                 \--*  FIELD     ref    hackishFieldName
               [000036] ------------                    \--*  LCL_VAR   ref    V00 this
```

</details>
and now we recognize such examples and determine the correct init stmt, still no diffs.
