### PR TITLE
Explicit test for injecting scoped IServiceProvider (#63225)

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/LightInject.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/LightInject.cs
@@ -8,11 +8,16 @@ using LightInject.Microsoft.DependencyInjection;
 
 namespace Microsoft.Extensions.DependencyInjection.Specification
 {
-    public class LightInjectDependencyInjectionSpecificationTests: DependencyInjectionSpecificationTests
+    public class LightInjectDependencyInjectionSpecificationTests : SkippableDependencyInjectionSpecificationTests
     {
         public override bool SupportsIServiceProviderIsService => false;
 
-        protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
+        public override string[] SkippedTests => new string[]
+        {
+            "NonSingletonService_WithInjectedProvider_ResolvesScopeProvider"
+        };
+
+        protected override IServiceProvider CreateServiceProviderImpl(IServiceCollection serviceCollection)
         {
             var builder = new ContainerBuilder();
             builder.Populate(serviceCollection);


### PR DESCRIPTION
Alternative to https://github.com/dotnet/runtime/pull/63226 which only adds a new test without modifying the existing ones.

The new test is analogous to the existing `SingletonServiceCanBeResolvedFromScope` but covers the more general (at least from my point of view) case of non-singleton injection.

I have also updated `LightInjectDependencyInjectionSpecificationTests` to skip this new test since it otherwise fails on the last line of the test `Assert.NotSame(fakeServiceFromScope1, fakeServiceFromScope2)`, meaning that LightInject actually injects the same scoped or transient service instance in both of the created service provider scopes - probably the result of making the original `SingletonServiceCanBeResolvedFromScope` test pass.