### PR TITLE
[wasm] Revert "Disable InspectVariableBeforeAndAfterAssignment test (#64546)"

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AssignmentTests.cs
@@ -38,7 +38,6 @@ namespace DebuggerTests
         };
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/64188")]
         [MemberData("GetTestData")]
         async Task InspectVariableBeforeAndAfterAssignment(string clazz, JObject checkDefault, JObject checkValue)
         {


### PR DESCRIPTION
This reverts commit 09f681f7aa481d441c45ebeb9807694aa6df547e.

This isn't needed as the tests are being run only in `runtime-staging`
now. And this commit itself doesn't build.