### PR TITLE
With `build -subset help` output "macro" subset components

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -105,14 +105,14 @@
     <SubsetName Include="Clr.NativePrereqs" Description="Managed tools that support building the native components of the runtime (such as DacTableGen)." />
     <SubsetName Include="Clr.ILTools" Description="The CoreCLR IL tools (ilasm/ildasm)." />
     <SubsetName Include="Clr.Runtime" Description="The CoreCLR .NET runtime. Includes clr.jit, clr.iltools, clr.hosts." />
-    <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools. Includes clr.hosts, clr.runtime, clr.jit, clr.paltests, clr.iltools, clr.nativeaotruntime, clr.spmi." />
+    <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools. Includes clr.hosts, clr.runtime, clr.jit, clr.alljits, clr.paltests, clr.iltools, clr.nativeaotruntime, clr.spmi." />
     <SubsetName Include="Clr.NativeAotLibs" Description="The CoreCLR native AOT CoreLib and other low level class libraries." />
     <SubsetName Include="Clr.NativeAotRuntime" Description="The stripped-down CoreCLR native AOT runtime." />
     <SubsetName Include="Clr.PalTests" OnDemand="true" Description="The CoreCLR PAL tests." />
     <SubsetName Include="Clr.PalTestList" OnDemand="true" Description="Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead." />
     <SubsetName Include="Clr.Hosts" Description="The CoreCLR corerun test host." />
     <SubsetName Include="Clr.Jit" Description="The JIT for the CoreCLR .NET runtime." />
-    <SubsetName Include="Clr.AllJits" OnDemand="true" Description="All of the cross-targeting JIT compilers for the CoreCLR .NET runtime." />
+    <SubsetName Include="Clr.AllJits" Description="All of the cross-targeting JIT compilers for the CoreCLR .NET runtime." />
     <SubsetName Include="Clr.Spmi" Description="SuperPMI, a tool for CoreCLR JIT testing." />
     <SubsetName Include="Clr.CoreLib" Description="The managed System.Private.CoreLib library for CoreCLR." />
     <SubsetName Include="Clr.NativeCoreLib" Description="Run crossgen on System.Private.CoreLib library for CoreCLR." />

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -37,7 +37,7 @@
     <DefaultSubsets Condition="('$(DotNetBuildFromSource)' == 'true' and '$(PrimaryRuntimeFlavor)' != 'Mono') or ('$(TargetOS)' == 'windows' and '$(TargetArchitecture)' != 'x86' and '$(TargetArchitecture)' != 'x64')">clr+libs+host+packs</DefaultSubsets>
   </PropertyGroup>
 
-  <!-- Init _subset here in to allow RuntimeFlavor to be set as early as possible -->
+  <!-- Init _subset here to allow RuntimeFlavor to be set as early as possible -->
   <PropertyGroup>
     <_subset Condition="'$(Subset)' != ''">+$(Subset.ToLowerInvariant())+</_subset>
     <_subset Condition="'$(Subset)' == ''">+$(DefaultSubsets)+</_subset>
@@ -101,7 +101,7 @@
 
   <ItemGroup>
     <!-- CoreClr -->
-    <SubsetName Include="Clr" Description="The CoreCLR runtime, LinuxDac, CoreLib (+ native), tools and packages." />
+    <SubsetName Include="Clr" Description="The full CoreCLR runtime: $(DefaultCoreClrSubsets)" />
     <SubsetName Include="Clr.NativePrereqs" Description="Managed tools that support building the native components of the runtime (such as DacTableGen)." />
     <SubsetName Include="Clr.ILTools" Description="The CoreCLR IL tools." />
     <SubsetName Include="Clr.Runtime" Description="The CoreCLR .NET runtime." />
@@ -124,7 +124,7 @@
             Description="Packaging of cross OS DAC. Requires all assets needed to be present at a folder specified by $(CrossDacArtifactsDir). See 'Microsoft.CrossOsDiag.Private.CoreCLR.proj' for details." />
 
     <!-- Mono -->
-    <SubsetName Include="Mono" Description="The Mono runtime and CoreLib." />
+    <SubsetName Include="Mono" Description="The Mono runtime and CoreLib: $(DefaultMonoSubsets)" />
     <SubsetName Include="Mono.Runtime" Description="The Mono .NET runtime." />
     <SubsetName Include="Mono.AotCross" Description="The cross-compiler runtime for Mono AOT." />
     <SubsetName Include="Mono.CoreLib" Description="The managed System.Private.CoreLib library for Mono." />
