### PR TITLE
Fix LLC cache issue on Apple M1

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -946,7 +946,12 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
     {
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
-        const bool success = sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+        const bool success = false
+            // macOS-arm64: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency 
+            // and performance cores separetely. "perflevel0" stands for "performance"
+            || sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+            // macOS-arm64: these report cache sizes for efficiency cores only:
+            || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
         if (success)

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -614,11 +614,12 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
         const bool success = false
+#if defined(HOST_ARM64) && defined(TARGET_OSX)
             // macOS-arm64: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency 
             // and performance cores separetely. "perflevel0" stands for "performance"
-            || sysctlbyname("hw.perflevel0.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
-            // macOS-arm64: these report cache sizes for efficiency cores only
+            // macOS-arm64: these report cache sizes for efficiency cores only:
+#endif
             || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -614,12 +614,10 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
         const bool success = false
-#if defined(HOST_ARM64) && defined(TARGET_OSX)
             // macOS-arm64: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency 
             // and performance cores separetely. "perflevel0" stands for "performance"
             || sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             // macOS-arm64: these report cache sizes for efficiency cores only:
-#endif
             || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -613,9 +613,16 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
     {
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);
-        const bool success = sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+        const bool success = false
+            // macOS-arm64: Since macOS 12.0, Apple added ".perflevelX." to determinate cache sizes for efficiency 
+            // and performance cores separetely. "perflevel0" stands for "performance"
+            || sysctlbyname("hw.perflevel0.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+            || sysctlbyname("hw.perflevel0.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
+            // macOS-arm64: these report cache sizes for efficiency cores only
+            || sysctlbyname("hw.l3cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l2cachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0
             || sysctlbyname("hw.l1dcachesize", &cacheSizeFromSysctl, &sz, nullptr, 0) == 0;
+
         if (success)
         {
             _ASSERTE(cacheSizeFromSysctl > 0);


### PR DESCRIPTION
Addresses the L3 cache issue we've found in https://github.com/dotnet/runtime/issues/60166 but for macOS-arm64

It seems that since macOS 12.0, Apple added more entries for `sysctl` (see https://github.com/dotnet/runtime/issues/62832#issuecomment-994754094). And it turns out the keys we were using report cache size for the "efficiency cores", not the performance ones. As the result, `PAL_GetLogicalProcessorCacheSizeFromOS` used to return `4mb` instead of expected `12mb`.

This change shows nice improvements for GC-bound benchmarks and should address https://github.com/dotnet/runtime/issues/60616#issuecomment-947423453

```csharp
using System;
using System.Runtime.CompilerServices;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

public class Test
{
    public static void Main(string[] args) => 
        BenchmarkSwitcher.FromAssembly(typeof(Test).Assembly).Run(args);

    [Benchmark]
    [Arguments(10000)]
    [Arguments(128)]
    public char[] AllocateUninit(int len) => GC.AllocateUninitializedArray<char>(len);

    [Benchmark]
    [Arguments(2000)]
    [Arguments(256)]
    public char[] AllocateArray(int len) => new char[len];
    
    [Benchmark]
    public object SmallAllocation() => new object[] { new(), new() };

    [Benchmark]
    public string IntToString() => 42.ToString();
}
```
Results (Apple M1 mac mini):

|          Method |             Toolchain |   len |       Mean |     Error |    StdDev | Ratio |
|---------------- |-----------------------|------ |-----------:|----------:|----------:|------:|
| SmallAllocation |    /Core_Root/corerun |     ? |  12.695 ns | 0.0422 ns | 0.0352 ns |  1.10 |
| SmallAllocation | /Core_Root_PR/corerun |     ? |  11.534 ns | 0.0453 ns | 0.0423 ns |  1.00 |
|                 |                       |       |            |           |           |       |
|     IntToString |    /Core_Root/corerun |     ? |   6.239 ns | 0.0058 ns | 0.0052 ns |  1.08 |
|     IntToString | /Core_Root_PR/corerun |     ? |   5.782 ns | 0.0074 ns | 0.0069 ns |  1.00 |
|                 |                       |       |            |           |           |       |
|  AllocateUninit |    /Core_Root/corerun |   128 |  14.195 ns | 0.1914 ns | 0.1790 ns |  1.43 |
|  AllocateUninit | /Core_Root_PR/corerun |   128 |   9.952 ns | 0.0622 ns | 0.0582 ns |  1.00 |
|                 |                       |       |            |           |           |       |
|   AllocateArray |    /Core_Root/corerun |   256 |  26.071 ns | 0.3068 ns | 0.2562 ns |  1.46 |
|   AllocateArray | /Core_Root_PR/corerun |   256 |  17.843 ns | 0.1272 ns | 0.1190 ns |  1.00 |
|                 |                       |       |            |           |           |       |
|   AllocateArray |    /Core_Root/corerun |  2000 | 180.445 ns | 3.6465 ns | 3.4110 ns |  1.66 |
|   AllocateArray | /Core_Root_PR/corerun |  2000 | 108.966 ns | 0.9273 ns | 0.8674 ns |  1.00 |
|                 |                       |       |            |           |           |       |
|  AllocateUninit |    /Core_Root/corerun | 10000 | 529.512 ns | 3.2077 ns | 3.0005 ns |  2.51 |
|  AllocateUninit | /Core_Root_PR/corerun | 10000 | 211.415 ns | 3.5344 ns | 3.3060 ns |  1.00 |
