### PR TITLE
add missing test for scenario when destination file is larger than source file (it needs to be truncated)

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
-using Microsoft.Win32.SafeHandles;
 using Xunit;
 
 namespace System.IO.Tests
@@ -359,14 +358,13 @@ namespace System.IO.Tests
             string sourcePath = GetTestFilePath();
             string destPath = GetTestFilePath();
 
-            const int SourceFileSize = 1000;
-            File.WriteAllBytes(sourcePath, RandomNumberGenerator.GetBytes(SourceFileSize));
-            File.WriteAllBytes(destPath, RandomNumberGenerator.GetBytes(SourceFileSize * 2));
+            byte[] content = RandomNumberGenerator.GetBytes(1000);
+            File.WriteAllBytes(sourcePath, content);
+            File.WriteAllBytes(destPath, RandomNumberGenerator.GetBytes(content.Length * 2));
 
             Copy(sourcePath, destPath, overwrite: true);
 
-            using SafeFileHandle destHandle = File.OpenHandle(destPath, FileMode.Open);
-            Assert.Equal(SourceFileSize, RandomAccess.GetLength(destHandle));
+            Assert.Equal(content, File.ReadAllBytes(destPath));
         }
     }
 

--- a/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Copy.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
 using Xunit;
 
 namespace System.IO.Tests
@@ -349,6 +351,22 @@ namespace System.IO.Tests
             // This always throws as you can't copy an alternate stream out (oddly)
             Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2, overwrite: true));
             Assert.Throws<IOException>(() => Copy(testFileAlternateStream, testFile2 + alternateStream, overwrite: true));
+        }
+
+        [Fact]
+        public void DestinationFileIsTruncatedWhenItsLargerThanSourceFile()
+        {
+            string sourcePath = GetTestFilePath();
+            string destPath = GetTestFilePath();
+
+            const int SourceFileSize = 1000;
+            File.WriteAllBytes(sourcePath, RandomNumberGenerator.GetBytes(SourceFileSize));
+            File.WriteAllBytes(destPath, RandomNumberGenerator.GetBytes(SourceFileSize * 2));
+
+            Copy(sourcePath, destPath, overwrite: true);
+
+            using SafeFileHandle destHandle = File.OpenHandle(destPath, FileMode.Open);
+            Assert.Equal(SourceFileSize, RandomAccess.GetLength(destHandle));
         }
     }
 


### PR DESCRIPTION
While experimenting with #61676 I've removed the file truncation in `File.CopyTo` for `overwrite == true` and all tests were passing.