### PR TITLE
Optimize path check to skip to if statement if result is false.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -14,18 +14,10 @@ namespace System.IO
         public static char[] GetInvalidPathChars() => new char[] { '\0' };
 
         // Checks if the given path is available for use.
-        private static bool ExistsCore(string fullPath)
+        private static bool ExistsCore(string fullPath, out bool isDirectory)
         {
             bool result = Interop.Sys.LStat(fullPath, out Interop.Sys.FileStatus fileInfo) == Interop.Errors.ERROR_SUCCESS;
-
-            if (result && PathInternal.IsDirectorySeparator(fullPath[fullPath.Length - 1]))
-            {
-                // If the path ends with trailing slash, we want to make sure it's a directory.
-                // Although Lstat returns the correct result on desktop platforms,
-                // on browser WASM, it seems to strip trailing slash, leading to false positives for files.
-                // This check prevents it from doing so.
-                result = (fileInfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
-            }
+            isDirectory = result && (fileInfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -17,13 +17,14 @@ namespace System.IO
         private static bool ExistsCore(string fullPath)
         {
             bool result = Interop.Sys.LStat(fullPath, out Interop.Sys.FileStatus fileInfo) == Interop.Errors.ERROR_SUCCESS;
-            if (PathInternal.IsDirectorySeparator(fullPath[fullPath.Length - 1]))
+
+            if (result && PathInternal.IsDirectorySeparator(fullPath[fullPath.Length - 1]))
             {
                 // If the path ends with trailing slash, we want to make sure it's a directory.
                 // Although Lstat returns the correct result on desktop platforms,
                 // on browser WASM, it seems to strip trailing slash, leading to false positives for files.
                 // This check prevents it from doing so.
-                result = result && (fileInfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
+                result = (fileInfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR;
             }
 
             return result;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -33,12 +33,12 @@ namespace System.IO
             int errorCode = FileSystem.FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
             bool result = (errorCode == Interop.Errors.ERROR_SUCCESS) && (data.dwFileAttributes != -1);
 
-            if (PathInternal.IsDirectorySeparator(fullPath[fullPath.Length - 1]))
+            if (result && PathInternal.IsDirectorySeparator(fullPath[fullPath.Length - 1]))
             {
                 // We want to make sure that if the path ends in a trailing slash, it's truly a directory
                 // because FillAttributeInfo syscall removes any trailing slashes and may give false positives
                 // for existing files.
-                result = result && (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) != 0;
+                result = (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) != 0;
             }
 
             return result;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -27,19 +27,12 @@ namespace System.IO
             (char)31
         };
 
-        private static bool ExistsCore(string fullPath)
+        private static bool ExistsCore(string fullPath, out bool isDirectory)
         {
             Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA data = default;
             int errorCode = FileSystem.FillAttributeInfo(fullPath, ref data, returnErrorOnNotFound: true);
             bool result = (errorCode == Interop.Errors.ERROR_SUCCESS) && (data.dwFileAttributes != -1);
-
-            if (result && PathInternal.IsDirectorySeparator(fullPath[fullPath.Length - 1]))
-            {
-                // We want to make sure that if the path ends in a trailing slash, it's truly a directory
-                // because FillAttributeInfo syscall removes any trailing slashes and may give false positives
-                // for existing files.
-                result = (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) != 0;
-            }
+            isDirectory = result && (data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) != 0;
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -107,7 +107,15 @@ namespace System.IO
                 return false;
             }
 
-            return ExistsCore(fullPath);
+            bool result = ExistsCore(fullPath, out bool isDirectory);
+            if (result && PathInternal.IsDirectorySeparator(fullPath[fullPath.Length - 1]))
+            {
+                // Some sys-calls remove all trailing slashes and may give false positives for existing files.
+                // We want to make sure that if the path ends in a trailing slash, it's truly a directory.
+                return isDirectory;
+            }
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
If result is false, there is no reason to run the `PathInternal.IsDirectorySeparator(...)` function.
No matter what it returns, the `result = result && ...` will always yeild false, since result is false already.

So the entire if statement can be skipped, if result is false, since it cannot possible change result to a true.