### PR TITLE
Fix several remaining IL tests I missed in my assembly name cleanup

### DIFF
--- a/src/tests/JIT/Methodical/Coverage/b518440.il
+++ b/src/tests/JIT/Methodical/Coverage/b518440.il
@@ -10,7 +10,6 @@
 
 .assembly extern mscorlib{}
 .assembly b518440{}
-.module b518440.exe
 
 .class public A
 {

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/ptr.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/ptr.il
@@ -9,9 +9,8 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
-.assembly 'test'
+.assembly 'ptr'
 { }
-.module 'test.exe'
 // MVID: {6048B3F7-DE21-4008-935A-6B43C5338841}
 .class value private explicit ansi sealed $MultiByte$size$120
 {

--- a/src/tests/JIT/Methodical/eh/basics/throwinexcept.il
+++ b/src/tests/JIT/Methodical/eh/basics/throwinexcept.il
@@ -10,9 +10,9 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'throwinexcept' {}
 
+.class public auto ansi Test_throwinexcept extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -84,4 +84,5 @@ done2:
   callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
   
   ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/basics/throwinfault.il
+++ b/src/tests/JIT/Methodical/eh/basics/throwinfault.il
@@ -10,9 +10,9 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'throwinfault' {}
 
+.class public auto ansi Test_throwinfault extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -78,4 +78,5 @@
   callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
   
   ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/basics/throwinfilter.il
+++ b/src/tests/JIT/Methodical/eh/basics/throwinfilter.il
@@ -10,9 +10,9 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'throwinfilter' {}
 
+.class public auto ansi Test_throwinfilter extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -81,4 +81,5 @@ done2:
   callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
   
   ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/basics/throwinfinallyintryfilter1.il
+++ b/src/tests/JIT/Methodical/eh/basics/throwinfinallyintryfilter1.il
@@ -10,10 +10,10 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'throwinfinallyintryfilter1' {}
 
 
+.class public auto ansi Test_throwinfinallyintryfilter1 extends [mscorlib] System.Object {
 .method public static int32 Main()
 {
   .entrypoint
@@ -78,7 +78,7 @@
   
   ret
 }
-
+}
 
 .method public static void  func(int32 i)
 {

--- a/src/tests/JIT/Methodical/eh/basics/throwinfinallyintryfilter2.il
+++ b/src/tests/JIT/Methodical/eh/basics/throwinfinallyintryfilter2.il
@@ -10,10 +10,10 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'throwinfinallyintryfilter2' {}
 
 
+.class public auto ansi Test_throwinfinallyintryfilter2 extends [mscorlib] System.Object {
 .method public static int32 Main()
 {
   .entrypoint
@@ -78,7 +78,7 @@
   
   ret
 }
-
+}
 
 .method public static void  func(int32 i)
 {

--- a/src/tests/JIT/Methodical/eh/basics/throwinfinallyintryfilter3.il
+++ b/src/tests/JIT/Methodical/eh/basics/throwinfinallyintryfilter3.il
@@ -10,10 +10,10 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'throwinfinallyintryfilter3' {}
 
 
+.class public auto ansi Test_throwinfinallyintryfilter3 extends [mscorlib] System.Object {
 .method public static int32 Main()
 {
   .entrypoint
@@ -87,7 +87,7 @@
   
   ret
 }
-
+}
 
 .method public static void  func(int32 i)
 {

--- a/src/tests/JIT/Methodical/eh/basics/tryexcept.il
+++ b/src/tests/JIT/Methodical/eh/basics/tryexcept.il
@@ -10,9 +10,9 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'tryexcept' {}
 
+.class public auto ansi Test_tryexcept extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -63,4 +63,5 @@ handler_begin:  pop
          
          ret
   .try try_start to filter_begin filter filter_begin handler handler_begin to done
+}
 }

--- a/src/tests/JIT/Methodical/eh/basics/tryfault.il
+++ b/src/tests/JIT/Methodical/eh/basics/tryfault.il
@@ -10,9 +10,9 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'tryfault' {}
 
+.class public auto ansi Test_tryfault extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -56,4 +56,5 @@
       callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
       
 	  ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/basics/tryfaulttrycatch.il
+++ b/src/tests/JIT/Methodical/eh/basics/tryfaulttrycatch.il
@@ -10,9 +10,9 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'tryfaulttrycatch' {}
 
+.class public auto ansi Test_tryfaulttrycatch extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -76,4 +76,5 @@
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/basics/tryfaulttrycatchfn.il
+++ b/src/tests/JIT/Methodical/eh/basics/tryfaulttrycatchfn.il
@@ -10,8 +10,7 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'tryfaulttrycatchfn' {}
 
 .method public static void middle() {
     .maxstack  1
@@ -38,6 +37,7 @@ done:
 }
 
 
+.class public auto ansi Test_tryfaulttrycatchfn extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -88,4 +88,5 @@ done:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/basics/trythrowexcept.il
+++ b/src/tests/JIT/Methodical/eh/basics/trythrowexcept.il
@@ -10,9 +10,9 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-.module test.exe
+.assembly 'trythrowexcept' {}
 
+.class public auto ansi Test_trythrowexcept extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -79,4 +79,5 @@ handler_begin:  pop
 
          ret
   .try try_start to filter_begin filter filter_begin handler handler_begin to done
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/deadnonlocalexit.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadnonlocalexit.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common{}
-.assembly test
+.assembly 'deadnonlocalexit'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_deadnonlocalexit extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -89,4 +89,5 @@
 	  ldloc.s    testLog
 	  callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
       ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/deadrgninfunclet.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadrgninfunclet.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common{}
-.assembly test
+.assembly 'deadrgninfunclet'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_deadrgninfunclet extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -120,4 +120,5 @@ L5:
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/deadtrycatch.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadtrycatch.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'deadtrycatch'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_deadtrycatch extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
       .maxstack  2
@@ -81,4 +81,5 @@
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/deadtryfinally.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadtryfinally.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common{}
-.assembly test
+.assembly 'deadtryfinally'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_deadtryfinally extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
       .maxstack  2
@@ -76,4 +76,5 @@
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 		ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/deadtryfinallythrow.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/deadtryfinallythrow.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common{}
-.assembly test
+.assembly 'deadtryfinallythrow'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_deadtryfinallythrow extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
       .maxstack  2
@@ -79,4 +79,5 @@
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 		ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/severaldeadehregions.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/severaldeadehregions.il
@@ -14,16 +14,16 @@
 }
 .assembly extern eh_common{}
 
-.assembly test
+.assembly 'severaldeadehregions'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_severaldeadehregions extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -177,4 +177,5 @@ skip:
 	  ldloc.s    testLog
 	  callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
       ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/severalnesteddeadehregions.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/severalnesteddeadehregions.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common{}
-.assembly test
+.assembly 'severalnesteddeadehregions'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_severalnesteddeadehregions extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -176,4 +176,5 @@ skip:
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/deadcode/simpledeadehregion.il
+++ b/src/tests/JIT/Methodical/eh/deadcode/simpledeadehregion.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common{}
-.assembly test
+.assembly 'simpledeadehregion'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_simpledeadehregion extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -83,4 +83,5 @@ done:
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
         ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/backwardleave.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/backwardleave.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'backwardleave'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_backwardleave extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -88,4 +88,5 @@
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/catchbeforetrybody.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/catchbeforetrybody.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common{}
-.assembly test
+.assembly 'catchbeforetrybody'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_catchbeforetrybody extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -74,4 +74,5 @@
     ldloc.s    testLog
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/catchtryintryfinally.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/catchtryintryfinally.il
@@ -13,15 +13,15 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'catchtryintryfinally'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
+.class public auto ansi Test_catchtryintryfinally extends [mscorlib] System.Object {
 .method public static int32  main() cil managed
 {
   .entrypoint
@@ -87,3 +87,4 @@
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     ret
 } 
+}

--- a/src/tests/JIT/Methodical/eh/disconnected/faultbeforetrybody.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/faultbeforetrybody.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'faultbeforetrybody'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_faultbeforetrybody extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -67,4 +67,5 @@
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/finallybeforetrybody.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/finallybeforetrybody.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'finallybeforetrybody'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_finallybeforetrybody extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -72,4 +72,5 @@
 	    ldloc.s    testLog
 	    callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/finallytryintryfinally.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/finallytryintryfinally.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'finallytryintryfinally'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_finallytryintryfinally extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  4
@@ -86,4 +86,5 @@
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/reversedhandlers.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/reversedhandlers.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'reversedhandlers'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_reversedhandlers extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -100,4 +100,5 @@
 	    ldloc.s    testLog
 	    callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/reversedtryblock.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/reversedtryblock.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'reversedtryblock'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_reversedtryblock extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -94,4 +94,5 @@
 	    ldloc.s    testLog
 	    callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/sehhandlerbeforetry.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/sehhandlerbeforetry.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'sehhandlerbeforetry'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_sehhandlerbeforetry extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  2
@@ -78,4 +78,5 @@ done:
 	ret
 	
 .try try_start to try_end filter filter_begin handler handler_begin to handler_end
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/testeit.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/testeit.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'testeit'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_testeit extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -112,4 +112,5 @@
 	    ldloc.s    testLog
 	    callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/trybodyinbetweencatchhandlers.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/trybodyinbetweencatchhandlers.il
@@ -13,16 +13,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'trybodyinbetweencatchhandlers'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_trybodyinbetweencatchhandlers extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -172,4 +172,5 @@
 	    ldloc.s    testLog
 	    callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/disconnected/tryfinallyincatchtry.il
+++ b/src/tests/JIT/Methodical/eh/disconnected/tryfinallyincatchtry.il
@@ -12,16 +12,16 @@
   .ver 0:0:0:0
 }
 .assembly extern eh_common {}
-.assembly test
+.assembly 'tryfinallyincatchtry'
 {
   .ver 0:0:0:0
 }
-.module test.exe
 .imagebase 0x00400000
 .subsystem 0x00000003
 .file alignment 512
 .corflags 0x00000001
 
+.class public auto ansi Test_tryfinallyincatchtry extends [mscorlib] System.Object {
 .method public static int32 main() {
     .entrypoint
     .maxstack  400
@@ -102,4 +102,5 @@
 		ldloc.s    testLog
 		callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
 	    ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/cascadedcatch.il
+++ b/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/cascadedcatch.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module cascadedcatch.exe
+.assembly 'cascadedcatch' {}
 
 
+
+.class public auto ansi Test_cascadedcatch extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -1496,4 +1496,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/cascadedexcept.il
+++ b/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/cascadedexcept.il
@@ -8,10 +8,10 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
+.assembly 'cascadedexcept' {}
 
-.module cascadedexcept.exe
 
+.class public auto ansi Test_cascadedexcept extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -1838,4 +1838,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedcatch.il
+++ b/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedcatch.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module cascadedcatch.exe
+.assembly 'throwincascadedcatch' {}
 
 
+
+.class public auto ansi Test_throwincascadedcatch extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -1676,4 +1676,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedcatchnofin.il
+++ b/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedcatchnofin.il
@@ -8,10 +8,10 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
+.assembly 'throwincascadedcatchnofin' {}
 
-.module throwincascadedcatchnofin.exe
 
+.class public auto ansi Test_throwincascadedcatchnofin extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -1855,4 +1855,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexcept.il
+++ b/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexcept.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module throwincascadedexcept.exe
+.assembly 'throwincascadedexcept' {}
 
 
+
+.class public auto ansi Test_throwincascadedexcept extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -2076,4 +2076,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexceptnofin.il
+++ b/src/tests/JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexceptnofin.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module throwincascadedexceptnofin.exe
+.assembly 'throwincascadedexceptnofin' {}
 
 
+
+.class public auto ansi Test_throwincascadedexceptnofin extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -2356,4 +2356,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/general/localvarincatch.il
+++ b/src/tests/JIT/Methodical/eh/nested/general/localvarincatch.il
@@ -10,10 +10,10 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
+.assembly 'localvarincatch' {}
 
-.module localvarincatch.exe
 
+.class public auto ansi Test_localvarincatch extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -201,4 +201,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtrycatch.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtrycatch.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module nestedtrycatch.exe
+.assembly 'nestedtrycatch' {}
 
 
+
+.class public auto ansi Test_nestedtrycatch extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -648,4 +648,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtryexcept.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtryexcept.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module nestedtryexcept.exe
+.assembly 'nestedtryexcept' {}
 
 
+
+.class public auto ansi Test_nestedtryexcept extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -998,4 +998,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtryfault.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtryfault.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module nestedtryfault.exe
+.assembly 'nestedtryfault' {}
 
 
+
+.class public auto ansi Test_nestedtryfault extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -598,4 +598,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtryfinally.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/nestedtryfinally.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module nestedtryfinally.exe
+.assembly 'nestedtryfinally' {}
 
 
+
+.class public auto ansi Test_nestedtryfinally extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -748,4 +748,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtrycatch.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtrycatch.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module throwinnestedtrycatch.exe
+.assembly 'throwinnestedtrycatch' {}
 
 
+
+.class public auto ansi Test_throwinnestedtrycatch extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -652,4 +652,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtryexcept.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtryexcept.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module throwinnestedtryexcept.exe
+.assembly 'throwinnestedtryexcept' {}
 
 
+
+.class public auto ansi Test_throwinnestedtryexcept extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -1152,4 +1152,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtryfault.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtryfault.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module throwinnestedtryfault.exe
+.assembly 'throwinnestedtryfault' {}
 
 
+
+.class public auto ansi Test_throwinnestedtryfault extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -750,4 +750,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtryfinally.il
+++ b/src/tests/JIT/Methodical/eh/nested/nestedtry/throwinnestedtryfinally.il
@@ -8,11 +8,11 @@
 }
 .assembly extern mscorlib {}
 .assembly extern eh_common {}
-.assembly test {}
-
-.module throwinnestedtryfinally.exe
+.assembly 'throwinnestedtryfinally' {}
 
 
+
+.class public auto ansi Test_throwinnestedtryfinally extends [mscorlib] System.Object {
 .method public static int32 main() {
   .entrypoint
   .maxstack  2
@@ -750,4 +750,5 @@ begin:
     callvirt   instance int32 [eh_common]TestUtil.TestLog::VerifyOutput()
     
     ret
+}
 }

--- a/src/tests/JIT/Methodical/xxblk/cpblk3.il
+++ b/src/tests/JIT/Methodical/xxblk/cpblk3.il
@@ -9,7 +9,7 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
-.assembly cpblk2 {}
+.assembly 'cpblk3' {}
 .class public explicit ansi sealed $MultiByte$size$34
        extends [mscorlib]System.ValueType
 {

--- a/src/tests/JIT/Methodical/xxblk/dynblk_order.il
+++ b/src/tests/JIT/Methodical/xxblk/dynblk_order.il
@@ -7,7 +7,7 @@
 .assembly extern System.Console { }
 .assembly extern xunit.core {}
 
-.assembly DynBlkOrder {}
+.assembly 'dynblk_order' {}
 
 .typedef [System.Runtime]System.OverflowException as OverflowException
 .typedef [System.Runtime]System.IndexOutOfRangeException as IndexOutOfRangeException

--- a/src/tests/JIT/Methodical/xxblk/initblk3.il
+++ b/src/tests/JIT/Methodical/xxblk/initblk3.il
@@ -9,8 +9,7 @@
   .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
   .ver 4:0:0:0
 }
-.assembly initblk2 {}
-.module initblk2.exe
+.assembly 'initblk3' {}
 
 .class public explicit ansi sealed $MultiByte$size$5000 extends [mscorlib]System.ValueType
 {


### PR DESCRIPTION
I have found out I had a case sensitivity bug in the ILTransform tool
that ended up missing about 50 IL sources with lowercase main() entry
point. This change cleans up the remaining source files and also
supplies an auto-generated class wrapper in tests where the entrypoint
was a global function.

Thanks

Tomas

/cc @dotnet/jit-contrib 