### PR TITLE
Optimize the remaining awaitable types in S.P.C.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs
@@ -498,7 +498,7 @@ namespace System.Runtime.CompilerServices
             // Its layout must remain the same.
 
             /// <summary>The task being awaited.</summary>
-            private readonly Task<TResult> m_task;
+            internal readonly Task<TResult> m_task;
             /// <summary>Whether to attempt marshaling back to the original context.</summary>
             private readonly bool m_continueOnCapturedContext;
 


### PR DESCRIPTION
There are a couple of internal interfaces in `System.Private.CoreLib` that allow optimizing awaitable types to not allocate any stub delegates when they are awaited. These interfaces are already supported in the common `configurable? value? task (of TResult)?` awaiters, as well as in `YieldAwaiter`, but there are a couple of internal awaitable types that did not get the treatment, namely `FileStreamHelpers.AsyncCopyToAwaitable`, `SemaphoreSlim.ConfiguredNoThrowAwaiter` and `TaskScheduler.TaskSchedulerAwaiter`.

This PR implements `IStateMachineBoxAwareAwaiter` in the first and last types, and `IConfiguredTaskAwaiter` in the middle one, avoiding some tiny delegate and thread pool work item allocations.