### PR TITLE
Remove ARMv6 from all platformgroups, matching s390x

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -53,7 +53,7 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
-- ${{ if or(containsValue(parameters.platforms, 'Linux_armv6'), or(and(ne(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'gcstress')), and(eq(parameters.runtimeFlavor, 'mono'), in(parameters.platformGroup, 'all', 'gcstress')))) }}:
+- ${{ if containsValue(parameters.platforms, 'Linux_armv6') }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}


### PR DESCRIPTION
Turns out CoreCLR uses platformgroups a lot for managing extra pipelines, and ignores valid subsets for these pipelines.

We should just... not try and get involved in platformgroups.

Ref. https://dev.azure.com/dnceng/public/_build/results?buildId=1580540&view=logs&jobId=86b05f7f-a5b8-51f0-63db-a6d409e0da15&j=86b05f7f-a5b8-51f0-63db-a6d409e0da15
Ref. https://github.com/dotnet/runtime/pull/64267#issuecomment-1025087151