### PR TITLE
Override DisposeAsync in PipeWriterStream

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
@@ -27,6 +27,15 @@ namespace System.IO.Pipelines
             base.Dispose(disposing);
         }
 
+        public async override ValueTask DisposeAsync()
+        {
+            if (!LeaveOpen)
+            {
+                await _pipeWriter.CompleteAsync().ConfigureAwait(false);
+            }
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+
         internal bool LeaveOpen { get; set; }
 
         public override bool CanRead => false;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
@@ -27,13 +27,17 @@ namespace System.IO.Pipelines
             base.Dispose(disposing);
         }
 
-        public async override ValueTask DisposeAsync()
+        public override ValueTask DisposeAsync()
         {
-            if (!LeaveOpen)
+            return DisposeAsyncCore();
+            async ValueTask DisposeAsyncCore()
             {
-                await _pipeWriter.CompleteAsync().ConfigureAwait(false);
+                if (!LeaveOpen)
+                {
+                    await _pipeWriter.CompleteAsync().ConfigureAwait(false);
+                }
+                await base.DisposeAsync().ConfigureAwait(false);
             }
-            await base.DisposeAsync().ConfigureAwait(false);
         }
 
         internal bool LeaveOpen { get; set; }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
@@ -24,17 +24,16 @@ namespace System.IO.Pipelines
             {
                 _pipeWriter.Complete();
             }
-            base.Dispose(disposing);
         }
 
 #if (!NETSTANDARD2_0 && !NETFRAMEWORK)
-        public async override ValueTask DisposeAsync()
+        public override ValueTask DisposeAsync()
         {
             if (!LeaveOpen)
             {
-                await _pipeWriter.CompleteAsync().ConfigureAwait(false);
+                return _pipeWriter.CompleteAsync();
             }
-            await base.DisposeAsync().ConfigureAwait(false);
+            return default;
         }
 #endif
 

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
@@ -27,18 +27,16 @@ namespace System.IO.Pipelines
             base.Dispose(disposing);
         }
 
-        public override ValueTask DisposeAsync()
+#if (!NETSTANDARD2_0 && !NETFRAMEWORK)
+        public async override ValueTask DisposeAsync()
         {
-            return DisposeAsyncCore();
-            async ValueTask DisposeAsyncCore()
+            if (!LeaveOpen)
             {
-                if (!LeaveOpen)
-                {
-                    await _pipeWriter.CompleteAsync().ConfigureAwait(false);
-                }
-                await base.DisposeAsync().ConfigureAwait(false);
+                await _pipeWriter.CompleteAsync().ConfigureAwait(false);
             }
+            await base.DisposeAsync().ConfigureAwait(false);
         }
+#endif
 
         internal bool LeaveOpen { get; set; }
 

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
@@ -177,10 +177,22 @@ namespace System.IO.Pipelines.Tests
             pipeWriter.AsStream(leaveOpen: true).Dispose();
         }
 
+        [Fact]
+        public void DisposeAsyncCallsCompleteAsync()
+        {
+            var pipeWriter = new TestPipeWriter();
+            Stream stream = pipeWriter.AsStream();
+
+            await stream.DisposeAsync();
+
+            Assert.True(pipeWriter.CompleteAsyncCalled);
+        }
+
         public class TestPipeWriter : PipeWriter
         {
             public bool FlushCalled { get; set; }
             public bool WriteAsyncCalled { get; set; }
+            public bool CompleteAsyncCalled { get; set; }
 
             public override void Advance(int bytes)
             {
@@ -195,6 +207,12 @@ namespace System.IO.Pipelines.Tests
             public override void Complete(Exception exception = null)
             {
                 throw new NotImplementedException();
+            }
+
+            public override ValueTask CompleteAsync(Exception exception = null)
+            {
+                CompleteAsyncCalled = true;
+                return default;
             }
 
             public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
@@ -204,10 +204,7 @@ namespace System.IO.Pipelines.Tests
                 throw new NotImplementedException();
             }
 
-            public override void Complete(Exception exception = null)
-            {
-                throw new NotImplementedException();
-            }
+            public override void Complete(Exception exception = null) {}
 
             public override ValueTask CompleteAsync(Exception exception = null)
             {

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
@@ -204,7 +204,10 @@ namespace System.IO.Pipelines.Tests
                 throw new NotImplementedException();
             }
 
-            public override void Complete(Exception exception = null) {}
+            public override void Complete(Exception exception = null)
+            {
+                throw new NotImplementedException();
+            }
 
             public override ValueTask CompleteAsync(Exception exception = null)
             {

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
@@ -178,7 +178,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public void DisposeAsyncCallsCompleteAsync()
+        public async Task DisposeAsyncCallsCompleteAsync()
         {
             var pipeWriter = new TestPipeWriter();
             Stream stream = pipeWriter.AsStream();


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/issues/64326 to stop us doing sync over async