@@ -134,14 +134,14 @@
     <SubsetName Include="Mono.Workloads" OnDemand="true" Description="Builds the installers and the insertion metadata for Blazor workloads." />
 
     <!-- Host -->
-    <SubsetName Include="Host" Description="The .NET hosts, packages, hosting libraries, and tests." />
+    <SubsetName Include="Host" Description="The .NET hosts, packages, hosting libraries, and tests: $(DefaultHostSubsets)" />
     <SubsetName Include="Host.Native" Description="The .NET hosts." />
     <SubsetName Include="Host.Pkg" Description="The .NET host packages." />
     <SubsetName Include="Host.Tools" Description="The .NET hosting libraries." />
     <SubsetName Include="Host.Tests" Description="The .NET hosting tests." />
 
     <!-- Libs -->
-    <SubsetName Include="Libs" Description="The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly)" />
+    <SubsetName Include="Libs" Description="The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly): $(DefaultLibrariesSubsets)" />
     <SubsetName Include="Libs.Native" Description="The native libraries used in the shared framework." />
     <SubsetName Include="Libs.Ref" Description="The managed reference libraries." />
     <SubsetName Include="Libs.Src" Description="The managed implementation libraries." />
@@ -150,7 +150,7 @@
     <SubsetName Include="Libs.Tests" OnDemand="true" Description="The test projects. Note that building this doesn't execute tests: you must also pass the '-test' argument." />
 
     <!-- Packs -->
-    <SubsetName Include="Packs" Description="Builds the shared framework packs, archives, bundles, installers, and the framework pack tests." />
+    <SubsetName Include="Packs" Description="Builds the shared framework packs, archives, bundles, installers, and the framework pack tests: $(DefaultPacksSubsets)" />
     <SubsetName Include="Packs.Product" Description="Builds the shared framework packs, archives, bundles, and installers." />
     <SubsetName Include="Packs.Installers" Description="Builds the shared framework bundles and installers." />
     <SubsetName Include="Packs.Tests" Description="The framework pack tests." />

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -58,7 +58,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs+clr.spmi</DefaultCoreClrSubsets>
+    <DefaultCoreClrSubsets>clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs</DefaultCoreClrSubsets>
     <!-- Even on platforms that do not support the CoreCLR runtime, we still want to build ilasm/ildasm. -->
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
@@ -101,18 +101,18 @@
 
   <ItemGroup>
     <!-- CoreClr -->
-    <SubsetName Include="Clr" Description="The full CoreCLR runtime: $(DefaultCoreClrSubsets)" />
+    <SubsetName Include="Clr" Description="The full CoreCLR runtime. Equivalent to: $(DefaultCoreClrSubsets)" />
     <SubsetName Include="Clr.NativePrereqs" Description="Managed tools that support building the native components of the runtime (such as DacTableGen)." />
-    <SubsetName Include="Clr.ILTools" Description="The CoreCLR IL tools." />
-    <SubsetName Include="Clr.Runtime" Description="The CoreCLR .NET runtime." />
-    <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools." />
+    <SubsetName Include="Clr.ILTools" Description="The CoreCLR IL tools (ilasm/ildasm)." />
+    <SubsetName Include="Clr.Runtime" Description="The CoreCLR .NET runtime. Includes clr.jit, clr.iltools, clr.hosts." />
+    <SubsetName Include="Clr.Native" Description="All CoreCLR native non-test components, including the runtime, jits, and other native tools. Includes clr.hosts, clr.runtime, clr.jit, clr.paltests, clr.iltools, clr.nativeaotruntime, clr.spmi." />
     <SubsetName Include="Clr.NativeAotLibs" Description="The CoreCLR native AOT CoreLib and other low level class libraries." />
     <SubsetName Include="Clr.NativeAotRuntime" Description="The stripped-down CoreCLR native AOT runtime." />
     <SubsetName Include="Clr.PalTests" OnDemand="true" Description="The CoreCLR PAL tests." />
     <SubsetName Include="Clr.PalTestList" OnDemand="true" Description="Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead." />
     <SubsetName Include="Clr.Hosts" Description="The CoreCLR corerun test host." />
     <SubsetName Include="Clr.Jit" Description="The JIT for the CoreCLR .NET runtime." />
