### PR TITLE
[ILVerify] Reporting verification error on protected blocks with more than one handler

### DIFF
--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -213,6 +214,26 @@ namespace Internal.IL
             FindEnclosingExceptionRegions();
             InitialPass();
             ImportBasicBlocks();
+            CheckExceptionRegions();
+        }
+
+        private void CheckExceptionRegions()
+        {
+            var tryOffsets = new HashSet<int>();
+            for (int i = 0; i < _exceptionRegions.Length; i++)
+            {
+                var region1 = _exceptionRegions[i];
+                for (int j = 0; j < _exceptionRegions.Length; j++)
+                {
+                    var region2 = _exceptionRegions[j];
+                    if (region1 != region2 &&
+                        region1.ILRegion.TryOffset == region2.ILRegion.TryOffset &&
+                        tryOffsets.Add(region1.ILRegion.TryOffset))
+                    {
+                        VerificationError(VerifierError.MoreThanOneHandler);
+                    }
+                }
+            }
         }
 
         private void FindEnclosingExceptionRegions()

--- a/src/coreclr/tools/ILVerification/Strings.resx
+++ b/src/coreclr/tools/ILVerification/Strings.resx
@@ -447,4 +447,7 @@
   <data name="InterfaceMethodNotImplemented" xml:space="preserve">
     <value>Class implements interface but not method, Class: '{0}' Interface: '{1}' Missing method: '{2}'.</value>
   </data>
+  <data name="MoreThanOneHandler" xml:space="preserve">
+    <value>Try block has more than one handler.</value>
+  </data>
 </root>

--- a/src/coreclr/tools/ILVerification/VerifierError.cs
+++ b/src/coreclr/tools/ILVerification/VerifierError.cs
@@ -45,6 +45,7 @@ namespace ILVerify
         //E_FIL_CONT_HND                "Filter contains handler."
         //E_FIL_CONT_FIL                "Nested filters."
         //E_FIL_GTEQ_CS                 "filter >= code size."
+        MoreThanOneHandler,             // Try block has more than one handler.
         FallthroughException,           // Fallthrough the end of an exception block.
         FallthroughIntoHandler,         // Fallthrough into an exception handler.
         FallthroughIntoFilter,          // Fallthrough into an exception filter.


### PR DESCRIPTION
Adds an additional check in ILVerify as described here: https://github.com/dotnet/runtime/issues/63198#issuecomment-1005388537

**Description**

ECMA-335 states:
> *I.12.4.2 Exception handling*
> There are four kinds of handlers for protected blocks. **A single protected block shall have exactly 
one handler associated with it**: 
> - A finally handler that shall be executed whenever the block exits, regardless of 
whether that occurs by normal control flow or by an unhandled exception. 
> - A fault handler that shall be executed if an exception occurs, but not on completion of 
normal control flow. 
> - A catch handler that handles any exception of a specified class or any of its sub-classes. 
> - A filter handler that runs a user-specified set of CIL instructions to determine if the 
exception should be handled by the associated handler, or passed on to the next 
protected block. 

Currently, ILVerify does not check for `A single protected block shall have exactly
one handler associated with it`, and the assembly would pass verification if a try block had more than one handler.

**Acceptance Criteria**

- [ ] Add tests