### PR TITLE
Fix for number of used frame infos during crossgen2 compilation

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3430,6 +3430,7 @@ namespace Internal.JitInterface
         {
             // We could add some logging here, but for now it's unnecessary.
             // CompileMethod is going to fail with this CorJitResult anyway.
+            _numFrameInfos = 0;
         }
 
         private void recordCallSite(uint instrOffset, CORINFO_SIG_INFO* callSig, CORINFO_METHOD_STRUCT_* methodHandle)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/59040

Problem with `JIT/Regression/JitBlue/GitHub_17777/GitHub_17777` happens because 1st `compCompile` invocation in `jitNativeCode` throws exception `CORJIT_INTERNALERROR`, but reserved unwind info (via `reserveUnwindInfo`) is never freed. Second attempt without opts succeeds, but `reserveUnwindInfo` is called again, so there's actually twice as much unwind info reserved as needed.

It might be worth to investigate the reason of `CORJIT_INTERNALERROR` on arm64 for GitHub_17777 separately. This change will still be needed, because compilation retry might happen on some other tests too for one reason or another.

Update: I've found the reason of `CORJIT_INTERNALERROR`. `NO_WAY` assert happens inside jit during compilation in emit.cpp:
```cpp
        /* Are we overflowing? */
        if (ig->igNext && (ig->igNum + 1 != ig->igNext->igNum))
        {
            NO_WAY("Too many instruction groups");
        }
```

`igNum` here is `unsigned` on all platforms, i.e. 32 bit. I guess this is currently a limitation of jit.

cc @alpencolt