-    <SubsetName Include="Clr.AllJits" Description="All of the cross-targeting JIT compilers for the CoreCLR .NET runtime." />
+    <SubsetName Include="Clr.AllJits" OnDemand="true" Description="All of the cross-targeting JIT compilers for the CoreCLR .NET runtime." />
     <SubsetName Include="Clr.Spmi" Description="SuperPMI, a tool for CoreCLR JIT testing." />
     <SubsetName Include="Clr.CoreLib" Description="The managed System.Private.CoreLib library for CoreCLR." />
     <SubsetName Include="Clr.NativeCoreLib" Description="Run crossgen on System.Private.CoreLib library for CoreCLR." />
@@ -124,7 +124,7 @@
             Description="Packaging of cross OS DAC. Requires all assets needed to be present at a folder specified by $(CrossDacArtifactsDir). See 'Microsoft.CrossOsDiag.Private.CoreCLR.proj' for details." />
 
     <!-- Mono -->
-    <SubsetName Include="Mono" Description="The Mono runtime and CoreLib: $(DefaultMonoSubsets)" />
+    <SubsetName Include="Mono" Description="The Mono runtime and CoreLib. Equivalent to: $(DefaultMonoSubsets)" />
     <SubsetName Include="Mono.Runtime" Description="The Mono .NET runtime." />
     <SubsetName Include="Mono.AotCross" Description="The cross-compiler runtime for Mono AOT." />
     <SubsetName Include="Mono.CoreLib" Description="The managed System.Private.CoreLib library for Mono." />
@@ -134,14 +134,14 @@
     <SubsetName Include="Mono.Workloads" OnDemand="true" Description="Builds the installers and the insertion metadata for Blazor workloads." />
 
     <!-- Host -->
-    <SubsetName Include="Host" Description="The .NET hosts, packages, hosting libraries, and tests: $(DefaultHostSubsets)" />
+    <SubsetName Include="Host" Description="The .NET hosts, packages, hosting libraries, and tests. Equivalent to: $(DefaultHostSubsets)" />
     <SubsetName Include="Host.Native" Description="The .NET hosts." />
     <SubsetName Include="Host.Pkg" Description="The .NET host packages." />
     <SubsetName Include="Host.Tools" Description="The .NET hosting libraries." />
     <SubsetName Include="Host.Tests" Description="The .NET hosting tests." />
 
     <!-- Libs -->
-    <SubsetName Include="Libs" Description="The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly): $(DefaultLibrariesSubsets)" />
+    <SubsetName Include="Libs" Description="The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly). Equivalent to: $(DefaultLibrariesSubsets)" />
     <SubsetName Include="Libs.Native" Description="The native libraries used in the shared framework." />
     <SubsetName Include="Libs.Ref" Description="The managed reference libraries." />
     <SubsetName Include="Libs.Src" Description="The managed implementation libraries." />
@@ -150,7 +150,7 @@
     <SubsetName Include="Libs.Tests" OnDemand="true" Description="The test projects. Note that building this doesn't execute tests: you must also pass the '-test' argument." />
 
     <!-- Packs -->
-    <SubsetName Include="Packs" Description="Builds the shared framework packs, archives, bundles, installers, and the framework pack tests: $(DefaultPacksSubsets)" />
+    <SubsetName Include="Packs" Description="Builds the shared framework packs, archives, bundles, installers, and the framework pack tests. Equivalent to: $(DefaultPacksSubsets)" />
     <SubsetName Include="Packs.Product" Description="Builds the shared framework packs, archives, bundles, and installers." />
     <SubsetName Include="Packs.Installers" Description="Builds the shared framework bundles and installers." />
     <SubsetName Include="Packs.Tests" Description="The framework pack tests." />


### PR DESCRIPTION
Subsets like "clr", "mono", "host" are "macro" subset names that imply several other subset names. To try to explain how these relate to all the other names in `build -subset help`, actually output what they "expand" into.

