### PR TITLE
Minor cleanup for CryptoServiceProviders

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/Helpers.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/Helpers.cs
@@ -42,6 +42,14 @@ namespace Internal.Cryptography
         public static bool IsRC2Supported => true;
 #endif
 
+        [UnsupportedOSPlatformGuard("browser")]
+        internal static bool HasMD5 { get; } =
+#if NET5_0_OR_GREATER
+            !OperatingSystem.IsBrowser();
+#else
+            true;
+#endif
+
         [return: NotNullIfNotNull("src")]
         public static byte[]? CloneByteArray(this byte[]? src)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Internal.Cryptography;
+using System.IO;
 
 namespace System.Security.Cryptography
 {
@@ -9,7 +10,59 @@ namespace System.Security.Cryptography
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "Weak algorithms are used as instructed by the caller")]
     internal static class HashOneShotHelpers
     {
-        public static int MacData(
+        internal static byte[] HashData(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> source)
+        {
+            if (hashAlgorithm == HashAlgorithmName.SHA256)
+            {
+                return SHA256.HashData(source);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA1)
+            {
+                return SHA1.HashData(source);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA512)
+            {
+                return SHA512.HashData(source);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA384)
+            {
+                return SHA384.HashData(source);
+            }
+            else if (Helpers.HasMD5 && hashAlgorithm == HashAlgorithmName.MD5)
+            {
+                return MD5.HashData(source);
+            }
+
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));
+        }
+
+        internal static byte[] HashData(HashAlgorithmName hashAlgorithm, Stream source)
+        {
+            if (hashAlgorithm == HashAlgorithmName.SHA256)
+            {
+                return SHA256.HashData(source);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA1)
+            {
+                return SHA1.HashData(source);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA512)
+            {
+                return SHA512.HashData(source);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA384)
+            {
+                return SHA384.HashData(source);
+            }
+            else if (Helpers.HasMD5 && hashAlgorithm == HashAlgorithmName.MD5)
+            {
+                return MD5.HashData(source);
+            }
+
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));
+        }
+
+        internal static int MacData(
             HashAlgorithmName hashAlgorithm,
             ReadOnlySpan<byte> key,
             ReadOnlySpan<byte> source,

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -1117,6 +1117,17 @@ namespace System.Security.Cryptography
                 _ => throw new ArgumentException(SR.Argument_InvalidValue, nameof(hashAlg)),
             };
 
+        internal static HashAlgorithmName AlgIdToHashAlgorithmName(int hashAlg) =>
+            hashAlg switch
+            {
+                CapiHelper.CALG_MD5 => HashAlgorithmName.MD5,
+                CapiHelper.CALG_SHA1 => HashAlgorithmName.SHA1,
+                CapiHelper.CALG_SHA_256 => HashAlgorithmName.SHA256,
+                CapiHelper.CALG_SHA_384 => HashAlgorithmName.SHA384,
+                CapiHelper.CALG_SHA_512 => HashAlgorithmName.SHA512,
+                _ => throw new ArgumentException(SR.Argument_InvalidValue, nameof(hashAlg)),
+            };
+
         /// <summary>
         /// Convert an OID into a CAPI-1 CALG ID.
         /// </summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
@@ -443,7 +443,7 @@ namespace System.Security.Cryptography
         {
             int calgHash = CapiHelper.ObjToHashAlgId(halg);
             HashAlgorithmName hashAlgorithmName = CapiHelper.AlgIdToHashAlgorithmName(calgHash);
-            byte[] hashVal = HashOneShotHelpers.HashData(hashAlgorithmName, buffer);
+            byte[] hashVal = HashOneShotHelpers.HashData(hashAlgorithmName, new ReadOnlySpan<byte>(buffer, offset, count));
             return SignHash(hashVal, calgHash);
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/RSACryptoServiceProvider.Windows.cs
@@ -442,8 +442,8 @@ namespace System.Security.Cryptography
         public byte[] SignData(byte[] buffer, int offset, int count, object halg)
         {
             int calgHash = CapiHelper.ObjToHashAlgId(halg);
-            HashAlgorithm hash = CapiHelper.ObjToHashAlgorithm(halg);
-            byte[] hashVal = hash.ComputeHash(buffer, offset, count);
+            HashAlgorithmName hashAlgorithmName = CapiHelper.AlgIdToHashAlgorithmName(calgHash);
+            byte[] hashVal = HashOneShotHelpers.HashData(hashAlgorithmName, buffer);
             return SignHash(hashVal, calgHash);
         }
 
@@ -457,8 +457,8 @@ namespace System.Security.Cryptography
         public byte[] SignData(byte[] buffer, object halg)
         {
             int calgHash = CapiHelper.ObjToHashAlgId(halg);
-            HashAlgorithm hash = CapiHelper.ObjToHashAlgorithm(halg);
-            byte[] hashVal = hash.ComputeHash(buffer);
+            HashAlgorithmName hashAlgorithmName = CapiHelper.AlgIdToHashAlgorithmName(calgHash);
+            byte[] hashVal = HashOneShotHelpers.HashData(hashAlgorithmName, buffer);
             return SignHash(hashVal, calgHash);
         }
 
@@ -472,8 +472,8 @@ namespace System.Security.Cryptography
         public byte[] SignData(Stream inputStream, object halg)
         {
             int calgHash = CapiHelper.ObjToHashAlgId(halg);
-            HashAlgorithm hash = CapiHelper.ObjToHashAlgorithm(halg);
-            byte[] hashVal = hash.ComputeHash(inputStream);
+            HashAlgorithmName hashAlgorithmName = CapiHelper.AlgIdToHashAlgorithmName(calgHash);
+            byte[] hashVal = HashOneShotHelpers.HashData(hashAlgorithmName, inputStream);
             return SignHash(hashVal, calgHash);
         }
 
@@ -522,8 +522,8 @@ namespace System.Security.Cryptography
         public bool VerifyData(byte[] buffer, object halg, byte[] signature)
         {
             int calgHash = CapiHelper.ObjToHashAlgId(halg);
-            HashAlgorithm hash = CapiHelper.ObjToHashAlgorithm(halg);
-            byte[] hashVal = hash.ComputeHash(buffer);
+            HashAlgorithmName hashAlgorithmName = CapiHelper.AlgIdToHashAlgorithmName(calgHash);
+            byte[] hashVal = HashOneShotHelpers.HashData(hashAlgorithmName, buffer);
             return VerifyHash(hashVal, calgHash, signature);
         }
 


### PR DESCRIPTION
This makes some small improvements to the RSA/DSA CryptoServiceProviders. They were constructing various `HashAlgorithm` instances without disposing of them. Initially, I introduced `using`s to clean them up, but noticed the one-shots would work in those situations.

I did not "stackalloc spanify" the code paths even though I could, simply because these are somewhat compatibility types. Folks that are concerned with performance should not be using the CryptoServiceProvider types, anyway.