e.g.,
```
  Accepted Subset values:
  - Clr
      The full CoreCLR runtime. Equivalent to: clr.native+linuxdac+clr.corelib+clr.tools+clr.nativecorelib+clr.packages+clr.nativeaotlibs
  - Clr.NativePrereqs
      Managed tools that support building the native components of the runtime (such as DacTableGen).
  - Clr.ILTools
      The CoreCLR IL tools (ilasm/ildasm).
  - Clr.Runtime
      The CoreCLR .NET runtime. Includes clr.jit, clr.iltools, clr.hosts.
  - Clr.Native
      All CoreCLR native non-test components, including the runtime, jits, and other native tools. Includes clr.hosts, clr.runtime, clr.jit, clr.alljits, clr.paltests, clr.iltools, clr.nativeaotruntime, clr.spmi.
  - Clr.NativeAotLibs
      The CoreCLR native AOT CoreLib and other low level class libraries.
  - Clr.NativeAotRuntime
      The stripped-down CoreCLR native AOT runtime.
  - Clr.PalTests [only runs on demand]
      The CoreCLR PAL tests.
  - Clr.PalTestList [only runs on demand]
      Generate the list of the CoreCLR PAL tests. When using the command line, use Clr.PalTests instead.
  - Clr.Hosts
      The CoreCLR corerun test host.
  - Clr.Jit
      The JIT for the CoreCLR .NET runtime.
  - Clr.AllJits
      All of the cross-targeting JIT compilers for the CoreCLR .NET runtime.
  - Clr.Spmi
      SuperPMI, a tool for CoreCLR JIT testing.
  - Clr.CoreLib
      The managed System.Private.CoreLib library for CoreCLR.
  - Clr.NativeCoreLib
      Run crossgen on System.Private.CoreLib library for CoreCLR.
  - Clr.Tools
      Managed tools that support CoreCLR development and testing.
  - Clr.Packages
      The projects that produce NuGet packages for the CoreCLR runtime, crossgen, and IL tools.
  - LinuxDac
      The cross-OS Windows->libc-based Linux DAC. Skipped on x86.
  - AlpineDac [only runs on demand]
      The cross-OS Windows->musl-libc-based Linux DAC. Skipped on x86
  - CrossDacPack [only runs on demand]
      Packaging of cross OS DAC. Requires all assets needed to be present at a folder specified by . See 'Microsoft.CrossOsDiag.Private.CoreCLR.proj' for details.
  - Mono
      The Mono runtime and CoreLib. Equivalent to: mono.runtime+mono.corelib+mono.packages
  - Mono.Runtime
      The Mono .NET runtime.
  - Mono.AotCross
      The cross-compiler runtime for Mono AOT.
  - Mono.CoreLib
      The managed System.Private.CoreLib library for Mono.
  - Mono.Packages
      The projects that produce NuGet packages for the Mono runtime.
  - Mono.WasmRuntime
      The WebAssembly runtime.
  - Mono.MsCorDbi
      The implementation of ICorDebug interface.
  - Mono.Workloads [only runs on demand]
      Builds the installers and the insertion metadata for Blazor workloads.
  - Host
      The .NET hosts, packages, hosting libraries, and tests. Equivalent to: host.native+host.tools+host.pkg+host.tests
  - Host.Native
      The .NET hosts.
  - Host.Pkg
      The .NET host packages.
  - Host.Tools
      The .NET hosting libraries.
  - Host.Tests
      The .NET hosting tests.
  - Libs
      The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly). Equivalent to: libs.native+libs.ref+libs.src+libs.pretest
  - Libs.Native
      The native libraries used in the shared framework.
  - Libs.Ref
      The managed reference libraries.
  - Libs.Src
      The managed implementation libraries.
  - Libs.PreTest
      Test assets which are necessary to run tests.
  - Libs.Packages
      The projects that produce NuGet packages from libraries.
  - Libs.Tests [only runs on demand]
      The test projects. Note that building this doesn't execute tests: you must also pass the '-test' argument.
  - Packs
      Builds the shared framework packs, archives, bundles, installers, and the framework pack tests. Equivalent to: packs.product+packs.tests
  - Packs.Product
      Builds the shared framework packs, archives, bundles, and installers.
  - Packs.Installers
      Builds the shared framework bundles and installers.
  - Packs.Tests
      The framework pack tests.
  - publish [only runs on demand]
      Generate asset manifests and prepare to publish to BAR.
  - RegenerateDownloadTable [only runs on demand]
      Regenerates the nightly build download table
```
